### PR TITLE
Error clean up

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -3,7 +3,7 @@ use std::iter::Iterator;
 use num_rational::Ratio;
 
 use buffer::RgbaImage;
-use image::ImageResult;
+use error::ImageResult;
 
 /// An implementation dependent iterator, reading the frames as requested
 pub struct Frames<'a> {

--- a/src/bmp/decoder.rs
+++ b/src/bmp/decoder.rs
@@ -7,7 +7,8 @@ use std::slice::ChunksMut;
 use byteorder::{LittleEndian, ReadBytesExt};
 
 use color::ColorType;
-use image::{self, ImageDecoder, ImageDecoderExt, ImageError, ImageResult, Progress};
+use image::{self, ImageDecoder, ImageDecoderExt, Progress};
+use error::{ImageError, ImageResult};
 
 const BITMAPCOREHEADER_SIZE: u32 = 12;
 const BITMAPINFOHEADER_SIZE: u32 = 40;

--- a/src/bmp/decoder.rs
+++ b/src/bmp/decoder.rs
@@ -679,8 +679,9 @@ impl<R: Read + Seek> BMPDecoder<R> {
             },
             // PNG and JPEG not implemented yet.
             _ => {
-                return Err(ImageError::UnsupportedError(
-                    "Unsupported image type".to_string(),
+                return Err(ImageError::UnsupportedFeature(
+                    ::ImageFormat::BMP,
+                    "Image type".to_string(),
                 ))
             }
         };
@@ -746,8 +747,9 @@ impl<R: Read + Seek> BMPDecoder<R> {
                 BITMAPV4HEADER_SIZE => BMPHeaderType::V4,
                 BITMAPV5HEADER_SIZE => BMPHeaderType::V5,
                 _ => {
-                    return Err(ImageError::UnsupportedError(
-                        "Unsupported Bitmap Header".to_string(),
+                    return Err(ImageError::UnsupportedFeature(
+                        ::ImageFormat::BMP,
+                        "Bitmap Header".to_string(),
                     ))
                 }
             };

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,5 +1,4 @@
 use num_traits::Zero;
-use std::io;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut, Index, IndexMut, Range};
 use std::path::Path;
@@ -9,6 +8,7 @@ use color::{ColorType, FromColor, Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
 use flat::{FlatSamples, SampleLayout};
 use dynimage::save_buffer;
 use image::{GenericImage, GenericImageView};
+use error::ImageResult;
 use traits::Primitive;
 use utils::expand_packed;
 
@@ -511,7 +511,7 @@ where
     ///
     /// The image format is derived from the file extension.
     /// Currently only jpeg and png files are supported.
-    pub fn save<Q>(&self, path: Q) -> io::Result<()>
+    pub fn save<Q>(&self, path: Q) -> ImageResult<()>
     where
         Q: AsRef<Path>,
     {

--- a/src/dxt.rs
+++ b/src/dxt.rs
@@ -10,7 +10,8 @@
 use std::io::{self, Read, Seek, SeekFrom, Write};
 
 use color::ColorType;
-use image::{self, ImageDecoder, ImageDecoderExt, ImageError, ImageReadBuffer, ImageResult, Progress};
+use image::{self, ImageDecoder, ImageDecoderExt, ImageReadBuffer, Progress};
+use error::{ImageError, ImageResult};
 
 /// What version of DXT compression are we using?
 /// Note that DXT2 and DXT4 are left away as they're

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,98 @@
+use std::error::Error;
+use std::fmt;
+use std::io;
+use color::ColorType;
+
+/// An enumeration of Image errors
+#[derive(Debug)]
+pub enum ImageError {
+    /// The Image is not formatted properly
+    FormatError(String),
+
+    /// The Image's dimensions are either too small or too large
+    DimensionError,
+
+    /// The Decoder does not support this image format
+    UnsupportedError(String),
+
+    /// The Decoder does not support this color type
+    UnsupportedColor(ColorType),
+
+    /// Not enough data was provided to the Decoder
+    /// to decode the image
+    NotEnoughData,
+
+    /// An I/O Error occurred while decoding the image
+    IoError(io::Error),
+
+    /// The end of the image has been reached
+    ImageEnd,
+
+    /// There is not enough memory to complete the given operation
+    InsufficientMemory,
+}
+
+impl fmt::Display for ImageError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ImageError::FormatError(ref e) => write!(fmt, "Format error: {}", e),
+            ImageError::DimensionError => write!(
+                fmt,
+                "The Image's dimensions are either too \
+                 small or too large"
+            ),
+            ImageError::UnsupportedError(ref f) => write!(
+                fmt,
+                "The Decoder does not support the \
+                 image format `{}`",
+                f
+            ),
+            ImageError::UnsupportedColor(ref c) => write!(
+                fmt,
+                "The decoder does not support \
+                 the color type `{:?}`",
+                c
+            ),
+            ImageError::NotEnoughData => write!(
+                fmt,
+                "Not enough data was provided to the \
+                 Decoder to decode the image"
+            ),
+            ImageError::IoError(ref e) => e.fmt(fmt),
+            ImageError::ImageEnd => write!(fmt, "The end of the image has been reached"),
+            ImageError::InsufficientMemory => write!(fmt, "Insufficient memory"),
+        }
+    }
+}
+
+impl Error for ImageError {
+    fn description(&self) -> &str {
+        match *self {
+            ImageError::FormatError(..) => "Format error",
+            ImageError::DimensionError => "Dimension error",
+            ImageError::UnsupportedError(..) => "Unsupported error",
+            ImageError::UnsupportedColor(..) => "Unsupported color",
+            ImageError::NotEnoughData => "Not enough data",
+            ImageError::IoError(..) => "IO error",
+            ImageError::ImageEnd => "Image end",
+            ImageError::InsufficientMemory => "Insufficient memory",
+        }
+    }
+
+    // TODO: use `Error::source` when minimal rust version is updated
+    fn cause(&self) -> Option<&Error> {
+        match *self {
+            ImageError::IoError(ref e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<io::Error> for ImageError {
+    fn from(err: io::Error) -> ImageError {
+        ImageError::IoError(err)
+    }
+}
+
+/// Result of an image decoding/encoding process
+pub type ImageResult<T> = Result<T, ImageError>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,7 +16,7 @@ pub enum ImageError {
     /// This image format is not supported
     UnsupportedFormat(String),
 
-    /// The Decoder does not support this color type
+    /// This color type is not supported
     UnsupportedColor(ColorType),
 
     /// Unsupported feature in a image format
@@ -52,8 +52,7 @@ impl fmt::Display for ImageError {
             ),
             ImageError::UnsupportedColor(ref c) => write!(
                 fmt,
-                "The decoder does not support \
-                 the color type `{:?}`",
+                "The color type {:?} is not supported",
                 c
             ),
             ImageError::UnsupportedFeature(ref fo, ref fe) => write!(

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@ use std::error::Error;
 use std::fmt;
 use std::io;
 use color::ColorType;
+use image::ImageFormat;
 
 /// An enumeration of Image errors
 #[derive(Debug)]
@@ -12,11 +13,14 @@ pub enum ImageError {
     /// The Image's dimensions are either too small or too large
     DimensionError,
 
-    /// The Decoder does not support this image format
-    UnsupportedError(String),
+    /// This image format is not supported
+    UnsupportedFormat(String),
 
     /// The Decoder does not support this color type
     UnsupportedColor(ColorType),
+
+    /// Unsupported feature in a image format
+    UnsupportedFeature(ImageFormat, String),
 
     /// Not enough data was provided to the Decoder
     /// to decode the image
@@ -41,10 +45,9 @@ impl fmt::Display for ImageError {
                 "The Image's dimensions are either too \
                  small or too large"
             ),
-            ImageError::UnsupportedError(ref f) => write!(
+            ImageError::UnsupportedFormat(ref f) => write!(
                 fmt,
-                "The Decoder does not support the \
-                 image format `{}`",
+                "The format `{}` is not supported",
                 f
             ),
             ImageError::UnsupportedColor(ref c) => write!(
@@ -52,6 +55,12 @@ impl fmt::Display for ImageError {
                 "The decoder does not support \
                  the color type `{:?}`",
                 c
+            ),
+            ImageError::UnsupportedFeature(ref fo, ref fe) => write!(
+                fmt,
+                "Unsupported `{}` in the format {:?}",
+                fe,
+                fo
             ),
             ImageError::NotEnoughData => write!(
                 fmt,
@@ -70,8 +79,9 @@ impl Error for ImageError {
         match *self {
             ImageError::FormatError(..) => "Format error",
             ImageError::DimensionError => "Dimension error",
-            ImageError::UnsupportedError(..) => "Unsupported error",
+            ImageError::UnsupportedFormat(..) => "Unsupported format",
             ImageError::UnsupportedColor(..) => "Unsupported color",
+            ImageError::UnsupportedFeature(..) => "Unsupported feature",
             ImageError::NotEnoughData => "Not enough data",
             ImageError::IoError(..) => "IO error",
             ImageError::ImageEnd => "Image end",

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -49,7 +49,8 @@ use num_traits::Zero;
 
 use buffer::{ImageBuffer, Pixel};
 use color::ColorType;
-use image::{GenericImage, GenericImageView, ImageError};
+use image::{GenericImage, GenericImageView};
+use error::ImageError;
 
 /// A flat buffer over a (multi channel) image.
 ///

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -186,7 +186,7 @@ impl<R: Read> Iterator for GifFrameIterator<R> {
         // create the image buffer from the raw frame
         let mut image_buffer = match ImageBuffer::from_raw(self.width, self.height, vec) {
             Some(buffer) => buffer,
-            None => return Some(Err(ImageError::UnsupportedError(
+            None => return Some(Err(ImageError::FormatError(
                 "Unknown error occured while reading gif frame".into()
             ))),
         };

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -39,7 +39,8 @@ use animation;
 use buffer::{ImageBuffer, Pixel};
 use color;
 use color::Rgba;
-use image::{AnimationDecoder, ImageDecoder, ImageError, ImageResult};
+use image::{AnimationDecoder, ImageDecoder};
+use error::{ImageError, ImageResult};
 use num_rational::Ratio;
 
 /// GIF decoder

--- a/src/hdr/hdr_decoder.rs
+++ b/src/hdr/hdr_decoder.rs
@@ -11,7 +11,8 @@ use std::path::Path;
 use Primitive;
 
 use color::{ColorType, Rgb};
-use image::{self, ImageDecoder, ImageDecoderExt, ImageError, ImageResult, Progress};
+use image::{self, ImageDecoder, ImageDecoderExt, Progress};
+use error::{ImageError, ImageResult};
 
 /// Adapter to conform to ```ImageDecoder``` trait
 #[derive(Debug)]

--- a/src/hdr/hdr_decoder.rs
+++ b/src/hdr/hdr_decoder.rs
@@ -673,7 +673,7 @@ impl HDRMetadata {
             Some(("FORMAT", val)) => {
                 if val.trim() != "32-bit_rle_rgbe" {
                     // XYZE isn't supported yet
-                    return Err(ImageError::UnsupportedError(limit_string_len(val, 20)));
+                    return Err(ImageError::UnsupportedFeature(::ImageFormat::HDR, format!("Format {}", limit_string_len(val, 20))));
                 }
             }
             Some(("EXPOSURE", val)) => {

--- a/src/hdr/hdr_encoder.rs
+++ b/src/hdr/hdr_encoder.rs
@@ -1,6 +1,8 @@
 use color::Rgb;
 use hdr::{rgbe8, RGBE8Pixel, SIGNATURE};
-use std::io::{Result, Write};
+use std::io::Write;
+
+use error::ImageResult;
 
 /// Radiance HDR encoder
 pub struct HDREncoder<W: Write> {
@@ -15,7 +17,7 @@ impl<W: Write> HDREncoder<W> {
 
     /// Encodes the image ```data```
     /// that has dimensions ```width``` and ```height```
-    pub fn encode(mut self, data: &[Rgb<f32>], width: usize, height: usize) -> Result<()> {
+    pub fn encode(mut self, data: &[Rgb<f32>], width: usize, height: usize) -> ImageResult<()> {
         assert!(data.len() >= width * height);
         let w = &mut self.w;
         try!(w.write_all(SIGNATURE));
@@ -220,8 +222,9 @@ fn rle_compress(data: &[u8], rle: &mut Vec<u8>) {
     }
 }
 
-fn write_rgbe8<W: Write>(w: &mut W, v: RGBE8Pixel) -> Result<()> {
-    w.write_all(&[v.c[0], v.c[1], v.c[2], v.e])
+fn write_rgbe8<W: Write>(w: &mut W, v: RGBE8Pixel) -> ImageResult<()> {
+    w.write_all(&[v.c[0], v.c[1], v.c[2], v.e])?;
+    Ok(())
 }
 
 /// Converts ```Rgb<f32>``` into ```RGBE8Pixel```

--- a/src/ico/decoder.rs
+++ b/src/ico/decoder.rs
@@ -219,8 +219,9 @@ impl<R: Read + Seek> ImageDecoder for ICODecoder<R> {
 
                 // The ICO decoder needs an alpha channel to apply the AND mask.
                 if decoder.colortype() != ColorType::RGBA(8) {
-                    return Err(ImageError::UnsupportedError(
-                        "Unsupported color type".to_string(),
+                    return Err(ImageError::UnsupportedFeature(
+                        ::ImageFormat::ICO,
+                        "Color type".to_string(),
                     ));
                 }
 

--- a/src/ico/decoder.rs
+++ b/src/ico/decoder.rs
@@ -2,7 +2,8 @@ use byteorder::{LittleEndian, ReadBytesExt};
 use std::io::{Cursor, Read, Seek, SeekFrom};
 
 use color::ColorType;
-use image::{ImageDecoder, ImageError, ImageResult};
+use image::ImageDecoder;
+use error::{ImageError, ImageResult};
 
 use self::InnerDecoder::*;
 use bmp::BMPDecoder;

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,5 +1,3 @@
-use std::error::Error;
-use std::fmt;
 use std::io;
 use std::io::Read;
 use std::mem;
@@ -8,104 +6,12 @@ use std::ops::{Deref, DerefMut};
 use buffer::{ImageBuffer, Pixel};
 use color;
 use color::ColorType;
+use error::{ImageError, ImageResult};
 
 use animation::Frames;
 
 #[cfg(feature = "pnm")]
 use pnm::PNMSubtype;
-
-/// An enumeration of Image errors
-#[derive(Debug)]
-pub enum ImageError {
-    /// The Image is not formatted properly
-    FormatError(String),
-
-    /// The Image's dimensions are either too small or too large
-    DimensionError,
-
-    /// The Decoder does not support this image format
-    UnsupportedError(String),
-
-    /// The Decoder does not support this color type
-    UnsupportedColor(ColorType),
-
-    /// Not enough data was provided to the Decoder
-    /// to decode the image
-    NotEnoughData,
-
-    /// An I/O Error occurred while decoding the image
-    IoError(io::Error),
-
-    /// The end of the image has been reached
-    ImageEnd,
-
-    /// There is not enough memory to complete the given operation
-    InsufficientMemory,
-}
-
-impl fmt::Display for ImageError {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        match *self {
-            ImageError::FormatError(ref e) => write!(fmt, "Format error: {}", e),
-            ImageError::DimensionError => write!(
-                fmt,
-                "The Image's dimensions are either too \
-                 small or too large"
-            ),
-            ImageError::UnsupportedError(ref f) => write!(
-                fmt,
-                "The Decoder does not support the \
-                 image format `{}`",
-                f
-            ),
-            ImageError::UnsupportedColor(ref c) => write!(
-                fmt,
-                "The decoder does not support \
-                 the color type `{:?}`",
-                c
-            ),
-            ImageError::NotEnoughData => write!(
-                fmt,
-                "Not enough data was provided to the \
-                 Decoder to decode the image"
-            ),
-            ImageError::IoError(ref e) => e.fmt(fmt),
-            ImageError::ImageEnd => write!(fmt, "The end of the image has been reached"),
-            ImageError::InsufficientMemory => write!(fmt, "Insufficient memory"),
-        }
-    }
-}
-
-impl Error for ImageError {
-    fn description(&self) -> &str {
-        match *self {
-            ImageError::FormatError(..) => "Format error",
-            ImageError::DimensionError => "Dimension error",
-            ImageError::UnsupportedError(..) => "Unsupported error",
-            ImageError::UnsupportedColor(..) => "Unsupported color",
-            ImageError::NotEnoughData => "Not enough data",
-            ImageError::IoError(..) => "IO error",
-            ImageError::ImageEnd => "Image end",
-            ImageError::InsufficientMemory => "Insufficient memory",
-        }
-    }
-
-    fn cause(&self) -> Option<&Error> {
-        match *self {
-            ImageError::IoError(ref e) => Some(e),
-            _ => None,
-        }
-    }
-}
-
-impl From<io::Error> for ImageError {
-    fn from(err: io::Error) -> ImageError {
-        ImageError::IoError(err)
-    }
-}
-
-/// Result of an image decoding/encoding process
-pub type ImageResult<T> = Result<T, ImageError>;
 
 /// An enumeration of supported image formats.
 /// Not all formats support both encoding and decoding.

--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -3,7 +3,8 @@ extern crate jpeg_decoder;
 use std::io::{Cursor, Read};
 
 use color::ColorType;
-use image::{ImageDecoder, ImageError, ImageResult};
+use image::ImageDecoder;
+use error::{ImageError, ImageResult};
 
 /// JPEG decoder
 pub struct JPEGDecoder<R> {

--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -102,9 +102,9 @@ impl From<jpeg_decoder::Error> for ImageError {
         use self::jpeg_decoder::Error::*;
         match err {
             Format(desc) => ImageError::FormatError(desc),
-            Unsupported(desc) => ImageError::UnsupportedError(format!("{:?}", desc)),
+            Unsupported(desc) => ImageError::UnsupportedFeature(::ImageFormat::JPEG, format!("{:?}", desc)),
             Io(err) => ImageError::IoError(err),
-            Internal(err) => ImageError::FormatError(err.description().to_owned()),
+            Internal(err) => ImageError::FormatError(err.to_string()),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@ extern crate quickcheck;
 
 use std::io::Write;
 
+pub use error::{ImageError, ImageResult};
+
 pub use color::ColorType::{self, Gray, GrayA, Palette, RGB, RGBA, BGR, BGRA};
 
 pub use color::{Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
@@ -32,8 +34,6 @@ pub use image::{AnimationDecoder,
                 GenericImageView,
                 ImageDecoder,
                 ImageDecoderExt,
-                ImageError,
-                ImageResult,
                 MutPixels,
                 // Iterators
                 Pixels,
@@ -100,6 +100,7 @@ pub mod tiff;
 #[cfg(feature = "webp")]
 pub mod webp;
 
+mod error;
 mod animation;
 mod buffer;
 mod color;

--- a/src/png.rs
+++ b/src/png.rs
@@ -14,7 +14,8 @@ use std;
 use std::io::{self, Read, Write};
 
 use color::ColorType;
-use image::{ImageDecoder, ImageError, ImageResult};
+use image::ImageDecoder;
+use error::{ImageError, ImageResult};
 
 /// PNG Reader
 ///

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -5,7 +5,8 @@ use std::fmt::Display;
 use super::{ArbitraryHeader, ArbitraryTuplType, BitmapHeader, GraymapHeader, PixmapHeader};
 use super::{HeaderRecord, PNMHeader, PNMSubtype, SampleEncoding};
 use color::ColorType;
-use image::{ImageDecoder, ImageError, ImageResult};
+use image::ImageDecoder;
+use error::{ImageError, ImageResult};
 
 use byteorder::{BigEndian, ByteOrder, NativeEndian};
 

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -223,12 +223,12 @@ impl<R: Read + Seek> TGADecoder<R> {
     /// by 8 and are less than 32.
     fn read_color_information(&mut self) -> ImageResult<()> {
         if self.header.pixel_depth % 8 != 0 {
-            return Err(ImageError::UnsupportedError(
+            return Err(ImageError::FormatError(
                 "Bit depth must be divisible by 8".to_string(),
             ));
         }
         if self.header.pixel_depth > 32 {
-            return Err(ImageError::UnsupportedError(
+            return Err(ImageError::FormatError(
                 "Bit depth must be less than 32".to_string(),
             ));
         }
@@ -239,8 +239,9 @@ impl<R: Read + Seek> TGADecoder<R> {
             self.header.map_entry_size
         } else {
             if num_alpha_bits > self.header.pixel_depth {
-                return Err(ImageError::UnsupportedError(
-                    format!("Color format not supported. Alpha bits: {}", num_alpha_bits)
+                return Err(ImageError::UnsupportedFeature(
+                    ::ImageFormat::TGA,
+                    format!("Color format with {} alpha bits", num_alpha_bits)
                         .to_string(),
                 ));
             }
@@ -258,9 +259,10 @@ impl<R: Read + Seek> TGADecoder<R> {
             (8, 8, false) => self.color_type = ColorType::GrayA(8),
             (0, 8, false) => self.color_type = ColorType::Gray(8),
             _ => {
-                return Err(ImageError::UnsupportedError(
+                return Err(ImageError::UnsupportedFeature(
+                    ::ImageFormat::TGA,
                     format!(
-                        "Color format not supported. Bit depth: {}, Alpha bits: {}",
+                        "Color format with bit depth: {} and alpha bits: {}",
                         other_channel_bits, num_alpha_bits
                     ).to_string(),
                 ))

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -3,7 +3,8 @@ use std::io;
 use std::io::{Read, Seek};
 
 use color::ColorType;
-use image::{ImageDecoder, ImageError, ImageReadBuffer, ImageResult};
+use image::{ImageDecoder, ImageReadBuffer};
+use error::{ImageError, ImageResult};
 
 enum ImageType {
     NoImageData = 0,

--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -46,7 +46,7 @@ impl From<tiff::TiffError> for ImageError {
         match err {
             tiff::TiffError::IoError(err) => ImageError::IoError(err),
             tiff::TiffError::FormatError(desc) => ImageError::FormatError(desc.to_string()),
-            tiff::TiffError::UnsupportedError(desc) => ImageError::UnsupportedError(desc.to_string()),
+            tiff::TiffError::UnsupportedError(desc) => ImageError::UnsupportedFeature(::ImageFormat::TIFF, desc.to_string()),
         }
     }
 }

--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -11,7 +11,8 @@ extern crate tiff;
 use std::io::{Cursor, Read, Seek};
 
 use color::ColorType;
-use image::{ImageDecoder, ImageResult, ImageError};
+use image::ImageDecoder;
+use error::{ImageError, ImageResult};
 use utils::vec_u16_into_u8;
 
 /// Decoder for TIFF images.

--- a/src/webp/decoder.rs
+++ b/src/webp/decoder.rs
@@ -3,9 +3,8 @@ use std::default::Default;
 use std::io;
 use std::io::{Cursor, Read};
 
-use image;
 use image::ImageDecoder;
-use image::ImageResult;
+use error::{ImageError, ImageResult};
 
 use color;
 
@@ -43,13 +42,13 @@ impl<R: Read> WebpDecoder<R> {
         try!(self.r.by_ref().take(4).read_to_end(&mut webp));
 
         if &*riff != b"RIFF" {
-            return Err(image::ImageError::FormatError(
+            return Err(ImageError::FormatError(
                 "Invalid RIFF signature.".to_string(),
             ));
         }
 
         if &*webp != b"WEBP" {
-            return Err(image::ImageError::FormatError(
+            return Err(ImageError::FormatError(
                 "Invalid WEBP signature.".to_string(),
             ));
         }
@@ -62,7 +61,7 @@ impl<R: Read> WebpDecoder<R> {
         try!(self.r.by_ref().take(4).read_to_end(&mut vp8));
 
         if &*vp8 != b"VP8 " {
-            return Err(image::ImageError::FormatError(
+            return Err(ImageError::FormatError(
                 "Invalid VP8 signature.".to_string(),
             ));
         }

--- a/tests/reference_images.rs
+++ b/tests/reference_images.rs
@@ -46,6 +46,7 @@ fn render_images() {
             // Do not fail on unsupported error
             // This might happen because the testsuite contains unsupported images
             // or because a specific decoder included via a feature.
+            Err(image::ImageError::UnsupportedFormat(..)) => return,
             Err(image::ImageError::UnsupportedFeature(..)) => return,
             Err(err) => panic!(format!("decoding of {:?} failed with: {}", path, err)),
         };
@@ -80,6 +81,7 @@ fn check_references() {
             // Do not fail on unsupported error
             // This might happen because the testsuite contains unsupported images
             // or because a specific decoder included via a feature.
+            Err(image::ImageError::UnsupportedFormat(..)) => return,
             Err(image::ImageError::UnsupportedFeature(..)) => return,
             Err(err) => panic!(format!("{}", err)),
         };
@@ -117,6 +119,7 @@ fn check_references() {
             // Do not fail on unsupported error
             // This might happen because the testsuite contains unsupported images
             // or because a specific decoder included via a feature.
+            Err(image::ImageError::UnsupportedFormat(..)) => return,
             Err(image::ImageError::UnsupportedFeature(..)) => return,
             Err(err) => panic!(format!("decoding of {:?} failed with: {}", path, err)),
         };

--- a/tests/reference_images.rs
+++ b/tests/reference_images.rs
@@ -46,7 +46,7 @@ fn render_images() {
             // Do not fail on unsupported error
             // This might happen because the testsuite contains unsupported images
             // or because a specific decoder included via a feature.
-            Err(image::ImageError::UnsupportedError(_)) => return,
+            Err(image::ImageError::UnsupportedFeature(..)) => return,
             Err(err) => panic!(format!("decoding of {:?} failed with: {}", path, err)),
         };
         let mut crc = Crc32::new();
@@ -80,7 +80,7 @@ fn check_references() {
             // Do not fail on unsupported error
             // This might happen because the testsuite contains unsupported images
             // or because a specific decoder included via a feature.
-            Err(image::ImageError::UnsupportedError(_)) => return,
+            Err(image::ImageError::UnsupportedFeature(..)) => return,
             Err(err) => panic!(format!("{}", err)),
         };
 
@@ -117,7 +117,7 @@ fn check_references() {
             // Do not fail on unsupported error
             // This might happen because the testsuite contains unsupported images
             // or because a specific decoder included via a feature.
-            Err(image::ImageError::UnsupportedError(_)) => return,
+            Err(image::ImageError::UnsupportedFeature(..)) => return,
             Err(err) => panic!(format!("decoding of {:?} failed with: {}", path, err)),
         };
         let mut test_crc = Crc32::new();


### PR DESCRIPTION
This is a start towards cleaning up error handling in this library, there is still a lot to do and it can be we want to rethink error handling somewhat, having error variants for specific decoders like a `ImageError::PngError` vs general variants like `ImageError::FormatError`. See some discussion in #921.

This should fix #921