### PR TITLE
Remove nearly all instances of unsafe

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -404,13 +404,11 @@ where
             return None
         }
 
-        Some(unsafe {
-            self.unsafe_pixel_indices(x, y)
-        })
+        Some(self.pixel_indices_unchecked(x, y))
     }
 
     #[inline(always)]
-    unsafe fn unsafe_pixel_indices(&self, x: u32, y: u32) -> Range<usize> {
+    fn pixel_indices_unchecked(&self, x: u32, y: u32) -> Range<usize> {
         let no_channels = <P as Pixel>::channel_count() as usize;
         // If in bounds, this can't overflow as we have tested that at construction!
         let min_index = (y as usize*self.width as usize + x as usize)*no_channels;
@@ -615,7 +613,7 @@ where
     /// Returns the pixel located at (x, y), ignoring bounds checking.
     #[inline(always)]
     unsafe fn unsafe_get_pixel(&self, x: u32, y: u32) -> P {
-        let indices = self.unsafe_pixel_indices(x, y);
+        let indices = self.pixel_indices_unchecked(x, y);
         *<P as Pixel>::from_slice(self.data.get_unchecked(indices))
     }
 
@@ -643,7 +641,7 @@ where
     /// Puts a pixel at location (x, y), ignoring bounds checking.
     #[inline(always)]
     unsafe fn unsafe_put_pixel(&mut self, x: u32, y: u32, pixel: P) {
-        let indices = self.unsafe_pixel_indices(x, y);
+        let indices = self.pixel_indices_unchecked(x, y);
         let p = <P as Pixel>::from_slice_mut(self.data.get_unchecked_mut(indices));
         *p = pixel
     }
@@ -756,9 +754,7 @@ impl GrayImage {
         let (width, height) = self.dimensions();
         let mut data = self.into_raw();
         let entries = data.len();
-        data.reserve_exact(entries.checked_mul(3).unwrap()); // 3 additional channels
-                                                             // set_len is save since type is u8 an the data never read
-        unsafe { data.set_len(entries.checked_mul(4).unwrap()) }; // 4 channels in total
+        data.resize(entries.checked_mul(4).unwrap(), 0);
         let mut buffer = ImageBuffer::from_vec(width, height, data).unwrap();
         expand_packed(&mut buffer, 4, 8, |idx, pixel| {
             let (r, g, b) = palette[idx as usize];

--- a/src/hdr/hdr_decoder.rs
+++ b/src/hdr/hdr_decoder.rs
@@ -128,7 +128,7 @@ pub struct HDRDecoder<R> {
 
 /// Refer to [wikipedia](https://en.wikipedia.org/wiki/RGBE_image_format)
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct RGBE8Pixel {
     /// Color components
     pub c: [u8; 3],
@@ -302,11 +302,7 @@ impl<R: BufRead> HDRDecoder<R> {
         }
         // expression self.width > 0 && self.height > 0 is true from now to the end of this method
         let pixel_count = self.width as usize * self.height as usize;
-        let mut ret = Vec::<RGBE8Pixel>::with_capacity(pixel_count);
-        unsafe {
-            // RGBE8Pixel doesn't implement Drop, so it's Ok to drop half-initialized ret
-            ret.set_len(pixel_count);
-        } // ret contains uninitialized data, so now it's my responsibility to return fully initialized ret
+        let mut ret = vec![Default::default(); pixel_count];
         for chunk in ret.chunks_mut(self.width as usize) {
             try!(read_scanline(&mut self.r, chunk));
         }
@@ -376,17 +372,10 @@ impl<R: BufRead> IntoIterator for HDRDecoder<R> {
     type IntoIter = HDRImageDecoderIterator<R>;
 
     fn into_iter(self) -> Self::IntoIter {
-        // scanline buffer
-        let mut buf = Vec::with_capacity(self.width as usize);
-        unsafe {
-            // dropping half-initialized vector of RGBE8Pixel is safe
-            // and I took care to hide half-initialized vector from a user
-            buf.set_len(self.width as usize);
-        }
         HDRImageDecoderIterator {
             r: self.r,
             scanline_cnt: self.height as usize,
-            buf,
+            buf: vec![Default::default(); self.width as usize],
             col: 0,
             scanline: 0,
             trouble: true, // make first call to `next()` read scanline

--- a/src/image.rs
+++ b/src/image.rs
@@ -686,10 +686,8 @@ pub trait GenericImage: GenericImageView {
 
         for i in 0..other.width() {
             for k in 0..other.height() {
-                unsafe {
-                    let p = other.unsafe_get_pixel(i, k);
-                    self.unsafe_put_pixel(i + x, k + y, p);
-                }
+                let p = other.get_pixel(i, k);
+                self.put_pixel(i + x, k + y, p);
             }
         }
         true

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,7 +1,8 @@
 //!  Utilities
 
+use byteorder::{NativeEndian, ByteOrder};
 use num_iter::range_step;
-use std::{mem, slice};
+use std::mem;
 use std::iter::repeat;
 
 #[inline(always)]
@@ -39,15 +40,7 @@ pub fn vec_u16_into_u8(vec: Vec<u16>) -> Vec<u8> {
 }
 
 pub fn vec_u16_copy_u8(vec: &Vec<u16>) -> Vec<u8> {
-    let original_slice = vec.as_slice();
-    let ptr = original_slice.as_ptr() as *const u8;
-    let len = original_slice.len() * mem::size_of::<u16>();
-
-    // Note: The original pointer points to `len` bytes and all bytes are initialized thus it is
-    // valid for this slice and for the lifetime of the method. Also, the alignment of `u8` is
-    // smaller than that of `u16` as per the assert. The `ptr` is non-null because it originates
-    // from a slice itself.
-    assert!(mem::align_of::<u8>() <= mem::align_of::<u16>());
-    let byte_slice = unsafe { slice::from_raw_parts(ptr, len) };
-    byte_slice.to_owned()
+    let mut new = vec![0; vec.len() * mem::size_of::<u16>()];
+    NativeEndian::write_u16_into(&vec[..], &mut new[..]);
+    new
 }


### PR DESCRIPTION
This is a less extreme version of #887. It leaves the public interface intact but removes a couple of unsafe blocks. 

Fixes #908