### PR TITLE
Fix a regression in the DXT encoder.

### DIFF
--- a/src/dxt.rs
+++ b/src/dxt.rs
@@ -618,7 +618,7 @@ fn encode_dxt_colors(source: &[u8], dest: &mut [u8]) {
             swap(&mut color0, &mut color1);
             // Indexes are packed 2 bits wide, swap index 0/1 but preserve 2/3.
             let filter = (chosen_indices & 0xAAAA_AAAA) >> 1;
-            chosen_indices ^= filter ^ 0x555_5555;
+            chosen_indices ^= filter ^ 0x5555_5555;
         }
     } else if !chosen_use_0 {
         swap(&mut color0, &mut color1);


### PR DESCRIPTION
I think someone made an accidental typo while doing cargo fmt and clippy fixing. This error would occasionally cause 2 pixels in a DXT block to be encoded wrong.

This commit simply restores the line of code to how it was before.

If necessary: I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.