### PR TITLE
Do not enable if_let explicitly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 #![warn(unused_qualifications)]
 #![warn(unused_typecasts)]
 #![feature(macro_rules)]
-#![feature(if_let)]
 // necessary for Primitive trait
 #![feature(default_type_params)]
 


### PR DESCRIPTION
The feature has been added to the language, enabling it explicitly now
issues a warning.
