### PR TITLE
Make color::Primitive trait public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 extern crate flate;
 
 pub use color::ColorType as ColorType;
+pub use color::Primitive;
 
 pub use color:: {
     Grey,


### PR DESCRIPTION
The [source code contains this line](https://github.com/PistonDevelopers/image/blob/ec4fbd02ecd4a300b3081467588fc24348dd7dce/src/image.rs#L257):

``` rust
impl<T: Primitive, P: Pixel<T>> ImageBuf<P> {
```

However the `Primitive` trait is private, which makes it impossible to use `ImageBuf` from outside the library.
