### PR TITLE
Bump compiler requirements to 1.34.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ notifications:
 os:
     - linux
 rust:
-    - 1.24.1
+    - 1.34.2
     - stable
     - beta
     - nightly
@@ -25,9 +25,9 @@ env:
 matrix:
     include:
         - os: osx
-          rust: 1.24.1
+          rust: 1.34.2
         - os: windows
-          rust: 1.24.1
+          rust: 1.34.2
         - os: osx
           rust: stable
         - os: windows


### PR DESCRIPTION
The version supports edition=2018 and several `const` improvements. It
is also the one shipped with current Debian stable (Buster, released one
day ago).

Since the oldest version supporting the new edition is not 18 weeks
older than the chosen one. But the stabilization of TryFrom, several
integer const functions, integer atomics and NonZero_ types are not
unlikely to get used eventually.

This PR is provided independent from the release PR to get last-minute
fixes the opportunity of good CI support. Does not affect the `0.21` branch.
