### PR TITLE
Always use custom struct for ImageDecoder::Reader

### DIFF
--- a/src/bmp/decoder.rs
+++ b/src/bmp/decoder.rs
@@ -1,6 +1,5 @@
-use std::cmp;
-use std::io;
-use std::io::{Cursor, Read, Seek, SeekFrom};
+use std::{cmp, mem};
+use std::io::{self, Cursor, Read, Seek, SeekFrom};
 use std::iter::{repeat, Iterator, Rev};
 use std::slice::ChunksMut;
 
@@ -1255,8 +1254,24 @@ impl<R: Read + Seek> BMPDecoder<R> {
     }
 }
 
+/// Wrapper struct around a `Cursor<Vec<u8>>`
+pub struct BmpReader(Cursor<Vec<u8>>);
+impl Read for BmpReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        if self.0.position() == 0 && buf.is_empty() {
+            mem::swap(buf, self.0.get_mut());
+            Ok(buf.len())
+        } else {
+            self.0.read_to_end(buf)
+        }
+    }
+}
+
 impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for BMPDecoder<R> {
-    type Reader = Cursor<Vec<u8>>;
+    type Reader = BmpReader;
 
     fn dimensions(&self) -> (u64, u64) {
         (self.width as u64, self.height as u64)
@@ -1271,7 +1286,7 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for BMPDecoder<R> {
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
-        Ok(Cursor::new(self.read_image()?))
+        Ok(BmpReader(Cursor::new(self.read_image()?)))
     }
 
     fn read_image(mut self) -> ImageResult<Vec<u8>> {

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -31,6 +31,7 @@ extern crate num_rational;
 
 use std::clone::Clone;
 use std::io::{self, Cursor, Read, Write};
+use std::marker::PhantomData;
 use std::mem;
 
 use self::gif::{ColorOutput, SetParameter};
@@ -61,8 +62,8 @@ impl<R: Read> Decoder<R> {
 }
 
 /// Wrapper struct around a `Cursor<Vec<u8>>`
-pub struct GifReader(Cursor<Vec<u8>>);
-impl Read for GifReader {
+pub struct GifReader<R>(Cursor<Vec<u8>>, PhantomData<R>);
+impl<R> Read for GifReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.0.read(buf)
     }
@@ -77,7 +78,7 @@ impl Read for GifReader {
 }
 
 impl<'a, R: 'a + Read> ImageDecoder<'a> for Decoder<R> {
-    type Reader = GifReader;
+    type Reader = GifReader<R>;
 
     fn dimensions(&self) -> (u64, u64) {
         (self.reader.width() as u64, self.reader.height() as u64)
@@ -88,7 +89,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for Decoder<R> {
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
-        Ok(GifReader(Cursor::new(self.read_image()?)))
+        Ok(GifReader(Cursor::new(self.read_image()?), PhantomData))
     }
 
     fn read_image(mut self) -> ImageResult<Vec<u8>> {

--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -1,6 +1,7 @@
 extern crate jpeg_decoder;
 
-use std::io::{Cursor, Read};
+use std::io::{self, Cursor, Read};
+use std::mem;
 
 use color::ColorType;
 use image::{ImageDecoder, ImageError, ImageResult};
@@ -31,8 +32,24 @@ impl<R: Read> JPEGDecoder<R> {
     }
 }
 
+/// Wrapper struct around a `Cursor<Vec<u8>>`
+pub struct JpegReader(Cursor<Vec<u8>>);
+impl Read for JpegReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        if self.0.position() == 0 && buf.is_empty() {
+            mem::swap(buf, self.0.get_mut());
+            Ok(buf.len())
+        } else {
+            self.0.read_to_end(buf)
+        }
+    }
+}
+
 impl<'a, R: 'a + Read> ImageDecoder<'a> for JPEGDecoder<R> {
-    type Reader = Cursor<Vec<u8>>;
+    type Reader = JpegReader;
 
     fn dimensions(&self) -> (u64, u64) {
         (self.metadata.width as u64, self.metadata.height as u64)
@@ -43,7 +60,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for JPEGDecoder<R> {
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
-        Ok(Cursor::new(self.read_image()?))
+        Ok(JpegReader(Cursor::new(self.read_image()?)))
     }
 
     fn read_image(mut self) -> ImageResult<Vec<u8>> {

--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -1,6 +1,7 @@
 extern crate jpeg_decoder;
 
 use std::io::{self, Cursor, Read};
+use std::marker::PhantomData;
 use std::mem;
 
 use color::ColorType;
@@ -33,8 +34,8 @@ impl<R: Read> JPEGDecoder<R> {
 }
 
 /// Wrapper struct around a `Cursor<Vec<u8>>`
-pub struct JpegReader(Cursor<Vec<u8>>);
-impl Read for JpegReader {
+pub struct JpegReader<R>(Cursor<Vec<u8>>, PhantomData<R>);
+impl<R> Read for JpegReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.0.read(buf)
     }
@@ -49,7 +50,7 @@ impl Read for JpegReader {
 }
 
 impl<'a, R: 'a + Read> ImageDecoder<'a> for JPEGDecoder<R> {
-    type Reader = JpegReader;
+    type Reader = JpegReader<R>;
 
     fn dimensions(&self) -> (u64, u64) {
         (self.metadata.width as u64, self.metadata.height as u64)
@@ -60,7 +61,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for JPEGDecoder<R> {
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
-        Ok(JpegReader(Cursor::new(self.read_image()?)))
+        Ok(JpegReader(Cursor::new(self.read_image()?), PhantomData))
     }
 
     fn read_image(mut self) -> ImageResult<Vec<u8>> {


### PR DESCRIPTION
As @HeroicKatora pointed out, changing the Reader type of a Decoder is a breaking change. Thus have all Decoders use an opaque struct as their Reader type instead of `Cursor<Vec<u8>>`. This way we can trigger all the breakage now and be able to add incremental decoding without breaking downstream users.

Side note: In this PR I made all newly added types follow the current Rust naming convention of capitalizing only the first letter of an acronym (i.e. GifReader rather than GIFReader). I can change this if desired.