### PR TITLE
Fix possible bug in gif.

### DIFF
--- a/src/gif/decoder.rs
+++ b/src/gif/decoder.rs
@@ -252,8 +252,8 @@ impl<R: Reader> GIFDecoder<R> {
             0u
         };
 
-        if global_table {
         let b = try!(self.r.read_u8());
+        if global_table {
             self.global_backgroud_index = Some(b);
         }
 


### PR DESCRIPTION
This is wrong if no global table is used.

Build is expected to fail due to the `num` dependency.
