### PR TITLE
Update fractal exemple.

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ fn main() {
             }
 
             let pixel = imgbuf.get_pixel_mut(x, y);
-            let image::Rgb(data) = *pixel;
+            let image::Rgb { data } = *pixel;
             *pixel = image::Rgb([data[0], i as u8, data[2]]);
         }
     }


### PR DESCRIPTION
The destructuring did not work, as Rgb is a struct and not a tuple.

<!-- 
If you are a new contributor, consent to licensing by including this text:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

Thank you for contributing, you can delete this comment.
-->

