### PR TITLE
Image reader

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -1,7 +1,6 @@
 use num_iter;
-use std::fs::File;
 use std::io;
-use std::io::{BufRead, BufReader, BufWriter, Seek, Write};
+use std::io::Write;
 use std::path::Path;
 use std::u32;
 
@@ -9,8 +8,6 @@ use std::u32;
 use bmp;
 #[cfg(feature = "gif_codec")]
 use gif;
-#[cfg(feature = "hdr")]
-use hdr;
 #[cfg(feature = "ico")]
 use ico;
 #[cfg(feature = "jpeg")]
@@ -19,12 +16,6 @@ use jpeg;
 use png;
 #[cfg(feature = "pnm")]
 use pnm;
-#[cfg(feature = "tga")]
-use tga;
-#[cfg(feature = "tiff")]
-use tiff;
-#[cfg(feature = "webp")]
-use webp;
 
 use buffer::{
     BgrImage, BgraImage, ConvertBuffer, GrayAlphaImage, GrayImage, ImageBuffer, Pixel, RgbImage,
@@ -36,6 +27,7 @@ use image;
 use image::{
     GenericImage, GenericImageView, ImageDecoder, ImageFormat, ImageOutputFormat, ImageResult,
 };
+use io::free_functions;
 use imageops;
 
 /// A Dynamic Image
@@ -735,17 +727,7 @@ where
     P: AsRef<Path>,
 {
     // thin wrapper function to strip generics before calling open_impl
-    open_impl(path.as_ref())
-}
-
-fn open_impl(path: &Path) -> ImageResult<DynamicImage> {
-    let fin = match File::open(path) {
-        Ok(f) => f,
-        Err(err) => return Err(image::ImageError::IoError(err)),
-    };
-    let fin = BufReader::new(fin);
-
-    load(fin, ImageFormat::from_path(path)?)
+    free_functions::open_impl(path.as_ref())
 }
 
 /// Read the dimensions of the image located at the specified path.
@@ -755,47 +737,7 @@ where
     P: AsRef<Path>,
 {
     // thin wrapper function to strip generics before calling open_impl
-    image_dimensions_impl(path.as_ref())
-}
-
-fn image_dimensions_impl(path: &Path) -> ImageResult<(u32, u32)> {
-    let fin = File::open(path)?;
-    let fin = BufReader::new(fin);
-
-    #[allow(unreachable_patterns)]
-    // Default is unreachable if all features are supported.
-    let (w, h): (u64, u64) = match image::ImageFormat::from_path(path)? {
-        #[cfg(feature = "jpeg")]
-        image::ImageFormat::JPEG => jpeg::JPEGDecoder::new(fin)?.dimensions(),
-        #[cfg(feature = "png_codec")]
-        image::ImageFormat::PNG => png::PNGDecoder::new(fin)?.dimensions(),
-        #[cfg(feature = "gif_codec")]
-        image::ImageFormat::GIF => gif::Decoder::new(fin)?.dimensions(),
-        #[cfg(feature = "webp")]
-        image::ImageFormat::WEBP => webp::WebpDecoder::new(fin)?.dimensions(),
-        #[cfg(feature = "tiff")]
-        image::ImageFormat::TIFF => tiff::TIFFDecoder::new(fin)?.dimensions(),
-        #[cfg(feature = "tga")]
-        image::ImageFormat::TGA => tga::TGADecoder::new(fin)?.dimensions(),
-        #[cfg(feature = "bmp")]
-        image::ImageFormat::BMP => bmp::BMPDecoder::new(fin)?.dimensions(),
-        #[cfg(feature = "ico")]
-        image::ImageFormat::ICO => ico::ICODecoder::new(fin)?.dimensions(),
-        #[cfg(feature = "hdr")]
-        image::ImageFormat::HDR => hdr::HDRAdapter::new(fin)?.dimensions(),
-        #[cfg(feature = "pnm")]
-        image::ImageFormat::PNM => pnm::PNMDecoder::new(fin)?.dimensions(),
-        format => {
-            return Err(image::ImageError::UnsupportedError(format!(
-                "Image format image/{:?} is not supported.",
-                format
-            )));
-        }
-    };
-    if w >= u64::from(u32::MAX) || h >= u64::from(u32::MAX) {
-        return Err(image::ImageError::DimensionError);
-    }
-    Ok((w as u32, h as u32))
+    free_functions::image_dimensions_impl(path.as_ref())
 }
 
 /// Saves the supplied buffer to a file at the path specified.
@@ -816,54 +758,7 @@ where
     P: AsRef<Path>,
 {
     // thin wrapper function to strip generics before calling save_buffer_impl
-    save_buffer_impl(path.as_ref(), buf, width, height, color)
-}
-
-fn save_buffer_impl(
-    path: &Path,
-    buf: &[u8],
-    width: u32,
-    height: u32,
-    color: color::ColorType,
-) -> io::Result<()> {
-    let fout = &mut BufWriter::new(File::create(path)?);
-    let ext = path
-        .extension()
-        .and_then(|s| s.to_str())
-        .map_or("".to_string(), |s| s.to_ascii_lowercase());
-
-    match &*ext {
-        #[cfg(feature = "ico")]
-        "ico" => ico::ICOEncoder::new(fout).encode(buf, width, height, color),
-        #[cfg(feature = "jpeg")]
-        "jpg" | "jpeg" => jpeg::JPEGEncoder::new(fout).encode(buf, width, height, color),
-        #[cfg(feature = "png_codec")]
-        "png" => png::PNGEncoder::new(fout).encode(buf, width, height, color),
-        #[cfg(feature = "pnm")]
-        "pbm" => pnm::PNMEncoder::new(fout)
-            .with_subtype(pnm::PNMSubtype::Bitmap(pnm::SampleEncoding::Binary))
-            .encode(buf, width, height, color),
-        #[cfg(feature = "pnm")]
-        "pgm" => pnm::PNMEncoder::new(fout)
-            .with_subtype(pnm::PNMSubtype::Graymap(pnm::SampleEncoding::Binary))
-            .encode(buf, width, height, color),
-        #[cfg(feature = "pnm")]
-        "ppm" => pnm::PNMEncoder::new(fout)
-            .with_subtype(pnm::PNMSubtype::Pixmap(pnm::SampleEncoding::Binary))
-            .encode(buf, width, height, color),
-        #[cfg(feature = "pnm")]
-        "pam" => pnm::PNMEncoder::new(fout).encode(buf, width, height, color),
-        #[cfg(feature = "bmp")]
-        "bmp" => bmp::BMPEncoder::new(fout).encode(buf, width, height, color),
-        #[cfg(feature = "tiff")]
-        "tif" | "tiff" => tiff::TiffEncoder::new(fout)
-            .encode(buf, width, height, color)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, Box::new(e))), // FIXME: see https://github.com/image-rs/image/issues/921
-        format => Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            &format!("Unsupported image format image/{:?}", format)[..],
-        )),
-    }
+    free_functions::save_buffer_impl(path.as_ref(), buf, width, height, color)
 }
 
 /// Saves the supplied buffer to a file at the path specified
@@ -886,120 +781,23 @@ where
     P: AsRef<Path>,
 {
     // thin wrapper function to strip generics
-    save_buffer_with_format_impl(path.as_ref(), buf, width, height, color, format)
+    free_functions::save_buffer_with_format_impl(path.as_ref(), buf, width, height, color, format)
 }
-
-fn save_buffer_with_format_impl(
-    path: &Path,
-    buf: &[u8],
-    width: u32,
-    height: u32,
-    color: color::ColorType,
-    format: ImageFormat,
-) -> io::Result<()> {
-    let fout = &mut BufWriter::new(File::create(path)?);
-
-    match format {
-        #[cfg(feature = "ico")]
-        image::ImageFormat::ICO => ico::ICOEncoder::new(fout).encode(buf, width, height, color),
-        #[cfg(feature = "jpeg")]
-        image::ImageFormat::JPEG => jpeg::JPEGEncoder::new(fout).encode(buf, width, height, color),
-        #[cfg(feature = "png_codec")]
-        image::ImageFormat::PNG => png::PNGEncoder::new(fout).encode(buf, width, height, color),
-        #[cfg(feature = "bmp")]
-        image::ImageFormat::BMP => bmp::BMPEncoder::new(fout).encode(buf, width, height, color),
-        #[cfg(feature = "tiff")]
-        image::ImageFormat::TIFF => tiff::TiffEncoder::new(fout)
-            .encode(buf, width, height, color)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, Box::new(e))),
-        _ => Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            &format!("Unsupported image format image/{:?}", format)[..],
-        )),
-    }
-}
-
-/// Create a new image from a Reader
-pub fn load<R: BufRead + Seek>(r: R, format: ImageFormat) -> ImageResult<DynamicImage> {
-    #[allow(deprecated, unreachable_patterns)]
-    // Default is unreachable if all features are supported.
-    match format {
-        #[cfg(feature = "png_codec")]
-        image::ImageFormat::PNG => decoder_to_image(png::PNGDecoder::new(r)?),
-        #[cfg(feature = "gif_codec")]
-        image::ImageFormat::GIF => decoder_to_image(gif::Decoder::new(r)?),
-        #[cfg(feature = "jpeg")]
-        image::ImageFormat::JPEG => decoder_to_image(jpeg::JPEGDecoder::new(r)?),
-        #[cfg(feature = "webp")]
-        image::ImageFormat::WEBP => decoder_to_image(webp::WebpDecoder::new(r)?),
-        #[cfg(feature = "tiff")]
-        image::ImageFormat::TIFF => decoder_to_image(tiff::TIFFDecoder::new(r)?),
-        #[cfg(feature = "tga")]
-        image::ImageFormat::TGA => decoder_to_image(tga::TGADecoder::new(r)?),
-        #[cfg(feature = "bmp")]
-        image::ImageFormat::BMP => decoder_to_image(bmp::BMPDecoder::new(r)?),
-        #[cfg(feature = "ico")]
-        image::ImageFormat::ICO => decoder_to_image(ico::ICODecoder::new(r)?),
-        #[cfg(feature = "hdr")]
-        image::ImageFormat::HDR => decoder_to_image(hdr::HDRAdapter::new(BufReader::new(r))?),
-        #[cfg(feature = "pnm")]
-        image::ImageFormat::PNM => decoder_to_image(pnm::PNMDecoder::new(BufReader::new(r))?),
-        _ => Err(image::ImageError::UnsupportedError(format!(
-            "A decoder for {:?} is not available.",
-            format
-        ))),
-    }
-}
-
-static MAGIC_BYTES: [(&[u8], ImageFormat); 17] = [
-    (b"\x89PNG\r\n\x1a\n", ImageFormat::PNG),
-    (&[0xff, 0xd8, 0xff], ImageFormat::JPEG),
-    (b"GIF89a", ImageFormat::GIF),
-    (b"GIF87a", ImageFormat::GIF),
-    (b"RIFF", ImageFormat::WEBP), // TODO: better magic byte detection, see https://github.com/image-rs/image/issues/660
-    (b"MM\x00*", ImageFormat::TIFF),
-    (b"II*\x00", ImageFormat::TIFF),
-    (b"BM", ImageFormat::BMP),
-    (&[0, 0, 1, 0], ImageFormat::ICO),
-    (b"#?RADIANCE", ImageFormat::HDR),
-    (b"P1", ImageFormat::PNM),
-    (b"P2", ImageFormat::PNM),
-    (b"P3", ImageFormat::PNM),
-    (b"P4", ImageFormat::PNM),
-    (b"P5", ImageFormat::PNM),
-    (b"P6", ImageFormat::PNM),
-    (b"P7", ImageFormat::PNM),
-];
 
 /// Create a new image from a byte slice
 ///
 /// Makes an educated guess about the image format.
 /// TGA is not supported by this function.
 pub fn load_from_memory(buffer: &[u8]) -> ImageResult<DynamicImage> {
-    load_from_memory_with_format(buffer, guess_format(buffer)?)
+    let format = free_functions::guess_format(buffer)?;
+    load_from_memory_with_format(buffer, format)
 }
 
 /// Create a new image from a byte slice
 #[inline(always)]
 pub fn load_from_memory_with_format(buf: &[u8], format: ImageFormat) -> ImageResult<DynamicImage> {
     let b = io::Cursor::new(buf);
-    load(b, format)
-}
-
-/// Guess image format from memory block
-///
-/// Makes an educated guess about the image format based on the Magic Bytes at the beginning.
-/// TGA is not supported by this function.
-/// This is not to be trusted on the validity of the whole memory block
-pub fn guess_format(buffer: &[u8]) -> ImageResult<ImageFormat> {
-    for &(signature, format) in &MAGIC_BYTES {
-        if buffer.starts_with(signature) {
-            return Ok(format);
-        }
-    }
-    Err(image::ImageError::UnsupportedError(
-        "Unsupported image format".to_string(),
-    ))
+    free_functions::load(b, format)
 }
 
 /// Calculates the width and height an image should be resized to.

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -722,6 +722,11 @@ fn image_to_bytes(image: &DynamicImage) -> Vec<u8> {
 
 /// Open the image located at the path specified.
 /// The image's format is determined from the path's file extension.
+///
+/// Try [`io::Reader`] for more advanced uses, including guessing the format based on the file's
+/// content before its path.
+///
+/// [`io::Reader`]: io/struct.Reader.html
 pub fn open<P>(path: P) -> ImageResult<DynamicImage>
 where
     P: AsRef<Path>,
@@ -732,6 +737,11 @@ where
 
 /// Read the dimensions of the image located at the specified path.
 /// This is faster than fully loading the image and then getting its dimensions.
+///
+/// Try [`io::Reader`] for more advanced uses, including guessing the format based on the file's
+/// content before its path or manually supplying the format.
+///
+/// [`io::Reader`]: io/struct.Reader.html
 pub fn image_dimensions<P>(path: P) -> ImageResult<(u32, u32)>
 where
     P: AsRef<Path>,
@@ -788,12 +798,24 @@ where
 ///
 /// Makes an educated guess about the image format.
 /// TGA is not supported by this function.
+///
+/// Try [`io::Reader`] for more advanced uses.
+///
+/// [`io::Reader`]: io/struct.Reader.html
 pub fn load_from_memory(buffer: &[u8]) -> ImageResult<DynamicImage> {
     let format = free_functions::guess_format(buffer)?;
     load_from_memory_with_format(buffer, format)
 }
 
 /// Create a new image from a byte slice
+///
+/// This is just a simple wrapper that constructs an `std::io::Cursor` around the buffer and then
+/// calls `load` with that reader.
+///
+/// Try [`io::Reader`] for more advanced uses.
+///
+/// [`load`]: fn.load.html
+/// [`io::Reader`]: io/struct.Reader.html
 #[inline(always)]
 pub fn load_from_memory_with_format(buf: &[u8], format: ImageFormat) -> ImageResult<DynamicImage> {
     let b = io::Cursor::new(buf);

--- a/src/image.rs
+++ b/src/image.rs
@@ -148,34 +148,8 @@ impl ImageFormat {
     /// Return the image format specified by the path's file extension.
     pub fn from_path<P>(path: P) -> ImageResult<Self> where P : AsRef<Path> {
         // thin wrapper function to strip generics before calling from_path_impl
-        Self::from_path_impl(path.as_ref())
-    }
-
-    fn from_path_impl(path: &Path) -> ImageResult<Self> {
-        let ext = path
-            .extension()
-            .and_then(|s| s.to_str())
-            .map_or("".to_string(), |s| s.to_ascii_lowercase());
-
-        let format = match &ext[..] {
-            "jpg" | "jpeg" => ImageFormat::JPEG,
-            "png" => ImageFormat::PNG,
-            "gif" => ImageFormat::GIF,
-            "webp" => ImageFormat::WEBP,
-            "tif" | "tiff" => ImageFormat::TIFF,
-            "tga" => ImageFormat::TGA,
-            "bmp" => ImageFormat::BMP,
-            "ico" => ImageFormat::ICO,
-            "hdr" => ImageFormat::HDR,
-            "pbm" | "pam" | "ppm" | "pgm" => ImageFormat::PNM,
-            format => {
-                return Err(ImageError::UnsupportedError(format!(
-                            "Image format image/{:?} is not supported.",
-                            format
-                            )))
-            }
-        };
-        Ok(format)
+        ::io::free_functions::guess_format_from_path_impl(path.as_ref())
+            .map_err(Into::into)
     }
 }
 

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -83,12 +83,20 @@ pub fn load<R: BufRead + Seek>(r: R, format: ImageFormat) -> ImageResult<Dynamic
 }
 
 pub(crate) fn image_dimensions_impl(path: &Path) -> ImageResult<(u32, u32)> {
+    let format = image::ImageFormat::from_path(path)?;
+
     let fin = File::open(path)?;
     let fin = BufReader::new(fin);
 
+    image_dimensions_with_format_impl(fin, format)
+}
+
+pub(crate) fn image_dimensions_with_format_impl<R: BufRead + Seek>(fin: R, format: ImageFormat)
+    -> ImageResult<(u32, u32)>
+{
     #[allow(unreachable_patterns)]
     // Default is unreachable if all features are supported.
-    let (w, h): (u64, u64) = match image::ImageFormat::from_path(path)? {
+    let (w, h): (u64, u64) = match format {
         #[cfg(feature = "jpeg")]
         image::ImageFormat::JPEG => jpeg::JPEGDecoder::new(fin)?.dimensions(),
         #[cfg(feature = "png_codec")]

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -210,8 +210,9 @@ pub(crate) fn save_buffer_with_format_impl(
 }
 
 /// Guess format from a path.
-/// If the path has no extension or it can not be convert to a `str` for comparison then this
-/// method will simply return `None`.
+///
+/// Returns `PathError::NoExtension` if the path has no extension or returns a
+/// `PathError::UnknownExtension` containing the extension if  it can not be convert to a `str`.
 pub(crate) fn guess_format_from_path_impl(path: &Path) -> Result<ImageFormat, PathError> {
     let exact_ext = path.extension();
 

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -1,0 +1,225 @@
+use std::fs::File;
+use std::io;
+use std::io::{BufRead, BufReader, BufWriter, Seek};
+use std::path::Path;
+use std::u32;
+
+#[cfg(feature = "bmp")]
+use bmp;
+#[cfg(feature = "gif_codec")]
+use gif;
+#[cfg(feature = "hdr")]
+use hdr;
+#[cfg(feature = "ico")]
+use ico;
+#[cfg(feature = "jpeg")]
+use jpeg;
+#[cfg(feature = "png_codec")]
+use png;
+#[cfg(feature = "pnm")]
+use pnm;
+#[cfg(feature = "tga")]
+use tga;
+#[cfg(feature = "tiff")]
+use tiff;
+#[cfg(feature = "webp")]
+use webp;
+
+// use buffer::{ConvertBuffer, GrayAlphaImage, GrayImage, ImageBuffer, Pixel, RgbImage, RgbaImage, BgrImage, BgraImage};
+use color;
+use image;
+use dynimage::DynamicImage;
+use image::{ImageDecoder, ImageFormat, ImageResult};
+
+pub(crate) fn open_impl(path: &Path) -> ImageResult<DynamicImage> {
+    let fin = match File::open(path) {
+        Ok(f) => f,
+        Err(err) => return Err(image::ImageError::IoError(err)),
+    };
+    let fin = BufReader::new(fin);
+
+    load(fin, ImageFormat::from_path(path)?)
+}
+
+/// Create a new image from a Reader
+pub fn load<R: BufRead + Seek>(r: R, format: ImageFormat) -> ImageResult<DynamicImage> {
+    #[allow(deprecated, unreachable_patterns)]
+    // Default is unreachable if all features are supported.
+    match format {
+        #[cfg(feature = "png_codec")]
+        image::ImageFormat::PNG => DynamicImage::from_decoder(png::PNGDecoder::new(r)?),
+        #[cfg(feature = "gif_codec")]
+        image::ImageFormat::GIF => DynamicImage::from_decoder(gif::Decoder::new(r)?),
+        #[cfg(feature = "jpeg")]
+        image::ImageFormat::JPEG => DynamicImage::from_decoder(jpeg::JPEGDecoder::new(r)?),
+        #[cfg(feature = "webp")]
+        image::ImageFormat::WEBP => DynamicImage::from_decoder(webp::WebpDecoder::new(r)?),
+        #[cfg(feature = "tiff")]
+        image::ImageFormat::TIFF => DynamicImage::from_decoder(tiff::TIFFDecoder::new(r)?),
+        #[cfg(feature = "tga")]
+        image::ImageFormat::TGA => DynamicImage::from_decoder(tga::TGADecoder::new(r)?),
+        #[cfg(feature = "bmp")]
+        image::ImageFormat::BMP => DynamicImage::from_decoder(bmp::BMPDecoder::new(r)?),
+        #[cfg(feature = "ico")]
+        image::ImageFormat::ICO => DynamicImage::from_decoder(ico::ICODecoder::new(r)?),
+        #[cfg(feature = "hdr")]
+        image::ImageFormat::HDR => DynamicImage::from_decoder(hdr::HDRAdapter::new(BufReader::new(r))?),
+        #[cfg(feature = "pnm")]
+        image::ImageFormat::PNM => DynamicImage::from_decoder(pnm::PNMDecoder::new(BufReader::new(r))?),
+        _ => Err(image::ImageError::UnsupportedError(format!(
+            "A decoder for {:?} is not available.",
+            format
+        ))),
+    }
+}
+
+pub(crate) fn image_dimensions_impl(path: &Path) -> ImageResult<(u32, u32)> {
+    let fin = File::open(path)?;
+    let fin = BufReader::new(fin);
+
+    #[allow(unreachable_patterns)]
+    // Default is unreachable if all features are supported.
+    let (w, h): (u64, u64) = match image::ImageFormat::from_path(path)? {
+        #[cfg(feature = "jpeg")]
+        image::ImageFormat::JPEG => jpeg::JPEGDecoder::new(fin)?.dimensions(),
+        #[cfg(feature = "png_codec")]
+        image::ImageFormat::PNG => png::PNGDecoder::new(fin)?.dimensions(),
+        #[cfg(feature = "gif_codec")]
+        image::ImageFormat::GIF => gif::Decoder::new(fin)?.dimensions(),
+        #[cfg(feature = "webp")]
+        image::ImageFormat::WEBP => webp::WebpDecoder::new(fin)?.dimensions(),
+        #[cfg(feature = "tiff")]
+        image::ImageFormat::TIFF => tiff::TIFFDecoder::new(fin)?.dimensions(),
+        #[cfg(feature = "tga")]
+        image::ImageFormat::TGA => tga::TGADecoder::new(fin)?.dimensions(),
+        #[cfg(feature = "bmp")]
+        image::ImageFormat::BMP => bmp::BMPDecoder::new(fin)?.dimensions(),
+        #[cfg(feature = "ico")]
+        image::ImageFormat::ICO => ico::ICODecoder::new(fin)?.dimensions(),
+        #[cfg(feature = "hdr")]
+        image::ImageFormat::HDR => hdr::HDRAdapter::new(fin)?.dimensions(),
+        #[cfg(feature = "pnm")]
+        image::ImageFormat::PNM => {
+            pnm::PNMDecoder::new(fin)?.dimensions()
+        }
+        format => return Err(image::ImageError::UnsupportedError(format!(
+            "Image format image/{:?} is not supported.",
+            format
+        ))),
+    };
+    if w >= u64::from(u32::MAX) || h >= u64::from(u32::MAX) {
+        return Err(image::ImageError::DimensionError);
+    }
+    Ok((w as u32, h as u32))
+}
+
+pub(crate) fn save_buffer_impl(
+    path: &Path,
+    buf: &[u8],
+    width: u32,
+    height: u32,
+    color: color::ColorType,
+) -> io::Result<()> {
+    let fout = &mut BufWriter::new(File::create(path)?);
+    let ext = path.extension()
+        .and_then(|s| s.to_str())
+        .map_or("".to_string(), |s| s.to_ascii_lowercase());
+
+    match &*ext {
+        #[cfg(feature = "ico")]
+        "ico" => ico::ICOEncoder::new(fout).encode(buf, width, height, color),
+        #[cfg(feature = "jpeg")]
+        "jpg" | "jpeg" => jpeg::JPEGEncoder::new(fout).encode(buf, width, height, color),
+        #[cfg(feature = "png_codec")]
+        "png" => png::PNGEncoder::new(fout).encode(buf, width, height, color),
+        #[cfg(feature = "pnm")]
+        "pbm" => pnm::PNMEncoder::new(fout)
+            .with_subtype(pnm::PNMSubtype::Bitmap(pnm::SampleEncoding::Binary))
+            .encode(buf, width, height, color),
+        #[cfg(feature = "pnm")]
+        "pgm" => pnm::PNMEncoder::new(fout)
+            .with_subtype(pnm::PNMSubtype::Graymap(pnm::SampleEncoding::Binary))
+            .encode(buf, width, height, color),
+        #[cfg(feature = "pnm")]
+        "ppm" => pnm::PNMEncoder::new(fout)
+            .with_subtype(pnm::PNMSubtype::Pixmap(pnm::SampleEncoding::Binary))
+            .encode(buf, width, height, color),
+        #[cfg(feature = "pnm")]
+        "pam" => pnm::PNMEncoder::new(fout).encode(buf, width, height, color),
+        #[cfg(feature = "bmp")]
+        "bmp" => bmp::BMPEncoder::new(fout).encode(buf, width, height, color),
+        #[cfg(feature = "tiff")]
+        "tif" | "tiff" => tiff::TiffEncoder::new(fout).encode(buf, width, height, color)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, Box::new(e))), // FIXME: see https://github.com/image-rs/image/issues/921
+        format => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            &format!("Unsupported image format image/{:?}", format)[..],
+        )),
+    }
+}
+
+pub(crate) fn save_buffer_with_format_impl(
+    path: &Path,
+    buf: &[u8],
+    width: u32,
+    height: u32,
+    color: color::ColorType,
+    format: ImageFormat,
+) -> io::Result<()> {
+    let fout = &mut BufWriter::new(File::create(path)?);
+
+    match format {
+        #[cfg(feature = "ico")]
+        image::ImageFormat::ICO => ico::ICOEncoder::new(fout).encode(buf, width, height, color),
+        #[cfg(feature = "jpeg")]
+        image::ImageFormat::JPEG => jpeg::JPEGEncoder::new(fout).encode(buf, width, height, color),
+        #[cfg(feature = "png_codec")]
+        image::ImageFormat::PNG => png::PNGEncoder::new(fout).encode(buf, width, height, color),
+        #[cfg(feature = "bmp")]
+        image::ImageFormat::BMP => bmp::BMPEncoder::new(fout).encode(buf, width, height, color),
+        #[cfg(feature = "tiff")]
+        image::ImageFormat::TIFF => tiff::TiffEncoder::new(fout)
+            .encode(buf, width, height, color)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, Box::new(e))),
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            &format!("Unsupported image format image/{:?}", format)[..],
+        )),
+    }
+}
+
+static MAGIC_BYTES: [(&'static [u8], ImageFormat); 17] = [
+    (b"\x89PNG\r\n\x1a\n", ImageFormat::PNG),
+    (&[0xff, 0xd8, 0xff], ImageFormat::JPEG),
+    (b"GIF89a", ImageFormat::GIF),
+    (b"GIF87a", ImageFormat::GIF),
+    (b"RIFF", ImageFormat::WEBP), // TODO: better magic byte detection, see https://github.com/image-rs/image/issues/660
+    (b"MM\x00*", ImageFormat::TIFF),
+    (b"II*\x00", ImageFormat::TIFF),
+    (b"BM", ImageFormat::BMP),
+    (&[0, 0, 1, 0], ImageFormat::ICO),
+    (b"#?RADIANCE", ImageFormat::HDR),
+    (b"P1", ImageFormat::PNM),
+    (b"P2", ImageFormat::PNM),
+    (b"P3", ImageFormat::PNM),
+    (b"P4", ImageFormat::PNM),
+    (b"P5", ImageFormat::PNM),
+    (b"P6", ImageFormat::PNM),
+    (b"P7", ImageFormat::PNM),
+];
+
+/// Guess image format from memory block
+///
+/// Makes an educated guess about the image format based on the Magic Bytes at the beginning.
+/// TGA is not supported by this function.
+/// This is not to be trusted on the validity of the whole memory block
+pub fn guess_format(buffer: &[u8]) -> ImageResult<ImageFormat> {
+    for &(signature, format) in &MAGIC_BYTES {
+        if buffer.starts_with(signature) {
+            return Ok(format);
+        }
+    }
+    Err(image::ImageError::UnsupportedError(
+        "Unsupported image format".to_string(),
+    ))
+}

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -51,6 +51,10 @@ pub(crate) fn open_impl(path: &Path) -> ImageResult<DynamicImage> {
 }
 
 /// Create a new image from a Reader
+///
+/// Try [`io::Reader`] for more advanced uses.
+///
+/// [`io::Reader`]: io/struct.Reader.html
 pub fn load<R: BufRead + Seek>(r: R, format: ImageFormat) -> ImageResult<DynamicImage> {
     #[allow(deprecated, unreachable_patterns)]
     // Default is unreachable if all features are supported.

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,2 +1,5 @@
 //! Input and output of images.
+mod reader;
 pub(crate) mod free_functions;
+
+pub use self::reader::Reader;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,0 +1,2 @@
+//! Input and output of images.
+pub(crate) mod free_functions;

--- a/src/io/reader.rs
+++ b/src/io/reader.rs
@@ -31,7 +31,8 @@ use super::free_functions;
 /// source is some blob in memory and you have constructed the reader in another way. Here is an
 /// example with a `pnm` black-and-white subformat that encodes its pixel matrix with ascii values.
 ///
-/// ```
+#[cfg_attr(feature = "pnm", doc = "```")]
+#[cfg_attr(not(feature = "pnm"), doc = "```no_run")]
 /// # use image::ImageError;
 /// # use image::io::Reader;
 /// # fn main() -> Result<(), ImageError> {

--- a/src/io/reader.rs
+++ b/src/io/reader.rs
@@ -1,0 +1,82 @@
+use std::io::{self, Read, Seek};
+use std::path::Path;
+
+use dynimage::DynamicImage;
+use image::ImageFormat;
+use ImageResult;
+
+/// A multi-format image reader.
+///
+/// Wraps an input reader to facilitate automatic detection of an image's format, appropriate
+/// decoding method, and dispatches into the set of supported `ImageDecoder` implementations.
+pub struct Reader<R> {
+    /// The reader.
+    inner: R,
+    /// The format, if one has been set or deduced.
+    format: Option<ImageFormat>,
+}
+
+impl<R: io::Read> Reader<R> {
+    pub fn new(reader: R) -> Self {
+        Reader {
+            inner: reader,
+            format: None,
+        }
+    }
+
+    /// Construct a reader with specified format.
+    pub fn with_format(reader: R, format: ImageFormat) -> Self {
+        Reader {
+            inner: reader,
+            format: Some(format),
+        }
+    }
+
+    /// Open a file to read. Format will be guessed.
+    /// Note: Failure to guess is not an error. The `Err` is only for `File::open`.
+    pub fn from_file<P>(path: P) -> io::Result<Self> where P: AsRef<Path> {
+        unimplemented!()
+    }
+}
+
+impl<R: Read + Seek> Reader<R> {
+    /// Replace the format with a guess based on the content.
+    ///
+    /// If the guess fails, the format is unchanged. Error is for seek, hence io::Error 
+    /// and not ImageError.
+    pub fn guess_format(&mut self) -> io::Result<()> {
+        unimplemented!()
+    }
+
+    /// Read the image dimensions.
+    /// Uses the current format to construct the correct reader.
+    pub fn image_dimensions(self) -> ImageResult<(u32, u32)> {
+        unimplemented!()
+    }
+
+    /// Read the image (replaces `load`).
+    /// Uses the current format to construct the correct reader.
+    pub fn load(self) -> ImageResult<DynamicImage> {
+        unimplemented!()
+    }
+}
+
+/// Potential apis, not part of the core proposal:
+impl<R: Read> Reader<R> {
+    /// Load for image formats that don't require seeking.
+    pub fn load_forward(self) -> ImageResult<DynamicImage> {
+        unimplemented!()
+    }
+}
+
+impl<R> Reader<R> {
+    /// Get the currently determined format.
+    pub fn format(&self) -> Option<ImageFormat> {
+        self.format
+    }
+
+    /// Unwrap the reader.
+    pub fn into_inner(self) -> R {
+        self.inner
+    }
+}

--- a/src/io/reader.rs
+++ b/src/io/reader.rs
@@ -1,9 +1,12 @@
-use std::io::{self, Read, Seek};
+use std::fs::File;
+use std::io::{self, BufReader, Read, Seek};
 use std::path::Path;
 
 use dynimage::DynamicImage;
 use image::ImageFormat;
 use ImageResult;
+
+use super::free_functions;
 
 /// A multi-format image reader.
 ///
@@ -31,11 +34,21 @@ impl<R: io::Read> Reader<R> {
             format: Some(format),
         }
     }
+}
 
+impl Reader<BufReader<File>> {
     /// Open a file to read. Format will be guessed.
     /// Note: Failure to guess is not an error. The `Err` is only for `File::open`.
-    pub fn from_file<P>(path: P) -> io::Result<Self> where P: AsRef<Path> {
-        unimplemented!()
+    pub fn open<P>(path: P) -> io::Result<Self> where P: AsRef<Path> {
+        let path = path.as_ref();
+
+        let file = File::open(path)?;
+        let format = ImageFormat::from_path(path);
+
+        Ok(Reader {
+            inner: BufReader::new(file),
+            format: format.ok(),
+        })
     }
 }
 

--- a/src/io/reader.rs
+++ b/src/io/reader.rs
@@ -42,8 +42,9 @@ use super::free_functions;
 ///     0 1\
 ///     1 0";
 ///
-/// let mut reader = Reader::new(Cursor::new(raw_data));
-/// reader.guess_format().expect("Cursor io never fails");
+/// let mut reader = Reader::new(Cursor::new(raw_data))
+///     .with_guessed_format()
+///     .expect("Cursor io never fails");
 /// assert_eq!(reader.format(), Some(ImageFormat::PNM));
 ///
 /// let image = reader.decode()?;
@@ -147,7 +148,18 @@ impl<R: BufRead + Seek> Reader<R> {
     ///
     /// ## Usage
     ///
-    /// ```
+    /// This supplements the path based type deduction from [`open`] with content based deduction.
+    /// This is more common in Linux and UNIX operating systems and also helpful if the path can
+    /// not be directly controlled.
+    ///
+    /// ```no_run
+    /// # use image::ImageError;
+    /// # use image::io::Reader;
+    /// # fn main() -> Result<(), ImageError> {
+    /// let image = Reader::open("image.unknown")?
+    ///     .with_guessed_format()?
+    ///     .decode()?;
+    /// # Ok(()) }
     /// ```
     pub fn with_guessed_format(mut self) -> io::Result<Self> {
         let format = self.guess_format()?;
@@ -156,8 +168,7 @@ impl<R: BufRead + Seek> Reader<R> {
         Ok(self)
     }
 
-    /// Guess the format based on read data.
-    pub fn guess_format(&mut self) -> io::Result<Option<ImageFormat>> {
+    fn guess_format(&mut self) -> io::Result<Option<ImageFormat>> {
         let mut start = [0; 16];
 
         // Save current offset, read start, restore offset.

--- a/src/io/reader.rs
+++ b/src/io/reader.rs
@@ -31,16 +31,16 @@ use super::free_functions;
 /// source is some blob in memory and you have constructed the reader in another way. Here is an
 /// example with a `pnm` black-and-white subformat that encodes its pixel matrix with ascii values.
 ///
-/// ```no_run
+/// ```
 /// # use image::ImageError;
 /// # use image::io::Reader;
 /// # fn main() -> Result<(), ImageError> {
 /// use std::io::Cursor;
 /// use image::ImageFormat;
 ///
-/// let raw_data = b"P1 2 2\
-///     0 1\
-///     1 0";
+/// let raw_data = b"P1 2 2\n\
+///     0 1\n\
+///     1 0\n";
 ///
 /// let mut reader = Reader::new(Cursor::new(raw_data))
 ///     .with_guessed_format()

--- a/src/io/reader.rs
+++ b/src/io/reader.rs
@@ -1,10 +1,10 @@
 use std::fs::File;
-use std::io::{self, BufReader, Read, Seek};
+use std::io::{self, BufRead, BufReader, Cursor, Read, Seek, SeekFrom};
 use std::path::Path;
 
 use dynimage::DynamicImage;
 use image::ImageFormat;
-use ImageResult;
+use {ImageError, ImageResult};
 
 use super::free_functions;
 
@@ -12,14 +12,14 @@ use super::free_functions;
 ///
 /// Wraps an input reader to facilitate automatic detection of an image's format, appropriate
 /// decoding method, and dispatches into the set of supported `ImageDecoder` implementations.
-pub struct Reader<R> {
+pub struct Reader<R: Read> {
     /// The reader.
     inner: R,
     /// The format, if one has been set or deduced.
     format: Option<ImageFormat>,
 }
 
-impl<R: io::Read> Reader<R> {
+impl<R: Read> Reader<R> {
     pub fn new(reader: R) -> Self {
         Reader {
             inner: reader,
@@ -33,6 +33,16 @@ impl<R: io::Read> Reader<R> {
             inner: reader,
             format: Some(format),
         }
+    }
+
+    /// Get the currently determined format.
+    pub fn format(&self) -> Option<ImageFormat> {
+        self.format
+    }
+
+    /// Unwrap the reader.
+    pub fn into_inner(self) -> R {
+        self.inner
     }
 }
 
@@ -52,25 +62,42 @@ impl Reader<BufReader<File>> {
     }
 }
 
-impl<R: Read + Seek> Reader<R> {
+impl<R: BufRead + Seek> Reader<R> {
     /// Replace the format with a guess based on the content.
     ///
-    /// If the guess fails, the format is unchanged. Error is for seek, hence io::Error 
+    /// If the guess fails, the format is unchanged. Error is for seek, hence io::Error
     /// and not ImageError.
     pub fn guess_format(&mut self) -> io::Result<()> {
-        unimplemented!()
+        let mut start = [0; 16];
+
+        // Save current offset, read start, restore offset.
+        let cur = self.inner.seek(SeekFrom::Current(0))?;
+        let len = io::copy(
+            // Accept shorter files but read at most 16 bytes.
+            &mut self.inner.by_ref().take(16),
+            &mut Cursor::new(&mut start[..]))?;
+        self.inner.seek(SeekFrom::Start(cur))?;
+
+        self.format = free_functions::guess_format(&start[..len as usize]).ok();
+        Ok(())
     }
 
     /// Read the image dimensions.
     /// Uses the current format to construct the correct reader.
-    pub fn image_dimensions(self) -> ImageResult<(u32, u32)> {
-        unimplemented!()
+    pub fn image_dimensions(mut self) -> ImageResult<(u32, u32)> {
+        let format = self.require_format()?;
+        free_functions::image_dimensions_with_format_impl(self.inner, format)
     }
 
     /// Read the image (replaces `load`).
     /// Uses the current format to construct the correct reader.
     pub fn load(self) -> ImageResult<DynamicImage> {
         unimplemented!()
+    }
+
+    fn require_format(&mut self) -> ImageResult<ImageFormat> {
+        self.format.ok_or_else(||
+            ImageError::UnsupportedError("Unable to determine image format".into()))
     }
 }
 
@@ -79,17 +106,5 @@ impl<R: Read> Reader<R> {
     /// Load for image formats that don't require seeking.
     pub fn load_forward(self) -> ImageResult<DynamicImage> {
         unimplemented!()
-    }
-}
-
-impl<R> Reader<R> {
-    /// Get the currently determined format.
-    pub fn format(&self) -> Option<ImageFormat> {
-        self.format
-    }
-
-    /// Unwrap the reader.
-    pub fn into_inner(self) -> R {
-        self.inner
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,8 @@ pub use flat::{FlatSamples};
 pub use traits::Primitive;
 
 // Opening and loading images
-pub use dynimage::{guess_format, load, load_from_memory, load_from_memory_with_format, open,
+pub use io::free_functions::{guess_format, load};
+pub use dynimage::{load_from_memory, load_from_memory_with_format, open,
                    save_buffer, save_buffer_with_format, image_dimensions};
 
 pub use dynimage::DynamicImage::{self, ImageLuma8, ImageLumaA8, ImageRgb8, ImageRgba8, ImageBgr8, ImageBgra8};
@@ -73,6 +74,9 @@ pub mod math;
 
 // Image processing functions
 pub mod imageops;
+
+// Io bindings
+pub mod io;
 
 // Buffer representations for ffi.
 pub mod flat;


### PR DESCRIPTION
Replace free reader functions with `Reader` structure as sketched [in this comment of #1007](https://github.com/image-rs/image/issues/1007#issuecomment-521040748). This provides an api for reading image metadata and pixels without coupling to format guessing instead of adding all possible combinations of methods.

Also makes the interface for directly turning an `ImageDecoder` into a `DynamicImage` public.

Closes: #1007 
Closes: #716
Closes: #577

Unresolved questions:
- [x] ~~Should opening a file automatically try to guess the format from the first bytes? Or only from the path? From neither?~~ ~~Offer two methods.~~ Offer a method and a builder style continuation.
- [x] ~~Should the path be contained in the data stored in the `Reader`? This would allow other methods to emulate having opened a file, without going through the actual `fs` api.~~ `ImageFormat::from_path` can be used.
- [x] ~~Should there be a special `load` for formats which do not require `Seek`?~~ Later, if the need arises.
- [x] ~~What about formats not requiring `BufRead` but only `Read`?~~ Easy to wrap in `BufReader`.