### PR TITLE
rework open() to use magic bytes with a fallback on file extension, fixes #577

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -927,8 +927,9 @@ pub fn load<R: Read + Seek>(r: R, format: ImageFormat) -> ImageResult<DynamicIma
 
 fn load_guess<R: Read + Seek>(mut r: R) -> ImageResult<DynamicImage> {
     let mut buffer: [u8; 16] = [0u8; 16];
+    let cur = r.seek(SeekFrom::Current(0))?;
     r.read_exact(&mut buffer[..])?;
-    r.seek(SeekFrom::Start(0))?;
+    r.seek(SeekFrom::Start(cur))?;
     load(r, guess_format(&buffer)?)
 }
 

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -767,19 +767,6 @@ fn open_impl(path: &Path) -> ImageResult<DynamicImage> {
     load(BufReader::new(&fin), format)
 }
 
-/// Open the image located at the path specified.
-/// The image's format is determined from the file header magic bytes.
-pub fn open_magic<P>(path: P) -> ImageResult<DynamicImage>
-where
-    P: AsRef<Path>,
-{
-    let fin = match File::open(path) {
-        Ok(f) => f,
-        Err(err) => return Err(image::ImageError::IoError(err)),
-    };
-    load_guess(BufReader::new(fin))
-}
-
 /// Read the dimensions of the image located at the specified path.
 /// This is faster than fully loading the image and then getting its dimensions.
 pub fn image_dimensions<P>(path: P) -> ImageResult<(u32, u32)>

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -736,8 +736,14 @@ fn open_impl(path: &Path) -> ImageResult<DynamicImage> {
 
     match load_guess(BufReader::new(&fin)) {
         Ok(im) => return Ok(im),
-        Err(_e) => {
-            // println!("load_guess failed loading {}: {} - failling back to extension format matching", path.display(), e);
+        Err(e) => {
+            match e {
+                image::ImageError::UnsupportedError(_) => {
+                    // fall-thru to extension based detection (should only happen for TGA images)
+                    // println!("load_guess failed loading {}: {}", path.display(), e);
+                }
+                _ => return Err(e),
+            };
         }
     };
 
@@ -1112,13 +1118,5 @@ mod test {
         let im_path = "./tests/images/jpg/progressive/cat.jpg";
         let dims = super::image_dimensions(im_path).unwrap();
         assert_eq!(dims, (320, 240));
-    }
-
-    #[cfg(feature = "jpeg")]
-    #[test]
-    fn open_magic() {
-        let im_path = "./tests/images/jpg/progressive/cat.jpg";
-        let im = super::open_magic(im_path).unwrap();
-        assert_eq!(im.raw_pixels().len(), 230400);
     }
 }

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -767,11 +767,6 @@ pub fn open_magic<P>(path: P) -> ImageResult<DynamicImage>
 where
     P: AsRef<Path>,
 {
-    // thin wrapper function to strip generics before calling open_magic_impl
-    open_magic_impl(path.as_ref())
-}
-
-fn open_magic_impl(path: &Path) -> ImageResult<DynamicImage> {
     let fin = match File::open(path) {
         Ok(f) => f,
         Err(err) => return Err(image::ImageError::IoError(err)),
@@ -933,11 +928,9 @@ pub fn load<R: BufRead + Seek>(r: R, format: ImageFormat) -> ImageResult<Dynamic
 
 fn load_guess<R: BufRead + Seek>(mut r: R) -> ImageResult<DynamicImage> {
     let mut buffer: [u8; 16] = [0u8; 16];
-    r.read(&mut buffer[..])?;
+    r.read_exact(&mut buffer[..])?;
     r.seek(SeekFrom::Start(0))?;
-
-    let format = guess_format(&buffer)?;
-    load(r, format)
+    load(r, guess_format(&buffer)?)
 }
 
 static MAGIC_BYTES: [(&'static [u8], ImageFormat); 17] = [

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -1,7 +1,7 @@
 use num_iter;
 use std::fs::File;
 use std::io;
-use std::io::{BufRead, BufReader, BufWriter, Seek, SeekFrom, Write};
+use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 use std::u32;
 
@@ -901,7 +901,7 @@ fn save_buffer_impl(
 }
 
 /// Create a new image from a Reader
-pub fn load<R: BufRead + Seek>(r: R, format: ImageFormat) -> ImageResult<DynamicImage> {
+pub fn load<R: Read + Seek>(r: R, format: ImageFormat) -> ImageResult<DynamicImage> {
     #[allow(deprecated, unreachable_patterns)]
     // Default is unreachable if all features are supported.
     match format {
@@ -932,7 +932,7 @@ pub fn load<R: BufRead + Seek>(r: R, format: ImageFormat) -> ImageResult<Dynamic
     }
 }
 
-fn load_guess<R: BufRead + Seek>(mut r: R) -> ImageResult<DynamicImage> {
+fn load_guess<R: Read + Seek>(mut r: R) -> ImageResult<DynamicImage> {
     let mut buffer: [u8; 16] = [0u8; 16];
     r.read_exact(&mut buffer[..])?;
     r.seek(SeekFrom::Start(0))?;

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -733,7 +733,13 @@ fn open_impl(path: &Path) -> ImageResult<DynamicImage> {
         Ok(f) => f,
         Err(err) => return Err(image::ImageError::IoError(err)),
     };
-    let fin = BufReader::new(fin);
+
+    match load_guess(BufReader::new(&fin)) {
+        Ok(im) => return Ok(im),
+        Err(_e) => {
+            // println!("load_guess failed loading {}: {} - failling back to extension format matching", path.display(), e);
+        }
+    };
 
     let ext = path.extension()
         .and_then(|s| s.to_str())
@@ -758,7 +764,7 @@ fn open_impl(path: &Path) -> ImageResult<DynamicImage> {
         }
     };
 
-    load(fin, format)
+    load(BufReader::new(&fin), format)
 }
 
 /// Open the image located at the path specified.

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -945,8 +945,8 @@ static MAGIC_BYTES: [(&'static [u8], ImageFormat); 17] = [
     (b"GIF89a", ImageFormat::GIF),
     (b"GIF87a", ImageFormat::GIF),
     (b"RIFF", ImageFormat::WEBP), // TODO: better magic byte detection, see https://github.com/image-rs/image/issues/660
-    (b"MM.*", ImageFormat::TIFF),
-    (b"II*.", ImageFormat::TIFF),
+    (b"MM\x00*", ImageFormat::TIFF),
+    (b"II*\x00", ImageFormat::TIFF),
     (b"BM", ImageFormat::BMP),
     (&[0, 0, 1, 0], ImageFormat::ICO),
     (b"#?RADIANCE", ImageFormat::HDR),


### PR DESCRIPTION
Not fully satisfied with the function name but I'm out of ideas.