### PR TITLE
Update tiff to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ version = "0.1"
 optional = true
 
 [dependencies.tiff]
-version = "0.2.0"
+version = "0.3.0"
 optional = true
 
 [dev-dependencies]

--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -48,6 +48,7 @@ impl From<tiff::TiffError> for ImageError {
             tiff::TiffError::IoError(err) => ImageError::IoError(err),
             tiff::TiffError::FormatError(desc) => ImageError::FormatError(desc.to_string()),
             tiff::TiffError::UnsupportedError(desc) => ImageError::UnsupportedError(desc.to_string()),
+            tiff::TiffError::LimitsExceeded => ImageError::InsufficientMemory,
         }
     }
 }


### PR DESCRIPTION
I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.