### PR TITLE
[WIP] Improve ColorType enum and split out CoreColorType

### DIFF
--- a/src/bmp/decoder.rs
+++ b/src/bmp/decoder.rs
@@ -1264,9 +1264,9 @@ impl<R: Read + Seek> ImageDecoder for BMPDecoder<R> {
 
     fn colortype(&self) -> ColorType {
         if self.add_alpha_channel {
-            ColorType::RGBA(8)
+            ColorType::RGBA
         } else {
-            ColorType::RGB(8)
+            ColorType::RGB
         }
     }
 

--- a/src/bmp/encoder.rs
+++ b/src/bmp/encoder.rs
@@ -66,7 +66,7 @@ impl<'a, W: Write + 'a> BMPEncoder<'a, W> {
             color::ColorType::RGB | color::ColorType::RGBA => {
                 try!(self.encode_rgb(image, width, height, row_pad_size, raw_pixel_size))
             }
-            color::ColorType::Gray(8) | color::ColorType::GrayA => {
+            color::ColorType::L(8) | color::ColorType::LA => {
                 try!(self.encode_gray(image, width, height, row_pad_size, raw_pixel_size))
             }
             _ => {
@@ -169,8 +169,8 @@ fn get_pixel_info(c: color::ColorType) -> io::Result<(u32, u32, u32)> {
     let sizes = match c {
         color::ColorType::RGB => (3, 3, 0),
         color::ColorType::RGBA => (4, 3, 0),
-        color::ColorType::Gray(8) => (1, 1, 256),
-        color::ColorType::GrayA => (2, 1, 256),
+        color::ColorType::L(8) => (1, 1, 256),
+        color::ColorType::LA => (2, 1, 256),
         _ => {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -232,7 +232,7 @@ mod tests {
     #[test]
     fn round_trip_gray() {
         let image = [0u8, 1, 2]; // 3 pixels
-        let decoded = round_trip_image(&image, 3, 1, ColorType::Gray(8));
+        let decoded = round_trip_image(&image, 3, 1, ColorType::L(8));
         // should be read back as 3 RGB pixels
         assert_eq!(9, decoded.len());
         assert_eq!(0, decoded[0]);
@@ -249,7 +249,7 @@ mod tests {
     #[test]
     fn round_trip_graya() {
         let image = [0u8, 0, 1, 0, 2, 0]; // 3 pixels, each with an alpha channel
-        let decoded = round_trip_image(&image, 1, 3, ColorType::GrayA);
+        let decoded = round_trip_image(&image, 1, 3, ColorType::LA);
         // should be read back as 3 RGB pixels
         assert_eq!(9, decoded.len());
         assert_eq!(0, decoded[0]);

--- a/src/bmp/encoder.rs
+++ b/src/bmp/encoder.rs
@@ -66,7 +66,7 @@ impl<'a, W: Write + 'a> BMPEncoder<'a, W> {
             color::ColorType::RGB | color::ColorType::RGBA => {
                 try!(self.encode_rgb(image, width, height, row_pad_size, raw_pixel_size))
             }
-            color::ColorType::L(8) | color::ColorType::LA => {
+            color::ColorType::L8 | color::ColorType::LA => {
                 try!(self.encode_gray(image, width, height, row_pad_size, raw_pixel_size))
             }
             _ => {
@@ -169,7 +169,7 @@ fn get_pixel_info(c: color::ColorType) -> io::Result<(u32, u32, u32)> {
     let sizes = match c {
         color::ColorType::RGB => (3, 3, 0),
         color::ColorType::RGBA => (4, 3, 0),
-        color::ColorType::L(8) => (1, 1, 256),
+        color::ColorType::L8 => (1, 1, 256),
         color::ColorType::LA => (2, 1, 256),
         _ => {
             return Err(io::Error::new(
@@ -232,7 +232,7 @@ mod tests {
     #[test]
     fn round_trip_gray() {
         let image = [0u8, 1, 2]; // 3 pixels
-        let decoded = round_trip_image(&image, 3, 1, ColorType::L(8));
+        let decoded = round_trip_image(&image, 3, 1, ColorType::L8);
         // should be read back as 3 RGB pixels
         assert_eq!(9, decoded.len());
         assert_eq!(0, decoded[0]);

--- a/src/bmp/encoder.rs
+++ b/src/bmp/encoder.rs
@@ -63,10 +63,10 @@ impl<'a, W: Write + 'a> BMPEncoder<'a, W> {
 
         // write image data
         match c {
-            color::ColorType::RGB(8) | color::ColorType::RGBA(8) => {
+            color::ColorType::RGB | color::ColorType::RGBA => {
                 try!(self.encode_rgb(image, width, height, row_pad_size, raw_pixel_size))
             }
-            color::ColorType::Gray(8) | color::ColorType::GrayA(8) => {
+            color::ColorType::Gray(8) | color::ColorType::GrayA => {
                 try!(self.encode_gray(image, width, height, row_pad_size, raw_pixel_size))
             }
             _ => {
@@ -167,10 +167,10 @@ fn get_unsupported_error_message(c: color::ColorType) -> String {
 /// Returns a tuple representing: (raw pixel size, written pixel size, palette color count).
 fn get_pixel_info(c: color::ColorType) -> io::Result<(u32, u32, u32)> {
     let sizes = match c {
-        color::ColorType::RGB(8) => (3, 3, 0),
-        color::ColorType::RGBA(8) => (4, 3, 0),
+        color::ColorType::RGB => (3, 3, 0),
+        color::ColorType::RGBA => (4, 3, 0),
         color::ColorType::Gray(8) => (1, 1, 256),
-        color::ColorType::GrayA(8) => (2, 1, 256),
+        color::ColorType::GrayA => (2, 1, 256),
         _ => {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -206,7 +206,7 @@ mod tests {
     #[test]
     fn round_trip_single_pixel_rgb() {
         let image = [255u8, 0, 0]; // single red pixel
-        let decoded = round_trip_image(&image, 1, 1, ColorType::RGB(8));
+        let decoded = round_trip_image(&image, 1, 1, ColorType::RGB);
         assert_eq!(3, decoded.len());
         assert_eq!(255, decoded[0]);
         assert_eq!(0, decoded[1]);
@@ -216,7 +216,7 @@ mod tests {
     #[test]
     fn round_trip_single_pixel_rgba() {
         let image = [255u8, 0, 0, 0]; // single red pixel
-        let decoded = round_trip_image(&image, 1, 1, ColorType::RGBA(8));
+        let decoded = round_trip_image(&image, 1, 1, ColorType::RGBA);
         assert_eq!(3, decoded.len());
         assert_eq!(255, decoded[0]);
         assert_eq!(0, decoded[1]);
@@ -226,7 +226,7 @@ mod tests {
     #[test]
     fn round_trip_3px_rgb() {
         let image = [0u8; 3 * 3 * 3]; // 3x3 pixels, 3 bytes per pixel
-        let _decoded = round_trip_image(&image, 3, 3, ColorType::RGB(8));
+        let _decoded = round_trip_image(&image, 3, 3, ColorType::RGB);
     }
 
     #[test]
@@ -249,7 +249,7 @@ mod tests {
     #[test]
     fn round_trip_graya() {
         let image = [0u8, 0, 1, 0, 2, 0]; // 3 pixels, each with an alpha channel
-        let decoded = round_trip_image(&image, 1, 3, ColorType::GrayA(8));
+        let decoded = round_trip_image(&image, 1, 3, ColorType::GrayA);
         // should be read back as 3 RGB pixels
         assert_eq!(9, decoded.len());
         assert_eq!(0, decoded[0]);

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -5,7 +5,7 @@ use std::ops::{Deref, DerefMut, Index, IndexMut, Range};
 use std::path::Path;
 use std::slice::{Chunks, ChunksMut};
 
-use color::{ColorType, FromColor, Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
+use color::{CoreColorType, FromColor, Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
 use flat::{FlatSamples, SampleLayout};
 use dynimage::save_buffer;
 use image::{GenericImage, GenericImageView};
@@ -33,7 +33,7 @@ pub trait Pixel: Copy + Clone {
     fn color_model() -> &'static str;
 
     /// Returns the ColorType for this pixel format
-    fn color_type() -> ColorType;
+    fn color_type() -> CoreColorType;
 
     /// Returns the channels of this pixel as a 4 tuple. If the pixel
     /// has less than 4 channels the remainder is filled with the maximum value
@@ -520,7 +520,7 @@ where
             self,
             self.width(),
             self.height(),
-            <P as Pixel>::color_type(),
+            <P as Pixel>::color_type().into(),
         )
     }
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -11,9 +11,6 @@ pub enum ColorType {
     /// Pixel is grayscale
     Gray(u8),
 
-    /// Pixel is an index into a color palette
-    Palette(u8),
-
     /// Pixel contains 8-bit R, G and B channels
     RGB,
 
@@ -35,7 +32,6 @@ pub enum ColorType {
 pub fn bits_per_pixel(c: ColorType) -> usize {
     match c {
         ColorType::Gray(n) => n as usize,
-        ColorType::Palette(n) => 3 * n as usize,
         ColorType::GrayA => 16,
         ColorType::RGB | ColorType::BGR => 24,
         ColorType::RGBA | ColorType::BGRA => 32,
@@ -47,7 +43,7 @@ pub fn num_components(c: ColorType) -> usize {
     match c {
         ColorType::Gray(_) => 1,
         ColorType::GrayA => 2,
-        ColorType::RGB | ColorType::Palette(_) | ColorType::BGR => 3,
+        ColorType::RGB | ColorType::BGR => 3,
         ColorType::RGBA | ColorType::BGRA => 4,
 
     }

--- a/src/color.rs
+++ b/src/color.rs
@@ -7,9 +7,6 @@ use traits::Primitive;
 /// An enumeration over supported color types and bit depths
 #[derive(Copy, PartialEq, Eq, Debug, Clone, Hash)]
 pub enum ColorType {
-    /// Pixel is an index into a color palette
-    Palette(u8),
-
     /// Pixel is 1-bit luminance
     L1,
 
@@ -35,6 +32,11 @@ pub enum ColorType {
     BGR,
     /// Pixel is 8-bit BGR with an alpha channel
     BGRA,
+
+    /// Pixel is of unknown color type with the specified bit depth. This can apply to pixels which
+    /// are associated with an external palette. In that case, the pixel value is an index into the
+    /// palette.
+    Unknown(u8),
 }
 
 /// Returns the number of bits contained in a pixel of `ColorType` ```c```
@@ -43,21 +45,21 @@ pub fn bits_per_pixel(c: ColorType) -> usize {
         ColorType::L1 => 1,
         ColorType::L8 => 8,
         ColorType::L16 => 16,
-        ColorType::Palette(n) => 3 * n as usize,
         ColorType::LA => 16,
         ColorType::RGB | ColorType::BGR => 24,
         ColorType::RGBA | ColorType::BGRA | ColorType::LA16 => 32,
         ColorType::RGB16 => 48,
         ColorType::RGBA16 => 64,
+        ColorType::Unknown(n) => n as usize,
     }
 }
 
 /// Returns the number of color channels that make up this pixel
 pub fn num_components(c: ColorType) -> usize {
     match c {
-        ColorType::L1 | ColorType::L8 | ColorType::L16 => 1,
+        ColorType::Unknown(_) | ColorType::L1 | ColorType::L8 | ColorType::L16 => 1,
         ColorType::LA | ColorType::LA16 => 2,
-        ColorType::RGB | ColorType::RGB16 | ColorType::Palette(_) | ColorType::BGR => 3,
+        ColorType::RGB | ColorType::RGB16| ColorType::BGR => 3,
         ColorType::RGBA | ColorType::RGBA16 | ColorType::BGRA => 4,
     }
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -9,7 +9,7 @@ use traits::Primitive;
 #[derive(Copy, PartialEq, Eq, Debug, Clone, Hash)]
 pub enum ColorType {
     /// Pixel is grayscale
-    Gray(u8),
+    L(u8),
 
     /// Pixel is an index into a color palette
     Palette(u8),
@@ -18,7 +18,7 @@ pub enum ColorType {
     RGB,
 
     /// Pixel is 8-bit grayscale with an alpha channel
-    GrayA,
+    LA,
 
     /// Pixel is 8-bit RGB with an alpha channel
     RGBA,
@@ -34,9 +34,9 @@ pub enum ColorType {
 /// Returns the number of bits contained in a pixel of `ColorType` ```c```
 pub fn bits_per_pixel(c: ColorType) -> usize {
     match c {
-        ColorType::Gray(n) => n as usize,
+        ColorType::L(n) => n as usize,
         ColorType::Palette(n) => 3 * n as usize,
-        ColorType::GrayA => 16,
+        ColorType::LA => 16,
         ColorType::RGB | ColorType::BGR => 24,
         ColorType::RGBA | ColorType::BGRA => 32,
     }
@@ -45,8 +45,8 @@ pub fn bits_per_pixel(c: ColorType) -> usize {
 /// Returns the number of color channels that make up this pixel
 pub fn num_components(c: ColorType) -> usize {
     match c {
-        ColorType::Gray(_) => 1,
-        ColorType::GrayA => 2,
+        ColorType::L(_) => 1,
+        ColorType::LA => 2,
         ColorType::RGB | ColorType::Palette(_) | ColorType::BGR => 3,
         ColorType::RGBA | ColorType::BGRA => 4,
 
@@ -90,8 +90,8 @@ impl<T: Primitive + 'static> Pixel for $ident<T> {
     fn color_type() -> ColorType {
         if mem::size_of::<T>() == 1 {
             $color_type
-        } else if $color_type == ColorType::Gray(8) {
-            ColorType::Gray(mem::size_of::<T>() as u8 * 8)
+        } else if $color_type == ColorType::L(8) {
+            ColorType::L(mem::size_of::<T>() as u8 * 8)
         } else {
             unimplemented!()
         }
@@ -234,10 +234,10 @@ impl<T: Primitive> IndexMut<usize> for $ident<T> {
 define_colors! {
     Rgb, 3, 0, "RGB", ColorType::RGB, #[doc = "RGB colors"];
     Bgr, 3, 0, "BGR", ColorType::BGR, #[doc = "BGR colors"];
-    Luma, 1, 0, "Y", ColorType::Gray(8), #[doc = "Grayscale colors"];
+    Luma, 1, 0, "Y", ColorType::L(8), #[doc = "Grayscale colors"];
     Rgba, 4, 1, "RGBA", ColorType::RGBA, #[doc = "RGB colors + alpha channel"];
     Bgra, 4, 1, "BGRA", ColorType::BGRA, #[doc = "BGR colors + alpha channel"];
-    LumaA, 2, 1, "YA", ColorType::GrayA, #[doc = "Grayscale colors + alpha channel"];
+    LumaA, 2, 1, "YA", ColorType::LA, #[doc = "Grayscale colors + alpha channel"];
 }
 
 /// Provides color conversions for the different pixel types.

--- a/src/color.rs
+++ b/src/color.rs
@@ -5,30 +5,34 @@ use std::ops::{Index, IndexMut};
 use buffer::Pixel;
 use traits::Primitive;
 
-/// An enumeration over supported color types and their bit depths
+/// An enumeration over supported color types and bit depths
 #[derive(Copy, PartialEq, Eq, Debug, Clone, Hash)]
 pub enum ColorType {
-    /// Pixel is grayscale
-    L(u8),
-
     /// Pixel is an index into a color palette
     Palette(u8),
 
-    /// Pixel contains 8-bit R, G and B channels
-    RGB,
-
+    /// Pixel is grayscale
+    L(u8),
     /// Pixel is 8-bit grayscale with an alpha channel
     LA,
-
+    /// Pixel contains 8-bit R, G and B channels
+    RGB,
     /// Pixel is 8-bit RGB with an alpha channel
     RGBA,
 
+    // /// Pixel is 16-bit luminance
+    // L16,
+    /// Pixel is 16-bit luminance with an alpha channel
+    LA16,
+    /// Pixel is 16-bit RGB.
+    RGB16,
+    /// Pixel is 16-bit RGBA.
+    RGBA16,
+
     /// Pixel contains 8-bit B, G and R channels
     BGR,
-
     /// Pixel is 8-bit BGR with an alpha channel
     BGRA,
-
 }
 
 /// Returns the number of bits contained in a pixel of `ColorType` ```c```
@@ -38,7 +42,9 @@ pub fn bits_per_pixel(c: ColorType) -> usize {
         ColorType::Palette(n) => 3 * n as usize,
         ColorType::LA => 16,
         ColorType::RGB | ColorType::BGR => 24,
-        ColorType::RGBA | ColorType::BGRA => 32,
+        ColorType::RGBA | ColorType::BGRA | ColorType::LA16 => 32,
+        ColorType::RGB16 => 48,
+        ColorType::RGBA16 => 64,
     }
 }
 
@@ -46,10 +52,9 @@ pub fn bits_per_pixel(c: ColorType) -> usize {
 pub fn num_components(c: ColorType) -> usize {
     match c {
         ColorType::L(_) => 1,
-        ColorType::LA => 2,
-        ColorType::RGB | ColorType::Palette(_) | ColorType::BGR => 3,
-        ColorType::RGBA | ColorType::BGRA => 4,
-
+        ColorType::LA | ColorType::LA16 => 2,
+        ColorType::RGB | ColorType::RGB16 | ColorType::Palette(_) | ColorType::BGR => 3,
+        ColorType::RGBA | ColorType::RGBA16 | ColorType::BGRA => 4,
     }
 }
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -11,6 +11,9 @@ pub enum ColorType {
     /// Pixel is grayscale
     Gray(u8),
 
+    /// Pixel is an index into a color palette
+    Palette(u8),
+
     /// Pixel contains 8-bit R, G and B channels
     RGB,
 
@@ -32,6 +35,7 @@ pub enum ColorType {
 pub fn bits_per_pixel(c: ColorType) -> usize {
     match c {
         ColorType::Gray(n) => n as usize,
+        ColorType::Palette(n) => 3 * n as usize,
         ColorType::GrayA => 16,
         ColorType::RGB | ColorType::BGR => 24,
         ColorType::RGBA | ColorType::BGRA => 32,
@@ -43,7 +47,7 @@ pub fn num_components(c: ColorType) -> usize {
     match c {
         ColorType::Gray(_) => 1,
         ColorType::GrayA => 2,
-        ColorType::RGB | ColorType::BGR => 3,
+        ColorType::RGB | ColorType::Palette(_) | ColorType::BGR => 3,
         ColorType::RGBA | ColorType::BGRA => 4,
 
     }

--- a/src/dxt.rs
+++ b/src/dxt.rs
@@ -49,8 +49,8 @@ impl DXTVariant {
     /// Returns the colortype that is stored in this DXT variant
     pub fn colortype(self) -> ColorType {
         match self {
-            DXTVariant::DXT1 => ColorType::RGB(8),
-            DXTVariant::DXT3 | DXTVariant::DXT5 => ColorType::RGBA(8),
+            DXTVariant::DXT1 => ColorType::RGB,
+            DXTVariant::DXT3 | DXTVariant::DXT5 => ColorType::RGBA,
         }
     }
 }

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -292,7 +292,7 @@ impl DynamicImage {
     /// Return this image's color type.
     pub fn color(&self) -> color::ColorType {
         match *self {
-            DynamicImage::ImageLuma8(_) => color::ColorType::L(8),
+            DynamicImage::ImageLuma8(_) => color::ColorType::L8,
             DynamicImage::ImageLumaA8(_) => color::ColorType::LA,
             DynamicImage::ImageRgb8(_) => color::ColorType::RGB,
             DynamicImage::ImageRgba8(_) => color::ColorType::RGBA,
@@ -652,17 +652,15 @@ pub fn decoder_to_image<I: ImageDecoder>(codec: I) -> ImageResult<DynamicImage> 
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageBgra8)
         }
 
-        color::ColorType::L(8) => {
+        color::ColorType::L8 => {
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLuma8)
         }
 
         color::ColorType::LA => {
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLumaA8)
         }
-        color::ColorType::L(bit_depth)
-            if bit_depth == 1 || bit_depth == 2 || bit_depth == 4 =>
-        {
-            gray_to_luma8(bit_depth, w, h, &buf).map(DynamicImage::ImageLuma8)
+        color::ColorType::L1 => {
+            gray_to_luma8(1, w, h, &buf).map(DynamicImage::ImageLuma8)
         }
         _ => return Err(image::ImageError::UnsupportedColor(color)),
     };

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -293,11 +293,11 @@ impl DynamicImage {
     pub fn color(&self) -> color::ColorType {
         match *self {
             DynamicImage::ImageLuma8(_) => color::ColorType::Gray(8),
-            DynamicImage::ImageLumaA8(_) => color::ColorType::GrayA(8),
-            DynamicImage::ImageRgb8(_) => color::ColorType::RGB(8),
-            DynamicImage::ImageRgba8(_) => color::ColorType::RGBA(8),
-            DynamicImage::ImageBgra8(_) => color::ColorType::BGRA(8),
-            DynamicImage::ImageBgr8(_) => color::ColorType::BGR(8),
+            DynamicImage::ImageLumaA8(_) => color::ColorType::GrayA,
+            DynamicImage::ImageRgb8(_) => color::ColorType::RGB,
+            DynamicImage::ImageRgba8(_) => color::ColorType::RGBA,
+            DynamicImage::ImageBgra8(_) => color::ColorType::BGRA,
+            DynamicImage::ImageBgr8(_) => color::ColorType::BGR,
         }
     }
 
@@ -483,11 +483,11 @@ impl DynamicImage {
                 match *self {
                     DynamicImage::ImageBgra8(_) => {
                         bytes=self.to_rgba().iter().cloned().collect();
-                        color=color::ColorType::RGBA(8);
+                        color=color::ColorType::RGBA;
                     },
                     DynamicImage::ImageBgr8(_) => {
                         bytes=self.to_rgb().iter().cloned().collect();
-                        color=color::ColorType::RGB(8);
+                        color=color::ColorType::RGB;
                     },
                     _ => {},
                 }
@@ -500,11 +500,11 @@ impl DynamicImage {
                 match *self {
                     DynamicImage::ImageBgra8(_) => {
                         bytes=self.to_rgba().iter().cloned().collect();
-                        color=color::ColorType::RGBA(8);
+                        color=color::ColorType::RGBA;
                     },
                     DynamicImage::ImageBgr8(_) => {
                         bytes=self.to_rgb().iter().cloned().collect();
-                        color=color::ColorType::RGB(8);
+                        color=color::ColorType::RGB;
                     },
                     _ => {},
                 }
@@ -636,19 +636,19 @@ pub fn decoder_to_image<I: ImageDecoder>(codec: I) -> ImageResult<DynamicImage> 
     let (w, h) = (w as u32, h as u32);
 
     let image = match color {
-        color::ColorType::RGB(8) => {
+        color::ColorType::RGB => {
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageRgb8)
         }
 
-        color::ColorType::RGBA(8) => {
+        color::ColorType::RGBA => {
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageRgba8)
         }
 
-        color::ColorType::BGR(8) => {
+        color::ColorType::BGR => {
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageBgr8)
         }
 
-        color::ColorType::BGRA(8) => {
+        color::ColorType::BGRA => {
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageBgra8)
         }
 
@@ -656,7 +656,7 @@ pub fn decoder_to_image<I: ImageDecoder>(codec: I) -> ImageResult<DynamicImage> 
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLuma8)
         }
 
-        color::ColorType::GrayA(8) => {
+        color::ColorType::GrayA => {
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLumaA8)
         }
         color::ColorType::Gray(bit_depth)

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -290,14 +290,14 @@ impl DynamicImage {
     }
 
     /// Return this image's color type.
-    pub fn color(&self) -> color::ColorType {
+    pub fn color(&self) -> color::CoreColorType {
         match *self {
-            DynamicImage::ImageLuma8(_) => color::ColorType::L8,
-            DynamicImage::ImageLumaA8(_) => color::ColorType::LA,
-            DynamicImage::ImageRgb8(_) => color::ColorType::RGB,
-            DynamicImage::ImageRgba8(_) => color::ColorType::RGBA,
-            DynamicImage::ImageBgra8(_) => color::ColorType::BGRA,
-            DynamicImage::ImageBgr8(_) => color::ColorType::BGR,
+            DynamicImage::ImageLuma8(_) => color::CoreColorType::L,
+            DynamicImage::ImageLumaA8(_) => color::CoreColorType::LA,
+            DynamicImage::ImageRgb8(_) => color::CoreColorType::RGB,
+            DynamicImage::ImageRgba8(_) => color::CoreColorType::RGBA,
+            DynamicImage::ImageBgra8(_) => color::CoreColorType::BGRA,
+            DynamicImage::ImageBgr8(_) => color::CoreColorType::BGR,
         }
     }
 
@@ -472,7 +472,7 @@ impl DynamicImage {
     ) -> ImageResult<()> {
         let mut bytes = self.raw_pixels();
         let (width, height) = self.dimensions();
-        let mut color = self.color();
+        let mut color = self.color().into();
         let format = format.into();
 
         #[allow(deprecated)]

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -292,8 +292,8 @@ impl DynamicImage {
     /// Return this image's color type.
     pub fn color(&self) -> color::ColorType {
         match *self {
-            DynamicImage::ImageLuma8(_) => color::ColorType::Gray(8),
-            DynamicImage::ImageLumaA8(_) => color::ColorType::GrayA,
+            DynamicImage::ImageLuma8(_) => color::ColorType::L(8),
+            DynamicImage::ImageLumaA8(_) => color::ColorType::LA,
             DynamicImage::ImageRgb8(_) => color::ColorType::RGB,
             DynamicImage::ImageRgba8(_) => color::ColorType::RGBA,
             DynamicImage::ImageBgra8(_) => color::ColorType::BGRA,
@@ -652,14 +652,14 @@ pub fn decoder_to_image<I: ImageDecoder>(codec: I) -> ImageResult<DynamicImage> 
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageBgra8)
         }
 
-        color::ColorType::Gray(8) => {
+        color::ColorType::L(8) => {
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLuma8)
         }
 
-        color::ColorType::GrayA => {
+        color::ColorType::LA => {
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLumaA8)
         }
-        color::ColorType::Gray(bit_depth)
+        color::ColorType::L(bit_depth)
             if bit_depth == 1 || bit_depth == 2 || bit_depth == 4 =>
         {
             gray_to_luma8(bit_depth, w, h, &buf).map(DynamicImage::ImageLuma8)

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -48,7 +48,7 @@ use std::marker::PhantomData;
 use num_traits::Zero;
 
 use buffer::{ImageBuffer, Pixel};
-use color::ColorType;
+use color::CoreColorType;
 use image::{GenericImage, GenericImageView, ImageError};
 
 /// A flat buffer over a (multi channel) image.
@@ -75,7 +75,7 @@ pub struct FlatSamples<Buffer> {
     /// converters. It is intended mainly as a way for types that convert to this buffer type to
     /// attach their otherwise static color information. A dynamic image representation could
     /// however use this to resolve representational ambiguities such as the order of RGB channels.
-    pub color_hint: Option<ColorType>,
+    pub color_hint: Option<CoreColorType>,
 }
 
 /// A ffi compatible description of a sample buffer.
@@ -927,7 +927,7 @@ pub enum Error {
     /// directly memory unsafe although that will likely alias pixels. One scenario is when you
     /// want to construct an `Rgba` image but have only 3 bytes per pixel and for some reason don't
     /// care about the value of the alpha channel even though you need `Rgba`.
-    WrongColor(ColorType),
+    WrongColor(CoreColorType),
 }
 
 /// Different normal forms of buffers.
@@ -1374,7 +1374,7 @@ impl From<Error> for ImageError {
     fn from(error: Error) -> ImageError {
         match error {
             Error::TooLarge => ImageError::DimensionError,
-            Error::WrongColor(color) => ImageError::UnsupportedColor(color),
+            Error::WrongColor(color) => ImageError::UnsupportedColor(color.into()),
             Error::NormalFormRequired(form) => ImageError::FormatError(
                 format!("Required sample buffer in normal form {:?}", form)),
         }

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -67,7 +67,7 @@ impl<R: Read> ImageDecoder for Decoder<R> {
     }
 
     fn colortype(&self) -> color::ColorType {
-        color::ColorType::RGBA(8)
+        color::ColorType::RGBA
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {

--- a/src/hdr/hdr_decoder.rs
+++ b/src/hdr/hdr_decoder.rs
@@ -74,7 +74,7 @@ impl<R: BufRead> ImageDecoder for HDRAdapter<R> {
     }
 
     fn colortype(&self) -> ColorType {
-        ColorType::RGB(8)
+        ColorType::RGB
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {

--- a/src/ico/decoder.rs
+++ b/src/ico/decoder.rs
@@ -199,7 +199,7 @@ impl<R: Read + Seek> ImageDecoder for ICODecoder<R> {
                 // Embedded PNG images can only be of the 32BPP RGBA format.
                 // https://blogs.msdn.microsoft.com/oldnewthing/20101022-00/?p=12473/
                 let color_type = decoder.colortype();
-                if let ColorType::RGBA(8) = color_type {
+                if let ColorType::RGBA = color_type {
                 } else {
                     return Err(ImageError::FormatError(
                         "The PNG is not in RGBA format!".to_string(),
@@ -217,7 +217,7 @@ impl<R: Read + Seek> ImageDecoder for ICODecoder<R> {
                 }
 
                 // The ICO decoder needs an alpha channel to apply the AND mask.
-                if decoder.colortype() != ColorType::RGBA(8) {
+                if decoder.colortype() != ColorType::RGBA {
                     return Err(ImageError::UnsupportedError(
                         "Unsupported color type".to_string(),
                     ));

--- a/src/image.rs
+++ b/src/image.rs
@@ -919,7 +919,7 @@ mod tests {
         impl ImageDecoder for MockDecoder {
             type Reader = Box<::std::io::Read>;
             fn dimensions(&self) -> (u64, u64) {(5, 5)}
-            fn colortype(&self) -> ColorType {  ColorType::Gray(8) }
+            fn colortype(&self) -> ColorType {  ColorType::L(8) }
             fn into_reader(self) -> ImageResult<Self::Reader> {unimplemented!()}
             fn scanline_bytes(&self) -> u64 { self.scanline_bytes }
         }

--- a/src/image.rs
+++ b/src/image.rs
@@ -919,7 +919,7 @@ mod tests {
         impl ImageDecoder for MockDecoder {
             type Reader = Box<::std::io::Read>;
             fn dimensions(&self) -> (u64, u64) {(5, 5)}
-            fn colortype(&self) -> ColorType {  ColorType::L(8) }
+            fn colortype(&self) -> ColorType {  ColorType::L8 }
             fn into_reader(self) -> ImageResult<Self::Reader> {unimplemented!()}
             fn scanline_bytes(&self) -> u64 { self.scanline_bytes }
         }

--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -89,7 +89,7 @@ impl From<jpeg_decoder::PixelFormat> for ColorType {
     fn from(pixel_format: jpeg_decoder::PixelFormat) -> ColorType {
         use self::jpeg_decoder::PixelFormat::*;
         match pixel_format {
-            L8 => ColorType::Gray(8),
+            L8 => ColorType::L(8),
             RGB24 => ColorType::RGB,
             CMYK32 => panic!(),
         }

--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -89,7 +89,7 @@ impl From<jpeg_decoder::PixelFormat> for ColorType {
     fn from(pixel_format: jpeg_decoder::PixelFormat) -> ColorType {
         use self::jpeg_decoder::PixelFormat::*;
         match pixel_format {
-            L8 => ColorType::L(8),
+            L8 => ColorType::L8,
             RGB24 => ColorType::RGB,
             CMYK32 => panic!(),
         }

--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -90,7 +90,7 @@ impl From<jpeg_decoder::PixelFormat> for ColorType {
         use self::jpeg_decoder::PixelFormat::*;
         match pixel_format {
             L8 => ColorType::Gray(8),
-            RGB24 => ColorType::RGB(8),
+            RGB24 => ColorType::RGB,
             CMYK32 => panic!(),
         }
     }

--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -449,7 +449,7 @@ impl<'a, W: Write> JPEGEncoder<'a, W> {
             color::ColorType::RGBA => {
                 try!(self.encode_rgb(image, width as usize, height as usize, 4))
             }
-            color::ColorType::L(8) => {
+            color::ColorType::L8 => {
                 try!(self.encode_gray(image, width as usize, height as usize, 1))
             }
             color::ColorType::LA => {
@@ -800,7 +800,7 @@ mod tests {
         {
             let mut encoder = JPEGEncoder::new_with_quality(&mut encoded_img, 100);
             encoder
-                .encode(&img, 2, 2, ColorType::L(8))
+                .encode(&img, 2, 2, ColorType::L8)
                 .expect("Could not encode image");
         }
 

--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -443,16 +443,16 @@ impl<'a, W: Write> JPEGEncoder<'a, W> {
         try!(self.writer.write_segment(SOS, Some(&buf)));
 
         match c {
-            color::ColorType::RGB(8) => {
+            color::ColorType::RGB => {
                 try!(self.encode_rgb(image, width as usize, height as usize, 3))
             }
-            color::ColorType::RGBA(8) => {
+            color::ColorType::RGBA => {
                 try!(self.encode_rgb(image, width as usize, height as usize, 4))
             }
             color::ColorType::Gray(8) => {
                 try!(self.encode_gray(image, width as usize, height as usize, 1))
             }
-            color::ColorType::GrayA(8) => {
+            color::ColorType::GrayA => {
                 try!(self.encode_gray(image, width as usize, height as usize, 2))
             }
             _ => {
@@ -772,7 +772,7 @@ mod tests {
         {
             let mut encoder = JPEGEncoder::new_with_quality(&mut encoded_img, 100);
             encoder
-                .encode(&img, 1, 1, ColorType::RGB(8))
+                .encode(&img, 1, 1, ColorType::RGB)
                 .expect("Could not encode image");
         }
 

--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -449,10 +449,10 @@ impl<'a, W: Write> JPEGEncoder<'a, W> {
             color::ColorType::RGBA => {
                 try!(self.encode_rgb(image, width as usize, height as usize, 4))
             }
-            color::ColorType::Gray(8) => {
+            color::ColorType::L(8) => {
                 try!(self.encode_gray(image, width as usize, height as usize, 1))
             }
-            color::ColorType::GrayA => {
+            color::ColorType::LA => {
                 try!(self.encode_gray(image, width as usize, height as usize, 2))
             }
             _ => {
@@ -800,7 +800,7 @@ mod tests {
         {
             let mut encoder = JPEGEncoder::new_with_quality(&mut encoded_img, 100);
             encoder
-                .encode(&img, 2, 2, ColorType::Gray(8))
+                .encode(&img, 2, 2, ColorType::L(8))
                 .expect("Could not encode image");
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ extern crate quickcheck;
 
 use std::io::Write;
 
-pub use color::ColorType::{self, Gray, GrayA, Palette, RGB, RGBA, BGR, BGRA};
+pub use color::ColorType::{self, L, LA, Palette, RGB, RGBA, BGR, BGRA};
 
 pub use color::{Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ extern crate quickcheck;
 
 use std::io::Write;
 
-pub use color::ColorType::{self, Gray, GrayA, Palette, RGB, RGBA, BGR, BGRA};
+pub use color::ColorType::{self, Gray, GrayA, RGB, RGBA, BGR, BGRA};
 
 pub use color::{Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ extern crate quickcheck;
 
 use std::io::Write;
 
-pub use color::ColorType::{self, Gray, GrayA, RGB, RGBA, BGR, BGRA};
+pub use color::ColorType::{self, Gray, GrayA, Palette, RGB, RGBA, BGR, BGRA};
 
 pub use color::{Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ extern crate quickcheck;
 
 use std::io::Write;
 
-pub use color::ColorType::{self, L, LA, Palette, RGB, RGBA, BGR, BGRA};
+pub use color::ColorType;
 
 pub use color::{Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
 

--- a/src/png.rs
+++ b/src/png.rs
@@ -81,13 +81,13 @@ impl<W: Write> PNGEncoder<W> {
 impl From<(png::ColorType, png::BitDepth)> for ColorType {
     fn from((ct, bits): (png::ColorType, png::BitDepth)) -> ColorType {
         use self::png::ColorType::*;
-        let bits = bits as u8;
-        match ct {
-            Grayscale => ColorType::Gray(bits),
-            RGB => ColorType::RGB(bits),
-            Indexed => ColorType::Palette(bits),
-            GrayscaleAlpha => ColorType::GrayA(bits),
-            RGBA => ColorType::RGBA(bits),
+        match (ct, bits as u8) {
+            (Grayscale, bits) => ColorType::Gray(bits),
+            (Indexed, bits) => ColorType::Palette(bits),
+            (RGB,8) => ColorType::RGB,
+            (GrayscaleAlpha, 8) => ColorType::GrayA,
+            (RGBA, 8) => ColorType::RGBA,
+            (_, _) => unimplemented!(),
         }
     }
 }
@@ -97,12 +97,12 @@ impl From<ColorType> for (png::ColorType, png::BitDepth) {
         use self::png::ColorType::*;
         let (ct, bits) = match ct {
             ColorType::Gray(bits) => (Grayscale, bits),
-            ColorType::RGB(bits) => (RGB, bits),
             ColorType::Palette(bits) => (Indexed, bits),
-            ColorType::GrayA(bits) => (GrayscaleAlpha, bits),
-            ColorType::RGBA(bits) => (RGBA, bits),
-            ColorType::BGRA(bits) => (RGBA, bits),
-            ColorType::BGR(bits) => (RGB, bits),
+            ColorType::RGB => (RGB, 8),
+            ColorType::GrayA => (GrayscaleAlpha, 8),
+            ColorType::RGBA => (RGBA, 8),
+            ColorType::BGRA => (RGBA, 8),
+            ColorType::BGR => (RGB, 8),
         };
         (ct, png::BitDepth::from_u8(bits).unwrap())
     }

--- a/src/png.rs
+++ b/src/png.rs
@@ -82,11 +82,14 @@ impl From<(png::ColorType, png::BitDepth)> for ColorType {
     fn from((ct, bits): (png::ColorType, png::BitDepth)) -> ColorType {
         use self::png::ColorType::*;
         match (ct, bits as u8) {
-            (Grayscale, bits) => ColorType::L(bits),
             (Indexed, bits) => ColorType::Palette(bits),
-            (RGB,8) => ColorType::RGB,
+            (Grayscale, bits) => ColorType::L(bits),
             (GrayscaleAlpha, 8) => ColorType::LA,
+            (GrayscaleAlpha, 16) => ColorType::LA16,
+            (RGB, 8) => ColorType::RGB,
+            (RGB, 16) => ColorType::RGB16,
             (RGBA, 8) => ColorType::RGBA,
+            (RGBA, 16) => ColorType::RGBA16,
             (_, _) => unimplemented!(),
         }
     }
@@ -96,13 +99,16 @@ impl From<ColorType> for (png::ColorType, png::BitDepth) {
     fn from(ct: ColorType) -> (png::ColorType, png::BitDepth) {
         use self::png::ColorType::*;
         let (ct, bits) = match ct {
-            ColorType::L(bits) => (Grayscale, bits),
             ColorType::Palette(bits) => (Indexed, bits),
-            ColorType::RGB => (RGB, 8),
+            ColorType::L(bits) => (Grayscale, bits),
             ColorType::LA => (GrayscaleAlpha, 8),
+            ColorType::LA16 => (GrayscaleAlpha, 16),
+            ColorType::RGB => (RGB, 8),
+            ColorType::RGB16 => (RGB, 16),
             ColorType::RGBA => (RGBA, 8),
-            ColorType::BGRA => (RGBA, 8),
+            ColorType::RGBA16 => (RGBA, 16),
             ColorType::BGR => (RGB, 8),
+            ColorType::BGRA => (RGBA, 8),
         };
         (ct, png::BitDepth::from_u8(bits).unwrap())
     }

--- a/src/png.rs
+++ b/src/png.rs
@@ -83,7 +83,9 @@ impl From<(png::ColorType, png::BitDepth)> for ColorType {
         use self::png::ColorType::*;
         match (ct, bits as u8) {
             (Indexed, bits) => ColorType::Palette(bits),
-            (Grayscale, bits) => ColorType::L(bits),
+            (Grayscale, 1) => ColorType::L1,
+            (Grayscale, 8) => ColorType::L8,
+            (Grayscale, 16) => ColorType::L16,
             (GrayscaleAlpha, 8) => ColorType::LA,
             (GrayscaleAlpha, 16) => ColorType::LA16,
             (RGB, 8) => ColorType::RGB,
@@ -100,7 +102,9 @@ impl From<ColorType> for (png::ColorType, png::BitDepth) {
         use self::png::ColorType::*;
         let (ct, bits) = match ct {
             ColorType::Palette(bits) => (Indexed, bits),
-            ColorType::L(bits) => (Grayscale, bits),
+            ColorType::L1 => (Grayscale, 1),
+            ColorType::L8 => (Grayscale, 8),
+            ColorType::L16 => (Grayscale, 16),
             ColorType::LA => (GrayscaleAlpha, 8),
             ColorType::LA16 => (GrayscaleAlpha, 16),
             ColorType::RGB => (RGB, 8),

--- a/src/png.rs
+++ b/src/png.rs
@@ -82,7 +82,6 @@ impl From<(png::ColorType, png::BitDepth)> for ColorType {
     fn from((ct, bits): (png::ColorType, png::BitDepth)) -> ColorType {
         use self::png::ColorType::*;
         match (ct, bits as u8) {
-            (Indexed, bits) => ColorType::Palette(bits),
             (Grayscale, 1) => ColorType::L1,
             (Grayscale, 8) => ColorType::L8,
             (Grayscale, 16) => ColorType::L16,
@@ -92,6 +91,7 @@ impl From<(png::ColorType, png::BitDepth)> for ColorType {
             (RGB, 16) => ColorType::RGB16,
             (RGBA, 8) => ColorType::RGBA,
             (RGBA, 16) => ColorType::RGBA16,
+            (Indexed, bits) => ColorType::Unknown(bits),
             (_, _) => unimplemented!(),
         }
     }
@@ -101,7 +101,7 @@ impl From<ColorType> for (png::ColorType, png::BitDepth) {
     fn from(ct: ColorType) -> (png::ColorType, png::BitDepth) {
         use self::png::ColorType::*;
         let (ct, bits) = match ct {
-            ColorType::Palette(bits) => (Indexed, bits),
+            ColorType::Unknown(bits) => (Indexed, bits),
             ColorType::L1 => (Grayscale, 1),
             ColorType::L8 => (Grayscale, 8),
             ColorType::L16 => (Grayscale, 16),

--- a/src/png.rs
+++ b/src/png.rs
@@ -82,10 +82,10 @@ impl From<(png::ColorType, png::BitDepth)> for ColorType {
     fn from((ct, bits): (png::ColorType, png::BitDepth)) -> ColorType {
         use self::png::ColorType::*;
         match (ct, bits as u8) {
-            (Grayscale, bits) => ColorType::Gray(bits),
+            (Grayscale, bits) => ColorType::L(bits),
             (Indexed, bits) => ColorType::Palette(bits),
             (RGB,8) => ColorType::RGB,
-            (GrayscaleAlpha, 8) => ColorType::GrayA,
+            (GrayscaleAlpha, 8) => ColorType::LA,
             (RGBA, 8) => ColorType::RGBA,
             (_, _) => unimplemented!(),
         }
@@ -96,10 +96,10 @@ impl From<ColorType> for (png::ColorType, png::BitDepth) {
     fn from(ct: ColorType) -> (png::ColorType, png::BitDepth) {
         use self::png::ColorType::*;
         let (ct, bits) = match ct {
-            ColorType::Gray(bits) => (Grayscale, bits),
+            ColorType::L(bits) => (Grayscale, bits),
             ColorType::Palette(bits) => (Indexed, bits),
             ColorType::RGB => (RGB, 8),
-            ColorType::GrayA => (GrayscaleAlpha, 8),
+            ColorType::LA => (GrayscaleAlpha, 8),
             ColorType::RGBA => (RGBA, 8),
             ColorType::BGRA => (RGBA, 8),
             ColorType::BGR => (RGB, 8),

--- a/src/png.rs
+++ b/src/png.rs
@@ -83,10 +83,10 @@ impl From<(png::ColorType, png::BitDepth)> for ColorType {
         use self::png::ColorType::*;
         match (ct, bits as u8) {
             (Grayscale, bits) => ColorType::Gray(bits),
+            (Indexed, bits) => ColorType::Palette(bits),
             (RGB,8) => ColorType::RGB,
             (GrayscaleAlpha, 8) => ColorType::GrayA,
             (RGBA, 8) => ColorType::RGBA,
-            (Indexed, _) => unreachable!(),
             (_, _) => unimplemented!(),
         }
     }
@@ -97,6 +97,7 @@ impl From<ColorType> for (png::ColorType, png::BitDepth) {
         use self::png::ColorType::*;
         let (ct, bits) = match ct {
             ColorType::Gray(bits) => (Grayscale, bits),
+            ColorType::Palette(bits) => (Indexed, bits),
             ColorType::RGB => (RGB, 8),
             ColorType::GrayA => (GrayscaleAlpha, 8),
             ColorType::RGBA => (RGBA, 8),

--- a/src/png.rs
+++ b/src/png.rs
@@ -83,10 +83,10 @@ impl From<(png::ColorType, png::BitDepth)> for ColorType {
         use self::png::ColorType::*;
         match (ct, bits as u8) {
             (Grayscale, bits) => ColorType::Gray(bits),
-            (Indexed, bits) => ColorType::Palette(bits),
             (RGB,8) => ColorType::RGB,
             (GrayscaleAlpha, 8) => ColorType::GrayA,
             (RGBA, 8) => ColorType::RGBA,
+            (Indexed, _) => unreachable!(),
             (_, _) => unimplemented!(),
         }
     }
@@ -97,7 +97,6 @@ impl From<ColorType> for (png::ColorType, png::BitDepth) {
         use self::png::ColorType::*;
         let (ct, bits) = match ct {
             ColorType::Gray(bits) => (Grayscale, bits),
-            ColorType::Palette(bits) => (Indexed, bits),
             ColorType::RGB => (RGB, 8),
             ColorType::GrayA => (GrayscaleAlpha, 8),
             ColorType::RGBA => (RGBA, 8),

--- a/src/png.rs
+++ b/src/png.rs
@@ -113,6 +113,7 @@ impl From<ColorType> for (png::ColorType, png::BitDepth) {
             ColorType::RGBA16 => (RGBA, 16),
             ColorType::BGR => (RGB, 8),
             ColorType::BGRA => (RGBA, 8),
+            _ => unimplemented!(),
         };
         (ct, png::BitDepth::from_u8(bits).unwrap())
     }

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -471,8 +471,8 @@ impl TupleType {
             BWBit => ColorType::Gray(1),
             GrayU8 => ColorType::Gray(8),
             GrayU16 => ColorType::Gray(16),
-            RGBU8 => ColorType::RGB(8),
-            RGBU16 => ColorType::GrayA(16),
+            RGBU8 => ColorType::RGB,
+            RGBU16 => unimplemented!(),//ColorType::GrayA(16),
         }
     }
 }
@@ -688,9 +688,9 @@ impl DecodableImageHeader for ArbitraryHeader {
     fn tuple_type(&self) -> ImageResult<TupleType> {
         match self.tupltype {
             None if self.depth == 1 => Ok(TupleType::GrayU8),
-            None if self.depth == 2 => Err(ImageError::UnsupportedColor(ColorType::GrayA(8))),
+            None if self.depth == 2 => Err(ImageError::UnsupportedColor(ColorType::GrayA)),
             None if self.depth == 3 => Ok(TupleType::RGBU8),
-            None if self.depth == 4 => Err(ImageError::UnsupportedColor(ColorType::RGBA(8))),
+            None if self.depth == 4 => Err(ImageError::UnsupportedColor(ColorType::RGBA)),
 
             Some(ArbitraryTuplType::BlackAndWhite) if self.maxval == 1 && self.depth == 1 => {
                 Ok(TupleType::BWBit)
@@ -719,14 +719,14 @@ impl DecodableImageHeader for ArbitraryHeader {
                 "Invalid depth for tuple type RGB".to_string(),
             )),
 
-            Some(ArbitraryTuplType::BlackAndWhiteAlpha) => {
-                Err(ImageError::UnsupportedColor(ColorType::GrayA(1)))
-            }
+            Some(ArbitraryTuplType::BlackAndWhiteAlpha) => Err(ImageError::FormatError(
+                "Unsupported colortype: BlackAndWhiteAlpha".to_string()
+            )),
             Some(ArbitraryTuplType::GrayscaleAlpha) => {
-                Err(ImageError::UnsupportedColor(ColorType::GrayA(8)))
+                Err(ImageError::UnsupportedColor(ColorType::GrayA))
             }
             Some(ArbitraryTuplType::RGBAlpha) => {
-                Err(ImageError::UnsupportedColor(ColorType::RGBA(8)))
+                Err(ImageError::UnsupportedColor(ColorType::RGBA))
             }
             _ => Err(ImageError::FormatError(
                 "Tuple type not recognized".to_string(),
@@ -831,7 +831,7 @@ HEIGHT 2
 ENDHDR
 \xde\xad\xbe\xef\xde\xad\xbe\xef\xde\xad\xbe\xef";
         let decoder = PNMDecoder::new(&pamdata[..]).unwrap();
-        assert_eq!(decoder.colortype(), ColorType::RGB(8));
+        assert_eq!(decoder.colortype(), ColorType::RGB);
         assert_eq!(decoder.dimensions(), (2, 2));
         assert_eq!(decoder.subtype(), PNMSubtype::ArbitraryMap);
 

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -467,10 +467,10 @@ impl TupleType {
     fn color(self) -> ColorType {
         use self::TupleType::*;
         match self {
-            PbmBit => ColorType::L(1),
-            BWBit => ColorType::L(1),
-            GrayU8 => ColorType::L(8),
-            GrayU16 => ColorType::L(16),
+            PbmBit => ColorType::L1,
+            BWBit => ColorType::L1,
+            GrayU8 => ColorType::L8,
+            GrayU16 => ColorType::L16,
             RGBU8 => ColorType::RGB,
             RGBU16 => ColorType::RGB16,
         }
@@ -750,7 +750,7 @@ TUPLTYPE BLACKANDWHITE
 ENDHDR
 \x01\x00\x00\x01\x01\x00\x00\x01\x01\x00\x00\x01\x01\x00\x00\x01";
         let decoder = PNMDecoder::new(&pamdata[..]).unwrap();
-        assert_eq!(decoder.colortype(), ColorType::L(1));
+        assert_eq!(decoder.colortype(), ColorType::L1);
         assert_eq!(decoder.dimensions(), (4, 4));
         assert_eq!(decoder.subtype(), PNMSubtype::ArbitraryMap);
 
@@ -791,7 +791,7 @@ TUPLTYPE GRAYSCALE
 ENDHDR
 \xde\xad\xbe\xef\xde\xad\xbe\xef\xde\xad\xbe\xef\xde\xad\xbe\xef";
         let decoder = PNMDecoder::new(&pamdata[..]).unwrap();
-        assert_eq!(decoder.colortype(), ColorType::L(8));
+        assert_eq!(decoder.colortype(), ColorType::L8);
         assert_eq!(decoder.dimensions(), (4, 4));
         assert_eq!(decoder.subtype(), PNMSubtype::ArbitraryMap);
         assert_eq!(
@@ -862,7 +862,7 @@ ENDHDR
         // comments on its format, see documentation of `impl SampleType for PbmBit`.
         let pbmbinary = [&b"P4 6 2\n"[..], &[0b01101100 as u8, 0b10110111]].concat();
         let decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
-        assert_eq!(decoder.colortype(), ColorType::L(1));
+        assert_eq!(decoder.colortype(), ColorType::L1);
         assert_eq!(decoder.dimensions(), (6, 2));
         assert_eq!(
             decoder.subtype(),
@@ -917,7 +917,7 @@ ENDHDR
         // whitespace characters that should be allowed (the 6 characters according to POSIX).
         let pbmbinary = b"P1 6 2\n 0 1 1 0 1 1\n1 0 1 1 0\t\n\x0b\x0c\r1";
         let decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
-        assert_eq!(decoder.colortype(), ColorType::L(1));
+        assert_eq!(decoder.colortype(), ColorType::L1);
         assert_eq!(decoder.dimensions(), (6, 2));
         assert_eq!(decoder.subtype(), PNMSubtype::Bitmap(SampleEncoding::Ascii));
         assert_eq!(decoder.read_image().unwrap(), vec![1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0]);
@@ -945,7 +945,7 @@ ENDHDR
         // whitespace for the pbm format or any mix.
         let pbmbinary = b"P1 6 2\n011011101101";
         let decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
-        assert_eq!(decoder.colortype(), ColorType::L(1));
+        assert_eq!(decoder.colortype(), ColorType::L1);
         assert_eq!(decoder.dimensions(), (6, 2));
         assert_eq!(decoder.subtype(), PNMSubtype::Bitmap(SampleEncoding::Ascii));
         assert_eq!(decoder.read_image().unwrap(), vec![1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0]);
@@ -973,7 +973,7 @@ ENDHDR
         let elements = (0..16).collect::<Vec<_>>();
         let pbmbinary = [&b"P5 4 4 255\n"[..], &elements].concat();
         let decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
-        assert_eq!(decoder.colortype(), ColorType::L(8));
+        assert_eq!(decoder.colortype(), ColorType::L8);
         assert_eq!(decoder.dimensions(), (4, 4));
         assert_eq!(
             decoder.subtype(),
@@ -1004,7 +1004,7 @@ ENDHDR
         // comments on its format, see documentation of `impl SampleType for PbmBit`.
         let pbmbinary = b"P2 4 4 255\n 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15";
         let decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
-        assert_eq!(decoder.colortype(), ColorType::L(8));
+        assert_eq!(decoder.colortype(), ColorType::L8);
         assert_eq!(decoder.dimensions(), (4, 4));
         assert_eq!(
             decoder.subtype(),

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -472,7 +472,7 @@ impl TupleType {
             GrayU8 => ColorType::L(8),
             GrayU16 => ColorType::L(16),
             RGBU8 => ColorType::RGB,
-            RGBU16 => unimplemented!(),//ColorType::LA(16),
+            RGBU16 => ColorType::RGB16,
         }
     }
 }

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -467,12 +467,12 @@ impl TupleType {
     fn color(self) -> ColorType {
         use self::TupleType::*;
         match self {
-            PbmBit => ColorType::Gray(1),
-            BWBit => ColorType::Gray(1),
-            GrayU8 => ColorType::Gray(8),
-            GrayU16 => ColorType::Gray(16),
+            PbmBit => ColorType::L(1),
+            BWBit => ColorType::L(1),
+            GrayU8 => ColorType::L(8),
+            GrayU16 => ColorType::L(16),
             RGBU8 => ColorType::RGB,
-            RGBU16 => unimplemented!(),//ColorType::GrayA(16),
+            RGBU16 => unimplemented!(),//ColorType::LA(16),
         }
     }
 }
@@ -688,7 +688,7 @@ impl DecodableImageHeader for ArbitraryHeader {
     fn tuple_type(&self) -> ImageResult<TupleType> {
         match self.tupltype {
             None if self.depth == 1 => Ok(TupleType::GrayU8),
-            None if self.depth == 2 => Err(ImageError::UnsupportedColor(ColorType::GrayA)),
+            None if self.depth == 2 => Err(ImageError::UnsupportedColor(ColorType::LA)),
             None if self.depth == 3 => Ok(TupleType::RGBU8),
             None if self.depth == 4 => Err(ImageError::UnsupportedColor(ColorType::RGBA)),
 
@@ -723,7 +723,7 @@ impl DecodableImageHeader for ArbitraryHeader {
                 "Unsupported colortype: BlackAndWhiteAlpha".to_string()
             )),
             Some(ArbitraryTuplType::GrayscaleAlpha) => {
-                Err(ImageError::UnsupportedColor(ColorType::GrayA))
+                Err(ImageError::UnsupportedColor(ColorType::LA))
             }
             Some(ArbitraryTuplType::RGBAlpha) => {
                 Err(ImageError::UnsupportedColor(ColorType::RGBA))
@@ -750,7 +750,7 @@ TUPLTYPE BLACKANDWHITE
 ENDHDR
 \x01\x00\x00\x01\x01\x00\x00\x01\x01\x00\x00\x01\x01\x00\x00\x01";
         let decoder = PNMDecoder::new(&pamdata[..]).unwrap();
-        assert_eq!(decoder.colortype(), ColorType::Gray(1));
+        assert_eq!(decoder.colortype(), ColorType::L(1));
         assert_eq!(decoder.dimensions(), (4, 4));
         assert_eq!(decoder.subtype(), PNMSubtype::ArbitraryMap);
 
@@ -791,7 +791,7 @@ TUPLTYPE GRAYSCALE
 ENDHDR
 \xde\xad\xbe\xef\xde\xad\xbe\xef\xde\xad\xbe\xef\xde\xad\xbe\xef";
         let decoder = PNMDecoder::new(&pamdata[..]).unwrap();
-        assert_eq!(decoder.colortype(), ColorType::Gray(8));
+        assert_eq!(decoder.colortype(), ColorType::L(8));
         assert_eq!(decoder.dimensions(), (4, 4));
         assert_eq!(decoder.subtype(), PNMSubtype::ArbitraryMap);
         assert_eq!(
@@ -862,7 +862,7 @@ ENDHDR
         // comments on its format, see documentation of `impl SampleType for PbmBit`.
         let pbmbinary = [&b"P4 6 2\n"[..], &[0b01101100 as u8, 0b10110111]].concat();
         let decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
-        assert_eq!(decoder.colortype(), ColorType::Gray(1));
+        assert_eq!(decoder.colortype(), ColorType::L(1));
         assert_eq!(decoder.dimensions(), (6, 2));
         assert_eq!(
             decoder.subtype(),
@@ -917,7 +917,7 @@ ENDHDR
         // whitespace characters that should be allowed (the 6 characters according to POSIX).
         let pbmbinary = b"P1 6 2\n 0 1 1 0 1 1\n1 0 1 1 0\t\n\x0b\x0c\r1";
         let decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
-        assert_eq!(decoder.colortype(), ColorType::Gray(1));
+        assert_eq!(decoder.colortype(), ColorType::L(1));
         assert_eq!(decoder.dimensions(), (6, 2));
         assert_eq!(decoder.subtype(), PNMSubtype::Bitmap(SampleEncoding::Ascii));
         assert_eq!(decoder.read_image().unwrap(), vec![1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0]);
@@ -945,7 +945,7 @@ ENDHDR
         // whitespace for the pbm format or any mix.
         let pbmbinary = b"P1 6 2\n011011101101";
         let decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
-        assert_eq!(decoder.colortype(), ColorType::Gray(1));
+        assert_eq!(decoder.colortype(), ColorType::L(1));
         assert_eq!(decoder.dimensions(), (6, 2));
         assert_eq!(decoder.subtype(), PNMSubtype::Bitmap(SampleEncoding::Ascii));
         assert_eq!(decoder.read_image().unwrap(), vec![1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0]);
@@ -973,7 +973,7 @@ ENDHDR
         let elements = (0..16).collect::<Vec<_>>();
         let pbmbinary = [&b"P5 4 4 255\n"[..], &elements].concat();
         let decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
-        assert_eq!(decoder.colortype(), ColorType::Gray(8));
+        assert_eq!(decoder.colortype(), ColorType::L(8));
         assert_eq!(decoder.dimensions(), (4, 4));
         assert_eq!(
             decoder.subtype(),
@@ -1004,7 +1004,7 @@ ENDHDR
         // comments on its format, see documentation of `impl SampleType for PbmBit`.
         let pbmbinary = b"P2 4 4 255\n 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15";
         let decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
-        assert_eq!(decoder.colortype(), ColorType::Gray(8));
+        assert_eq!(decoder.colortype(), ColorType::L(8));
         assert_eq!(decoder.dimensions(), (4, 4));
         assert_eq!(
             decoder.subtype(),

--- a/src/pnm/encoder.rs
+++ b/src/pnm/encoder.rs
@@ -328,7 +328,7 @@ impl<'a> CheckedDimensions<'a> {
         let components = match color {
             ColorType::Gray(_) => 1,
             ColorType::GrayA => 2,
-            ColorType::RGB | ColorType::BGR => 3,
+            ColorType::Palette(_) | ColorType::RGB | ColorType::BGR => 3,
             ColorType::RGBA | ColorType::BGRA => 4,
         };
 
@@ -423,14 +423,17 @@ impl<'a> CheckedHeaderColor<'a> {
         // We trust the image color bit count to be correct at least.
         let max_sample = match self.color {
             // Protects against overflows from shifting and gives a better error.
-            ColorType::Gray(n) if n > 16 =>
+            ColorType::Gray(n)
+            | ColorType::Palette(n) if n > 16 =>
             {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
                     "Encoding colors with a bit depth greater 16 not supported",
                 ))
             }
-            ColorType::Gray(n) => (1 << n) - 1,
+            ColorType::Gray(n)
+            | ColorType::Palette(n)
+                => (1 << n) - 1,
             ColorType::GrayA
             | ColorType::RGB
             | ColorType::RGBA
@@ -640,7 +643,7 @@ mod tests {
 
         PNMEncoder::new(&mut output)
             .with_header(header.into())
-            .encode(&data[..], 2, 2, ColorType::RGB)
+            .encode(&data[..], 2, 2, ColorType::Palette(8))
             .expect("Failed encoding custom color value");
     }
 }

--- a/src/pnm/encoder.rs
+++ b/src/pnm/encoder.rs
@@ -444,6 +444,7 @@ impl<'a> CheckedHeaderColor<'a> {
             | ColorType::RGB16
             | ColorType::RGBA16
                 => 0xffff,
+            _ => unimplemented!(),
         };
 
         // Avoid the performance heavy check if possible, e.g. if the header has been chosen by us.

--- a/src/pnm/encoder.rs
+++ b/src/pnm/encoder.rs
@@ -424,13 +424,13 @@ impl<'a> CheckedHeaderColor<'a> {
         // We trust the image color bit count to be correct at least.
         let max_sample = match self.color {
             // Protects against overflows from shifting and gives a better error.
-            ColorType::Palette(n) if n > 16 => {
+            ColorType::Unknown(n) if n > 16 => {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
                     "Encoding colors with a bit depth greater 16 not supported",
                 ))
             }
-            ColorType::Palette(n) => (1 << n) - 1,
+            ColorType::Unknown(n) => (1 << n) - 1,
             ColorType::L1 => 1,
             ColorType::L8
             | ColorType::LA
@@ -636,9 +636,9 @@ mod tests {
         let data: [u8; 12] = [0, 0, 0, 1, 1, 1, 255, 255, 255, 0, 0, 0];
 
         let header = ArbitraryHeader {
-            width: 2,
-            height: 2,
-            depth: 3,
+            width: 3,
+            height: 4,
+            depth: 1,
             maxval: 255,
             tupltype: Some(ArbitraryTuplType::Custom("Palette".to_string())),
         };
@@ -647,7 +647,7 @@ mod tests {
 
         PNMEncoder::new(&mut output)
             .with_header(header.into())
-            .encode(&data[..], 2, 2, ColorType::Palette(8))
+            .encode(&data[..], 3, 4, ColorType::Unknown(8))
             .expect("Failed encoding custom color value");
     }
 }

--- a/src/pnm/encoder.rs
+++ b/src/pnm/encoder.rs
@@ -328,7 +328,7 @@ impl<'a> CheckedDimensions<'a> {
         let components = match color {
             ColorType::Gray(_) => 1,
             ColorType::GrayA => 2,
-            ColorType::Palette(_) | ColorType::RGB | ColorType::BGR => 3,
+            ColorType::RGB | ColorType::BGR => 3,
             ColorType::RGBA | ColorType::BGRA => 4,
         };
 
@@ -423,17 +423,14 @@ impl<'a> CheckedHeaderColor<'a> {
         // We trust the image color bit count to be correct at least.
         let max_sample = match self.color {
             // Protects against overflows from shifting and gives a better error.
-            ColorType::Gray(n)
-            | ColorType::Palette(n) if n > 16 =>
+            ColorType::Gray(n) if n > 16 =>
             {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
                     "Encoding colors with a bit depth greater 16 not supported",
                 ))
             }
-            ColorType::Gray(n)
-            | ColorType::Palette(n)
-                => (1 << n) - 1,
+            ColorType::Gray(n) => (1 << n) - 1,
             ColorType::GrayA
             | ColorType::RGB
             | ColorType::RGBA
@@ -643,7 +640,7 @@ mod tests {
 
         PNMEncoder::new(&mut output)
             .with_header(header.into())
-            .encode(&data[..], 2, 2, ColorType::Palette(8))
+            .encode(&data[..], 2, 2, ColorType::RGB)
             .expect("Failed encoding custom color value");
     }
 }

--- a/src/pnm/encoder.rs
+++ b/src/pnm/encoder.rs
@@ -325,12 +325,7 @@ impl<'a> CheckedDimensions<'a> {
     // the comination is bogus (e.g. combining Pixmap and Palette) but allows uncertain
     // combinations (basically a ArbitraryTuplType::Custom with any color of fitting depth).
     fn check_header_color(self, color: ColorType) -> io::Result<CheckedHeaderColor<'a>> {
-        let components = match color {
-            ColorType::L(_) => 1,
-            ColorType::LA => 2,
-            ColorType::Palette(_) | ColorType::RGB | ColorType::BGR => 3,
-            ColorType::RGBA | ColorType::BGRA => 4,
-        };
+        let components = num_components(color) as u32;
 
         match *self.unchecked.header {
             PNMHeader {
@@ -439,7 +434,11 @@ impl<'a> CheckedHeaderColor<'a> {
             | ColorType::RGBA
             | ColorType::BGR
             | ColorType::BGRA
-                => (1 << 8) - 1,
+                => 0xff,
+            ColorType::LA16
+            | ColorType::RGB16
+            | ColorType::RGBA16
+                => 0xffff,
         };
 
         // Avoid the performance heavy check if possible, e.g. if the header has been chosen by us.

--- a/src/pnm/mod.rs
+++ b/src/pnm/mod.rs
@@ -119,20 +119,20 @@ mod tests {
             255, 255, 255,
             255, 255, 255,
         ];
-        execute_roundtrip_default(&buf, 3, 3, ColorType::RGB(8));
-        execute_roundtrip_with_subtype(&buf, 3, 3, ColorType::RGB(8), PNMSubtype::ArbitraryMap);
+        execute_roundtrip_default(&buf, 3, 3, ColorType::RGB);
+        execute_roundtrip_with_subtype(&buf, 3, 3, ColorType::RGB, PNMSubtype::ArbitraryMap);
         execute_roundtrip_with_subtype(
             &buf,
             3,
             3,
-            ColorType::RGB(8),
+            ColorType::RGB,
             PNMSubtype::Pixmap(SampleEncoding::Binary),
         );
         execute_roundtrip_with_subtype(
             &buf,
             3,
             3,
-            ColorType::RGB(8),
+            ColorType::RGB,
             PNMSubtype::Pixmap(SampleEncoding::Ascii),
         );
     }

--- a/src/pnm/mod.rs
+++ b/src/pnm/mod.rs
@@ -141,6 +141,6 @@ mod tests {
     fn roundtrip_u16() {
         let buf: [u16; 6] = [0, 1, 0xFFFF, 0x1234, 0x3412, 0xBEAF];
 
-        execute_roundtrip_u16(&buf, 6, 1, ColorType::Gray(16));
+        execute_roundtrip_u16(&buf, 6, 1, ColorType::L(16));
     }
 }

--- a/src/pnm/mod.rs
+++ b/src/pnm/mod.rs
@@ -141,6 +141,6 @@ mod tests {
     fn roundtrip_u16() {
         let buf: [u16; 6] = [0, 1, 0xFFFF, 0x1234, 0x3412, 0xBEAF];
 
-        execute_roundtrip_u16(&buf, 6, 1, ColorType::L(16));
+        execute_roundtrip_u16(&buf, 6, 1, ColorType::L16);
     }
 }

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -184,7 +184,7 @@ impl<R: Read + Seek> TGADecoder<R> {
             has_loaded_metadata: false,
 
             image_type: ImageType::Unknown,
-            color_type: ColorType::Gray(1),
+            color_type: ColorType::L(1),
 
             header: Header::new(),
             color_map: None,
@@ -254,8 +254,8 @@ impl<R: Read + Seek> TGADecoder<R> {
             (0, 32, true) => self.color_type = ColorType::RGBA,
             (8, 24, true) => self.color_type = ColorType::RGBA,
             (0, 24, true) => self.color_type = ColorType::RGB,
-            (8, 8, false) => self.color_type = ColorType::GrayA,
-            (0, 8, false) => self.color_type = ColorType::Gray(8),
+            (8, 8, false) => self.color_type = ColorType::LA,
+            (0, 8, false) => self.color_type = ColorType::L(8),
             _ => {
                 return Err(ImageError::UnsupportedError(
                     format!(

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -251,10 +251,10 @@ impl<R: Read + Seek> TGADecoder<R> {
         match (num_alpha_bits, other_channel_bits, color) {
             // really, the encoding is BGR and BGRA, this is fixed
             // up with `TGADecoder::reverse_encoding`.
-            (0, 32, true) => self.color_type = ColorType::RGBA(8),
-            (8, 24, true) => self.color_type = ColorType::RGBA(8),
-            (0, 24, true) => self.color_type = ColorType::RGB(8),
-            (8, 8, false) => self.color_type = ColorType::GrayA(8),
+            (0, 32, true) => self.color_type = ColorType::RGBA,
+            (8, 24, true) => self.color_type = ColorType::RGBA,
+            (0, 24, true) => self.color_type = ColorType::RGB,
+            (8, 8, false) => self.color_type = ColorType::GrayA,
             (0, 8, false) => self.color_type = ColorType::Gray(8),
             _ => {
                 return Err(ImageError::UnsupportedError(
@@ -420,7 +420,7 @@ impl<R: Read + Seek> TGADecoder<R> {
     fn reverse_encoding(&mut self, pixels: &mut [u8]) {
         // We only need to reverse the encoding of color images
         match self.color_type {
-            ColorType::RGB(8) | ColorType::RGBA(8) => {
+            ColorType::RGB | ColorType::RGBA => {
                 for chunk in pixels.chunks_mut(self.bytes_per_pixel) {
                     chunk.swap(0, 2);
                 }

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -184,7 +184,7 @@ impl<R: Read + Seek> TGADecoder<R> {
             has_loaded_metadata: false,
 
             image_type: ImageType::Unknown,
-            color_type: ColorType::L(1),
+            color_type: ColorType::L1,
 
             header: Header::new(),
             color_map: None,
@@ -255,7 +255,7 @@ impl<R: Read + Seek> TGADecoder<R> {
             (8, 24, true) => self.color_type = ColorType::RGBA,
             (0, 24, true) => self.color_type = ColorType::RGB,
             (8, 8, false) => self.color_type = ColorType::LA,
-            (0, 8, false) => self.color_type = ColorType::L(8),
+            (0, 8, false) => self.color_type = ColorType::L8,
             _ => {
                 return Err(ImageError::UnsupportedError(
                     format!(

--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -54,7 +54,9 @@ impl From<tiff::ColorType> for ColorType {
     fn from(ct: tiff::ColorType) -> ColorType {
         match ct {
             tiff::ColorType::Palette(depth) => ColorType::Palette(depth),
-            tiff::ColorType::Gray(depth) => ColorType::L(depth),
+            tiff::ColorType::Gray(1) => ColorType::L1,
+            tiff::ColorType::Gray(8) => ColorType::L8,
+            tiff::ColorType::Gray(16) => ColorType::L16,
             tiff::ColorType::GrayA(8) => ColorType::LA,
             tiff::ColorType::GrayA(16) => ColorType::LA16,
             tiff::ColorType::RGB(8) => ColorType::RGB,

--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -53,11 +53,14 @@ impl From<tiff::TiffError> for ImageError {
 impl From<tiff::ColorType> for ColorType {
     fn from(ct: tiff::ColorType) -> ColorType {
         match ct {
-            tiff::ColorType::Gray(depth) => ColorType::L(depth),
             tiff::ColorType::Palette(depth) => ColorType::Palette(depth),
-            tiff::ColorType::RGB(8) => ColorType::RGB,
-            tiff::ColorType::RGBA(8) => ColorType::RGBA,
+            tiff::ColorType::Gray(depth) => ColorType::L(depth),
             tiff::ColorType::GrayA(8) => ColorType::LA,
+            tiff::ColorType::GrayA(16) => ColorType::LA16,
+            tiff::ColorType::RGB(8) => ColorType::RGB,
+            tiff::ColorType::RGB(16) => ColorType::RGB16,
+            tiff::ColorType::RGBA(8) => ColorType::RGBA,
+            tiff::ColorType::RGBA(16) => ColorType::RGBA16,
             tiff::ColorType::CMYK(_) => unimplemented!(),
             _ => unimplemented!(),
         }

--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -54,11 +54,11 @@ impl From<tiff::ColorType> for ColorType {
     fn from(ct: tiff::ColorType) -> ColorType {
         match ct {
             tiff::ColorType::Gray(depth) => ColorType::Gray(depth),
+            tiff::ColorType::Palette(depth) => ColorType::Palette(depth),
             tiff::ColorType::RGB(8) => ColorType::RGB,
             tiff::ColorType::RGBA(8) => ColorType::RGBA,
             tiff::ColorType::GrayA(8) => ColorType::GrayA,
             tiff::ColorType::CMYK(_) => unimplemented!(),
-            tiff::ColorType::Palette(_) => unreachable!(),
             _ => unimplemented!(),
         }
     }

--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -54,11 +54,11 @@ impl From<tiff::ColorType> for ColorType {
     fn from(ct: tiff::ColorType) -> ColorType {
         match ct {
             tiff::ColorType::Gray(depth) => ColorType::Gray(depth),
-            tiff::ColorType::Palette(depth) => ColorType::Palette(depth),
             tiff::ColorType::RGB(8) => ColorType::RGB,
             tiff::ColorType::RGBA(8) => ColorType::RGBA,
             tiff::ColorType::GrayA(8) => ColorType::GrayA,
             tiff::ColorType::CMYK(_) => unimplemented!(),
+            tiff::ColorType::Palette(_) => unreachable!(),
             _ => unimplemented!(),
         }
     }

--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -53,11 +53,11 @@ impl From<tiff::TiffError> for ImageError {
 impl From<tiff::ColorType> for ColorType {
     fn from(ct: tiff::ColorType) -> ColorType {
         match ct {
-            tiff::ColorType::Gray(depth) => ColorType::Gray(depth),
+            tiff::ColorType::Gray(depth) => ColorType::L(depth),
             tiff::ColorType::Palette(depth) => ColorType::Palette(depth),
             tiff::ColorType::RGB(8) => ColorType::RGB,
             tiff::ColorType::RGBA(8) => ColorType::RGBA,
-            tiff::ColorType::GrayA(8) => ColorType::GrayA,
+            tiff::ColorType::GrayA(8) => ColorType::LA,
             tiff::ColorType::CMYK(_) => unimplemented!(),
             _ => unimplemented!(),
         }

--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -53,7 +53,7 @@ impl From<tiff::TiffError> for ImageError {
 impl From<tiff::ColorType> for ColorType {
     fn from(ct: tiff::ColorType) -> ColorType {
         match ct {
-            tiff::ColorType::Palette(depth) => ColorType::Palette(depth),
+            tiff::ColorType::Palette(depth) => ColorType::Unknown(depth),
             tiff::ColorType::Gray(1) => ColorType::L1,
             tiff::ColorType::Gray(8) => ColorType::L8,
             tiff::ColorType::Gray(16) => ColorType::L16,

--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -54,11 +54,12 @@ impl From<tiff::ColorType> for ColorType {
     fn from(ct: tiff::ColorType) -> ColorType {
         match ct {
             tiff::ColorType::Gray(depth) => ColorType::Gray(depth),
-            tiff::ColorType::RGB(depth) => ColorType::RGB(depth),
             tiff::ColorType::Palette(depth) => ColorType::Palette(depth),
-            tiff::ColorType::GrayA(depth) => ColorType::GrayA(depth),
-            tiff::ColorType::RGBA(depth) => ColorType::RGBA(depth),
-            tiff::ColorType::CMYK(_) => unimplemented!()
+            tiff::ColorType::RGB(8) => ColorType::RGB,
+            tiff::ColorType::RGBA(8) => ColorType::RGBA,
+            tiff::ColorType::GrayA(8) => ColorType::GrayA,
+            tiff::ColorType::CMYK(_) => unimplemented!(),
+            _ => unimplemented!(),
         }
     }
 }

--- a/src/webp/decoder.rs
+++ b/src/webp/decoder.rs
@@ -105,7 +105,7 @@ impl<R: Read> ImageDecoder for WebpDecoder<R> {
     }
 
     fn colortype(&self) -> color::ColorType {
-        color::ColorType::L(8)
+        color::ColorType::L8
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {

--- a/src/webp/decoder.rs
+++ b/src/webp/decoder.rs
@@ -105,7 +105,7 @@ impl<R: Read> ImageDecoder for WebpDecoder<R> {
     }
 
     fn colortype(&self) -> color::ColorType {
-        color::ColorType::Gray(8)
+        color::ColorType::L(8)
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {


### PR DESCRIPTION
Alternative fix for #855 (compare to #865) This version splits out a separate CoreColorType which only contains color types that are fully supported by the library. 