### PR TITLE
Remove unused lzw dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ byteorder = "1.2.1"
 num-iter = "0.1.32"
 num-rational = { version = "0.2.1", default-features = false }
 num-traits = "0.2.0"
-lzw = "0.10.0"
 
 [dependencies.gif]
 version = "0.10.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
 #![allow(clippy::many_single_char_names)]
 
 extern crate byteorder;
-extern crate lzw;
 extern crate num_iter;
 extern crate num_rational;
 extern crate num_traits;
@@ -111,7 +110,7 @@ mod utils;
 
 // Can't use the macro-call itself within the `doc` attribute. So force it to eval it as part of
 // the macro invocation.
-// 
+//
 // The inspiration for the macro and implementation is from
 // <https://github.com/GuillaumeGomez/doc-comment>
 //


### PR DESCRIPTION
I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.