### PR TITLE
Reduce builds on windows and osx to full check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ notifications:
     irc: "irc.mozilla.org#piston-internals"
 os:
     - linux
-    - osx
-    - windows
 rust:
     - 1.24.1
     - stable
@@ -24,6 +22,20 @@ env:
       - FEATURES='tiff'
       - FEATURES='webp'
       - FEATURES='hdr'
+matrix:
+    include:
+        - os: osx
+          rust: 1.24.1
+        - os: windows
+          rust: 1.24.1
+        - os: osx
+          rust: stable
+        - os: windows
+          rust: stable
+        - os: osx
+          rust: nightly
+        - os: windows
+          rust: nightly
 script:
     - if [ -z "$FEATURES" ]; then
         cargo build -v &&


### PR DESCRIPTION
We don't gain any interesting insight with feature flag combinations
other than 'all features' (the default). Still builds on stable and
nightly, but not beta, and 1.24.1 so that we are (somewhat) warned when
a dependency requires updating the minimum compiler version.