### PR TITLE
Fixing palette interlaced images and palette pictures with width % 8 != 0

### DIFF
--- a/src/png/decoder.rs
+++ b/src/png/decoder.rs
@@ -455,10 +455,9 @@ impl<R: Reader> ImageDecoder for PNGDecoder<R> {
                         ((bits * width as uint + 7) / 8)
                     ), rlength)
                 );
-                let expanded_width = self.width * bytes as u32;
                 expand_pass(
-                    buf.as_mut_slice(), expanded_width,
-                    pass_buf.slice_to_mut(expanded_width as uint), pass, line, bytes as u8
+                    buf.as_mut_slice(), self.width * bytes as u32,
+                    pass_buf.slice_to_mut(width as uint * bytes), pass, line, bytes as u8
                 );
                 old_pass = pass;
             }


### PR DESCRIPTION
This hopefully just works like a charm. It could potentially be faster because all of these bounds checks but I supposed that they get dwarfed by the index calculations… 
