### PR TITLE
Save image with specified format

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -775,6 +775,9 @@ where
 {
     /// Saves the buffer to a file at the specified path in
     /// the specified format.
+    ///
+    /// See [`save_buffer_with_format`](fn.save_buffer_with_format.html) for
+    /// supported types.
     pub fn save_with_format<Q>(&self, path: Q, format: ImageFormat) -> io::Result<()>
     where
         Q: AsRef<Path>,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -773,7 +773,7 @@ where
     P: Pixel<Subpixel = u8> + 'static,
     Container: Deref<Target = [u8]>,
 {
-    /// Saves the buffer to a file at the path specified in
+    /// Saves the buffer to a file at the specified path in
     /// the specified format.
     pub fn save_with_format<Q>(&self, path: Q, format: ImageFormat) -> io::Result<()>
     where

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -7,8 +7,8 @@ use std::slice::{Chunks, ChunksMut};
 
 use color::{ColorType, FromColor, Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
 use flat::{FlatSamples, SampleLayout};
-use dynimage::save_buffer;
-use image::{GenericImage, GenericImageView};
+use dynimage::{save_buffer, save_buffer_with_format};
+use image::{GenericImage, GenericImageView, ImageFormat};
 use traits::Primitive;
 use utils::expand_packed;
 
@@ -764,6 +764,29 @@ where
             self.width(),
             self.height(),
             <P as Pixel>::COLOR_TYPE,
+        )
+    }
+}
+
+impl<P, Container> ImageBuffer<P, Container>
+where
+    P: Pixel<Subpixel = u8> + 'static,
+    Container: Deref<Target = [u8]>,
+{
+    /// Saves the buffer to a file at the path specified in
+    /// the specified format.
+    pub fn save_with_format<Q>(&self, path: Q, format: ImageFormat) -> io::Result<()>
+    where
+        Q: AsRef<Path>,
+    {
+        // This is valid as the subpixel is u8.
+        save_buffer_with_format(
+            path,
+            self,
+            self.width(),
+            self.height(),
+            <P as Pixel>::COLOR_TYPE,
+            format,
         )
     }
 }

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -567,6 +567,9 @@ impl DynamicImage {
 
     /// Saves the buffer to a file at the specified path in
     /// the specified format.
+    ///
+    /// See [`save_buffer_with_format`](fn.save_buffer_with_format.html) for
+    /// supported types.
     pub fn save_with_format<Q>(&self, path: Q, format: ImageFormat) -> io::Result<()>
     where
         Q: AsRef<Path>,
@@ -898,7 +901,7 @@ fn save_buffer_impl(
 /// The buffer is assumed to have the correct format according
 /// to the specified color type.
 /// This will lead to corrupted files if the buffer contains
-/// malformed data. Currently only jpeg, png, ico, pnm, bmp and
+/// malformed data. Currently only jpeg, png, ico, bmp and
 /// tiff files are supported.
 pub fn save_buffer_with_format<P>(
     path: P,

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -565,7 +565,7 @@ impl DynamicImage {
         })
     }
 
-    /// Saves the buffer to a file at the path specified in
+    /// Saves the buffer to a file at the specified path in
     /// the specified format.
     pub fn save_with_format<Q>(&self, path: Q, format: ImageFormat) -> io::Result<()>
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub use traits::Primitive;
 
 // Opening and loading images
 pub use dynimage::{guess_format, load, load_from_memory, load_from_memory_with_format, open,
-                   save_buffer, image_dimensions};
+                   save_buffer, save_buffer_with_format, image_dimensions};
 
 pub use dynimage::DynamicImage::{self, ImageLuma8, ImageLumaA8, ImageRgb8, ImageRgba8, ImageBgr8, ImageBgra8};
 


### PR DESCRIPTION
Ran into the use case where I wanted to save an image without specifying the file extension in the filename. This PR lets you do just that:
```rust
img.save_with_format(&"path/to/img_file", ImageFormat::PNG);
```
I'm not sure if this is a wanted addition or not, so I'm mostly looking for feedback.

I used the `image::ImageFormat` enum for accepting formats. This enum doesn't include `pbm`, `pgm`, `ppm`, and `pam`, so I left those out as I'm not familiar enough with the library to make changes to the enum. Alternatively we can just make another enum.

------
I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.