### PR TITLE
Style fixes

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -7,12 +7,12 @@ use image::ImageResult;
 
 /// An implementation dependent iterator, reading the frames as requested
 pub struct Frames<'a> {
-    iterator: Box<Iterator<Item = ImageResult<Frame>> + 'a>
+    iterator: Box<dyn Iterator<Item = ImageResult<Frame>> + 'a>
 }
 
 impl<'a> Frames<'a> {
     /// Creates a new `Frames` from an implementation specific iterator.
-    pub fn new(iterator: Box<Iterator<Item = ImageResult<Frame>> + 'a>) -> Self {
+    pub fn new(iterator: Box<dyn Iterator<Item = ImageResult<Frame>> + 'a>) -> Self {
         Frames { iterator }
     }
 

--- a/src/bmp/decoder.rs
+++ b/src/bmp/decoder.rs
@@ -217,19 +217,19 @@ where
 
     if !top_down {
         for row in buffer.chunks_mut(row_width).rev() {
-            try!(func(row));
+            func(row)?;
         }
 
         // If we need more space, extend the buffer.
         if buffer.len() < full_image_size {
             let new_space = extend_buffer(buffer, full_image_size, false);
             for row in new_space.chunks_mut(row_width).rev() {
-                try!(func(row));
+                func(row)?;
             }
         }
     } else {
         for row in buffer.chunks_mut(row_width) {
-            try!(func(row));
+            func(row)?;
         }
         if buffer.len() < full_image_size {
             // If the image is stored in top-down order, we can simply use the extend function
@@ -238,7 +238,7 @@ where
             buffer.extend(repeat(0xFF).take(extend));
             let len = buffer.len();
             for row in buffer[len - row_width..].chunks_mut(row_width) {
-                try!(func(row));
+                func(row)?;
             }
         };
     }
@@ -410,10 +410,10 @@ impl Bitfields {
         max_len: u32,
     ) -> ImageResult<Bitfields> {
         let bitfields = Bitfields {
-            r: try!(Bitfield::from_mask(r_mask, max_len)),
-            g: try!(Bitfield::from_mask(g_mask, max_len)),
-            b: try!(Bitfield::from_mask(b_mask, max_len)),
-            a: try!(Bitfield::from_mask(a_mask, max_len)),
+            r: Bitfield::from_mask(r_mask, max_len)?,
+            g: Bitfield::from_mask(g_mask, max_len)?,
+            b: Bitfield::from_mask(b_mask, max_len)?,
+            a: Bitfield::from_mask(a_mask, max_len)?,
         };
         if bitfields.r.len == 0 || bitfields.g.len == 0 || bitfields.b.len == 0 {
             return Err(ImageError::FormatError("Missing bitfield mask".to_string()));
@@ -571,7 +571,7 @@ impl<R: Read + Seek> BMPDecoder<R> {
             return Ok(());
         }
         let mut signature = [0; 2];
-        try!(self.r.read_exact(&mut signature));
+        self.r.read_exact(&mut signature)?;
 
         if signature != b"BM"[..] {
             return Err(ImageError::FormatError(
@@ -581,8 +581,8 @@ impl<R: Read + Seek> BMPDecoder<R> {
 
         // The next 8 bytes represent file size, followed the 4 reserved bytes
         // We're not interesting these values
-        try!(self.r.read_u32::<LittleEndian>());
-        try!(self.r.read_u32::<LittleEndian>());
+        self.r.read_u32::<LittleEndian>()?;
+        self.r.read_u32::<LittleEndian>()?;
 
         self.data_offset = u64::from(self.r.read_u32::<LittleEndian>()?);
 
@@ -611,7 +611,7 @@ impl<R: Read + Seek> BMPDecoder<R> {
             ));
         }
 
-        self.bit_count = try!(self.r.read_u16::<LittleEndian>());
+        self.bit_count = self.r.read_u16::<LittleEndian>()?;
         self.image_type = match self.bit_count {
             1 | 4 | 8 => ImageType::Palette,
             24 => ImageType::RGB24,
@@ -626,8 +626,8 @@ impl<R: Read + Seek> BMPDecoder<R> {
     ///
     /// returns Err if any of the values are invalid.
     fn read_bitmap_info_header(&mut self) -> ImageResult<()> {
-        self.width = try!(self.r.read_i32::<LittleEndian>());
-        self.height = try!(self.r.read_i32::<LittleEndian>());
+        self.width = self.r.read_i32::<LittleEndian>()?;
+        self.height = self.r.read_i32::<LittleEndian>()?;
 
         // Width can not be negative
         if self.width < 0 {
@@ -661,8 +661,8 @@ impl<R: Read + Seek> BMPDecoder<R> {
             ));
         }
 
-        self.bit_count = try!(self.r.read_u16::<LittleEndian>());
-        let image_type_u32 = try!(self.r.read_u32::<LittleEndian>());
+        self.bit_count = self.r.read_u16::<LittleEndian>()?;
+        let image_type_u32 = self.r.read_u32::<LittleEndian>()?;
 
         // Top-down dibs can not be compressed.
         if self.top_down && image_type_u32 != 0 && image_type_u32 != 3 {
@@ -719,23 +719,23 @@ impl<R: Read + Seek> BMPDecoder<R> {
         // followed the horizontal and vertical printing resolutions
         // We will calculate the pixel array size using width & height of image
         // We're not interesting the horz or vert printing resolutions
-        try!(self.r.read_u32::<LittleEndian>());
-        try!(self.r.read_u32::<LittleEndian>());
-        try!(self.r.read_u32::<LittleEndian>());
+        self.r.read_u32::<LittleEndian>()?;
+        self.r.read_u32::<LittleEndian>()?;
+        self.r.read_u32::<LittleEndian>()?;
 
-        self.colors_used = try!(self.r.read_u32::<LittleEndian>());
+        self.colors_used = self.r.read_u32::<LittleEndian>()?;
 
         // The next 4 bytes represent number of "important" colors
         // We're not interested in this value, so we'll skip it
-        try!(self.r.read_u32::<LittleEndian>());
+        self.r.read_u32::<LittleEndian>()?;
 
         Ok(())
     }
 
     fn read_bitmasks(&mut self) -> ImageResult<()> {
-        let r_mask = try!(self.r.read_u32::<LittleEndian>());
-        let g_mask = try!(self.r.read_u32::<LittleEndian>());
-        let b_mask = try!(self.r.read_u32::<LittleEndian>());
+        let r_mask = self.r.read_u32::<LittleEndian>()?;
+        let g_mask = self.r.read_u32::<LittleEndian>()?;
+        let b_mask = self.r.read_u32::<LittleEndian>()?;
 
         let a_mask = match self.bmp_header_type {
             BMPHeaderType::V3 | BMPHeaderType::V4 | BMPHeaderType::V5 => {
@@ -763,9 +763,9 @@ impl<R: Read + Seek> BMPDecoder<R> {
 
     fn read_metadata(&mut self) -> ImageResult<()> {
         if !self.has_loaded_metadata {
-            try!(self.read_file_header());
-            let bmp_header_offset = try!(self.r.seek(SeekFrom::Current(0)));
-            let bmp_header_size = try!(self.r.read_u32::<LittleEndian>());
+            self.read_file_header()?;
+            let bmp_header_offset = self.r.seek(SeekFrom::Current(0))?;
+            let bmp_header_size = self.r.read_u32::<LittleEndian>()?;
             let bmp_header_end = bmp_header_offset + u64::from(bmp_header_size);
 
             self.bmp_header_type = match bmp_header_size {
@@ -784,32 +784,32 @@ impl<R: Read + Seek> BMPDecoder<R> {
 
             match self.bmp_header_type {
                 BMPHeaderType::Core => {
-                    try!(self.read_bitmap_core_header());
+                    self.read_bitmap_core_header()?;
                 }
                 BMPHeaderType::Info
                 | BMPHeaderType::V2
                 | BMPHeaderType::V3
                 | BMPHeaderType::V4
                 | BMPHeaderType::V5 => {
-                    try!(self.read_bitmap_info_header());
+                    self.read_bitmap_info_header()?;
                 }
             };
 
             match self.image_type {
-                ImageType::Bitfields16 | ImageType::Bitfields32 => try!(self.read_bitmasks()),
+                ImageType::Bitfields16 | ImageType::Bitfields32 => self.read_bitmasks()?,
                 _ => {}
             };
 
-            try!(self.r.seek(SeekFrom::Start(bmp_header_end)));
+            self.r.seek(SeekFrom::Start(bmp_header_end))?;
 
             match self.image_type {
-                ImageType::Palette | ImageType::RLE4 | ImageType::RLE8 => try!(self.read_palette()),
+                ImageType::Palette | ImageType::RLE4 | ImageType::RLE8 => self.read_palette()?,
                 _ => {}
             };
 
             if self.no_file_header {
                 // Use the offset of the end of metadata instead of reading a BMP file header.
-                self.data_offset = try!(self.r.seek(SeekFrom::Current(0)));
+                self.data_offset = self.r.seek(SeekFrom::Current(0))?;
             }
 
             self.has_loaded_metadata = true;
@@ -822,7 +822,7 @@ impl<R: Read + Seek> BMPDecoder<R> {
     pub fn read_metadata_in_ico_format(&mut self) -> ImageResult<()> {
         self.no_file_header = true;
         self.add_alpha_channel = true;
-        try!(self.read_metadata());
+        self.read_metadata()?;
 
         // The height field in an ICO file is doubled to account for the AND mask
         // (whether or not an AND mask is actually present).
@@ -856,7 +856,7 @@ impl<R: Read + Seek> BMPDecoder<R> {
         const MAX_PALETTE_SIZE: usize = 256; // Palette indices are u8.
 
         let bytes_per_color = self.bytes_per_color();
-        let palette_size = try!(self.get_palette_size());
+        let palette_size = self.get_palette_size()?;
         let max_length = MAX_PALETTE_SIZE * bytes_per_color;
 
         let length = palette_size * bytes_per_color;
@@ -866,7 +866,7 @@ impl<R: Read + Seek> BMPDecoder<R> {
         // We limit the buffer to at most 256 colours to avoid any oom issues as
         // 8-bit images can't reference more than 256 indexes anyhow.
         buf.resize(cmp::min(length, max_length), 0);
-        try!(self.r.by_ref().read_exact(&mut buf));
+        self.r.by_ref().read_exact(&mut buf)?;
 
         // Allocate 256 entries even if palette_size is smaller, to prevent corrupt files from
         // causing an out-of-bounds array access.
@@ -874,7 +874,7 @@ impl<R: Read + Seek> BMPDecoder<R> {
             buf.resize(max_length, 0);
         } else if length > max_length {
             // Ignore any excess palette colors.
-            try!(self.r.seek(SeekFrom::Current((length - max_length) as i64)));
+            self.r.seek(SeekFrom::Current((length - max_length) as i64))?;
         };
 
         let p: Vec<(u8, u8, u8)> = (0..MAX_PALETTE_SIZE)
@@ -936,7 +936,7 @@ impl<R: Read + Seek> BMPDecoder<R> {
         let reader = &mut self.r;
         let width = self.width as usize;
 
-        try!(reader.seek(SeekFrom::Start(self.data_offset)));
+        reader.seek(SeekFrom::Start(self.data_offset))?;
 
         try!(with_rows(
             &mut pixel_data,
@@ -945,7 +945,7 @@ impl<R: Read + Seek> BMPDecoder<R> {
             num_channels,
             self.top_down,
             |row| {
-                try!(reader.read_exact(&mut indices));
+                reader.read_exact(&mut indices)?;
                 let mut pixel_iter = row.chunks_mut(num_channels);
                 match bit_count {
                     1 => {
@@ -980,7 +980,7 @@ impl<R: Read + Seek> BMPDecoder<R> {
         };
         let reader = &mut self.r;
 
-        try!(reader.seek(SeekFrom::Start(self.data_offset)));
+        reader.seek(SeekFrom::Start(self.data_offset))?;
 
         try!(with_rows(
             &mut pixel_data,
@@ -1014,7 +1014,7 @@ impl<R: Read + Seek> BMPDecoder<R> {
         let bitfields = self.bitfields.as_ref().unwrap();
 
         let reader = &mut self.r;
-        try!(reader.seek(SeekFrom::Start(self.data_offset)));
+        reader.seek(SeekFrom::Start(self.data_offset))?;
 
         try!(with_rows(
             &mut pixel_data,
@@ -1024,7 +1024,7 @@ impl<R: Read + Seek> BMPDecoder<R> {
             self.top_down,
             |row| {
                 for pixel in row.chunks_mut(num_channels) {
-                    let data = try!(reader.read_u32::<LittleEndian>());
+                    let data = reader.read_u32::<LittleEndian>()?;
 
                     pixel[0] = bitfields.r.read(data);
                     pixel[1] = bitfields.g.read(data);
@@ -1050,7 +1050,7 @@ impl<R: Read + Seek> BMPDecoder<R> {
         };
         let row_padding = &mut [0; 4][..row_padding_len];
 
-        try!(self.r.seek(SeekFrom::Start(self.data_offset)));
+        self.r.seek(SeekFrom::Start(self.data_offset))?;
 
         let reader = &mut self.r;
 
@@ -1063,22 +1063,22 @@ impl<R: Read + Seek> BMPDecoder<R> {
             |row| {
                 for pixel in row.chunks_mut(num_channels) {
                     if *format == FormatFullBytes::Format888 {
-                        try!(reader.read_u8());
+                        reader.read_u8()?;
                     }
 
                     // Read the colour values (b, g, r).
                     // Reading 3 bytes and reversing them is significantly faster than reading one
                     // at a time.
-                    try!(reader.read_exact(&mut pixel[0..3]));
+                    reader.read_exact(&mut pixel[0..3])?;
                     pixel[0..3].reverse();
 
                     if *format == FormatFullBytes::RGB32 {
-                        try!(reader.read_u8());
+                        reader.read_u8()?;
                     }
 
                     // Read the alpha channel if present
                     if *format == FormatFullBytes::RGBA32 {
-                        try!(reader.read_exact(&mut pixel[3..4]));
+                        reader.read_exact(&mut pixel[3..4])?;
                     }
                 }
                 reader.read_exact(row_padding)
@@ -1090,7 +1090,7 @@ impl<R: Read + Seek> BMPDecoder<R> {
 
     fn read_rle_data(&mut self, image_type: ImageType) -> ImageResult<Vec<u8>> {
         // Seek to the start of the actual image data.
-        try!(self.r.seek(SeekFrom::Start(self.data_offset)));
+        self.r.seek(SeekFrom::Start(self.data_offset))?;
 
         let full_image_size = try!(
             num_bytes(self.width, self.height, self.num_channels()).ok_or_else(|| {
@@ -1099,7 +1099,7 @@ impl<R: Read + Seek> BMPDecoder<R> {
         );
         let mut pixel_data = self.create_pixel_data();
         let (skip_pixels, skip_rows, eof_hit) =
-            try!(self.read_rle_data_step(&mut pixel_data, image_type, 0, 0));
+            self.read_rle_data_step(&mut pixel_data, image_type, 0, 0)?;
         // Extend the buffer if there is still data left.
         // If eof_hit is true, it means that we hit an end-of-file marker in the last step and
         // we won't extend the buffer further to avoid small files with a large specified size causing memory issues.
@@ -1107,7 +1107,7 @@ impl<R: Read + Seek> BMPDecoder<R> {
         // file would now have to at least have some data in it.
         if pixel_data.len() < full_image_size && !eof_hit {
             let new = extend_buffer(&mut pixel_data, full_image_size, true);
-            try!(self.read_rle_data_step(new, image_type, skip_pixels, skip_rows));
+            self.read_rle_data_step(new, image_type, skip_pixels, skip_rows)?;
         }
         Ok(pixel_data)
     }

--- a/src/bmp/encoder.rs
+++ b/src/bmp/encoder.rs
@@ -30,7 +30,7 @@ impl<'a, W: Write + 'a> BMPEncoder<'a, W> {
     ) -> io::Result<()> {
         let bmp_header_size = BITMAPFILEHEADER_SIZE;
 
-        let (dib_header_size, written_pixel_size, palette_color_count) = try!(get_pixel_info(c));
+        let (dib_header_size, written_pixel_size, palette_color_count) = get_pixel_info(c)?;
         let row_pad_size = (4 - (width * written_pixel_size) % 4) % 4; // each row must be padded to a multiple of 4 bytes
 
         let image_size = width * height * written_pixel_size + (height * row_pad_size);
@@ -38,62 +38,62 @@ impl<'a, W: Write + 'a> BMPEncoder<'a, W> {
         let file_size = bmp_header_size + dib_header_size + palette_size + image_size;
 
         // write BMP header
-        try!(self.writer.write_u8(b'B'));
-        try!(self.writer.write_u8(b'M'));
-        try!(self.writer.write_u32::<LittleEndian>(file_size)); // file size
-        try!(self.writer.write_u16::<LittleEndian>(0)); // reserved 1
-        try!(self.writer.write_u16::<LittleEndian>(0)); // reserved 2
+        self.writer.write_u8(b'B')?;
+        self.writer.write_u8(b'M')?;
+        self.writer.write_u32::<LittleEndian>(file_size)?; // file size
+        self.writer.write_u16::<LittleEndian>(0)?; // reserved 1
+        self.writer.write_u16::<LittleEndian>(0)?; // reserved 2
         try!(
             self.writer
                 .write_u32::<LittleEndian>(bmp_header_size + dib_header_size + palette_size)
         ); // image data offset
 
         // write DIB header
-        try!(self.writer.write_u32::<LittleEndian>(dib_header_size));
-        try!(self.writer.write_i32::<LittleEndian>(width as i32));
-        try!(self.writer.write_i32::<LittleEndian>(height as i32));
-        try!(self.writer.write_u16::<LittleEndian>(1)); // color planes
+        self.writer.write_u32::<LittleEndian>(dib_header_size)?;
+        self.writer.write_i32::<LittleEndian>(width as i32)?;
+        self.writer.write_i32::<LittleEndian>(height as i32)?;
+        self.writer.write_u16::<LittleEndian>(1)?; // color planes
         try!(
             self.writer
                 .write_u16::<LittleEndian>((written_pixel_size * 8) as u16)
         ); // bits per pixel
         if dib_header_size >= BITMAPV4HEADER_SIZE {
             // Assume BGRA32
-            try!(self.writer.write_u32::<LittleEndian>(3)); // compression method - bitfields
+            self.writer.write_u32::<LittleEndian>(3)?; // compression method - bitfields
         } else {
-            try!(self.writer.write_u32::<LittleEndian>(0)); // compression method - no compression
+            self.writer.write_u32::<LittleEndian>(0)?; // compression method - no compression
         }
-        try!(self.writer.write_u32::<LittleEndian>(image_size));
-        try!(self.writer.write_i32::<LittleEndian>(0)); // horizontal ppm
-        try!(self.writer.write_i32::<LittleEndian>(0)); // vertical ppm
-        try!(self.writer.write_u32::<LittleEndian>(palette_color_count));
-        try!(self.writer.write_u32::<LittleEndian>(0)); // all colors are important
+        self.writer.write_u32::<LittleEndian>(image_size)?;
+        self.writer.write_i32::<LittleEndian>(0)?; // horizontal ppm
+        self.writer.write_i32::<LittleEndian>(0)?; // vertical ppm
+        self.writer.write_u32::<LittleEndian>(palette_color_count)?;
+        self.writer.write_u32::<LittleEndian>(0)?; // all colors are important
         if dib_header_size >= BITMAPV4HEADER_SIZE {
             // Assume BGRA32
-            try!(self.writer.write_u32::<LittleEndian>(0xff << 16)); // red mask
-            try!(self.writer.write_u32::<LittleEndian>(0xff << 8)); // green mask
-            try!(self.writer.write_u32::<LittleEndian>(0xff << 0)); // blue mask
-            try!(self.writer.write_u32::<LittleEndian>(0xff << 24)); // alpha mask
-            try!(self.writer.write_u32::<LittleEndian>(0x73524742)); // colorspace - sRGB
+            self.writer.write_u32::<LittleEndian>(0xff << 16)?; // red mask
+            self.writer.write_u32::<LittleEndian>(0xff << 8)?; // green mask
+            self.writer.write_u32::<LittleEndian>(0xff << 0)?; // blue mask
+            self.writer.write_u32::<LittleEndian>(0xff << 24)?; // alpha mask
+            self.writer.write_u32::<LittleEndian>(0x73524742)?; // colorspace - sRGB
             // endpoints (3x3) and gamma (3)
             for _ in 0..12 {
-                try!(self.writer.write_u32::<LittleEndian>(0));
+                self.writer.write_u32::<LittleEndian>(0)?;
             }
         }
 
         // write image data
         match c {
             color::ColorType::RGB(8) => {
-                try!(self.encode_rgb(image, width, height, row_pad_size, 3))
+                self.encode_rgb(image, width, height, row_pad_size, 3)?
             }
             color::ColorType::RGBA(8) => {
-                try!(self.encode_rgba(image, width, height, row_pad_size, 4))
+                self.encode_rgba(image, width, height, row_pad_size, 4)?
             }
             color::ColorType::Gray(8) => {
-                try!(self.encode_gray(image, width, height, row_pad_size, 1))
+                self.encode_gray(image, width, height, row_pad_size, 1)?
             }
             color::ColorType::GrayA(8) => {
-                try!(self.encode_gray(image, width, height, row_pad_size, 2))
+                self.encode_gray(image, width, height, row_pad_size, 2)?
             }
             _ => {
                 return Err(io::Error::new(
@@ -125,13 +125,13 @@ impl<'a, W: Write + 'a> BMPEncoder<'a, W> {
                 let g = image[pixel_start + 1];
                 let b = image[pixel_start + 2];
                 // written as BGR
-                try!(self.writer.write_u8(b));
-                try!(self.writer.write_u8(g));
-                try!(self.writer.write_u8(r));
+                self.writer.write_u8(b)?;
+                self.writer.write_u8(g)?;
+                self.writer.write_u8(r)?;
                 // alpha is never written as it's not widely supported
             }
 
-            try!(self.write_row_pad(row_pad_size));
+            self.write_row_pad(row_pad_size)?;
         }
 
         Ok(())
@@ -157,13 +157,13 @@ impl<'a, W: Write + 'a> BMPEncoder<'a, W> {
                 let b = image[pixel_start + 2];
                 let a = image[pixel_start + 3];
                 // written as BGRA
-                try!(self.writer.write_u8(b));
-                try!(self.writer.write_u8(g));
-                try!(self.writer.write_u8(r));
-                try!(self.writer.write_u8(a));
+                self.writer.write_u8(b)?;
+                self.writer.write_u8(g)?;
+                self.writer.write_u8(r)?;
+                self.writer.write_u8(a)?;
             }
 
-            try!(self.write_row_pad(row_pad_size));
+            self.write_row_pad(row_pad_size)?;
         }
 
         Ok(())
@@ -181,10 +181,10 @@ impl<'a, W: Write + 'a> BMPEncoder<'a, W> {
         for val in 0..256 {
             // each color is written as BGRA, where A is always 0 and since only grayscale is being written, B = G = R = index
             let val = val as u8;
-            try!(self.writer.write_u8(val));
-            try!(self.writer.write_u8(val));
-            try!(self.writer.write_u8(val));
-            try!(self.writer.write_u8(0));
+            self.writer.write_u8(val)?;
+            self.writer.write_u8(val)?;
+            self.writer.write_u8(val)?;
+            self.writer.write_u8(0)?;
         }
 
         // write image data
@@ -196,11 +196,11 @@ impl<'a, W: Write + 'a> BMPEncoder<'a, W> {
             for col in 0..width {
                 let pixel_start = (row_start + (col * x_stride)) as usize;
                 // color value is equal to the palette index
-                try!(self.writer.write_u8(image[pixel_start]));
+                self.writer.write_u8(image[pixel_start])?;
                 // alpha is never written as it's not widely supported
             }
 
-            try!(self.write_row_pad(row_pad_size));
+            self.write_row_pad(row_pad_size)?;
         }
 
         Ok(())
@@ -208,7 +208,7 @@ impl<'a, W: Write + 'a> BMPEncoder<'a, W> {
 
     fn write_row_pad(&mut self, row_pad_size: u32) -> io::Result<()> {
         for _ in 0..row_pad_size {
-            try!(self.writer.write_u8(0));
+            self.writer.write_u8(0)?;
         }
 
         Ok(())

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -492,7 +492,7 @@ impl DynamicImage {
                     },
                     _ => {},
                 }
-                try!(p.encode(&bytes, width, height, color));
+                p.encode(&bytes, width, height, color)?;
                 Ok(())
             }
             #[cfg(feature = "pnm")]
@@ -509,14 +509,14 @@ impl DynamicImage {
                     },
                     _ => {},
                 }
-                try!(p.encode(&bytes[..], width, height, color));
+                p.encode(&bytes[..], width, height, color)?;
                 Ok(())
             }
             #[cfg(feature = "jpeg")]
             image::ImageOutputFormat::JPEG(quality) => {
                 let mut j = jpeg::JPEGEncoder::new_with_quality(w, quality);
 
-                try!(j.encode(&bytes, width, height, color));
+                j.encode(&bytes, width, height, color)?;
                 Ok(())
             }
 
@@ -536,14 +536,14 @@ impl DynamicImage {
             image::ImageOutputFormat::ICO => {
                 let i = ico::ICOEncoder::new(w);
 
-                try!(i.encode(&bytes, width, height, color));
+                i.encode(&bytes, width, height, color)?;
                 Ok(())
             }
 
             #[cfg(feature = "bmp")]
             image::ImageOutputFormat::BMP => {
                 let mut b = bmp::BMPEncoder::new(w);
-                try!(b.encode(&bytes, width, height, color));
+                b.encode(&bytes, width, height, color)?;
                 Ok(())
             }
 
@@ -643,7 +643,7 @@ impl GenericImage for DynamicImage {
 pub fn decoder_to_image<'a, I: ImageDecoder<'a>>(codec: I) -> ImageResult<DynamicImage> {
     let color = codec.colortype();
     let (w, h) = codec.dimensions();
-    let buf = try!(codec.read_image());
+    let buf = codec.read_image()?;
 
     // TODO: Avoid this cast by having ImageBuffer use u64's
     assert!(w <= u32::max_value() as u64);
@@ -857,7 +857,7 @@ fn save_buffer_impl(
     height: u32,
     color: color::ColorType,
 ) -> io::Result<()> {
-    let fout = &mut BufWriter::new(try!(File::create(path)));
+    let fout = &mut BufWriter::new(File::create(path)?);
     let ext = path.extension()
         .and_then(|s| s.to_str())
         .map_or("".to_string(), |s| s.to_ascii_lowercase());

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -280,7 +280,7 @@ impl<W: Write> Encoder<W> {
             result = encoder.write_frame(frame).map_err(|err| err.into());
         } else {
             let writer = self.w.take().unwrap();
-            let mut encoder = try!(gif::Encoder::new(writer, frame.width, frame.height, &[]));
+            let mut encoder = gif::Encoder::new(writer, frame.width, frame.height, &[])?;
             result = encoder.write_frame(&frame).map_err(|err| err.into());
             self.gif_encoder = Some(encoder);
         }

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -212,7 +212,7 @@ impl<R: Read> Iterator for GifFrameIterator<R> {
         // frame need to be used
         for (x, y, pixel) in image_buffer.enumerate_pixels_mut() {
             let previous_img_buffer = &self.non_disposed_frame;
-            let mut adjusted_pixel: &mut Rgba<u8> = pixel;
+            let adjusted_pixel: &mut Rgba<u8> = pixel;
             let previous_pixel: &Rgba<u8> = previous_img_buffer.get_pixel(x, y);
 
             let pixel_alpha = adjusted_pixel.channels()[3];

--- a/src/hdr/encoder.rs
+++ b/src/hdr/encoder.rs
@@ -18,15 +18,15 @@ impl<W: Write> HDREncoder<W> {
     pub fn encode(mut self, data: &[Rgb<f32>], width: usize, height: usize) -> Result<()> {
         assert!(data.len() >= width * height);
         let w = &mut self.w;
-        try!(w.write_all(SIGNATURE));
-        try!(w.write_all(b"\n"));
-        try!(w.write_all(b"# Rust HDR encoder\n"));
-        try!(w.write_all(b"FORMAT=32-bit_rle_rgbe\n\n"));
-        try!(w.write_all(format!("-Y {} +X {}\n", height, width).as_bytes()));
+        w.write_all(SIGNATURE)?;
+        w.write_all(b"\n")?;
+        w.write_all(b"# Rust HDR encoder\n")?;
+        w.write_all(b"FORMAT=32-bit_rle_rgbe\n\n")?;
+        w.write_all(format!("-Y {} +X {}\n", height, width).as_bytes())?;
 
         if width < 8 || width > 32_768 {
             for &pix in data {
-                try!(write_rgbe8(w, to_rgbe8(pix)));
+                write_rgbe8(w, to_rgbe8(pix))?;
             }
         } else {
             // new RLE marker contains scanline width
@@ -54,19 +54,19 @@ impl<W: Write> HDREncoder<W> {
                     *b = cp.c[2];
                     *e = cp.e;
                 }
-                try!(write_rgbe8(w, marker)); // New RLE encoding marker
+                write_rgbe8(w, marker)?; // New RLE encoding marker
                 rle_buf.clear();
                 rle_compress(&bufr[..], &mut rle_buf);
-                try!(w.write_all(&rle_buf[..]));
+                w.write_all(&rle_buf[..])?;
                 rle_buf.clear();
                 rle_compress(&bufg[..], &mut rle_buf);
-                try!(w.write_all(&rle_buf[..]));
+                w.write_all(&rle_buf[..])?;
                 rle_buf.clear();
                 rle_compress(&bufb[..], &mut rle_buf);
-                try!(w.write_all(&rle_buf[..]));
+                w.write_all(&rle_buf[..])?;
                 rle_buf.clear();
                 rle_compress(&bufe[..], &mut rle_buf);
-                try!(w.write_all(&rle_buf[..]));
+                w.write_all(&rle_buf[..])?;
             }
         }
         Ok(())

--- a/src/ico/decoder.rs
+++ b/src/ico/decoder.rs
@@ -42,9 +42,9 @@ struct DirEntry {
 impl<R: Read + Seek> ICODecoder<R> {
     /// Create a new decoder that decodes from the stream ```r```
     pub fn new(mut r: R) -> ImageResult<ICODecoder<R>> {
-        let entries = try!(read_entries(&mut r));
-        let entry = try!(best_entry(entries));
-        let decoder = try!(entry.decoder(r));
+        let entries = read_entries(&mut r)?;
+        let entry = best_entry(entries)?;
+        let decoder = entry.decoder(r)?;
 
         Ok(ICODecoder {
             selected_entry: entry,
@@ -54,24 +54,24 @@ impl<R: Read + Seek> ICODecoder<R> {
 }
 
 fn read_entries<R: Read>(r: &mut R) -> ImageResult<Vec<DirEntry>> {
-    let _reserved = try!(r.read_u16::<LittleEndian>());
-    let _type = try!(r.read_u16::<LittleEndian>());
-    let count = try!(r.read_u16::<LittleEndian>());
+    let _reserved = r.read_u16::<LittleEndian>()?;
+    let _type = r.read_u16::<LittleEndian>()?;
+    let count = r.read_u16::<LittleEndian>()?;
     (0..count).map(|_| read_entry(r)).collect()
 }
 
 fn read_entry<R: Read>(r: &mut R) -> ImageResult<DirEntry> {
     let mut entry = DirEntry::default();
 
-    entry.width = try!(r.read_u8());
-    entry.height = try!(r.read_u8());
-    entry.color_count = try!(r.read_u8());
+    entry.width = r.read_u8()?;
+    entry.height = r.read_u8()?;
+    entry.color_count = r.read_u8()?;
     // Reserved value (not used)
-    entry.reserved = try!(r.read_u8());
+    entry.reserved = r.read_u8()?;
 
     // This may be either the number of color planes (0 or 1), or the horizontal coordinate
     // of the hotspot for CUR files.
-    entry.num_color_planes = try!(r.read_u16::<LittleEndian>());
+    entry.num_color_planes = r.read_u16::<LittleEndian>()?;
     if entry.num_color_planes > 256 {
         return Err(ImageError::FormatError(
             "ICO image entry has a too large color planes/hotspot value".to_string(),
@@ -80,22 +80,22 @@ fn read_entry<R: Read>(r: &mut R) -> ImageResult<DirEntry> {
 
     // This may be either the bit depth (may be 0 meaning unspecified),
     // or the vertical coordinate of the hotspot for CUR files.
-    entry.bits_per_pixel = try!(r.read_u16::<LittleEndian>());
+    entry.bits_per_pixel = r.read_u16::<LittleEndian>()?;
     if entry.bits_per_pixel > 256 {
         return Err(ImageError::FormatError(
             "ICO image entry has a too large bits per pixel/hotspot value".to_string(),
         ));
     }
 
-    entry.image_length = try!(r.read_u32::<LittleEndian>());
-    entry.image_offset = try!(r.read_u32::<LittleEndian>());
+    entry.image_length = r.read_u32::<LittleEndian>()?;
+    entry.image_offset = r.read_u32::<LittleEndian>()?;
 
     Ok(entry)
 }
 
 /// Find the entry with the highest (color depth, size).
 fn best_entry(mut entries: Vec<DirEntry>) -> ImageResult<DirEntry> {
-    let mut best = try!(entries.pop().ok_or(ImageError::ImageEnd));
+    let mut best = entries.pop().ok_or(ImageError::ImageEnd)?;
     let mut best_score = (
         best.bits_per_pixel,
         u32::from(best.real_width()) * u32::from(best.real_height()),
@@ -134,23 +134,23 @@ impl DirEntry {
     }
 
     fn seek_to_start<R: Read + Seek>(&self, r: &mut R) -> ImageResult<()> {
-        try!(r.seek(SeekFrom::Start(u64::from(self.image_offset))));
+        r.seek(SeekFrom::Start(u64::from(self.image_offset)))?;
         Ok(())
     }
 
     fn is_png<R: Read + Seek>(&self, r: &mut R) -> ImageResult<bool> {
-        try!(self.seek_to_start(r));
+        self.seek_to_start(r)?;
 
         // Read the first 8 bytes to sniff the image.
         let mut signature = [0u8; 8];
-        try!(r.read_exact(&mut signature));
+        r.read_exact(&mut signature)?;
 
         Ok(signature == PNG_SIGNATURE)
     }
 
     fn decoder<R: Read + Seek>(&self, mut r: R) -> ImageResult<InnerDecoder<R>> {
-        let is_png = try!(self.is_png(&mut r));
-        try!(self.seek_to_start(&mut r));
+        let is_png = self.is_png(&mut r)?;
+        self.seek_to_start(&mut r)?;
 
         if is_png {
             Ok(PNG(PNGDecoder::new(r)?))
@@ -245,7 +245,7 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for ICODecoder<R> {
 
                 // If there's an AND mask following the image, read and apply it.
                 let r = decoder.reader();
-                let mask_start = try!(r.seek(SeekFrom::Current(0)));
+                let mask_start = r.seek(SeekFrom::Current(0))?;
                 let mask_end =
                     u64::from(self.selected_entry.image_offset + self.selected_entry.image_length);
                 let mask_length = mask_end - mask_start;
@@ -262,7 +262,7 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for ICODecoder<R> {
                         let mut x = 0;
                         for _ in 0..mask_row_bytes {
                             // Apply the bits of each byte until we reach the end of the row.
-                            let mask_byte = try!(r.read_u8());
+                            let mask_byte = r.read_u8()?;
                             for bit in (0..8).rev() {
                                 if x >= width {
                                     break;

--- a/src/ico/encoder.rs
+++ b/src/ico/encoder.rs
@@ -34,9 +34,9 @@ impl<W: Write> ICOEncoder<W> {
         color: ColorType,
     ) -> io::Result<()> {
         let mut image_data: Vec<u8> = Vec::new();
-        try!(PNGEncoder::new(&mut image_data).encode(data, width, height, color));
+        PNGEncoder::new(&mut image_data).encode(data, width, height, color)?;
 
-        try!(write_icondir(&mut self.w, 1));
+        write_icondir(&mut self.w, 1)?;
         try!(write_direntry(
             &mut self.w,
             width,
@@ -45,18 +45,18 @@ impl<W: Write> ICOEncoder<W> {
             ICO_ICONDIR_SIZE + ICO_DIRENTRY_SIZE,
             image_data.len() as u32
         ));
-        try!(self.w.write_all(&image_data));
+        self.w.write_all(&image_data)?;
         Ok(())
     }
 }
 
 fn write_icondir<W: Write>(w: &mut W, num_images: u16) -> io::Result<()> {
     // Reserved field (must be zero):
-    try!(w.write_u16::<LittleEndian>(0));
+    w.write_u16::<LittleEndian>(0)?;
     // Image type (ICO or CUR):
-    try!(w.write_u16::<LittleEndian>(ICO_IMAGE_TYPE));
+    w.write_u16::<LittleEndian>(ICO_IMAGE_TYPE)?;
     // Number of images in the file:
-    try!(w.write_u16::<LittleEndian>(num_images));
+    w.write_u16::<LittleEndian>(num_images)?;
     Ok(())
 }
 
@@ -69,20 +69,20 @@ fn write_direntry<W: Write>(
     data_size: u32,
 ) -> io::Result<()> {
     // Image dimensions:
-    try!(write_width_or_height(w, width));
-    try!(write_width_or_height(w, height));
+    write_width_or_height(w, width)?;
+    write_width_or_height(w, height)?;
     // Number of colors in palette (or zero for no palette):
-    try!(w.write_u8(0));
+    w.write_u8(0)?;
     // Reserved field (must be zero):
-    try!(w.write_u8(0));
+    w.write_u8(0)?;
     // Color planes:
-    try!(w.write_u16::<LittleEndian>(0));
+    w.write_u16::<LittleEndian>(0)?;
     // Bits per pixel:
-    try!(w.write_u16::<LittleEndian>(bits_per_pixel(color) as u16));
+    w.write_u16::<LittleEndian>(bits_per_pixel(color) as u16)?;
     // Image data size, in bytes:
-    try!(w.write_u32::<LittleEndian>(data_size));
+    w.write_u32::<LittleEndian>(data_size)?;
     // Image data offset, in bytes:
-    try!(w.write_u32::<LittleEndian>(data_start));
+    w.write_u32::<LittleEndian>(data_start)?;
     Ok(())
 }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -89,7 +89,7 @@ impl Error for ImageError {
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         match *self {
             ImageError::IoError(ref e) => Some(e),
             _ => None,
@@ -778,8 +778,9 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::io;
 
-    use super::{GenericImage, GenericImageView};
+    use super::{ColorType, ImageDecoder, ImageResult, GenericImage, GenericImageView, load_rect};
     use buffer::ImageBuffer;
     use color::Rgba;
 
@@ -852,11 +853,9 @@ mod tests {
 
     #[test]
     fn test_load_rect() {
-        use super::*;
-
         struct MockDecoder {scanline_number: u64, scanline_bytes: u64}
         impl<'a> ImageDecoder<'a> for MockDecoder {
-            type Reader = Box<::std::io::Read>;
+            type Reader = Box<dyn io::Read>;
             fn dimensions(&self) -> (u64, u64) {(5, 5)}
             fn colortype(&self) -> ColorType {  ColorType::Gray(8) }
             fn into_reader(self) -> ImageResult<Self::Reader> {unimplemented!()}

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -34,7 +34,7 @@ pub enum FilterType {
 /// A Representation of a separable filter.
 pub struct Filter<'a> {
     /// The filter's filter function.
-    pub kernel: Box<Fn(f32) -> f32 + 'a>,
+    pub kernel: Box<dyn Fn(f32) -> f32 + 'a>,
 
     /// The window on which this filter operates.
     pub support: f32,

--- a/src/png.rs
+++ b/src/png.rs
@@ -156,7 +156,7 @@ impl<W: Write> PNGEncoder<W> {
         let mut encoder = png::Encoder::new(self.w, width, height);
         encoder.set_color(ct);
         encoder.set_depth(bits);
-        let mut writer = try!(encoder.write_header());
+        let mut writer = encoder.write_header()?;
         writer.write_image_data(data).map_err(|e| e.into())
     }
 }

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -29,7 +29,7 @@ trait Sample {
     fn from_bytes(bytes: &[u8], width: u32, height: u32, samples: u32)
         -> ImageResult<Vec<u8>>;
 
-    fn from_ascii(reader: &mut Read, width: u32, height: u32, samples: u32)
+    fn from_ascii(reader: &mut dyn Read, width: u32, height: u32, samples: u32)
         -> ImageResult<Vec<u8>>;
 }
 
@@ -500,7 +500,7 @@ impl TupleType {
     }
 }
 
-fn read_separated_ascii<T: FromStr>(reader: &mut Read) -> ImageResult<T>
+fn read_separated_ascii<T: FromStr>(reader: &mut dyn Read) -> ImageResult<T>
     where T::Err: Display
 {
     let is_separator = |v: &u8| match *v {
@@ -547,7 +547,7 @@ impl Sample for U8 {
     }
 
     fn from_ascii(
-        reader: &mut Read,
+        reader: &mut dyn Read,
         width: u32,
         height: u32,
         samples: u32,
@@ -580,7 +580,7 @@ impl Sample for U16 {
     }
 
     fn from_ascii(
-        reader: &mut Read,
+        reader: &mut dyn Read,
         width: u32,
         height: u32,
         samples: u32,
@@ -614,7 +614,7 @@ impl Sample for PbmBit {
     }
 
     fn from_ascii(
-        reader: &mut Read,
+        reader: &mut dyn Read,
         width: u32,
         height: u32,
         samples: u32,
@@ -668,7 +668,7 @@ impl Sample for BWBit {
     }
 
     fn from_ascii(
-        _reader: &mut Read,
+        _reader: &mut dyn Read,
         _width: u32,
         _height: u32,
         _samples: u32,

--- a/src/pnm/encoder.rs
+++ b/src/pnm/encoder.rs
@@ -170,10 +170,10 @@ impl<W: Write> PNMEncoder<W> {
         let (maxval, tupltype) = match color {
             ColorType::Gray(1) => (1, ArbitraryTuplType::BlackAndWhite),
             ColorType::GrayA(1) => (1, ArbitraryTuplType::BlackAndWhiteAlpha),
-            ColorType::Gray(n @ 1...16) => ((1 << n) - 1, ArbitraryTuplType::Grayscale),
-            ColorType::GrayA(n @ 1...16) => ((1 << n) - 1, ArbitraryTuplType::GrayscaleAlpha),
-            ColorType::RGB(n @ 1...16) => ((1 << n) - 1, ArbitraryTuplType::RGB),
-            ColorType::RGBA(n @ 1...16) => ((1 << n) - 1, ArbitraryTuplType::RGBAlpha),
+            ColorType::Gray(n @ 1..=16) => ((1 << n) - 1, ArbitraryTuplType::Grayscale),
+            ColorType::GrayA(n @ 1..=16) => ((1 << n) - 1, ArbitraryTuplType::GrayscaleAlpha),
+            ColorType::RGB(n @ 1..=16) => ((1 << n) - 1, ArbitraryTuplType::RGB),
+            ColorType::RGBA(n @ 1..=16) => ((1 << n) - 1, ArbitraryTuplType::RGBAlpha),
             _ => {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
@@ -251,7 +251,7 @@ impl<W: Write> PNMEncoder<W> {
     ///
     /// Returns how the body should be written if successful.
     fn write_with_header(
-        writer: &mut Write,
+        writer: &mut dyn Write,
         header: &PNMHeader,
         image: FlatSamples,
         width: u32,
@@ -472,7 +472,7 @@ impl<'a> CheckedHeaderColor<'a> {
 }
 
 impl<'a> CheckedHeader<'a> {
-    fn write_header(self, writer: &mut Write) -> io::Result<TupleEncoding<'a>> {
+    fn write_header(self, writer: &mut dyn Write) -> io::Result<TupleEncoding<'a>> {
         self.header().write(writer)?;
         Ok(self.encoding)
     }
@@ -482,7 +482,7 @@ impl<'a> CheckedHeader<'a> {
     }
 }
 
-struct SampleWriter<'a>(&'a mut Write);
+struct SampleWriter<'a>(&'a mut dyn Write);
 
 impl<'a> SampleWriter<'a> {
     fn write_samples_ascii<V>(self, samples: V) -> io::Result<()>
@@ -596,7 +596,7 @@ impl<'a> From<&'a [u16]> for FlatSamples<'a> {
 }
 
 impl<'a> TupleEncoding<'a> {
-    fn write_image(&self, writer: &mut Write) -> io::Result<()> {
+    fn write_image(&self, writer: &mut dyn Write) -> io::Result<()> {
         match *self {
             TupleEncoding::PbmBits {
                 samples: FlatSamples::U8(samples),

--- a/src/pnm/header.rs
+++ b/src/pnm/header.rs
@@ -232,7 +232,7 @@ impl PNMHeader {
     }
 
     /// Write the header back into a binary stream
-    pub fn write(&self, writer: &mut io::Write) -> io::Result<()> {
+    pub fn write(&self, writer: &mut dyn io::Write) -> io::Result<()> {
         writer.write_all(self.subtype().magic_constant())?;
         match *self {
             PNMHeader {

--- a/src/pnm/mod.rs
+++ b/src/pnm/mod.rs
@@ -34,7 +34,7 @@ mod tests {
         }
 
         let (header, loaded_color, loaded_image) = {
-            let mut decoder = PNMDecoder::new(&encoded_buffer[..]).unwrap();
+            let decoder = PNMDecoder::new(&encoded_buffer[..]).unwrap();
             let colortype = decoder.colortype();
             let image = decoder.read_image().expect("Failed to decode the image");
             let (_, header) = PNMDecoder::new(&encoded_buffer[..]).unwrap().into_inner();
@@ -64,7 +64,7 @@ mod tests {
         }
 
         let (header, loaded_color, loaded_image) = {
-            let mut decoder = PNMDecoder::new(&encoded_buffer[..]).unwrap();
+            let decoder = PNMDecoder::new(&encoded_buffer[..]).unwrap();
             let colortype = decoder.colortype();
             let image = decoder.read_image().expect("Failed to decode the image");
             let (_, header) = PNMDecoder::new(&encoded_buffer[..]).unwrap().into_inner();
@@ -89,7 +89,7 @@ mod tests {
         }
 
         let (header, loaded_color, loaded_image) = {
-            let mut decoder = PNMDecoder::new(&encoded_buffer[..]).unwrap();
+            let decoder = PNMDecoder::new(&encoded_buffer[..]).unwrap();
             let colortype = decoder.colortype();
             let image = decoder.read_image().expect("Failed to decode the image");
             let (_, header) = PNMDecoder::new(&encoded_buffer[..]).unwrap().into_inner();

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -103,18 +103,18 @@ impl Header {
     /// Load the header with values from the reader
     fn from_reader(r: &mut Read) -> ImageResult<Header> {
         Ok(Header {
-            id_length: try!(r.read_u8()),
-            map_type: try!(r.read_u8()),
-            image_type: try!(r.read_u8()),
-            map_origin: try!(r.read_u16::<LittleEndian>()),
-            map_length: try!(r.read_u16::<LittleEndian>()),
-            map_entry_size: try!(r.read_u8()),
-            x_origin: try!(r.read_u16::<LittleEndian>()),
-            y_origin: try!(r.read_u16::<LittleEndian>()),
-            image_width: try!(r.read_u16::<LittleEndian>()),
-            image_height: try!(r.read_u16::<LittleEndian>()),
-            pixel_depth: try!(r.read_u8()),
-            image_desc: try!(r.read_u8()),
+            id_length: r.read_u8()?,
+            map_type: r.read_u8()?,
+            image_type: r.read_u8()?,
+            map_origin: r.read_u16::<LittleEndian>()?,
+            map_length: r.read_u16::<LittleEndian>()?,
+            map_entry_size: r.read_u8()?,
+            x_origin: r.read_u16::<LittleEndian>()?,
+            y_origin: r.read_u16::<LittleEndian>()?,
+            image_width: r.read_u16::<LittleEndian>()?,
+            image_height: r.read_u16::<LittleEndian>()?,
+            pixel_depth: r.read_u8()?,
+            image_desc: r.read_u8()?,
         })
     }
 }
@@ -136,7 +136,7 @@ impl ColorMap {
         let bytes_per_entry = (bits_per_entry as usize + 7) / 8;
 
         let mut bytes = vec![0; bytes_per_entry * num_entries as usize];
-        try!(r.read_exact(&mut bytes));
+        r.read_exact(&mut bytes)?;
 
         Ok(ColorMap {
             entry_size: bytes_per_entry,
@@ -197,7 +197,7 @@ impl<R: Read + Seek> TGADecoder<R> {
     }
 
     fn read_header(&mut self) -> ImageResult<()> {
-        self.header = try!(Header::from_reader(&mut self.r));
+        self.header = Header::from_reader(&mut self.r)?;
         self.image_type = ImageType::new(self.header.image_type);
         self.width = self.header.image_width as usize;
         self.height = self.header.image_height as usize;
@@ -207,10 +207,10 @@ impl<R: Read + Seek> TGADecoder<R> {
 
     fn read_metadata(&mut self) -> ImageResult<()> {
         if !self.has_loaded_metadata {
-            try!(self.read_header());
-            try!(self.read_image_id());
-            try!(self.read_color_map());
-            try!(self.read_color_information());
+            self.read_header()?;
+            self.read_image_id()?;
+            self.read_color_map()?;
+            self.read_color_information()?;
             self.has_loaded_metadata = true;
         }
         Ok(())
@@ -326,7 +326,7 @@ impl<R: Read + Seek> TGADecoder<R> {
         } else {
             let num_raw_bytes = self.width * self.height * self.bytes_per_pixel;
             let mut buf = vec![0; num_raw_bytes];
-            try!(self.r.by_ref().read_exact(&mut buf));
+            self.r.by_ref().read_exact(&mut buf)?;
             buf
         };
 
@@ -347,7 +347,7 @@ impl<R: Read + Seek> TGADecoder<R> {
         let mut pixel_data = Vec::with_capacity(num_bytes);
 
         while pixel_data.len() < num_bytes {
-            let run_packet = try!(self.r.read_u8());
+            let run_packet = self.r.read_u8()?;
             // If the highest bit in `run_packet` is set, then we repeat pixels
             //
             // Note: the TGA format adds 1 to both counts because having a count

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -101,7 +101,7 @@ impl Header {
     }
 
     /// Load the header with values from the reader
-    fn from_reader(r: &mut Read) -> ImageResult<Header> {
+    fn from_reader(r: &mut dyn Read) -> ImageResult<Header> {
         Ok(Header {
             id_length: r.read_u8()?,
             map_type: r.read_u8()?,
@@ -128,7 +128,7 @@ struct ColorMap {
 
 impl ColorMap {
     pub fn from_reader(
-        r: &mut Read,
+        r: &mut dyn Read,
         start_offset: u16,
         num_entries: u16,
         bits_per_entry: u8,

--- a/src/webp/decoder.rs
+++ b/src/webp/decoder.rs
@@ -38,10 +38,10 @@ impl<R: Read> WebpDecoder<R> {
 
     fn read_riff_header(&mut self) -> ImageResult<u32> {
         let mut riff = Vec::with_capacity(4);
-        try!(self.r.by_ref().take(4).read_to_end(&mut riff));
-        let size = try!(self.r.read_u32::<LittleEndian>());
+        self.r.by_ref().take(4).read_to_end(&mut riff)?;
+        let size = self.r.read_u32::<LittleEndian>()?;
         let mut webp = Vec::with_capacity(4);
-        try!(self.r.by_ref().take(4).read_to_end(&mut webp));
+        self.r.by_ref().take(4).read_to_end(&mut webp)?;
 
         if &*riff != b"RIFF" {
             return Err(image::ImageError::FormatError(
@@ -60,7 +60,7 @@ impl<R: Read> WebpDecoder<R> {
 
     fn read_vp8_header(&mut self) -> ImageResult<()> {
         let mut vp8 = Vec::with_capacity(4);
-        try!(self.r.by_ref().take(4).read_to_end(&mut vp8));
+        self.r.by_ref().take(4).read_to_end(&mut vp8)?;
 
         if &*vp8 != b"VP8 " {
             return Err(image::ImageError::FormatError(
@@ -68,18 +68,18 @@ impl<R: Read> WebpDecoder<R> {
             ));
         }
 
-        let _len = try!(self.r.read_u32::<LittleEndian>());
+        let _len = self.r.read_u32::<LittleEndian>()?;
 
         Ok(())
     }
 
     fn read_frame(&mut self) -> ImageResult<()> {
         let mut framedata = Vec::new();
-        try!(self.r.read_to_end(&mut framedata));
+        self.r.read_to_end(&mut framedata)?;
         let m = io::Cursor::new(framedata);
 
         let mut v = VP8Decoder::new(m);
-        let frame = try!(v.decode_frame());
+        let frame = v.decode_frame()?;
 
         self.frame = frame.clone();
 
@@ -88,9 +88,9 @@ impl<R: Read> WebpDecoder<R> {
 
     fn read_metadata(&mut self) -> ImageResult<()> {
         if !self.have_frame {
-            try!(self.read_riff_header());
-            try!(self.read_vp8_header());
-            try!(self.read_frame());
+            self.read_riff_header()?;
+            self.read_vp8_header()?;
+            self.read_frame()?;
 
             self.have_frame = true;
         }

--- a/src/webp/vp8.rs
+++ b/src/webp/vp8.rs
@@ -1363,9 +1363,9 @@ impl<R: Read> VP8Decoder<R> {
                     continue;
                 }
 
-                literal @ DCT_1...DCT_4 => i16::from(literal),
+                literal @ DCT_1..=DCT_4 => i16::from(literal),
 
-                category @ DCT_CAT1...DCT_CAT6 => {
+                category @ DCT_CAT1..=DCT_CAT6 => {
                     let t = PROB_DCT_CAT[(category - DCT_CAT1) as usize];
 
                     let mut extra = 0i16;


### PR DESCRIPTION
Replace `try!` with `?`-operator (finally!) and preemptively applies some future deprecations for trait dynamically sized trait-objects without `dyn`, which is forbidden in Rust edition 2018 and thus helps transition if wanted.

