### PR TITLE
Add templates for issues and pull request

### DIFF
--- a/docs/ISSUE_TEMPLATE/bug-template.md
+++ b/docs/ISSUE_TEMPLATE/bug-template.md
@@ -1,0 +1,19 @@
+----
+labels: bug
+name: Bug report
+about: Reporting a bug
+----
+
+This happens in ,...
+
+## Expected
+
+What behaviour should have happened
+
+## Actual behaviour
+
+What did happen
+
+## Reproduction steps
+
+Provide source code, a repository link, or steps

--- a/docs/PULL_REQUEST_TEMPLATE/pull-request.md
+++ b/docs/PULL_REQUEST_TEMPLATE/pull-request.md
@@ -1,0 +1,13 @@
+-----
+name: Pull request
+about: Default template with contributor agreement
+-----
+<!-- 
+If you are a new contributor, consent to licensing by including this text:
+
+I license past and future contributions under the dual MIT/Apache-2.0 license,
+allowing licensees to chose either at their option.
+
+Thank you for contributing, you can delete this comment.
+-->
+


### PR DESCRIPTION
Github documentation makes it harder than necessary to create this
outside the webinterface but hopefully this is correct.