### PR TITLE
Fix compilation with latest nightly (2014-12-16)

### DIFF
--- a/src/gif/decoder.rs
+++ b/src/gif/decoder.rs
@@ -104,7 +104,7 @@ impl<R: Reader> GIFDecoder<R> {
                 break
             }
 
-            data = data + b;
+            data = data + b.as_slice();
         }
 
         let m = io::MemReader::new(data);

--- a/src/gif/lzw.rs
+++ b/src/gif/lzw.rs
@@ -103,7 +103,8 @@ impl<R: Reader> LZWReader<R> {
             }
 
             if self.dict[code as uint].is_none() {
-                self.dict.as_mut_slice()[code as uint] = Some(self.prev.clone() + vec![self.prev[0]]);
+                self.dict.as_mut_slice()[code as uint] =
+                    Some(self.prev.clone() + self.prev.as_slice().slice_to(1));
             }
 
             if self.prev.len() > 0 {


### PR DESCRIPTION
The add function signature no longer uses references for self and rhs,
and in case of vectors the addition is Vec<T> + &[T], so we need to use
a slice on one side.
