### PR TITLE
Add function to retrieve image dimensions without loading full image

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -760,6 +760,59 @@ fn open_impl(path: &Path) -> ImageResult<DynamicImage> {
     load(fin, format)
 }
 
+/// Read the dimensions of the image located at the specified path.
+/// This is faster than fully loading the image and then getting its dimensions.
+pub fn image_dimensions<P>(path: P) -> ImageResult<(u32, u32)>
+where
+    P: AsRef<Path>
+{
+    // thin wrapper function to strip generics before calling open_impl
+    image_dimensions_impl(path.as_ref())
+}
+
+fn image_dimensions_impl(path: &Path) -> ImageResult<(u32, u32)> {
+    let fin = File::open(path)?;
+    let fin = BufReader::new(fin);
+
+    let ext = path
+        .extension()
+        .and_then(|s| s.to_str())
+        .map_or("".to_string(), |s| s.to_ascii_lowercase());
+
+    match &ext[..] {
+        #[cfg(feature = "jpeg")]
+        "jpg" | "jpeg" => Ok(jpeg::JPEGDecoder::new(fin)?.dimensions()),
+        #[cfg(feature = "png_codec")]
+        "png" => Ok(png::PNGDecoder::new(fin)?.dimensions()),
+        #[cfg(feature = "gif_codec")]
+        "gif" => Ok(gif::Decoder::new(fin)?.dimensions()),
+        #[cfg(feature = "webp")]
+        "webp" => Ok(webp::WebpDecoder::new(fin)?.dimensions()),
+        #[cfg(feature = "tiff")]
+        "tif" | "tiff" => Ok(tiff::TIFFDecoder::new(fin)?.dimensions()),
+        #[cfg(feature = "tga")]
+        "tga" => Ok(tga::TGADecoder::new(fin)?.dimensions()),
+        #[cfg(feature = "bmp")]
+        "bmp" => Ok(bmp::BMPDecoder::new(fin)?.dimensions()),
+        #[cfg(feature = "ico")]
+        "ico" => Ok(ico::ICODecoder::new(fin)?.dimensions()),
+        #[cfg(feature = "hdr")]
+        "hdr" => Ok(hdr::HDRAdapter::new(fin)?.dimensions()),
+        #[cfg(feature = "pnm")]
+        "pbm" | "pam" | "ppm" | "pgm" => {
+            Ok(pnm::PNMDecoder::new(fin)?.dimensions())
+        }
+        format => Err(image::ImageError::UnsupportedError(format!(
+            "Image format image/{:?} is not supported.",
+            format
+        ))),
+    }
+     // TODO possible overflow here, though not probable since it would
+     // require an extremely large image.
+    .map(|(w, h)| (w as u32, h as u32))
+}
+
+
 /// Saves the supplied buffer to a file at the path specified.
 ///
 /// The image format is derived from the file extension. The buffer is assumed to have
@@ -1032,5 +1085,13 @@ mod test {
             4, 1, 2,
             &[0b11110011, 0b00001100],
             vec![255, 0]);
+    }
+
+    #[cfg(feature = "jpeg")]
+    #[test]
+    fn image_dimensions() {
+        let im_path = "./tests/images/jpg/progressive/cat.jpg";
+        let dims = super::image_dimensions(im_path).unwrap();
+        assert_eq!(dims, (320, 240));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ pub use traits::Primitive;
 
 // Opening and loading images
 pub use dynimage::{guess_format, load, load_from_memory, load_from_memory_with_format, open,
-                   save_buffer};
+                   save_buffer, image_dimensions};
 
 pub use dynimage::DynamicImage::{self, ImageLuma8, ImageLumaA8, ImageRgb8, ImageRgba8, ImageBgr8, ImageBgra8};
 


### PR DESCRIPTION
This is way faster than loading a full image, and is useful if one needs to, for instance, check that all images in a folder have the same resolution, or if one needs to know the dimensions of all the images to compute some layout.

I've been using a variant of this function in [a photo album generator](https://github.com/vbarrielle/phototex/blob/master/src/main.rs#L81-L119) but I thought this might be useful for other users of the image crate.