### PR TITLE
Renamed into_ascii_lower to into_ascii_lowercase.

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -471,7 +471,7 @@ pub fn open(path: &Path) -> ImageResult<DynamicImage> {
     };
 
     let ext = path.extension_str()
-                  .map_or("".to_string(), | s | s.to_string().into_ascii_lower());
+                  .map_or("".to_string(), | s | s.to_string().into_ascii_lowercase());
 
     let format = match ext.as_slice() {
         "jpg" |
@@ -501,7 +501,7 @@ pub fn open(path: &Path) -> ImageResult<DynamicImage> {
 pub fn save_buffer(path: &Path, buf: &[u8], width: u32, height: u32, color: color::ColorType) ->  io::IoResult<()> {
     let fout = try!(io::File::create(path));
     let ext = path.extension_str()
-                  .map_or("".to_string(), | s | s.to_string().into_ascii_lower());
+                  .map_or("".to_string(), | s | s.to_string().into_ascii_lowercase());
 
     match ext.as_slice() {
         "jpg" |


### PR DESCRIPTION
This fixes the fallout of `std::ascii` reform (rust-lang/rust#19916).
Note: tests will stop failing once rust-lang/glob#17 is merged.
