### PR TITLE
Added glob as a package dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ authors = [
 name = "image"
 path = "./src/lib.rs"
 
-[dependencies.glob]
+[dev-dependencies.glob]
 
 git = "https://github.com/rust-lang/glob"


### PR DESCRIPTION
There is a deprecation warning in `cargo test`:

```
src/png/decoder.rs:484:25: 484:35 warning: use of deprecated item: This is now a cargo package located at: https://github.com/rust-lang/glob, #[warn(deprecated)] on by default
src/png/decoder.rs:484         let mut paths = glob::glob(pattern.as_str().unwrap())
```

So this fixes it, although `glob` isn't really necessary here for anything else other than tests.
In Ruby gems we can specify development dependecies and runtime (production) dependencies so development dependencies don't get downloaded if not necessary. Is this possible here, too?
