### PR TITLE
[WIP] Fix mutable iteration over pixels

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -8,7 +8,7 @@ use std::slice::{Chunks, ChunksMut};
 use color::{ColorType, FromColor, Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
 use flat::{FlatSamples, SampleLayout};
 use dynimage::save_buffer;
-use image::{GenericImage, GenericImageView};
+use image::{GenericImage, GenericImageView, PixelsMut as GenericPixelsMut};
 use traits::Primitive;
 use utils::expand_packed;
 
@@ -643,6 +643,10 @@ where
         let indices = self.unsafe_pixel_indices(x, y);
         let p = <P as Pixel>::from_slice_mut(self.data.get_unchecked_mut(indices));
         *p = pixel
+    }
+
+    fn pixels_mut(&mut self) -> GenericPixelsMut<Self> {
+        GenericPixelsMut::from_buffer(ImageBuffer::enumerate_pixels_mut(self))
     }
 
     /// Put a pixel at location (x, y), taking into account alpha channels

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -30,7 +30,7 @@ use flat::FlatSamples;
 use color;
 use image;
 use image::{GenericImage, GenericImageView, ImageDecoder, ImageFormat, ImageOutputFormat,
-            ImageResult};
+            ImageResult, PixelsMut};
 use imageops;
 
 /// A Dynamic Image
@@ -616,7 +616,12 @@ impl GenericImage for DynamicImage {
 
     /// DEPRECATED: Do not use is function: It is unimplemented!
     fn get_pixel_mut(&mut self, _: u32, _: u32) -> &mut color::Rgba<u8> {
-        unimplemented!()
+        panic!("Dynamic image can not provide mutable references to its pixels.")
+    }
+
+    /// DEPRECATED: Do not use is function: It is unimplemented!
+    fn pixels_mut(&mut self) -> PixelsMut<Self> {
+        panic!("Dynamic image can not provide mutable references to its pixels.")
     }
 
     fn inner_mut(&mut self) -> &mut Self::InnerImage {

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -49,7 +49,7 @@ use num_traits::Zero;
 
 use buffer::{ImageBuffer, Pixel};
 use color::ColorType;
-use image::{GenericImage, GenericImageView, ImageError};
+use image::{GenericImage, GenericImageView, ImageError, PixelsMut};
 
 /// A flat buffer over a (multi channel) image.
 ///
@@ -1367,6 +1367,11 @@ impl<Buffer, P: Pixel> GenericImage for ViewMut<Buffer, P>
 
     fn inner_mut(&mut self) -> &mut Self {
         self
+    }
+
+    fn pixels_mut(&mut self) -> PixelsMut<Self> {
+        // TODO: Create an iterator similar to `buffer::PixelsMut`.
+        unimplemented!("No decision on whether an allocation is actually fine here.")
     }
 }
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,0 +1,191 @@
+use std::mem;
+
+use buffer::{Pixel, EnumeratePixelsMut};
+use image::{GenericImage, GenericImageView};
+
+/// Immutable pixel iterator
+pub struct Pixels<'a, I: ?Sized + 'a> {
+    image: &'a I,
+    x: u32,
+    y: u32,
+    width: u32,
+    height: u32,
+}
+
+impl<'a, I: GenericImageView + ?Sized + 'a> Pixels<'a, I> {
+    /// Create an iterator over enumerated pixels.
+    ///
+    /// This is a generic method that will sequentially access pixels via the
+    /// `GenericImageView::get_pixel` method. Other iterator methods on specialized types may have
+    /// better performance.
+    pub fn new(image: &'a I) -> Self {
+        let (width, height) = image.dimensions();
+
+        Pixels {
+            image,
+            x: 0,
+            y: 0,
+            width,
+            height,
+        }
+    }
+}
+
+impl<'a, I: GenericImageView + ?Sized + 'a> Iterator for Pixels<'a, I> {
+    type Item = (u32, u32, I::Pixel);
+
+    fn next(&mut self) -> Option<(u32, u32, I::Pixel)> {
+        if self.x >= self.width {
+            self.x = 0;
+            self.y += 1;
+        }
+
+        if self.y >= self.height {
+            None
+        } else {
+            let pixel = self.image.get_pixel(self.x, self.y);
+            let p = (self.x, self.y, pixel);
+
+            self.x += 1;
+
+            Some(p)
+        }
+    }
+}
+
+/// Mutable pixel iterator
+pub struct PixelsMut<'a, I: GenericImage + ?Sized + 'a> {
+    inner: PixelsMutImpl<'a, I>,
+}
+
+enum PixelsMutImpl<'a, I: GenericImage + ?Sized + 'a> {
+    /// Provide pixels via one mutable reference on `I`.
+    ///
+    /// This subverts lifetime checks, and is highly unsafe.
+    Unsafe(PixelsMutUnsafe<'a, I>),
+
+    /// Iterator when the buffer is in compact format.
+    Buffer(EnumeratePixelsMut<'a, I::Pixel>),
+
+    /// Fallback when nothing else is available.
+    Boxed(Box<Iterator<Item=(u32, u32, &'a mut I::Pixel)> + 'a>),
+}
+
+struct PixelsMutUnsafe<'a, I: ?Sized + 'a> {
+    image: &'a mut I,
+    x: u32,
+    y: u32,
+    width: u32,
+    height: u32,
+}
+
+impl<'a, I: GenericImage + ?Sized + 'a> PixelsMut<'a, I> {
+    /// Iterate mutable over the pixels of `I`.
+    ///
+    /// This is highly unsafe. It subverts lifetime checks by transmuting references to the pixels.
+    /// Therefore, the caller of this function must ensure that *all* calls to `I::get_pixel_mut`
+    /// with different parameters will surely return unique references. Moreover, actually defined
+    /// behaviour implies that the image itself does not hold any direct reference to its storage
+    /// but only references it via pointers.
+    ///
+    /// Use with utmost care! The long name is not by accident.
+    pub unsafe fn simultaneous_pixels_mut_unchecked(image: &'a mut I) -> Self {
+        PixelsMut {
+            inner: PixelsMutImpl::Unsafe(PixelsMutUnsafe::new(image)),
+        }
+    }
+
+    /// Convert an iterator over an image buffer.
+    ///
+    /// This does not enforce that the image iterated over actually holds the supplied buffer.
+    /// Instead, it should be used by image types that can convert their internal buffer into an
+    /// `ImageBuffer` temporarily, for example through `ImageBuffer::from_raw`.
+    pub fn from_buffer(enumerate: EnumeratePixelsMut<'a, I::Pixel>) -> Self {
+        PixelsMut {
+            inner: PixelsMutImpl::Buffer(enumerate),
+        }
+    }
+
+    /// Wrap a boxed iterator.
+    ///
+    /// This does not enforce that the image iterated over actually holds the supplied buffer. This
+    /// should be used as a fallback when no library supplied image reference type can provide the
+    /// necessary wrapping. Still, this is much safer than resorting to
+    /// `simultaneous_pixels_mut_unchecked`. If your custom implementation has to use this method
+    /// but you feel like it provides a generalizable pattern, feel free to request an additional
+    /// internal stack based variant for it to avoid the allocation.
+    pub fn boxed(iterator: Box<dyn Iterator<Item=(u32, u32, &'a mut I::Pixel)> + 'a>) -> Self {
+        PixelsMut {
+            inner: PixelsMutImpl::Boxed(iterator.into()),
+        }
+    }
+
+    /// Box an arbitrary iterator.
+    ///
+    /// This is a utility method simply forwarding to `boxed`.
+    pub fn box_it<T>(iterator: T) -> Self 
+        where T: Iterator<Item=(u32, u32, &'a mut I::Pixel)> + 'a
+    {
+        Self::boxed(Box::new(iterator))
+    }
+}
+
+impl<'a, I: GenericImage + ?Sized + 'a> Iterator for PixelsMut<'a, I>
+{
+    type Item = (u32, u32, &'a mut I::Pixel);
+
+    fn next(&mut self) -> Option<(u32, u32, &'a mut I::Pixel)> {
+        match &mut self.inner {
+            PixelsMutImpl::Unsafe(inner) => inner.next(),
+            PixelsMutImpl::Buffer(buffer) => buffer.next(),
+            PixelsMutImpl::Boxed(boxed) => boxed.next(),
+        }
+    }
+}
+
+impl<'a, I: GenericImage + ?Sized + 'a> PixelsMutUnsafe<'a, I> {
+    pub fn new(image: &'a mut I) -> Self {
+        let (width, height) = image.dimensions();
+
+        PixelsMutUnsafe {
+            image,
+            x: 0,
+            y: 0,
+            width,
+            height,
+        }
+    }
+}
+
+impl<'a, I: GenericImage + ?Sized + 'a> Iterator for PixelsMutUnsafe<'a, I>
+where
+    I::Pixel: 'a,
+    <I::Pixel as Pixel>::Subpixel: 'a,
+{
+    type Item = (u32, u32, &'a mut I::Pixel);
+
+    fn next(&mut self) -> Option<(u32, u32, &'a mut I::Pixel)> {
+        if self.x >= self.width {
+            self.x = 0;
+            self.y += 1;
+        }
+
+        if self.y >= self.height {
+            None
+        } else {
+            let tmp = self.image.get_pixel_mut(self.x, self.y);
+
+            // NOTE: This is the dangerous operation. It would require the signature 
+            // `fn next(&'a mut self)` to be safe.  However, any implementor of `GenericImage` that
+            // constructed this iterator has opted into this being safe, although it is very
+            // unlikely true.
+            let ptr = unsafe { mem::transmute(tmp) };
+
+            let p = (self.x, self.y, ptr);
+
+            self.x += 1;
+
+            Some(p)
+        }
+    }
+}

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -114,7 +114,7 @@ impl<'a, I: GenericImage + ?Sized + 'a> PixelsMut<'a, I> {
     /// `simultaneous_pixels_mut_unchecked`. If your custom implementation has to use this method
     /// but you feel like it provides a generalizable pattern, feel free to request an additional
     /// internal stack based variant for it to avoid the allocation.
-    pub fn boxed(iterator: Box<dyn Iterator<Item=(u32, u32, &'a mut I::Pixel)> + 'a>) -> Self {
+    pub fn boxed(iterator: Box<Iterator<Item=(u32, u32, &'a mut I::Pixel)> + 'a>) -> Self {
         PixelsMut {
             inner: PixelsMutImpl::Boxed(iterator.into()),
         }
@@ -136,9 +136,9 @@ impl<'a, I: GenericImage + ?Sized + 'a> Iterator for PixelsMut<'a, I>
 
     fn next(&mut self) -> Option<(u32, u32, &'a mut I::Pixel)> {
         match &mut self.inner {
-            PixelsMutImpl::Unsafe(inner) => inner.next(),
-            PixelsMutImpl::Buffer(buffer) => buffer.next(),
-            PixelsMutImpl::Boxed(boxed) => boxed.next(),
+            &mut PixelsMutImpl::Unsafe(ref mut inner) => inner.next(),
+            &mut PixelsMutImpl::Buffer(ref mut buffer) => buffer.next(),
+            &mut PixelsMutImpl::Boxed(ref mut boxed) => boxed.next(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ pub use image::{AnimationDecoder,
                 ImageDecoderExt,
                 ImageError,
                 ImageResult,
-                MutPixels,
+                PixelsMut,
                 // Iterators
                 Pixels,
                 SubImage};
@@ -106,6 +106,7 @@ mod buffer;
 mod color;
 mod dynimage;
 mod image;
+mod iter;
 mod traits;
 mod utils;
 


### PR DESCRIPTION
Addresses points made in #854

The `unsafe` burden of constructing the iterator type will now lie on
the implementor of `GenericImage` instead of the library. This should
ensure that this decision is made more conciously. Some additional
blessed internal variants are provided to ensure that performant
iterators are still possible for the library types.