### PR TITLE
Provide bits_per_pixel and num_components as ColorType methods

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -31,24 +31,35 @@ pub enum ColorType {
 
 }
 
+impl ColorType {
+    /// Returns the number of bits contained in a pixel of this `ColorType`
+    pub fn bits_per_pixel(&self) -> u16 {
+        bits_per_pixel(*self)
+    }
+
+    /// Returns the number of color channels that make up this pixel
+    pub fn channel_count(&self) -> u8 {
+        channel_count(*self)
+    }
+}
+
 /// Returns the number of bits contained in a pixel of `ColorType` ```c```
-pub fn bits_per_pixel(c: ColorType) -> usize {
+pub fn bits_per_pixel(c: ColorType) -> u16 {
     match c {
-        ColorType::Gray(n) => n as usize,
-        ColorType::GrayA(n) => 2 * n as usize,
-        ColorType::RGB(n) | ColorType::Palette(n)| ColorType::BGR(n) => 3 * n as usize,
-        ColorType::RGBA(n) | ColorType::BGRA(n) => 4 * n as usize,
+        ColorType::Gray(n) => n as u16,
+        ColorType::GrayA(n) => 2 * n as u16,
+        ColorType::RGB(n) | ColorType::Palette(n)| ColorType::BGR(n) => 3 * n as u16,
+        ColorType::RGBA(n) | ColorType::BGRA(n) => 4 * n as u16,
     }
 }
 
 /// Returns the number of color channels that make up this pixel
-pub fn num_components(c: ColorType) -> usize {
+pub fn channel_count(c: ColorType) -> u8 {
     match c {
         ColorType::Gray(_) => 1,
         ColorType::GrayA(_) => 2,
         ColorType::RGB(_) | ColorType::Palette(_) | ColorType::BGR(_)=> 3,
         ColorType::RGBA(_) | ColorType::BGRA(_) => 4,
-
     }
 }
 

--- a/src/ico/encoder.rs
+++ b/src/ico/encoder.rs
@@ -78,7 +78,7 @@ fn write_direntry<W: Write>(
     // Color planes:
     w.write_u16::<LittleEndian>(0)?;
     // Bits per pixel:
-    w.write_u16::<LittleEndian>(bits_per_pixel(color) as u16)?;
+    w.write_u16::<LittleEndian>(bits_per_pixel(color))?;
     // Image data size, in bytes:
     w.write_u32::<LittleEndian>(data_size)?;
     // Image data offset, in bytes:

--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -374,7 +374,7 @@ impl<'a, W: Write> JPEGEncoder<'a, W> {
         height: u32,
         c: color::ColorType,
     ) -> io::Result<()> {
-        let n = color::num_components(c);
+        let n = color::channel_count(c);
         let num_components = if n == 1 || n == 2 { 1 } else { 3 };
 
         self.writer.write_segment(SOI, None)?;

--- a/src/pnm/encoder.rs
+++ b/src/pnm/encoder.rs
@@ -7,7 +7,7 @@ use std::io::Write;
 use super::AutoBreak;
 use super::{ArbitraryHeader, ArbitraryTuplType, BitmapHeader, GraymapHeader, PixmapHeader};
 use super::{HeaderRecord, PNMHeader, PNMSubtype, SampleEncoding};
-use color::{num_components, ColorType};
+use color::{channel_count, ColorType};
 
 use byteorder::{BigEndian, WriteBytesExt};
 
@@ -166,7 +166,7 @@ impl<W: Write> PNMEncoder<W> {
         height: u32,
         color: ColorType,
     ) -> io::Result<()> {
-        let depth = num_components(color) as u32;
+        let depth = channel_count(color).into();
         let (maxval, tupltype) = match color {
             ColorType::Gray(1) => (1, ArbitraryTuplType::BlackAndWhite),
             ColorType::GrayA(1) => (1, ArbitraryTuplType::BlackAndWhiteAlpha),
@@ -276,7 +276,7 @@ impl<'a> CheckedImageBuffer<'a> {
         height: u32,
         color: ColorType,
     ) -> io::Result<CheckedImageBuffer<'a>> {
-        let components = num_components(color);
+        let components = channel_count(color) as usize;
         let uwidth = width as usize;
         let uheight = height as usize;
         match Some(components)


### PR DESCRIPTION
<!-- 
If you are a new contributor, consent to licensing by including this text:

Thank you for contributing, you can delete this comment.
-->

It is possible to get `ColorType` by calling `.color()` on `DynamicImage` but `bits_per_pixel()` nor `num_components()` function are available because they are not exported.

This PR exports them so they are available to use with `ColorType` structs returned from `DynamicImage`.

@nwin, @ccgn @HeroicKatora 

--------
I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.
