### PR TITLE
Fixes backport for 1.24.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ env:
       - FEATURES='tiff'
       - FEATURES='webp'
       - FEATURES='hdr'
+matrix:
+    exclude:
+    - rust: 1.24.1
+      env: FEATURES=''
 script:
     - if [ -z "$FEATURES" ]; then
         cargo build -v &&


### PR DESCRIPTION
The known build issues (with rayon) masked that the actual backport was not compatible. This should fix the `.travis.yml` file to not run tests with `jpeg_rayon` on `1.24.1`. The less convenient 
conversion features and pointer offsetting in that version prompted me to include even more 
assertions and length checks, to be less dependent on thoroughness of my judgement.