### PR TITLE
Remove unnecessary lifetime

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -954,7 +954,7 @@ pub fn load<R: BufRead + Seek>(r: R, format: ImageFormat) -> ImageResult<Dynamic
     }
 }
 
-static MAGIC_BYTES: [(&'static [u8], ImageFormat); 17] = [
+static MAGIC_BYTES: [(&[u8], ImageFormat); 17] = [
     (b"\x89PNG\r\n\x1a\n", ImageFormat::PNG),
     (&[0xff, 0xd8, 0xff], ImageFormat::JPEG),
     (b"GIF89a", ImageFormat::GIF),


### PR DESCRIPTION
Static variable has `'static` lifetime by default so explicit one is unnecessary.