### PR TITLE
Note TIFF encoding support in README (minor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ https://docs.rs/image
 | GIF    | Yes | Yes |
 | BMP    | Yes | RGB(8), RGBA(8), Gray(8), GrayA(8) |
 | ICO    | Yes | Yes |
-| TIFF   | Baseline(no fax support) + LZW + PackBits | No |
+| TIFF   | Baseline(no fax support) + LZW + PackBits | RGB(8), RGBA(8), Gray(8) |
 | Webp   | Lossy(Luma channel only) | No |
 | PNM    | PBM, PGM, PPM, standard PAM | Yes |
 


### PR DESCRIPTION
Trivial change, but this feature is important to note.

I've contributed before, but it was awhile ago, so:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

