### PR TITLE
Replace try! macros with ? operators

### DIFF
--- a/src/bmp/encoder.rs
+++ b/src/bmp/encoder.rs
@@ -43,20 +43,16 @@ impl<'a, W: Write + 'a> BMPEncoder<'a, W> {
         self.writer.write_u32::<LittleEndian>(file_size)?; // file size
         self.writer.write_u16::<LittleEndian>(0)?; // reserved 1
         self.writer.write_u16::<LittleEndian>(0)?; // reserved 2
-        try!(
-            self.writer
-                .write_u32::<LittleEndian>(bmp_header_size + dib_header_size + palette_size)
-        ); // image data offset
+        self.writer
+            .write_u32::<LittleEndian>(bmp_header_size + dib_header_size + palette_size)?; // image data offset
 
         // write DIB header
         self.writer.write_u32::<LittleEndian>(dib_header_size)?;
         self.writer.write_i32::<LittleEndian>(width as i32)?;
         self.writer.write_i32::<LittleEndian>(height as i32)?;
         self.writer.write_u16::<LittleEndian>(1)?; // color planes
-        try!(
-            self.writer
-                .write_u16::<LittleEndian>((written_pixel_size * 8) as u16)
-        ); // bits per pixel
+        self.writer
+            .write_u16::<LittleEndian>((written_pixel_size * 8) as u16)?; // bits per pixel
         if dib_header_size >= BITMAPV4HEADER_SIZE {
             // Assume BGRA32
             self.writer.write_u32::<LittleEndian>(3)?; // compression method - bitfields

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -524,11 +524,11 @@ impl DynamicImage {
             image::ImageOutputFormat::GIF => {
                 let mut g = gif::Encoder::new(w);
 
-                try!(g.encode(&gif::Frame::from_rgba(
+                g.encode(&gif::Frame::from_rgba(
                     width as u16,
                     height as u16,
                     &mut *self.to_rgba().iter().cloned().collect::<Vec<u8>>()
-                )));
+                ))?;
                 Ok(())
             }
 
@@ -936,17 +936,17 @@ pub fn load<R: BufRead + Seek>(r: R, format: ImageFormat) -> ImageResult<Dynamic
         #[cfg(feature = "webp")]
         image::ImageFormat::WEBP => decoder_to_image(webp::WebpDecoder::new(r)?),
         #[cfg(feature = "tiff")]
-        image::ImageFormat::TIFF => decoder_to_image(try!(tiff::TIFFDecoder::new(r))),
+        image::ImageFormat::TIFF => decoder_to_image(tiff::TIFFDecoder::new(r)?),
         #[cfg(feature = "tga")]
         image::ImageFormat::TGA => decoder_to_image(tga::TGADecoder::new(r)?),
         #[cfg(feature = "bmp")]
         image::ImageFormat::BMP => decoder_to_image(bmp::BMPDecoder::new(r)?),
         #[cfg(feature = "ico")]
-        image::ImageFormat::ICO => decoder_to_image(try!(ico::ICODecoder::new(r))),
+        image::ImageFormat::ICO => decoder_to_image(ico::ICODecoder::new(r)?),
         #[cfg(feature = "hdr")]
-        image::ImageFormat::HDR => decoder_to_image(try!(hdr::HDRAdapter::new(BufReader::new(r)))),
+        image::ImageFormat::HDR => decoder_to_image(hdr::HDRAdapter::new(BufReader::new(r))?),
         #[cfg(feature = "pnm")]
-        image::ImageFormat::PNM => decoder_to_image(try!(pnm::PNMDecoder::new(BufReader::new(r)))),
+        image::ImageFormat::PNM => decoder_to_image(pnm::PNMDecoder::new(BufReader::new(r))?),
         _ => Err(image::ImageError::UnsupportedError(format!(
             "A decoder for {:?} is not available.",
             format
@@ -979,7 +979,7 @@ static MAGIC_BYTES: [(&'static [u8], ImageFormat); 17] = [
 /// Makes an educated guess about the image format.
 /// TGA is not supported by this function.
 pub fn load_from_memory(buffer: &[u8]) -> ImageResult<DynamicImage> {
-    load_from_memory_with_format(buffer, try!(guess_format(buffer)))
+    load_from_memory_with_format(buffer, guess_format(buffer)?)
 }
 
 /// Create a new image from a byte slice

--- a/src/hdr/decoder.rs
+++ b/src/hdr/decoder.rs
@@ -342,7 +342,7 @@ impl<R: BufRead> HDRDecoder<R> {
         let chunks_iter = output_slice.chunks_mut(self.width as usize);
         let mut pool = Pool::new(8); //
 
-        try!(pool.scoped(|scope| {
+        (pool.scoped(|scope| {
             for chunk in chunks_iter {
                 let mut buf = vec![Default::default(); self.width as usize];
                 read_scanline(&mut self.r, &mut buf[..])?;
@@ -354,7 +354,7 @@ impl<R: BufRead> HDRDecoder<R> {
                 });
             }
             Ok(())
-        }) as Result<(), ImageError>);
+        }) as Result<(), ImageError>)?;
         Ok(())
     }
 
@@ -775,26 +775,18 @@ fn parse_space_separated_f32(line: &str, vals: &mut [f32], name: &str) -> ImageR
 fn parse_dimensions_line(line: &str, strict: bool) -> ImageResult<(u32, u32)> {
     let mut dim_parts = line.split_whitespace();
     let err = "Malformed dimensions line";
-    let c1_tag = try!(
-        dim_parts
+    let c1_tag = dim_parts
             .next()
-            .ok_or_else(|| ImageError::FormatError(err.into()))
-    );
-    let c1_str = try!(
-        dim_parts
+            .ok_or_else(|| ImageError::FormatError(err.into()))?;
+    let c1_str = dim_parts
             .next()
-            .ok_or_else(|| ImageError::FormatError(err.into()))
-    );
-    let c2_tag = try!(
-        dim_parts
+            .ok_or_else(|| ImageError::FormatError(err.into()))?;
+    let c2_tag = dim_parts
             .next()
-            .ok_or_else(|| ImageError::FormatError(err.into()))
-    );
-    let c2_str = try!(
-        dim_parts
+            .ok_or_else(|| ImageError::FormatError(err.into()))?;
+    let c2_str = dim_parts
             .next()
-            .ok_or_else(|| ImageError::FormatError(err.into()))
-    );
+            .ok_or_else(|| ImageError::FormatError(err.into()))?;
     if strict && dim_parts.next().is_some() {
         // extra data in dimensions line
         return Err(ImageError::FormatError(err.into()));

--- a/src/ico/encoder.rs
+++ b/src/ico/encoder.rs
@@ -37,14 +37,14 @@ impl<W: Write> ICOEncoder<W> {
         PNGEncoder::new(&mut image_data).encode(data, width, height, color)?;
 
         write_icondir(&mut self.w, 1)?;
-        try!(write_direntry(
+        write_direntry(
             &mut self.w,
             width,
             height,
             color,
             ICO_ICONDIR_SIZE + ICO_DIRENTRY_SIZE,
             image_data.len() as u32
-        ));
+        )?;
         self.w.write_all(&image_data)?;
         Ok(())
     }

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -273,21 +273,19 @@ impl<R: Read + Seek> TGADecoder<R> {
     /// We're not interested in this field, so this function skips it if it
     /// is present
     fn read_image_id(&mut self) -> ImageResult<()> {
-        try!(
-            self.r
-                .seek(io::SeekFrom::Current(i64::from(self.header.id_length)))
-        );
+        self.r
+            .seek(io::SeekFrom::Current(i64::from(self.header.id_length)))?;
         Ok(())
     }
 
     fn read_color_map(&mut self) -> ImageResult<()> {
         if self.header.map_type == 1 {
-            self.color_map = Some(try!(ColorMap::from_reader(
+            self.color_map = Some(ColorMap::from_reader(
                 &mut self.r,
                 self.header.map_origin,
                 self.header.map_length,
                 self.header.map_entry_size
-            )));
+            )?);
         }
         Ok(())
     }
@@ -322,7 +320,7 @@ impl<R: Read + Seek> TGADecoder<R> {
     fn read_image_data(&mut self) -> ImageResult<Vec<u8>> {
         // read the pixels from the data region
         let mut pixel_data = if self.image_type.is_encoded() {
-            try!(self.read_all_encoded_data())
+            self.read_all_encoded_data()?
         } else {
             let num_raw_bytes = self.width * self.height * self.bytes_per_pixel;
             let mut buf = vec![0; num_raw_bytes];
@@ -356,24 +354,20 @@ impl<R: Read + Seek> TGADecoder<R> {
                 // high bit set, so we will repeat the data
                 let repeat_count = ((run_packet & !0x80) + 1) as usize;
                 let mut data = Vec::with_capacity(self.bytes_per_pixel);
-                try!(
-                    self.r
-                        .by_ref()
-                        .take(self.bytes_per_pixel as u64)
-                        .read_to_end(&mut data)
-                );
+                self.r
+                    .by_ref()
+                    .take(self.bytes_per_pixel as u64)
+                    .read_to_end(&mut data)?;
                 for _ in 0usize..repeat_count {
                     pixel_data.extend(data.iter().cloned());
                 }
             } else {
                 // not set, so `run_packet+1` is the number of non-encoded pixels
                 let num_raw_bytes = (run_packet + 1) as usize * self.bytes_per_pixel;
-                try!(
-                    self.r
-                        .by_ref()
-                        .take(num_raw_bytes as u64)
-                        .read_to_end(&mut pixel_data)
-                );
+                self.r
+                    .by_ref()
+                    .take(num_raw_bytes as u64)
+                    .read_to_end(&mut pixel_data)?;
             }
         }
 


### PR DESCRIPTION
Nightly build says `try!` macro is now deprecated and use `?` operators.
This PR replaces `try!` macros with `?` operators.
Note that, this may contain formatting issue but I leave it because the diff will be large when I run `cargo fmt`. I'm happy to send a PR to run `cargo fmt` later.