### PR TITLE
Move travis notifications to gitter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: rust
 sudo: false
 notifications:
-    irc: "irc.mozilla.org#piston-internals"
+    webhooks:
+        urls:
+            - https://webhooks.gitter.im/e/816755464e93a0defff0
+        on_success: change
+        on_failure: always
+        on_start: never
 os:
     - linux
 rust:


### PR DESCRIPTION
Noted that notifications were still sent to piston related irc. The webhook configuration is already done in the Gitter channel, that's where the url comes from.