### PR TITLE
Fix some clippy warnings

### DIFF
--- a/src/dxt.rs
+++ b/src/dxt.rs
@@ -114,7 +114,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for DXTDecoder<R> {
     type Reader = DXTReader<R>;
 
     fn dimensions(&self) -> (u64, u64) {
-        (self.width_blocks as u64 * 4, self.height_blocks as u64 * 4)
+        (u64::from(self.width_blocks) * 4, u64::from(self.height_blocks) * 4)
     }
 
     fn colortype(&self) -> ColorType {
@@ -122,7 +122,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for DXTDecoder<R> {
     }
 
     fn scanline_bytes(&self) -> u64 {
-        self.variant.decoded_bytes_per_block() as u64 * self.width_blocks as u64
+        self.variant.decoded_bytes_per_block() as u64 * u64::from(self.width_blocks)
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
@@ -160,7 +160,7 @@ impl<'a, R: 'a + Read + Seek> ImageDecoderExt<'a> for DXTDecoder<R> {
         progress_callback: F,
     ) -> ImageResult<()> {
         let encoded_scanline_bytes = self.variant.encoded_bytes_per_block() as u64
-            * self.width_blocks as u64;
+            * u64::from(self.width_blocks);
 
         let start = self.inner.seek(SeekFrom::Current(0))?;
         image::load_rect(x, y, width, height, buf, progress_callback, self,
@@ -181,7 +181,7 @@ pub struct DXTReader<R: Read> {
 }
 impl<R: Read> Read for DXTReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let ref mut decoder = &mut self.decoder;
+        let decoder = &mut (&mut self.decoder);
         self.buffer.read(buf, |buf| decoder.read_scanline(buf))
     }
 }

--- a/src/dxt.rs
+++ b/src/dxt.rs
@@ -181,7 +181,7 @@ pub struct DXTReader<R: Read> {
 }
 impl<R: Read> Read for DXTReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let decoder = &mut (&mut self.decoder);
+        let decoder = &mut self.decoder;
         self.buffer.read(buf, |buf| decoder.read_scanline(buf))
     }
 }

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -646,8 +646,8 @@ pub fn decoder_to_image<'a, I: ImageDecoder<'a>>(codec: I) -> ImageResult<Dynami
     let buf = codec.read_image()?;
 
     // TODO: Avoid this cast by having ImageBuffer use u64's
-    assert!(w <= u32::max_value() as u64);
-    assert!(h <= u32::max_value() as u64);
+    assert!(w <= u64::from(u32::max_value()));
+    assert!(h <= u64::from(u32::max_value()));
     let (w, h) = (w as u32, h as u32);
 
     let image = match color {
@@ -822,7 +822,7 @@ fn image_dimensions_impl(path: &Path) -> ImageResult<(u32, u32)> {
             format
         ))),
     };
-    if w >= u32::MAX as u64 || h >= u32::MAX as u64 {
+    if w >= u64::from(u32::MAX) || h >= u64::from(u32::MAX) {
         return Err(image::ImageError::DimensionError);
     }
     Ok((w as u32, h as u32))

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -351,7 +351,7 @@ impl SampleLayout {
             }
         }
 
-        return true;
+        true
     }
 
     /// Check that the pixel and the channel index are in bounds.
@@ -360,7 +360,7 @@ impl SampleLayout {
     /// buffer index does not overflow. However, if such a buffer large enough to hold all samples
     /// actually exists in memory, this porperty of course follows.
     pub fn in_bounds(&self, channel: u8, x: u32, y: u32) -> bool {
-        return channel < self.channels && x < self.width && y < self.height
+        channel < self.channels && x < self.width && y < self.height
     }
 
     /// Resolve the index of a particular sample.
@@ -545,7 +545,7 @@ impl<Buffer> FlatSamples<Buffer> {
         where Buffer: AsMut<[T]>,
     {
         match self.index(channel, x, y) {
-            None => return None,
+            None => None,
             Some(idx) => self.samples.as_mut().get_mut(idx),
         }
     }
@@ -1288,7 +1288,7 @@ impl<Buffer, P: Pixel> GenericImageView for View<Buffer, P>
             *to = image[index];
         });
 
-        P::from_slice(&buffer[..channels]).clone()
+        *P::from_slice(&buffer[..channels])
     }
 
     fn inner(&self) -> &Self {
@@ -1333,7 +1333,7 @@ impl<Buffer, P: Pixel> GenericImageView for ViewMut<Buffer, P>
             *to = image[index];
         });
 
-        P::from_slice(&buffer[..channels]).clone()
+        *P::from_slice(&buffer[..channels])
     }
 
     fn inner(&self) -> &Self {

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -24,7 +24,7 @@
 //! # Ok(())
 //! # }
 //! ```
-#![cfg_attr(feature = "cargo-clippy", allow(while_let_loop))]
+#![allow(clippy::while_let_loop)]
 
 extern crate gif;
 extern crate num_rational;
@@ -81,7 +81,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for Decoder<R> {
     type Reader = GifReader<R>;
 
     fn dimensions(&self) -> (u64, u64) {
-        (self.reader.width() as u64, self.reader.height() as u64)
+        (u64::from(self.reader.width()), u64::from(self.reader.height()))
     }
 
     fn colortype(&self) -> color::ColorType {

--- a/src/hdr/encoder.rs
+++ b/src/hdr/encoder.rs
@@ -33,13 +33,9 @@ impl<W: Write> HDREncoder<W> {
             let marker = rgbe8(2, 2, (width / 256) as u8, (width % 256) as u8);
             // buffers for encoded pixels
             let mut bufr = vec![0; width];
-            bufr.resize(width, 0);
             let mut bufg = vec![0; width];
-            bufg.resize(width, 0);
             let mut bufb = vec![0; width];
-            bufb.resize(width, 0);
             let mut bufe = vec![0; width];
-            bufe.resize(width, 0);
             let mut rle_buf = vec![0; width];
             for scanline in data.chunks(width) {
                 for ((((r, g), b), e), &pix) in bufr.iter_mut()

--- a/src/hdr/encoder.rs
+++ b/src/hdr/encoder.rs
@@ -32,15 +32,15 @@ impl<W: Write> HDREncoder<W> {
             // new RLE marker contains scanline width
             let marker = rgbe8(2, 2, (width / 256) as u8, (width % 256) as u8);
             // buffers for encoded pixels
-            let mut bufr = Vec::with_capacity(width);
+            let mut bufr = vec![0; width];
             bufr.resize(width, 0);
-            let mut bufg = Vec::with_capacity(width);
+            let mut bufg = vec![0; width];
             bufg.resize(width, 0);
-            let mut bufb = Vec::with_capacity(width);
+            let mut bufb = vec![0; width];
             bufb.resize(width, 0);
-            let mut bufe = Vec::with_capacity(width);
+            let mut bufe = vec![0; width];
             bufe.resize(width, 0);
-            let mut rle_buf = Vec::with_capacity(width);
+            let mut rle_buf = vec![0; width];
             for scanline in data.chunks(width) {
                 for ((((r, g), b), e), &pix) in bufr.iter_mut()
                     .zip(bufg.iter_mut())

--- a/src/ico/decoder.rs
+++ b/src/ico/decoder.rs
@@ -253,7 +253,7 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for ICODecoder<R> {
                 if mask_length > 0 {
                     // A mask row contains 1 bit per pixel, padded to 4 bytes.
                     let mask_row_bytes = ((width + 31) / 32) * 4;
-                    let expected_length = u64::from(mask_row_bytes * height);
+                    let expected_length = mask_row_bytes * height;
                     if mask_length < expected_length {
                         return Err(ImageError::ImageEnd);
                     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 use std::error::Error;
 use std::fmt;
 use std::io;

--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -53,7 +53,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for JPEGDecoder<R> {
     type Reader = JpegReader<R>;
 
     fn dimensions(&self) -> (u64, u64) {
-        (self.metadata.width as u64, self.metadata.height as u64)
+        (u64::from(self.metadata.width), u64::from(self.metadata.height))
     }
 
     fn colortype(&self) -> ColorType {

--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
+#![allow(clippy::too_many_arguments)]
 
 use byteorder::{BigEndian, WriteBytesExt};
 use math::utils::clamp;
@@ -28,7 +28,7 @@ static APP0: u8 = 0xE0;
 
 // section K.1
 // table K.1
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 static STD_LUMA_QTABLE: [u8; 64] = [
     16, 11, 10, 16,  24,  40,  51,  61,
     12, 12, 14, 19,  26,  58,  60,  55,
@@ -41,7 +41,7 @@ static STD_LUMA_QTABLE: [u8; 64] = [
 ];
 
 // table K.2
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 static STD_CHROMA_QTABLE: [u8; 64] = [
     17, 18, 24, 47, 99, 99, 99, 99,
     18, 21, 26, 66, 99, 99, 99, 99,
@@ -120,7 +120,7 @@ static CHROMABLUEID: u8 = 2;
 static CHROMAREDID: u8 = 3;
 
 /// The permutation of dct coefficients.
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 static UNZIGZAG: [u8; 64] = [
      0,  1,  8, 16,  9,  2,  3, 10,
     17, 24, 32, 25, 18, 11,  4,  5,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 #![deny(missing_copy_implementations)]
 #![cfg_attr(all(test, feature = "benchmarks"), feature(test))]
 // it's a bit of a pain otherwise
-#![cfg_attr(feature = "cargo-clippy", allow(many_single_char_names))]
+#![allow(clippy::many_single_char_names)]
 
 extern crate byteorder;
 extern crate lzw;

--- a/src/png.rs
+++ b/src/png.rs
@@ -113,7 +113,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for PNGDecoder<R> {
 
     fn dimensions(&self) -> (u64, u64) {
         let (w, h) = self.reader.info().size();
-        (w as u64, h as u64)
+        (u64::from(w), u64::from(h))
     }
 
     fn colortype(&self) -> ColorType {

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -286,7 +286,7 @@ trait HeaderReader: BufRead {
             let len = self.read_line(&mut line).map_err(ImageError::IoError)?;
             if len == 0 {
                 return Err(ImageError::FormatError(
-                    format!("Unexpected end of pnm header"),
+                    "Unexpected end of pnm header".to_string(),
                 ))
             }
             if line.as_bytes()[0] == b'#' {
@@ -428,7 +428,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for PNMDecoder<R> {
     type Reader = PnmReader<R>;
 
     fn dimensions(&self) -> (u64, u64) {
-        (self.header.width() as u64, self.header.height() as u64)
+        (u64::from(self.header.width()), u64::from(self.header.height()))
     }
 
     fn colortype(&self) -> ColorType {
@@ -467,11 +467,11 @@ impl<R: Read> PNMDecoder<R> {
                     .read_exact(&mut bytes)
                     .map_err(|_| ImageError::NotEnoughData)?;
                 let samples = S::from_bytes(&bytes, width, height, components)?;
-                Ok(samples.into())
+                Ok(samples)
             }
             SampleEncoding::Ascii => {
                 let samples = self.read_ascii::<S>(components)?;
-                Ok(samples.into())
+                Ok(samples)
             }
         }
     }

--- a/src/pnm/mod.rs
+++ b/src/pnm/mod.rs
@@ -107,7 +107,7 @@ mod tests {
 
     #[test]
     fn roundtrip_rgb() {
-        #[cfg_attr(rustfmt, rustfmt_skip)]
+        #[rustfmt::skip]
         let buf: [u8; 27] = [
               0,   0,   0,
               0,   0, 255,

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -535,7 +535,7 @@ pub struct TGAReader<R> {
 }
 impl<R: Read + Seek> Read for TGAReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let decoder = &mut (&mut self.decoder);
+        let decoder = &mut self.decoder;
         self.buffer.read(buf, |buf| decoder.read_scanline(buf))
     }
 }

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -535,7 +535,7 @@ pub struct TGAReader<R> {
 }
 impl<R: Read + Seek> Read for TGAReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let ref mut decoder = &mut self.decoder;
+        let decoder = &mut (&mut self.decoder);
         self.buffer.read(buf, |buf| decoder.read_scanline(buf))
     }
 }

--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -86,7 +86,7 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for TIFFDecoder<R> {
     type Reader = TiffReader<R>;
 
     fn dimensions(&self) -> (u64, u64) {
-        (self.dimensions.0 as u64, self.dimensions.1 as u64)
+        (u64::from(self.dimensions.0), u64::from(self.dimensions.1))
     }
 
     fn colortype(&self) -> ColorType {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -39,7 +39,7 @@ pub fn vec_u16_into_u8(vec: Vec<u16>) -> Vec<u8> {
     vec_u16_copy_u8(&vec)
 }
 
-pub fn vec_u16_copy_u8(vec: &Vec<u16>) -> Vec<u8> {
+pub fn vec_u16_copy_u8(vec: &[u16]) -> Vec<u8> {
     let mut new = vec![0; vec.len() * mem::size_of::<u16>()];
     NativeEndian::write_u16_into(&vec[..], &mut new[..]);
     new

--- a/src/webp/decoder.rs
+++ b/src/webp/decoder.rs
@@ -119,7 +119,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for WebpDecoder<R> {
     type Reader = WebpReader<R>;
 
     fn dimensions(&self) -> (u64, u64) {
-        (self.frame.width as u64, self.frame.height as u64)
+        (u64::from(self.frame.width), u64::from(self.frame.height))
     }
 
     fn colortype(&self) -> color::ColorType {

--- a/src/webp/vp8.rs
+++ b/src/webp/vp8.rs
@@ -620,7 +620,7 @@ static PROB_DCT_CAT: [[Prob; 12]; 6] = [
 static DCT_CAT_BASE: [u8; 6] = [5, 7, 11, 19, 35, 67];
 static COEFF_BANDS: [u8; 16] = [0, 1, 2, 3, 6, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 7];
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 static DC_QUANT: [i16; 128] = [
       4,   5,   6,   7,   8,   9,  10,  10,
      11,  12,  13,  14,  15,  16,  17,  17,
@@ -640,7 +640,7 @@ static DC_QUANT: [i16; 128] = [
     138, 140, 143, 145, 148, 151, 154, 157,
 ];
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
 static AC_QUANT: [i16; 128] = [
       4,   5,   6,   7,   8,    9,  10,  11,
       12,  13,  14,  15,  16,  17,  18,  19,
@@ -1143,7 +1143,7 @@ impl<R: Read> VP8Decoder<R> {
 
             if color_space != 0 {
                 return Err(ImageError::FormatError(
-                    format!("Only YUV color space is specified.")))
+                    "Only YUV color space is specified.".to_string()))
             }
         }
 


### PR DESCRIPTION
Fix some clippy warnings:

* use `from` for lossless cast
* remove redundant code
* replace deprecated attributes

etc.