### PR TITLE
Make Pixel structs more idiomatic

### DIFF
--- a/examples/fractal.rs
+++ b/examples/fractal.rs
@@ -35,7 +35,7 @@ fn main() {
             }
 
             let pixel = imgbuf.get_pixel_mut(x, y);
-            let data = (*pixel as image::Rgb<u8>).data;
+            let data = (*pixel as image::Rgb<u8>).0;
             *pixel = image::Rgb([data[0], i as u8, data[2]]);
         }
     }

--- a/src/color.rs
+++ b/src/color.rs
@@ -68,13 +68,7 @@ $( // START Structure definitions
 #[derive(PartialEq, Eq, Clone, Debug, Copy, Hash)]
 #[repr(C)]
 #[allow(missing_docs)]
-pub struct $ident<T: Primitive> { pub data: [T; $channels] }
-#[allow(non_snake_case, missing_docs)]
-pub fn $ident<T: Primitive>(data: [T; $channels]) -> $ident<T> {
-    $ident {
-        data: data
-    }
-}
+pub struct $ident<T: Primitive> (pub [T; $channels]);
 
 impl<T: Primitive + 'static> Pixel for $ident<T> {
 
@@ -91,17 +85,17 @@ impl<T: Primitive + 'static> Pixel for $ident<T> {
     }
     #[inline(always)]
     fn channels(&self) -> &[T] {
-        &self.data
+        &self.0
     }
     #[inline(always)]
     fn channels_mut(&mut self) -> &mut [T] {
-        &mut self.data
+        &mut self.0
     }
 
     #[allow(trivial_casts)]
     fn channels4(&self) -> (T, T, T, T) {
         let mut channels = [T::max_value(); 4];
-        channels[0..$channels].copy_from_slice(&self.data);
+        channels[0..$channels].copy_from_slice(&self.0);
         (channels[0], channels[1], channels[2], channels[3])
     }
 
@@ -119,37 +113,37 @@ impl<T: Primitive + 'static> Pixel for $ident<T> {
     }
 
     fn to_rgb(&self) -> Rgb<T> {
-        let mut pix = Rgb {data: [Zero::zero(), Zero::zero(), Zero::zero()]};
+        let mut pix = Rgb([Zero::zero(), Zero::zero(), Zero::zero()]);
         pix.from_color(self);
         pix
     }
 
     fn to_bgr(&self) -> Bgr<T> {
-        let mut pix = Bgr {data: [Zero::zero(), Zero::zero(), Zero::zero()]};
+        let mut pix = Bgr([Zero::zero(), Zero::zero(), Zero::zero()]);
         pix.from_color(self);
         pix
     }
 
     fn to_rgba(&self) -> Rgba<T> {
-        let mut pix = Rgba {data: [Zero::zero(), Zero::zero(), Zero::zero(), Zero::zero()]};
+        let mut pix = Rgba([Zero::zero(), Zero::zero(), Zero::zero(), Zero::zero()]);
         pix.from_color(self);
         pix
     }
 
     fn to_bgra(&self) -> Bgra<T> {
-        let mut pix = Bgra {data: [Zero::zero(), Zero::zero(), Zero::zero(), Zero::zero()]};
+        let mut pix = Bgra([Zero::zero(), Zero::zero(), Zero::zero(), Zero::zero()]);
         pix.from_color(self);
         pix
     }
 
     fn to_luma(&self) -> Luma<T> {
-        let mut pix = Luma {data: [Zero::zero()]};
+        let mut pix = Luma([Zero::zero()]);
         pix.from_color(self);
         pix
     }
 
     fn to_luma_alpha(&self) -> LumaA<T> {
-        let mut pix = LumaA {data: [Zero::zero(), Zero::zero()]};
+        let mut pix = LumaA([Zero::zero(), Zero::zero()]);
         pix.from_color(self);
         pix
     }
@@ -161,7 +155,7 @@ impl<T: Primitive + 'static> Pixel for $ident<T> {
     }
 
     fn apply<F>(&mut self, mut f: F) where F: FnMut(T) -> T {
-        for v in &mut self.data {
+        for v in &mut self.0 {
             *v = f(*v)
         }
     }
@@ -174,11 +168,11 @@ impl<T: Primitive + 'static> Pixel for $ident<T> {
 
     #[allow(trivial_casts)]
     fn apply_with_alpha<F, G>(&mut self, mut f: F, mut g: G) where F: FnMut(T) -> T, G: FnMut(T) -> T {
-        for v in self.data[..$channels as usize-$alphas as usize].iter_mut() {
+        for v in self.0[..$channels as usize-$alphas as usize].iter_mut() {
             *v = f(*v)
         }
         if $alphas as usize != 0 {
-            let v = &mut self.data[$channels as usize-$alphas as usize];
+            let v = &mut self.0[$channels as usize-$alphas as usize];
             *v = g(*v)
         }
     }
@@ -190,7 +184,7 @@ impl<T: Primitive + 'static> Pixel for $ident<T> {
     }
 
     fn apply2<F>(&mut self, other: &$ident<T>, mut f: F) where F: FnMut(T, T) -> T {
-        for (a, &b) in self.data.iter_mut().zip(other.data.iter()) {
+        for (a, &b) in self.0.iter_mut().zip(other.0.iter()) {
             *a = f(*a, b)
         }
     }
@@ -208,14 +202,14 @@ impl<T: Primitive> Index<usize> for $ident<T> {
     type Output = T;
     #[inline(always)]
     fn index(&self, _index: usize) -> &T {
-        &self.data[_index]
+        &self.0[_index]
     }
 }
 
 impl<T: Primitive> IndexMut<usize> for $ident<T> {
     #[inline(always)]
     fn index_mut(&mut self, _index: usize) -> &mut T {
-        &mut self.data[_index]
+        &mut self.0[_index]
     }
 }
 
@@ -589,8 +583,8 @@ impl<T: Primitive> Blend for LumaA<T> {
     fn blend(&mut self, other: &LumaA<T>) {
         let max_t = T::max_value();
         let max_t = max_t.to_f32().unwrap();
-        let (bg_luma, bg_a) = (self.data[0], self.data[1]);
-        let (fg_luma, fg_a) = (other.data[0], other.data[1]);
+        let (bg_luma, bg_a) = (self.0[0], self.0[1]);
+        let (fg_luma, fg_a) = (other.0[0], other.0[1]);
 
         let (bg_luma, bg_a) = (
             bg_luma.to_f32().unwrap() / max_t,
@@ -631,8 +625,8 @@ impl<T: Primitive> Blend for Rgba<T> {
         // First, as we don't know what type our pixel is, we have to convert to floats between 0.0 and 1.0
         let max_t = T::max_value();
         let max_t = max_t.to_f32().unwrap();
-        let (bg_r, bg_g, bg_b, bg_a) = (self.data[0], self.data[1], self.data[2], self.data[3]);
-        let (fg_r, fg_g, fg_b, fg_a) = (other.data[0], other.data[1], other.data[2], other.data[3]);
+        let (bg_r, bg_g, bg_b, bg_a) = (self.0[0], self.0[1], self.0[2], self.0[3]);
+        let (fg_r, fg_g, fg_b, fg_a) = (other.0[0], other.0[1], other.0[2], other.0[3]);
         let (bg_r, bg_g, bg_b, bg_a) = (
             bg_r.to_f32().unwrap() / max_t,
             bg_g.to_f32().unwrap() / max_t,
@@ -689,8 +683,8 @@ impl<T: Primitive> Blend for Bgra<T> {
         // First, as we don't know what type our pixel is, we have to convert to floats between 0.0 and 1.0
         let max_t = T::max_value();
         let max_t = max_t.to_f32().unwrap();
-        let (bg_r, bg_g, bg_b, bg_a) = (self.data[2], self.data[1], self.data[0], self.data[3]);
-        let (fg_r, fg_g, fg_b, fg_a) = (other.data[2], other.data[1], other.data[0], other.data[3]);
+        let (bg_r, bg_g, bg_b, bg_a) = (self.0[2], self.0[1], self.0[0], self.0[3]);
+        let (fg_r, fg_g, fg_b, fg_a) = (other.0[2], other.0[1], other.0[0], other.0[3]);
         let (bg_r, bg_g, bg_b, bg_a) = (
             bg_r.to_f32().unwrap() / max_t,
             bg_g.to_f32().unwrap() / max_t,
@@ -759,7 +753,7 @@ pub trait Invert {
 
 impl<T: Primitive> Invert for LumaA<T> {
     fn invert(&mut self) {
-        let l = self.data;
+        let l = self.0;
         let max = T::max_value();
 
         *self = LumaA([max - l[0], l[1]])
@@ -768,18 +762,18 @@ impl<T: Primitive> Invert for LumaA<T> {
 
 impl<T: Primitive> Invert for Luma<T> {
     fn invert(&mut self) {
-        let l = self.data;
+        let l = self.0;
 
         let max = T::max_value();
         let l1 = max - l[0];
 
-        *self = Luma { data: [l1] }
+        *self = Luma([l1])
     }
 }
 
 impl<T: Primitive> Invert for Rgba<T> {
     fn invert(&mut self) {
-        let rgba = self.data;
+        let rgba = self.0;
 
         let max = T::max_value();
 
@@ -790,7 +784,7 @@ impl<T: Primitive> Invert for Rgba<T> {
 
 impl<T: Primitive> Invert for Bgra<T> {
     fn invert(&mut self) {
-        let bgra = self.data;
+        let bgra = self.0;
 
         let max = T::max_value();
 
@@ -801,7 +795,7 @@ impl<T: Primitive> Invert for Bgra<T> {
 
 impl<T: Primitive> Invert for Rgb<T> {
     fn invert(&mut self) {
-        let rgb = self.data;
+        let rgb = self.0;
 
         let max = T::max_value();
 
@@ -815,7 +809,7 @@ impl<T: Primitive> Invert for Rgb<T> {
 
 impl<T: Primitive> Invert for Bgr<T> {
     fn invert(&mut self) {
-        let bgr = self.data;
+        let bgr = self.0;
 
         let max = T::max_value();
 
@@ -833,157 +827,105 @@ mod tests {
 
     #[test]
     fn test_apply_with_alpha_rgba() {
-        let mut rgba = Rgba { data: [0, 0, 0, 0] };
+        let mut rgba = Rgba([0, 0, 0, 0]);
         rgba.apply_with_alpha(|s| s, |_| 0xFF);
-        assert_eq!(
-            rgba,
-            Rgba {
-                data: [0, 0, 0, 0xFF]
-            }
-        );
+        assert_eq!(rgba, Rgba([0, 0, 0, 0xFF]));
     }
 
     #[test]
     fn test_apply_with_alpha_bgra() {
-        let mut bgra = Bgra { data: [0, 0, 0, 0] };
+        let mut bgra = Bgra([0, 0, 0, 0]);
         bgra.apply_with_alpha(|s| s, |_| 0xFF);
-        assert_eq!(
-            bgra,
-            Bgra {
-                data: [0, 0, 0, 0xFF]
-            }
-        );
+        assert_eq!(bgra, Bgra([0, 0, 0, 0xFF]));
     }
 
     #[test]
     fn test_apply_with_alpha_rgb() {
-        let mut rgb = Rgb { data: [0, 0, 0] };
+        let mut rgb = Rgb([0, 0, 0]);
         rgb.apply_with_alpha(|s| s, |_| panic!("bug"));
-        assert_eq!(rgb, Rgb { data: [0, 0, 0] });
+        assert_eq!(rgb, Rgb([0, 0, 0]));
     }
 
     #[test]
     fn test_apply_with_alpha_bgr() {
-        let mut bgr = Bgr { data: [0, 0, 0] };
+        let mut bgr = Bgr([0, 0, 0]);
         bgr.apply_with_alpha(|s| s, |_| panic!("bug"));
-        assert_eq!(bgr, Bgr { data: [0, 0, 0] });
+        assert_eq!(bgr, Bgr([0, 0, 0]));
     }
 
 
     #[test]
     fn test_map_with_alpha_rgba() {
-        let rgba = Rgba { data: [0, 0, 0, 0] }.map_with_alpha(|s| s, |_| 0xFF);
-        assert_eq!(
-            rgba,
-            Rgba {
-                data: [0, 0, 0, 0xFF]
-            }
-        );
+        let rgba = Rgba([0, 0, 0, 0]).map_with_alpha(|s| s, |_| 0xFF);
+        assert_eq!(rgba, Rgba([0, 0, 0, 0xFF]));
     }
 
     #[test]
     fn test_map_with_alpha_rgb() {
-        let rgb = Rgb { data: [0, 0, 0] }.map_with_alpha(|s| s, |_| panic!("bug"));
-        assert_eq!(rgb, Rgb { data: [0, 0, 0] });
+        let rgb = Rgb([0, 0, 0]).map_with_alpha(|s| s, |_| panic!("bug"));
+        assert_eq!(rgb, Rgb([0, 0, 0]));
     }
 
     #[test]
     fn test_map_with_alpha_bgr() {
-        let bgr = Bgr { data: [0, 0, 0] }.map_with_alpha(|s| s, |_| panic!("bug"));
-        assert_eq!(bgr, Bgr { data: [0, 0, 0] });
+        let bgr = Bgr([0, 0, 0]).map_with_alpha(|s| s, |_| panic!("bug"));
+        assert_eq!(bgr, Bgr([0, 0, 0]));
     }
 
 
     #[test]
     fn test_map_with_alpha_bgra() {
-        let bgra = Bgra { data: [0, 0, 0, 0] }.map_with_alpha(|s| s, |_| 0xFF);
-        assert_eq!(
-            bgra,
-            Bgra {
-                data: [0, 0, 0, 0xFF]
-            }
-        );
+        let bgra = Bgra([0, 0, 0, 0]).map_with_alpha(|s| s, |_| 0xFF);
+        assert_eq!(bgra, Bgra([0, 0, 0, 0xFF]));
     }
 
     #[test]
     fn test_blend_luma_alpha() {
-        let ref mut a = LumaA {
-            data: [255 as u8, 255],
-        };
-        let b = LumaA {
-            data: [255 as u8, 255],
-        };
+        let ref mut a = LumaA([255 as u8, 255]);
+        let b = LumaA([255 as u8, 255]);
         a.blend(&b);
-        assert_eq!(a.data[0], 255);
-        assert_eq!(a.data[1], 255);
+        assert_eq!(a.0[0], 255);
+        assert_eq!(a.0[1], 255);
 
-        let ref mut a = LumaA {
-            data: [255 as u8, 0],
-        };
-        let b = LumaA {
-            data: [255 as u8, 255],
-        };
+        let ref mut a = LumaA([255 as u8, 0]);
+        let b = LumaA([255 as u8, 255]);
         a.blend(&b);
-        assert_eq!(a.data[0], 255);
-        assert_eq!(a.data[1], 255);
+        assert_eq!(a.0[0], 255);
+        assert_eq!(a.0[1], 255);
 
-        let ref mut a = LumaA {
-            data: [255 as u8, 255],
-        };
-        let b = LumaA {
-            data: [255 as u8, 0],
-        };
+        let ref mut a = LumaA([255 as u8, 255]);
+        let b = LumaA([255 as u8, 0]);
         a.blend(&b);
-        assert_eq!(a.data[0], 255);
-        assert_eq!(a.data[1], 255);
+        assert_eq!(a.0[0], 255);
+        assert_eq!(a.0[1], 255);
 
-        let ref mut a = LumaA {
-            data: [255 as u8, 0],
-        };
-        let b = LumaA {
-            data: [255 as u8, 0],
-        };
+        let ref mut a = LumaA([255 as u8, 0]);
+        let b = LumaA([255 as u8, 0]);
         a.blend(&b);
-        assert_eq!(a.data[0], 255);
-        assert_eq!(a.data[1], 0);
+        assert_eq!(a.0[0], 255);
+        assert_eq!(a.0[1], 0);
     }
 
     #[test]
     fn test_blend_rgba() {
-        let ref mut a = Rgba {
-            data: [255 as u8, 255, 255, 255],
-        };
-        let b = Rgba {
-            data: [255 as u8, 255, 255, 255],
-        };
+        let ref mut a = Rgba([255 as u8, 255, 255, 255]);
+        let b = Rgba([255 as u8, 255, 255, 255]);
         a.blend(&b);
-        assert_eq!(a.data, [255, 255, 255, 255]);
+        assert_eq!(a.0, [255, 255, 255, 255]);
 
-        let ref mut a = Rgba {
-            data: [255 as u8, 255, 255, 0],
-        };
-        let b = Rgba {
-            data: [255 as u8, 255, 255, 255],
-        };
+        let ref mut a = Rgba([255 as u8, 255, 255, 0]);
+        let b = Rgba([255 as u8, 255, 255, 255]);
         a.blend(&b);
-        assert_eq!(a.data, [255, 255, 255, 255]);
+        assert_eq!(a.0, [255, 255, 255, 255]);
 
-        let ref mut a = Rgba {
-            data: [255 as u8, 255, 255, 255],
-        };
-        let b = Rgba {
-            data: [255 as u8, 255, 255, 0],
-        };
+        let ref mut a = Rgba([255 as u8, 255, 255, 255]);
+        let b = Rgba([255 as u8, 255, 255, 0]);
         a.blend(&b);
-        assert_eq!(a.data, [255, 255, 255, 255]);
+        assert_eq!(a.0, [255, 255, 255, 255]);
 
-        let ref mut a = Rgba {
-            data: [255 as u8, 255, 255, 0],
-        };
-        let b = Rgba {
-            data: [255 as u8, 255, 255, 0],
-        };
+        let ref mut a = Rgba([255 as u8, 255, 255, 0]);
+        let b = Rgba([255 as u8, 255, 255, 0]);
         a.blend(&b);
-        assert_eq!(a.data, [255, 255, 255, 0]);
+        assert_eq!(a.0, [255, 255, 255, 0]);
     }
 }

--- a/src/hdr/hdr_decoder.rs
+++ b/src/hdr/hdr_decoder.rs
@@ -54,7 +54,7 @@ impl<R: BufRead> HDRAdapter<R> {
                 let target = self.data.get_or_insert_with(|| Vec::with_capacity(len));
                 target.clear();
 
-                for Rgb { data } in img {
+                for Rgb(data) in img {
                     target.extend_from_slice(&data);
                 }
 
@@ -180,7 +180,7 @@ impl RGBE8Pixel {
     /// Panics when scale or gamma is NaN
     #[inline]
     pub fn to_ldr_scale_gamma<T: Primitive + Zero>(self, scale: f32, gamma: f32) -> Rgb<T> {
-        let Rgb { data } = self.to_hdr();
+        let Rgb(data) = self.to_hdr();
         let (r, g, b) = (data[0], data[1], data[2]);
         #[inline]
         fn sg<T: Primitive + Zero>(v: f32, scale: f32, gamma: f32) -> T {

--- a/src/hdr/hdr_encoder.rs
+++ b/src/hdr/hdr_encoder.rs
@@ -226,7 +226,7 @@ fn write_rgbe8<W: Write>(w: &mut W, v: RGBE8Pixel) -> Result<()> {
 
 /// Converts ```Rgb<f32>``` into ```RGBE8Pixel```
 pub fn to_rgbe8(pix: Rgb<f32>) -> RGBE8Pixel {
-    let pix = pix.data;
+    let pix = pix.0;
     let mx = f32::max(pix[0], f32::max(pix[1], pix[2]));
     if mx <= 0.0 {
         RGBE8Pixel { c: [0, 0, 0], e: 0 }
@@ -274,13 +274,13 @@ fn to_rgbe8_test() {
     }
     fn relative_dist(a: Rgb<f32>, b: Rgb<f32>) -> f32 {
         // maximal difference divided by maximal value
-        let max_diff = a.data
+        let max_diff = a.0
             .iter()
-            .zip(b.data.iter())
+            .zip(b.0.iter())
             .fold(0.0, |diff, (&a, &b)| f32::max(diff, (a - b).abs()));
-        let max_val = a.data
+        let max_val = a.0
             .iter()
-            .chain(b.data.iter())
+            .chain(b.0.iter())
             .fold(0.0, |maxv, &a| f32::max(maxv, a));
         if max_val == 0.0 {
             0.0

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -196,7 +196,7 @@ impl ColorMap for BiLevel {
 
     #[inline(always)]
     fn index_of(&self, color: &Luma<u8>) -> usize {
-        let luma = color.data;
+        let luma = color.0;
         if luma[0] > 127 {
             1
         } else {
@@ -207,7 +207,7 @@ impl ColorMap for BiLevel {
     #[inline(always)]
     fn map_color(&self, color: &mut Luma<u8>) {
         let new_color = 0xFF * self.index_of(color) as u8;
-        let luma = &mut color.data;
+        let luma = &mut color.0;
         luma[0] = new_color;
     }
 }


### PR DESCRIPTION
Right now we have both structs and functions named Rgb, Rgba, etc. There is no reason for this duplication, and it clutters up the crate documentation page.  This is a breaking change, though I'm not sure how much code will be broken in practice.