### PR TITLE
Remove nearly all instances of unsafe

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -852,13 +852,6 @@ where
         *self.get_pixel(x, y)
     }
 
-    /// Returns the pixel located at (x, y), ignoring bounds checking.
-    #[inline(always)]
-    unsafe fn unsafe_get_pixel(&self, x: u32, y: u32) -> P {
-        let indices = self.pixel_indices_unchecked(x, y);
-        *<P as Pixel>::from_slice(self.data.get_unchecked(indices))
-    }
-
     fn inner(&self) -> &Self::InnerImageView {
         self
     }
@@ -878,14 +871,6 @@ where
 
     fn put_pixel(&mut self, x: u32, y: u32, pixel: P) {
         *self.get_pixel_mut(x, y) = pixel
-    }
-
-    /// Puts a pixel at location (x, y), ignoring bounds checking.
-    #[inline(always)]
-    unsafe fn unsafe_put_pixel(&mut self, x: u32, y: u32, pixel: P) {
-        let indices = self.pixel_indices_unchecked(x, y);
-        let p = <P as Pixel>::from_slice_mut(self.data.get_unchecked_mut(indices));
-        *p = pixel
     }
 
     /// Put a pixel at location (x, y), taking into account alpha channels

--- a/src/image.rs
+++ b/src/image.rs
@@ -539,14 +539,6 @@ pub trait GenericImageView {
     /// TODO: change this signature to &P
     fn get_pixel(&self, x: u32, y: u32) -> Self::Pixel;
 
-    /// Returns the pixel located at (x, y)
-    ///
-    /// This function can be implemented in a way that ignores bounds checking.
-    #[deprecated = "Generally offers little advantage over get_pixel. If you must, prefer dedicated methods or other realizations on the specific image type instead."]
-    unsafe fn unsafe_get_pixel(&self, x: u32, y: u32) -> Self::Pixel {
-        self.get_pixel(x, y)
-    }
-
     /// Returns an Iterator over the pixels of this image.
     /// The iterator yields the coordinates of each pixel
     /// along with their value
@@ -591,14 +583,6 @@ pub trait GenericImage: GenericImageView {
     ///
     /// Panics if `(x, y)` is out of bounds.
     fn put_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel);
-
-    /// Puts a pixel at location (x, y)
-    ///
-    /// This function can be implemented in a way that ignores bounds checking.
-    #[deprecated = "Generally offers little advantage over put_pixel. If you must, prefer dedicated methods or other realizations on the specific image type instead."]
-    unsafe fn unsafe_put_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel) {
-        self.put_pixel(x, y, pixel);
-    }
 
     /// Put a pixel at location (x, y), taking into account alpha channels
     ///


### PR DESCRIPTION
This sketches out how we can remove nearly all instances of unsafe code in this crate. A majority of these cases are performance related (removing bounds checks or avoiding zeroing memory before use) but I think the safe versions should optimize reasonably well. The only places left are in the implementation of `Pixel` for the various pixel structs so if we could find a way to eliminate them we could mark the entire crate `#![deny(unsafe_code)]`:
```rust
fn from_slice(slice: &[T]) -> &$ident<T> {
    assert_eq!(slice.len(), $channels);
    unsafe { &*(slice.as_ptr() as *const $ident<T>) }
}

fn from_slice_mut(slice: &mut [T]) -> &mut $ident<T> {
    assert_eq!(slice.len(), $channels);
    unsafe { &mut *(slice.as_ptr() as *mut $ident<T>) }
}
```
