### PR TITLE
Fix README example to updated color tuple struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ fn main() {
             }
 
             let pixel = imgbuf.get_pixel_mut(x, y);
-            let data = (*pixel as image::Rgb<u8>).data;
+            let image::Rgb(data) = *pixel;
             *pixel = image::Rgb([data[0], i as u8, data[2]]);
         }
     }


### PR DESCRIPTION
This was missed by CI integration since both PRs were open in the same
timespan but the build job was not restarted after the merge of the
struct rework. This would have to be done manually.