### PR TITLE
Replace the ImageFormat enum with mime types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ num-traits = "0.2.0"
 lzw = "0.10.0"
 mime_guess = "2.0.0-alpha.6"
 mime = "0.3.13"
+lazy_static = "1.3.0"
 
 [dependencies.gif]
 version = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ num-iter = "0.1.32"
 num-rational = { version = "0.2.1", default-features = false }
 num-traits = "0.2.0"
 lzw = "0.10.0"
+mime_guess = "2.0.0-alpha.6"
+mime = "0.3.13"
 
 [dependencies.gif]
 version = "0.10.0"

--- a/examples/opening.rs
+++ b/examples/opening.rs
@@ -27,5 +27,5 @@ fn main() {
     let fout = &mut File::create(&Path::new(&format!("{}.png", file))).unwrap();
 
     // Write the contents of this image to the Writer in PNG format.
-    im.write_to(fout, image::PNG).unwrap();
+    im.write_to(fout, image::ImageOutputFormat::PNG).unwrap();
 }

--- a/examples/scaledown/main.rs
+++ b/examples/scaledown/main.rs
@@ -1,6 +1,6 @@
 extern crate image;
 
-use image::{FilterType, PNG};
+use image::{FilterType, ImageOutputFormat::PNG};
 use std::fmt;
 use std::fs::File;
 use std::time::{Duration, Instant};

--- a/examples/scaleup/main.rs
+++ b/examples/scaleup/main.rs
@@ -1,6 +1,6 @@
 extern crate image;
 
-use image::{FilterType, PNG};
+use image::{FilterType, ImageOutputFormat::PNG};
 use std::fmt;
 use std::fs::File;
 use std::time::{Duration, Instant};

--- a/src/bmp/decoder.rs
+++ b/src/bmp/decoder.rs
@@ -1255,7 +1255,7 @@ impl<R: Read + Seek> BMPDecoder<R> {
     }
 }
 
-impl<R: Read + Seek> ImageDecoder for BMPDecoder<R> {
+impl<'a, R: Read + Seek> ImageDecoder<'a> for BMPDecoder<R> {
     type Reader = Cursor<Vec<u8>>;
 
     fn dimensions(&self) -> (u64, u64) {
@@ -1279,7 +1279,7 @@ impl<R: Read + Seek> ImageDecoder for BMPDecoder<R> {
     }
 }
 
-impl<R: Read + Seek> ImageDecoderExt for BMPDecoder<R> {
+impl<'a, R: Read + Seek> ImageDecoderExt<'a> for BMPDecoder<R> {
     fn read_rect_with_progress<F: Fn(Progress)>(
         &mut self,
         x: u64,

--- a/src/dxt.rs
+++ b/src/dxt.rs
@@ -113,7 +113,7 @@ impl<R: Read> DXTDecoder<R> {
 
 // Note that, due to the way that DXT compression works, a scanline is considered to consist out of
 // 4 lines of pixels.
-impl<R: Read> ImageDecoder for DXTDecoder<R> {
+impl<'a, R: 'a + Read> ImageDecoder<'a> for DXTDecoder<R> {
     type Reader = DXTReader<R>;
 
     fn dimensions(&self) -> (u64, u64) {
@@ -152,7 +152,7 @@ impl<R: Read> ImageDecoder for DXTDecoder<R> {
     }
 }
 
-impl<R: Read + Seek> ImageDecoderExt for DXTDecoder<R> {
+impl<'a, R: 'a + Read + Seek> ImageDecoderExt<'a> for DXTDecoder<R> {
     fn read_rect_with_progress<F: Fn(Progress)>(
         &mut self,
         x: u64,

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -626,7 +626,7 @@ impl GenericImage for DynamicImage {
 }
 
 /// Decodes an image and stores it into a dynamic image
-pub fn decoder_to_image<I: ImageDecoder>(codec: I) -> ImageResult<DynamicImage> {
+pub fn decoder_to_image<'a, I: ImageDecoder<'a>>(codec: I) -> ImageResult<DynamicImage> {
     let color = codec.colortype();
     let (w, h) = codec.dimensions();
     let buf = try!(codec.read_image());

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -59,7 +59,7 @@ impl<R: Read> Decoder<R> {
     }
 }
 
-impl<R: Read> ImageDecoder for Decoder<R> {
+impl<'a, R: Read> ImageDecoder<'a> for Decoder<R> {
     type Reader = Cursor<Vec<u8>>;
 
     fn dimensions(&self) -> (u64, u64) {

--- a/src/hdr/hdr_decoder.rs
+++ b/src/hdr/hdr_decoder.rs
@@ -66,7 +66,7 @@ impl<R: BufRead> HDRAdapter<R> {
 
 }
 
-impl<R: BufRead> ImageDecoder for HDRAdapter<R> {
+impl<'a, R: BufRead> ImageDecoder<'a> for HDRAdapter<R> {
     type Reader = Cursor<Vec<u8>>;
 
     fn dimensions(&self) -> (u64, u64) {
@@ -91,7 +91,7 @@ impl<R: BufRead> ImageDecoder for HDRAdapter<R> {
     }
 }
 
-impl<R: BufRead + Seek> ImageDecoderExt for HDRAdapter<R> {
+impl<'a, R: BufRead + Seek> ImageDecoderExt<'a> for HDRAdapter<R> {
     fn read_rect_with_progress<F: Fn(Progress)>(
         &mut self,
         x: u64,

--- a/src/ico/decoder.rs
+++ b/src/ico/decoder.rs
@@ -158,7 +158,7 @@ impl DirEntry {
     }
 }
 
-impl<R: Read + Seek> ImageDecoder for ICODecoder<R> {
+impl<'a, R: Read + Seek> ImageDecoder<'a> for ICODecoder<R> {
     type Reader = Cursor<Vec<u8>>;
 
     fn dimensions(&self) -> (u64, u64) {

--- a/src/image.rs
+++ b/src/image.rs
@@ -11,6 +11,8 @@ use color::ColorType;
 
 use animation::Frames;
 
+use mime::Mime;
+
 #[cfg(feature = "pnm")]
 use pnm::PNMSubtype;
 
@@ -141,6 +143,24 @@ pub enum ImageFormat {
     /// An Image in Radiance HDR Format
     HDR,
 }
+impl ImageFormat {
+    /// Get the MIME type associated with this image format.
+    pub(crate) fn mime(&self) -> Mime {
+        match *self {
+            ImageFormat::PNG => "image/png",
+            ImageFormat::JPEG => "image/jepg",
+            ImageFormat::GIF => "image/gif",
+            ImageFormat::WEBP => "image/webp",
+            ImageFormat::PNM => "image/x-portable-anymap",
+            ImageFormat::TIFF => "image/tiff",
+            ImageFormat::TGA => "image/x-tga",
+            ImageFormat::BMP => "image/bmp",
+            ImageFormat::ICO => "image/x-icon",
+            ImageFormat::HDR => "image/vnd.radiancer",
+        }.parse().unwrap()
+    }
+}
+
 
 /// An enumeration of supported image formats for encoding.
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/src/image.rs
+++ b/src/image.rs
@@ -11,8 +11,6 @@ use color::ColorType;
 
 use animation::Frames;
 
-use mime::Mime;
-
 #[cfg(feature = "pnm")]
 use pnm::PNMSubtype;
 
@@ -109,59 +107,6 @@ impl From<io::Error> for ImageError {
 /// Result of an image decoding/encoding process
 pub type ImageResult<T> = Result<T, ImageError>;
 
-/// An enumeration of supported image formats.
-/// Not all formats support both encoding and decoding.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum ImageFormat {
-    /// An Image in PNG Format
-    PNG,
-
-    /// An Image in JPEG Format
-    JPEG,
-
-    /// An Image in GIF Format
-    GIF,
-
-    /// An Image in WEBP Format
-    WEBP,
-
-    /// An Image in general PNM Format
-    PNM,
-
-    /// An Image in TIFF Format
-    TIFF,
-
-    /// An Image in TGA Format
-    TGA,
-
-    /// An Image in BMP Format
-    BMP,
-
-    /// An Image in ICO Format
-    ICO,
-
-    /// An Image in Radiance HDR Format
-    HDR,
-}
-impl ImageFormat {
-    /// Get the MIME type associated with this image format.
-    pub(crate) fn mime(&self) -> Mime {
-        match *self {
-            ImageFormat::PNG => "image/png",
-            ImageFormat::JPEG => "image/jepg",
-            ImageFormat::GIF => "image/gif",
-            ImageFormat::WEBP => "image/webp",
-            ImageFormat::PNM => "image/x-portable-anymap",
-            ImageFormat::TIFF => "image/tiff",
-            ImageFormat::TGA => "image/x-tga",
-            ImageFormat::BMP => "image/bmp",
-            ImageFormat::ICO => "image/x-icon",
-            ImageFormat::HDR => "image/vnd.radiancer",
-        }.parse().unwrap()
-    }
-}
-
-
 /// An enumeration of supported image formats for encoding.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum ImageOutputFormat {
@@ -193,30 +138,6 @@ pub enum ImageOutputFormat {
     // Note: When TryFrom is stabilized, this value should not be needed, and
     // a TryInto<ImageOutputFormat> should be used instead of an Into<ImageOutputFormat>.
     Unsupported(String),
-}
-
-impl From<ImageFormat> for ImageOutputFormat {
-    fn from(fmt: ImageFormat) -> Self {
-        match fmt {
-            #[cfg(feature = "png_codec")]
-            ImageFormat::PNG => ImageOutputFormat::PNG,
-            #[cfg(feature = "jpeg")]
-            ImageFormat::JPEG => ImageOutputFormat::JPEG(75),
-            #[cfg(feature = "pnm")]
-            ImageFormat::PNM => ImageOutputFormat::PNM(PNMSubtype::ArbitraryMap),
-            #[cfg(feature = "gif_codec")]
-            ImageFormat::GIF => ImageOutputFormat::GIF,
-            #[cfg(feature = "ico")]
-            ImageFormat::ICO => ImageOutputFormat::ICO,
-            #[cfg(feature = "bmp")]
-            ImageFormat::BMP => ImageOutputFormat::BMP,
-
-            f => ImageOutputFormat::Unsupported(format!(
-                "Image format {:?} not supported for encoding.",
-                f
-            )),
-        }
-    }
 }
 
 // This struct manages buffering associated with implementing `Read` and `Seek` on decoders that can

--- a/src/image.rs
+++ b/src/image.rs
@@ -264,12 +264,12 @@ impl ImageReadBuffer {
 
 /// Decodes a specific region of the image, represented by the rectangle
 /// starting from ```x``` and ```y``` and having ```length``` and ```width```
-pub(crate) fn load_rect<D, F, F1, F2>(x: u64, y: u64, width: u64, height: u64, buf: &mut [u8],
-                                      progress_callback: F,
-                                      decoder: &mut D,
-                                      mut seek_scanline: F1,
-                                      mut read_scanline: F2) -> ImageResult<()>
-    where D: ImageDecoder,
+pub(crate) fn load_rect<'a, D, F, F1, F2>(x: u64, y: u64, width: u64, height: u64, buf: &mut [u8],
+                                          progress_callback: F,
+                                          decoder: &mut D,
+                                          mut seek_scanline: F1,
+                                          mut read_scanline: F2) -> ImageResult<()>
+    where D: ImageDecoder<'a>,
           F: Fn(Progress),
           F1: FnMut(&mut D, u64) -> io::Result<()>,
           F2: FnMut(&mut D, &mut [u8]) -> io::Result<usize>
@@ -359,9 +359,9 @@ pub struct Progress {
 }
 
 /// The trait that all decoders implement
-pub trait ImageDecoder: Sized {
+pub trait ImageDecoder<'a>: Sized {
     /// The type of reader produced by `into_reader`.
-    type Reader: Read;
+    type Reader: Read + 'a;
 
     /// Returns a tuple containing the width and height of the image
     fn dimensions(&self) -> (u64, u64);
@@ -435,7 +435,7 @@ pub trait ImageDecoder: Sized {
 }
 
 /// ImageDecoderExt trait
-pub trait ImageDecoderExt: ImageDecoder + Sized {
+pub trait ImageDecoderExt<'a>: ImageDecoder<'a> + Sized {
     /// Read a rectangular section of the image.
     fn read_rect(
         &mut self,
@@ -916,7 +916,7 @@ mod tests {
         use super::*;
 
         struct MockDecoder {scanline_number: u64, scanline_bytes: u64}
-        impl ImageDecoder for MockDecoder {
+        impl<'a> ImageDecoder<'a> for MockDecoder {
             type Reader = Box<::std::io::Read>;
             fn dimensions(&self) -> (u64, u64) {(5, 5)}
             fn colortype(&self) -> ColorType {  ColorType::Gray(8) }

--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -31,7 +31,7 @@ impl<R: Read> JPEGDecoder<R> {
     }
 }
 
-impl<R: Read> ImageDecoder for JPEGDecoder<R> {
+impl<'a, R: Read> ImageDecoder<'a> for JPEGDecoder<R> {
     type Reader = Cursor<Vec<u8>>;
 
     fn dimensions(&self) -> (u64, u64) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@
 #![cfg_attr(feature = "cargo-clippy", allow(many_single_char_names))]
 
 extern crate byteorder;
+#[macro_use]
+extern crate lazy_static;
 extern crate lzw;
 extern crate num_iter;
 extern crate num_rational;
@@ -42,8 +44,6 @@ pub use image::{AnimationDecoder,
                 SubImage};
 
 pub use imageops::FilterType::{self, CatmullRom, Gaussian, Lanczos3, Nearest, Triangle};
-
-pub use image::ImageFormat::{self, BMP, GIF, ICO, JPEG, PNG, PNM, WEBP};
 
 pub use image::ImageOutputFormat;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@ extern crate lzw;
 extern crate num_iter;
 extern crate num_rational;
 extern crate num_traits;
+extern crate mime;
+extern crate mime_guess;
 #[cfg(all(test, feature = "benchmarks"))]
 extern crate test;
 

--- a/src/png.rs
+++ b/src/png.rs
@@ -111,7 +111,7 @@ impl<R: Read> PNGDecoder<R> {
     }
 }
 
-impl<R: Read> ImageDecoder for PNGDecoder<R> {
+impl<'a, R: 'a + Read> ImageDecoder<'a> for PNGDecoder<R> {
     type Reader = PNGReader<R>;
 
     fn dimensions(&self) -> (u64, u64) {

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -406,7 +406,7 @@ trait HeaderReader: BufRead {
 
 impl<R: Read> HeaderReader for BufReader<R> {}
 
-impl<R: Read> ImageDecoder for PNMDecoder<R> {
+impl<'a, R: Read> ImageDecoder<'a> for PNMDecoder<R> {
     type Reader = Cursor<Vec<u8>>;
 
     fn dimensions(&self) -> (u64, u64) {

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -498,7 +498,7 @@ impl<R: Read + Seek> TGADecoder<R> {
     }
 }
 
-impl<R: Read + Seek> ImageDecoder for TGADecoder<R> {
+impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for TGADecoder<R> {
     type Reader = TGAReader<R>;
 
     fn dimensions(&self) -> (u64, u64) {

--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -63,7 +63,7 @@ impl From<tiff::ColorType> for ColorType {
     }
 }
 
-impl<R: Read + Seek> ImageDecoder for TIFFDecoder<R> {
+impl<'a, R: Read + Seek> ImageDecoder<'a> for TIFFDecoder<R> {
     type Reader = Cursor<Vec<u8>>;
 
     fn dimensions(&self) -> (u64, u64) {

--- a/src/webp/decoder.rs
+++ b/src/webp/decoder.rs
@@ -97,7 +97,7 @@ impl<R: Read> WebpDecoder<R> {
     }
 }
 
-impl<R: Read> ImageDecoder for WebpDecoder<R> {
+impl<'a, R: Read> ImageDecoder<'a> for WebpDecoder<R> {
     type Reader = Cursor<Vec<u8>>;
 
     fn dimensions(&self) -> (u64, u64) {

--- a/tests/save_jpeg.rs
+++ b/tests/save_jpeg.rs
@@ -2,14 +2,14 @@
 #![cfg(all(feature = "jpeg", feature = "tiff"))]
 extern crate image;
 
-use image::{ImageOutputFormat, JPEG};
+use image::ImageOutputFormat;
 
 #[test]
 fn jqeg_qualitys() {
     let img = image::open("tests/images/tiff/testsuite/lenna.tiff").unwrap();
 
     let mut default = vec![];
-    img.write_to(&mut default, JPEG).unwrap();
+    img.write_to(&mut default, ImageOutputFormat::JPEG(75)).unwrap();
     assert_eq!(&[255, 216], &default[..2]);
 
     let mut small = vec![];


### PR DESCRIPTION
This PR replaces all uses of the ImageFormat enum with with the Mime struct (from the crate of the same name). This allows us to tap into the broader Rust ecosystem for file type handling, including the mime_guess crate which provides conversions from file extension to file type.

Depends on #903 and abonander/mime_guess#45