### PR TITLE
Backport fix for unsafety in hdr decoder

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,13 @@ Rust image aims to be a pure-Rust implementation of various popular image format
 
 ## Changes
 
+### Version 0.21.3
+
+- Fixed an issue in `HdrDecoder::read_image_transform` that could drop
+  uninitialized instances of arbitrary types on panic or expose uninitialized
+  memory. The fix entails not dropping any value on error or panic, the method
+  should only be used to read to types without `Drop` implementations.
+
 ### Version 0.21.2
 
 - Fixed a variety of crashes and opaque errors in webp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "image"
-version = "0.21.2"
+version = "0.21.3"
 license = "MIT"
 description = "Imaging library written in Rust. Provides basic filters and decoders for the most common image formats."
 authors = [

--- a/src/hdr/decoder.rs
+++ b/src/hdr/decoder.rs
@@ -309,11 +309,15 @@ impl<R: BufRead> HDRDecoder<R> {
         Ok(ret)
     }
 
-    /// Consumes decoder and returns a vector of transformed pixels
+    /// Consumes decoder and returns a vector of transformed pixels.
+    ///
+    /// **Note**: This method should not be called with a parameter `T` that has a `Drop` impl. In case of
+    /// error or panic, it will never call this `Drop` implementation even for pixels that have
+    /// already been successfully decoded.
     #[deprecated(
         since = "0.21.3",
         note = "For trivial types `T` this interface is less safe and less efficient than one taking\
-                an output slice. Consider upgrading to v0.22.")]
+                an output slice. Semantics may be confusing for non-trivial types. Consider upgrading to v0.22.")]
     pub fn read_image_transform<T: Send, F: Send + Sync + Fn(RGBE8Pixel) -> T>(
         mut self,
         f: F,


### PR DESCRIPTION
Must initialize all memory of Vec<T> (according to valid T) prior to
calling set_len, even for zeroed memory. Furthermore, we can leak some
type instances-since they should not have a Drop implementation as per
documentation-which is safe. This allows us to complete all read
operations prior to setting the vector length, ensuring initialization
of all elements without default values.

This is a backport that avoids the interface changes made in the change
that fixed in in `0.22`, #985. It may look scary since it involves even *more* 
unsafe blocks but each has reasoning attached, that's how `unsafe` is 
supposed to be used and the reason why it is available. Please review the
reasoning carefully.

Backport feels somewhat necessary since ~50% of usage is still on `0.21` 
(as predicted from adoption speed of previous major versions). This will
get a release `0.21.3` once landed.


