### PR TITLE
[Don't merge yet] Update url references to image-rs group

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ authors = [
 ]
 readme = "README.md"
 documentation = "https://docs.rs/image"
-repository = "https://github.com/PistonDevelopers/image.git"
-homepage = "https://github.com/PistonDevelopers/image"
+repository = "https://github.com/image-rs/image.git"
+homepage = "https://github.com/image-rs/image"
 categories = ["multimedia::images", "multimedia::encoding"]
 exclude = [
     "src/png/testdata/*",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Image [![Build Status](https://travis-ci.org/PistonDevelopers/image.svg?branch=master)](https://travis-ci.org/PistonDevelopers/image)
+# Image [![Build Status](https://travis-ci.org/image-rs/image.svg?branch=master)](https://travis-ci.org/image-rs/image)
 
 Maintainers: @nwin, @ccgn
 


### PR DESCRIPTION
Complement the move to [`image-rs`](https://github.com/image-rs) by updating the references to the repository in `Readme` and `Cargo.toml`.