### PR TITLE
Remove unecessary 'static bounds on affine operations

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -304,6 +304,9 @@ pub struct ImageBuffer<P: Pixel, Container> {
 }
 
 // generic implementation, shared along all image buffers
+//
+// TODO: Is the 'static bound on `I::Pixel` really required? Can we avoid it?  Remember to remove
+// the bounds on `imageops` in case this changes!
 impl<P, Container> ImageBuffer<P, Container>
 where
     P: Pixel + 'static,

--- a/src/imageops/affine.rs
+++ b/src/imageops/affine.rs
@@ -4,13 +4,10 @@ use buffer::{ImageBuffer, Pixel};
 use image::GenericImageView;
 
 /// Rotate an image 90 degrees clockwise.
-// TODO: Is the 'static bound on `I` really required? Can we avoid it?
-pub fn rotate90<I: GenericImageView + 'static>(
+pub fn rotate90<I: GenericImageView>(
     image: &I,
 ) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
-where
-    I::Pixel: 'static,
-    <I::Pixel as Pixel>::Subpixel: 'static,
+    where I::Pixel: 'static,
 {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(height, width);
@@ -26,13 +23,10 @@ where
 }
 
 /// Rotate an image 180 degrees clockwise.
-// TODO: Is the 'static bound on `I` really required? Can we avoid it?
-pub fn rotate180<I: GenericImageView + 'static>(
+pub fn rotate180<I: GenericImageView>(
     image: &I,
 ) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
-where
-    I::Pixel: 'static,
-    <I::Pixel as Pixel>::Subpixel: 'static,
+    where I::Pixel: 'static,
 {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
@@ -48,13 +42,10 @@ where
 }
 
 /// Rotate an image 270 degrees clockwise.
-// TODO: Is the 'static bound on `I` really required? Can we avoid it?
-pub fn rotate270<I: GenericImageView + 'static>(
+pub fn rotate270<I: GenericImageView>(
     image: &I,
 ) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
-where
-    I::Pixel: 'static,
-    <I::Pixel as Pixel>::Subpixel: 'static,
+    where I::Pixel: 'static,
 {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(height, width);
@@ -70,13 +61,10 @@ where
 }
 
 /// Flip an image horizontally
-// TODO: Is the 'static bound on `I` really required? Can we avoid it?
-pub fn flip_horizontal<I: GenericImageView + 'static>(
+pub fn flip_horizontal<I: GenericImageView>(
     image: &I,
 ) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
-where
-    I::Pixel: 'static,
-    <I::Pixel as Pixel>::Subpixel: 'static,
+    where I::Pixel: 'static,
 {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
@@ -92,13 +80,10 @@ where
 }
 
 /// Flip an image vertically
-// TODO: Is the 'static bound on `I` really required? Can we avoid it?
-pub fn flip_vertical<I: GenericImageView + 'static>(
+pub fn flip_vertical<I: GenericImageView>(
     image: &I,
 ) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
-where
-    I::Pixel: 'static,
-    <I::Pixel as Pixel>::Subpixel: 'static,
+    where I::Pixel: 'static,
 {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -122,14 +122,13 @@ pub fn box_kernel(_x: f32) -> f32 {
 // The height of the image remains unchanged.
 // ```new_width``` is the desired width of the new image
 // ```filter``` is the filter to use for sampling.
-// TODO: Do we really need the 'static bound on `I`? Can we avoid it?
 fn horizontal_sample<I, P, S>(
     image: &I,
     new_width: u32,
     filter: &mut Filter,
 ) -> ImageBuffer<P, Vec<S>>
 where
-    I: GenericImageView<Pixel = P> + 'static,
+    I: GenericImageView<Pixel = P>,
     P: Pixel<Subpixel = S> + 'static,
     S: Primitive + 'static,
 {
@@ -214,14 +213,13 @@ where
 // The width of the image remains unchanged.
 // ```new_height``` is the desired height of the new image
 // ```filter``` is the filter to use for sampling.
-// TODO: Do we really need the 'static bound on `I`? Can we avoid it?
 fn vertical_sample<I, P, S>(
     image: &I,
     new_height: u32,
     filter: &mut Filter,
 ) -> ImageBuffer<P, Vec<S>>
 where
-    I: GenericImageView<Pixel = P> + 'static,
+    I: GenericImageView<Pixel = P>,
     P: Pixel<Subpixel = S> + 'static,
     S: Primitive + 'static,
 {
@@ -566,10 +564,9 @@ where
 
 /// Perform a 3x3 box filter on the supplied image.
 /// ```kernel``` is an array of the filter weights of length 9.
-// TODO: Do we really need the 'static bound on `I`? Can we avoid it?
 pub fn filter3x3<I, P, S>(image: &I, kernel: &[f32]) -> ImageBuffer<P, Vec<S>>
 where
-    I: GenericImageView<Pixel = P> + 'static,
+    I: GenericImageView<Pixel = P>,
     P: Pixel<Subpixel = S> + 'static,
     S: Primitive + 'static,
 {
@@ -647,8 +644,7 @@ where
 /// Resize the supplied image to the specified dimensions.
 /// ```nwidth``` and ```nheight``` are the new dimensions.
 /// ```filter``` is the sampling filter to use.
-// TODO: Do we really need the 'static bound on `I`? Can we avoid it?
-pub fn resize<I: GenericImageView + 'static>(
+pub fn resize<I: GenericImageView>(
     image: &I,
     nwidth: u32,
     nheight: u32,
@@ -687,14 +683,12 @@ where
 
 /// Performs a Gaussian blur on the supplied image.
 /// ```sigma``` is a measure of how much to blur by.
-// TODO: Do we really need the 'static bound on `I`? Can we avoid it?
-pub fn blur<I: GenericImageView + 'static>(
+pub fn blur<I: GenericImageView>(
     image: &I,
     sigma: f32,
 ) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
 where
     I::Pixel: 'static,
-    <I::Pixel as Pixel>::Subpixel: 'static,
 {
     let sigma = if sigma < 0.0 { 1.0 } else { sigma };
 
@@ -716,10 +710,9 @@ where
 /// ```threshold``` is the threshold for the difference between
 ///
 /// See <https://en.wikipedia.org/wiki/Unsharp_masking#Digital_unsharp_masking>
-// TODO: Do we really need the 'static bound on `I`? Can we avoid it?
 pub fn unsharpen<I, P, S>(image: &I, sigma: f32, threshold: i32) -> ImageBuffer<P, Vec<S>>
 where
-    I: GenericImageView<Pixel = P> + 'static,
+    I: GenericImageView<Pixel = P>,
     P: Pixel<Subpixel = S> + 'static,
     S: Primitive + 'static,
 {


### PR DESCRIPTION
We only require the pixel itself to be static, probably as the
`ImageBuffer` will allocate it into a vector and never mention any
lifetime bounds in its interface? The complete removal of the static
bound is left to another set of patches since it requires modifying the
implementation of `ImageBuffer`.