### PR TITLE
Remove pixels_mut and deprecate unsafe_get_pixel/unsafe_set_pixel

### DIFF
--- a/src/flat.rs
+++ b/src/flat.rs
@@ -1444,37 +1444,6 @@ mod tests {
     }
 
     #[test]
-    fn mutable_view() {
-        let mut buffer = FlatSamples {
-            samples: [0; 18],
-            layout: SampleLayout {
-                channels: 2,
-                channel_stride: 1,
-                width: 3,
-                width_stride: 2,
-                height: 3,
-                height_stride: 6,
-            },
-            color_hint: None,
-        };
-
-        {
-            let mut view = buffer.as_view_mut::<LumaA<usize>>()
-                .expect("This should be a valid mutable buffer");
-            #[allow(deprecated)]
-            let pixel_count = view.pixels_mut()
-                .enumerate()
-                .map(|(idx, (_, _, pixel))| *pixel = LumaA([2*idx, 2*idx + 1]))
-                .count();
-            assert_eq!(pixel_count, 9);
-        }
-
-        buffer.samples.iter()
-            .enumerate()
-            .for_each(|(idx, sample)| assert_eq!(idx, *sample));
-    }
-
-    #[test]
     fn normal_forms() {
         assert!(FlatSamples {
             samples: [0u8; 0],

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -1418,7 +1418,7 @@ impl PartialOrd for NormalForm {
 mod tests {
     use super::*;
     use buffer::GrayAlphaImage;
-    use color::{LumaA, Rgb};
+    use color::Rgb;
 
     #[test]
     fn aliasing_view() {

--- a/src/image.rs
+++ b/src/image.rs
@@ -2,7 +2,6 @@ use std::error::Error;
 use std::fmt;
 use std::io;
 use std::io::Read;
-use std::mem;
 use std::ops::{Deref, DerefMut};
 
 use buffer::{ImageBuffer, Pixel};

--- a/src/image.rs
+++ b/src/image.rs
@@ -542,7 +542,7 @@ pub trait GenericImageView {
     /// Returns the pixel located at (x, y)
     ///
     /// This function can be implemented in a way that ignores bounds checking.
-    #[deprecated]
+    #[deprecated = "Generally offers little advantage over get_pixel. If you must, prefer dedicated methods or other realizations on the specific image type instead."]
     unsafe fn unsafe_get_pixel(&self, x: u32, y: u32) -> Self::Pixel {
         self.get_pixel(x, y)
     }
@@ -595,7 +595,7 @@ pub trait GenericImage: GenericImageView {
     /// Puts a pixel at location (x, y)
     ///
     /// This function can be implemented in a way that ignores bounds checking.
-    #[deprecated]
+    #[deprecated = "Generally offers little advantage over put_pixel. If you must, prefer dedicated methods or other realizations on the specific image type instead."]
     unsafe fn unsafe_put_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel) {
         self.put_pixel(x, y, pixel);
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -543,6 +543,7 @@ pub trait GenericImageView {
     /// Returns the pixel located at (x, y)
     ///
     /// This function can be implemented in a way that ignores bounds checking.
+    #[deprecated]
     unsafe fn unsafe_get_pixel(&self, x: u32, y: u32) -> Self::Pixel {
         self.get_pixel(x, y)
     }
@@ -595,6 +596,7 @@ pub trait GenericImage: GenericImageView {
     /// Puts a pixel at location (x, y)
     ///
     /// This function can be implemented in a way that ignores bounds checking.
+    #[deprecated]
     unsafe fn unsafe_put_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel) {
         self.put_pixel(x, y, pixel);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,6 @@ pub use image::{AnimationDecoder,
                 ImageDecoderExt,
                 ImageError,
                 ImageResult,
-                MutPixels,
                 // Iterators
                 Pixels,
                 SubImage};


### PR DESCRIPTION
This is a continuation of the effort to purge unsafe code from the image crate.