### PR TITLE
Add lifetime bound on ImageDecoder trait

### DIFF
--- a/src/bmp/decoder.rs
+++ b/src/bmp/decoder.rs
@@ -1255,7 +1255,7 @@ impl<R: Read + Seek> BMPDecoder<R> {
     }
 }
 
-impl<'a, R: Read + Seek> ImageDecoder<'a> for BMPDecoder<R> {
+impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for BMPDecoder<R> {
     type Reader = Cursor<Vec<u8>>;
 
     fn dimensions(&self) -> (u64, u64) {
@@ -1279,7 +1279,7 @@ impl<'a, R: Read + Seek> ImageDecoder<'a> for BMPDecoder<R> {
     }
 }
 
-impl<'a, R: Read + Seek> ImageDecoderExt<'a> for BMPDecoder<R> {
+impl<'a, R: 'a + Read + Seek> ImageDecoderExt<'a> for BMPDecoder<R> {
     fn read_rect_with_progress<F: Fn(Progress)>(
         &mut self,
         x: u64,

--- a/src/bmp/decoder.rs
+++ b/src/bmp/decoder.rs
@@ -1255,7 +1255,7 @@ impl<R: Read + Seek> BMPDecoder<R> {
     }
 }
 
-impl<R: Read + Seek> ImageDecoder for BMPDecoder<R> {
+impl<'a, R: Read + Seek> ImageDecoder<'a> for BMPDecoder<R> {
     type Reader = Cursor<Vec<u8>>;
 
     fn dimensions(&self) -> (u64, u64) {
@@ -1279,7 +1279,7 @@ impl<R: Read + Seek> ImageDecoder for BMPDecoder<R> {
     }
 }
 
-impl<R: Read + Seek> ImageDecoderExt for BMPDecoder<R> {
+impl<'a, R: Read + Seek> ImageDecoderExt<'a> for BMPDecoder<R> {
     fn read_rect_with_progress<F: Fn(Progress)>(
         &mut self,
         x: u64,

--- a/src/dxt.rs
+++ b/src/dxt.rs
@@ -110,7 +110,7 @@ impl<R: Read> DXTDecoder<R> {
 
 // Note that, due to the way that DXT compression works, a scanline is considered to consist out of
 // 4 lines of pixels.
-impl<R: Read> ImageDecoder for DXTDecoder<R> {
+impl<'a, R: 'a + Read> ImageDecoder<'a> for DXTDecoder<R> {
     type Reader = DXTReader<R>;
 
     fn dimensions(&self) -> (u64, u64) {
@@ -149,7 +149,7 @@ impl<R: Read> ImageDecoder for DXTDecoder<R> {
     }
 }
 
-impl<R: Read + Seek> ImageDecoderExt for DXTDecoder<R> {
+impl<'a, R: 'a + Read + Seek> ImageDecoderExt<'a> for DXTDecoder<R> {
     fn read_rect_with_progress<F: Fn(Progress)>(
         &mut self,
         x: u64,

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -626,7 +626,7 @@ impl GenericImage for DynamicImage {
 }
 
 /// Decodes an image and stores it into a dynamic image
-pub fn decoder_to_image<I: ImageDecoder>(codec: I) -> ImageResult<DynamicImage> {
+pub fn decoder_to_image<'a, I: ImageDecoder<'a>>(codec: I) -> ImageResult<DynamicImage> {
     let color = codec.colortype();
     let (w, h) = codec.dimensions();
     let buf = try!(codec.read_image());

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -59,7 +59,7 @@ impl<R: Read> Decoder<R> {
     }
 }
 
-impl<R: Read> ImageDecoder for Decoder<R> {
+impl<'a, R: Read> ImageDecoder<'a> for Decoder<R> {
     type Reader = Cursor<Vec<u8>>;
 
     fn dimensions(&self) -> (u64, u64) {

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -59,7 +59,7 @@ impl<R: Read> Decoder<R> {
     }
 }
 
-impl<'a, R: Read> ImageDecoder<'a> for Decoder<R> {
+impl<'a, R: 'a + Read> ImageDecoder<'a> for Decoder<R> {
     type Reader = Cursor<Vec<u8>>;
 
     fn dimensions(&self) -> (u64, u64) {

--- a/src/hdr/hdr_decoder.rs
+++ b/src/hdr/hdr_decoder.rs
@@ -66,7 +66,7 @@ impl<R: BufRead> HDRAdapter<R> {
 
 }
 
-impl<'a, R: BufRead> ImageDecoder<'a> for HDRAdapter<R> {
+impl<'a, R: 'a + BufRead> ImageDecoder<'a> for HDRAdapter<R> {
     type Reader = Cursor<Vec<u8>>;
 
     fn dimensions(&self) -> (u64, u64) {
@@ -91,7 +91,7 @@ impl<'a, R: BufRead> ImageDecoder<'a> for HDRAdapter<R> {
     }
 }
 
-impl<'a, R: BufRead + Seek> ImageDecoderExt<'a> for HDRAdapter<R> {
+impl<'a, R: 'a + BufRead + Seek> ImageDecoderExt<'a> for HDRAdapter<R> {
     fn read_rect_with_progress<F: Fn(Progress)>(
         &mut self,
         x: u64,

--- a/src/hdr/hdr_decoder.rs
+++ b/src/hdr/hdr_decoder.rs
@@ -66,7 +66,7 @@ impl<R: BufRead> HDRAdapter<R> {
 
 }
 
-impl<R: BufRead> ImageDecoder for HDRAdapter<R> {
+impl<'a, R: BufRead> ImageDecoder<'a> for HDRAdapter<R> {
     type Reader = Cursor<Vec<u8>>;
 
     fn dimensions(&self) -> (u64, u64) {
@@ -91,7 +91,7 @@ impl<R: BufRead> ImageDecoder for HDRAdapter<R> {
     }
 }
 
-impl<R: BufRead + Seek> ImageDecoderExt for HDRAdapter<R> {
+impl<'a, R: BufRead + Seek> ImageDecoderExt<'a> for HDRAdapter<R> {
     fn read_rect_with_progress<F: Fn(Progress)>(
         &mut self,
         x: u64,

--- a/src/ico/decoder.rs
+++ b/src/ico/decoder.rs
@@ -158,7 +158,7 @@ impl DirEntry {
     }
 }
 
-impl<R: Read + Seek> ImageDecoder for ICODecoder<R> {
+impl<'a, R: Read + Seek> ImageDecoder<'a> for ICODecoder<R> {
     type Reader = Cursor<Vec<u8>>;
 
     fn dimensions(&self) -> (u64, u64) {

--- a/src/ico/decoder.rs
+++ b/src/ico/decoder.rs
@@ -158,7 +158,7 @@ impl DirEntry {
     }
 }
 
-impl<'a, R: Read + Seek> ImageDecoder<'a> for ICODecoder<R> {
+impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for ICODecoder<R> {
     type Reader = Cursor<Vec<u8>>;
 
     fn dimensions(&self) -> (u64, u64) {

--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -31,7 +31,7 @@ impl<R: Read> JPEGDecoder<R> {
     }
 }
 
-impl<R: Read> ImageDecoder for JPEGDecoder<R> {
+impl<'a, R: Read> ImageDecoder<'a> for JPEGDecoder<R> {
     type Reader = Cursor<Vec<u8>>;
 
     fn dimensions(&self) -> (u64, u64) {

--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -31,7 +31,7 @@ impl<R: Read> JPEGDecoder<R> {
     }
 }
 
-impl<'a, R: Read> ImageDecoder<'a> for JPEGDecoder<R> {
+impl<'a, R: 'a + Read> ImageDecoder<'a> for JPEGDecoder<R> {
     type Reader = Cursor<Vec<u8>>;
 
     fn dimensions(&self) -> (u64, u64) {

--- a/src/png.rs
+++ b/src/png.rs
@@ -111,7 +111,7 @@ impl<R: Read> PNGDecoder<R> {
     }
 }
 
-impl<R: Read> ImageDecoder for PNGDecoder<R> {
+impl<'a, R: 'a + Read> ImageDecoder<'a> for PNGDecoder<R> {
     type Reader = PNGReader<R>;
 
     fn dimensions(&self) -> (u64, u64) {

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -406,7 +406,7 @@ trait HeaderReader: BufRead {
 
 impl<R: Read> HeaderReader for BufReader<R> {}
 
-impl<'a, R: Read> ImageDecoder<'a> for PNMDecoder<R> {
+impl<'a, R: 'a + Read> ImageDecoder<'a> for PNMDecoder<R> {
     type Reader = Cursor<Vec<u8>>;
 
     fn dimensions(&self) -> (u64, u64) {

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -406,7 +406,7 @@ trait HeaderReader: BufRead {
 
 impl<R: Read> HeaderReader for BufReader<R> {}
 
-impl<R: Read> ImageDecoder for PNMDecoder<R> {
+impl<'a, R: Read> ImageDecoder<'a> for PNMDecoder<R> {
     type Reader = Cursor<Vec<u8>>;
 
     fn dimensions(&self) -> (u64, u64) {

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -498,7 +498,7 @@ impl<R: Read + Seek> TGADecoder<R> {
     }
 }
 
-impl<R: Read + Seek> ImageDecoder for TGADecoder<R> {
+impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for TGADecoder<R> {
     type Reader = TGAReader<R>;
 
     fn dimensions(&self) -> (u64, u64) {

--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -63,7 +63,7 @@ impl From<tiff::ColorType> for ColorType {
     }
 }
 
-impl<'a, R: Read + Seek> ImageDecoder<'a> for TIFFDecoder<R> {
+impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for TIFFDecoder<R> {
     type Reader = Cursor<Vec<u8>>;
 
     fn dimensions(&self) -> (u64, u64) {

--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -63,7 +63,7 @@ impl From<tiff::ColorType> for ColorType {
     }
 }
 
-impl<R: Read + Seek> ImageDecoder for TIFFDecoder<R> {
+impl<'a, R: Read + Seek> ImageDecoder<'a> for TIFFDecoder<R> {
     type Reader = Cursor<Vec<u8>>;
 
     fn dimensions(&self) -> (u64, u64) {

--- a/src/webp/decoder.rs
+++ b/src/webp/decoder.rs
@@ -98,7 +98,7 @@ impl<R: Read> WebpDecoder<R> {
     }
 }
 
-impl<R: Read> ImageDecoder for WebpDecoder<R> {
+impl<'a, R: Read> ImageDecoder<'a> for WebpDecoder<R> {
     type Reader = Cursor<Vec<u8>>;
 
     fn dimensions(&self) -> (u64, u64) {

--- a/src/webp/decoder.rs
+++ b/src/webp/decoder.rs
@@ -98,7 +98,7 @@ impl<R: Read> WebpDecoder<R> {
     }
 }
 
-impl<'a, R: Read> ImageDecoder<'a> for WebpDecoder<R> {
+impl<'a, R: 'a + Read> ImageDecoder<'a> for WebpDecoder<R> {
     type Reader = Cursor<Vec<u8>>;
 
     fn dimensions(&self) -> (u64, u64) {


### PR DESCRIPTION
This was overlooked in the initial overhaul of the trait, but is necessary for writing certain sorts of generic code over decoders.