### PR TITLE
Make copy_from return an ImageResult instead of a boolean

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -618,8 +618,7 @@ pub trait GenericImage: GenericImageView {
     /// In order to copy only a piece of the other image, use `sub_image`.
     ///
     /// # Returns
-    /// `true` if the copy was successful, `false` if the image could not
-    /// be copied due to size constraints.
+    /// Returns an error if the image is too large to be copied at the given position
     fn copy_from<O>(&mut self, other: &O, x: u32, y: u32) -> bool
     where
         O: GenericImageView<Pixel = Self::Pixel>,
@@ -627,7 +626,7 @@ pub trait GenericImage: GenericImageView {
         // Do bounds checking here so we can use the non-bounds-checking
         // functions to copy pixels.
         if self.width() < other.width() + x || self.height() < other.height() + y {
-            return false;
+            return Err(ImageError::DimensionError);
         }
 
         for i in 0..other.width() {
@@ -636,7 +635,7 @@ pub trait GenericImage: GenericImageView {
                 self.put_pixel(i + x, k + y, p);
             }
         }
-        true
+        Ok(())
     }
 
     /// Returns a mutable reference to the underlying image.

--- a/src/image.rs
+++ b/src/image.rs
@@ -619,7 +619,7 @@ pub trait GenericImage: GenericImageView {
     ///
     /// # Returns
     /// Returns an error if the image is too large to be copied at the given position
-    fn copy_from<O>(&mut self, other: &O, x: u32, y: u32) -> bool
+    fn copy_from<O>(&mut self, other: &O, x: u32, y: u32) -> ImageResult<()>
     where
         O: GenericImageView<Pixel = Self::Pixel>,
     {


### PR DESCRIPTION
Fixes #901

<!-- 
If you are a new contributor, consent to licensing by including this text:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

Thank you for contributing, you can delete this comment.
-->

