### PR TITLE
Add a function to derive a ImageFormat from a path

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -766,32 +766,29 @@ fn image_dimensions_impl(path: &Path) -> ImageResult<(u32, u32)> {
     let fin = File::open(path)?;
     let fin = BufReader::new(fin);
 
-    let ext = path
-        .extension()
-        .and_then(|s| s.to_str())
-        .map_or("".to_string(), |s| s.to_ascii_lowercase());
-
-    let (w, h): (u64, u64) = match &ext[..] {
+    #[allow(unreachable_patterns)]
+    // Default is unreachable if all features are supported.
+    let (w, h): (u64, u64) = match image::ImageFormat::from_path(path)? {
         #[cfg(feature = "jpeg")]
-        "jpg" | "jpeg" => jpeg::JPEGDecoder::new(fin)?.dimensions(),
+        image::ImageFormat::JPEG => jpeg::JPEGDecoder::new(fin)?.dimensions(),
         #[cfg(feature = "png_codec")]
-        "png" => png::PNGDecoder::new(fin)?.dimensions(),
+        image::ImageFormat::PNG => png::PNGDecoder::new(fin)?.dimensions(),
         #[cfg(feature = "gif_codec")]
-        "gif" => gif::Decoder::new(fin)?.dimensions(),
+        image::ImageFormat::GIF => gif::Decoder::new(fin)?.dimensions(),
         #[cfg(feature = "webp")]
-        "webp" => webp::WebpDecoder::new(fin)?.dimensions(),
+        image::ImageFormat::WEBP => webp::WebpDecoder::new(fin)?.dimensions(),
         #[cfg(feature = "tiff")]
-        "tif" | "tiff" => tiff::TIFFDecoder::new(fin)?.dimensions(),
+        image::ImageFormat::TIFF => tiff::TIFFDecoder::new(fin)?.dimensions(),
         #[cfg(feature = "tga")]
-        "tga" => tga::TGADecoder::new(fin)?.dimensions(),
+        image::ImageFormat::TGA => tga::TGADecoder::new(fin)?.dimensions(),
         #[cfg(feature = "bmp")]
-        "bmp" => bmp::BMPDecoder::new(fin)?.dimensions(),
+        image::ImageFormat::BMP => bmp::BMPDecoder::new(fin)?.dimensions(),
         #[cfg(feature = "ico")]
-        "ico" => ico::ICODecoder::new(fin)?.dimensions(),
+        image::ImageFormat::ICO => ico::ICODecoder::new(fin)?.dimensions(),
         #[cfg(feature = "hdr")]
-        "hdr" => hdr::HDRAdapter::new(fin)?.dimensions(),
+        image::ImageFormat::HDR => hdr::HDRAdapter::new(fin)?.dimensions(),
         #[cfg(feature = "pnm")]
-        "pbm" | "pam" | "ppm" | "pgm" => {
+        image::ImageFormat::PNM => {
             pnm::PNMDecoder::new(fin)?.dimensions()
         }
         format => return Err(image::ImageError::UnsupportedError(format!(

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -749,30 +749,7 @@ fn open_impl(path: &Path) -> ImageResult<DynamicImage> {
     };
     let fin = BufReader::new(fin);
 
-    let ext = path.extension()
-        .and_then(|s| s.to_str())
-        .map_or("".to_string(), |s| s.to_ascii_lowercase());
-
-    let format = match &ext[..] {
-        "jpg" | "jpeg" => image::ImageFormat::JPEG,
-        "png" => image::ImageFormat::PNG,
-        "gif" => image::ImageFormat::GIF,
-        "webp" => image::ImageFormat::WEBP,
-        "tif" | "tiff" => image::ImageFormat::TIFF,
-        "tga" => image::ImageFormat::TGA,
-        "bmp" => image::ImageFormat::BMP,
-        "ico" => image::ImageFormat::ICO,
-        "hdr" => image::ImageFormat::HDR,
-        "pbm" | "pam" | "ppm" | "pgm" => image::ImageFormat::PNM,
-        format => {
-            return Err(image::ImageError::UnsupportedError(format!(
-                "Image format image/{:?} is not supported.",
-                format
-            )))
-        }
-    };
-
-    load(fin, format)
+    load(fin, ImageFormat::from_path(path)?)
 }
 
 /// Read the dimensions of the image located at the specified path.

--- a/src/image.rs
+++ b/src/image.rs
@@ -964,18 +964,19 @@ mod tests {
         }
         assert_eq!(from_path("./a.jpg").unwrap(), ImageFormat::JPEG);
         assert_eq!(from_path("./a.jpeg").unwrap(), ImageFormat::JPEG);
-        assert_eq!(from_path("./a.png").unwrap(), ImageFormat::PNG);
+        assert_eq!(from_path("./a.JPEG").unwrap(), ImageFormat::JPEG);
+        assert_eq!(from_path("./a.pNg").unwrap(), ImageFormat::PNG);
         assert_eq!(from_path("./a.gif").unwrap(), ImageFormat::GIF);
         assert_eq!(from_path("./a.webp").unwrap(), ImageFormat::WEBP);
-        assert_eq!(from_path("./a.tiff").unwrap(), ImageFormat::TIFF);
+        assert_eq!(from_path("./a.tiFF").unwrap(), ImageFormat::TIFF);
         assert_eq!(from_path("./a.tif").unwrap(), ImageFormat::TIFF);
         assert_eq!(from_path("./a.tga").unwrap(), ImageFormat::TGA);
         assert_eq!(from_path("./a.bmp").unwrap(), ImageFormat::BMP);
-        assert_eq!(from_path("./a.ico").unwrap(), ImageFormat::ICO);
+        assert_eq!(from_path("./a.Ico").unwrap(), ImageFormat::ICO);
         assert_eq!(from_path("./a.hdr").unwrap(), ImageFormat::HDR);
         assert_eq!(from_path("./a.pbm").unwrap(), ImageFormat::PNM);
-        assert_eq!(from_path("./a.pam").unwrap(), ImageFormat::PNM);
-        assert_eq!(from_path("./a.ppm").unwrap(), ImageFormat::PNM);
+        assert_eq!(from_path("./a.pAM").unwrap(), ImageFormat::PNM);
+        assert_eq!(from_path("./a.Ppm").unwrap(), ImageFormat::PNM);
         assert_eq!(from_path("./a.pgm").unwrap(), ImageFormat::PNM);
         assert!(from_path("./a.txt").is_err());
         assert!(from_path("./a").is_err());


### PR DESCRIPTION
This was originally inlined as part of `open`'s implementation, however, I
have a usecase where I want to open a file handle and extract metadata
about the image (exif) then turn the file into an image for doing things
such as creating thumbnails, etc.

This seems like the best way to achieve this, is to expose a function
like this (I'm open to a different API FWIW). My code would then be something like:

```rust
let mut file = File::open(path);

let metadata = extract_image_metadata(&file);
let image = image::load(BufReader::new(file), image::ImageFormat::from_path(path)?)?;
image.thumbnail(256, 256).save(thumbnail_path)?;
```

Is there a better way to do something like this using this library?
Otherwise I'm inclined to believe this patch is useful for my usecase
and (hopefully) in general to other users of this library as well.



I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.
