### PR TITLE
Dynimage from decoder

### DIFF
--- a/src/bmp/decoder.rs
+++ b/src/bmp/decoder.rs
@@ -88,7 +88,7 @@ enum Chunker<'a> {
     FromBottom(Rev<ChunksMut<'a, u8>>),
 }
 
-pub struct RowIterator<'a> {
+pub(crate) struct RowIterator<'a> {
     chunks: Chunker<'a>,
 }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1074,9 +1074,9 @@ pub type GrayImage = ImageBuffer<Luma<u8>, Vec<u8>>;
 /// Sendable grayscale + alpha channel image buffer
 pub type GrayAlphaImage = ImageBuffer<LumaA<u8>, Vec<u8>>;
 /// Sendable Bgr image buffer
-pub type BgrImage = ImageBuffer<Bgr<u8>, Vec<u8>>;
+pub(crate) type BgrImage = ImageBuffer<Bgr<u8>, Vec<u8>>;
 /// Sendable Bgr + alpha channel image buffer
-pub type BgraImage = ImageBuffer<Bgra<u8>, Vec<u8>>;
+pub(crate) type BgraImage = ImageBuffer<Bgra<u8>, Vec<u8>>;
 
 #[cfg(test)]
 mod test {

--- a/src/color.rs
+++ b/src/color.rs
@@ -44,7 +44,7 @@ impl ColorType {
 }
 
 /// Returns the number of bits contained in a pixel of `ColorType` ```c```
-pub fn bits_per_pixel(c: ColorType) -> u16 {
+pub(crate) fn bits_per_pixel(c: ColorType) -> u16 {
     match c {
         ColorType::Gray(n) => n as u16,
         ColorType::GrayA(n) => 2 * n as u16,
@@ -54,7 +54,7 @@ pub fn bits_per_pixel(c: ColorType) -> u16 {
 }
 
 /// Returns the number of color channels that make up this pixel
-pub fn channel_count(c: ColorType) -> u8 {
+pub(crate) fn channel_count(c: ColorType) -> u8 {
     match c {
         ColorType::Gray(_) => 1,
         ColorType::GrayA(_) => 2,
@@ -582,7 +582,7 @@ impl<T: Primitive + 'static> FromColor<Luma<T>> for Bgr<T> {
 
 
 /// Blends a color inter another one
-pub trait Blend {
+pub(crate) trait Blend {
     /// Blends a color in-place.
     fn blend(&mut self, other: &Self);
 }
@@ -754,7 +754,7 @@ impl<T: Primitive> Blend for Bgr<T> {
 
 
 /// Invert a color
-pub trait Invert {
+pub(crate) trait Invert {
     /// Inverts a color in-place.
     fn invert(&mut self);
 }

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -138,6 +138,13 @@ impl DynamicImage {
         DynamicImage::ImageBgr8(ImageBuffer::new(w, h))
     }
 
+    /// Decodes an encoded image into a dynamic image.
+    pub fn from_decoder<'a>(decoder: impl ImageDecoder<'a>)
+        -> ImageResult<Self>
+    {
+        decoder_to_image(decoder)
+    }
+
     /// Returns a copy of this image as an RGB image.
     pub fn to_rgb(&self) -> RgbImage {
         dynamic_map!(*self, ref p -> {
@@ -640,8 +647,7 @@ impl GenericImage for DynamicImage {
     }
 }
 
-/// Decodes an image and stores it into a dynamic image
-pub fn decoder_to_image<'a, I: ImageDecoder<'a>>(codec: I) -> ImageResult<DynamicImage> {
+fn decoder_to_image<'a, I: ImageDecoder<'a>>(codec: I) -> ImageResult<DynamicImage> {
     let color = codec.colortype();
     let (w, h) = codec.dimensions();
     let buf = codec.read_image()?;

--- a/src/image.rs
+++ b/src/image.rs
@@ -247,7 +247,7 @@ pub(crate) struct ImageReadBuffer {
     offset: usize,
 }
 impl ImageReadBuffer {
-    pub fn new(scanline_bytes: usize, total_bytes: usize) -> Self {
+    pub(crate) fn new(scanline_bytes: usize, total_bytes: usize) -> Self {
         Self {
             scanline_bytes,
             buffer: Vec::new(),
@@ -256,7 +256,7 @@ impl ImageReadBuffer {
             offset: 0,
         }
     }
-    pub fn read<F>(&mut self, buf: &mut [u8], mut read_scanline: F) -> io::Result<usize>
+    pub(crate) fn read<F>(&mut self, buf: &mut [u8], mut read_scanline: F) -> io::Result<usize>
     where
         F: FnMut(&mut [u8]) -> io::Result<usize>,
     {

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -32,12 +32,12 @@ pub enum FilterType {
 }
 
 /// A Representation of a separable filter.
-pub struct Filter<'a> {
+pub(crate) struct Filter<'a> {
     /// The filter's filter function.
-    pub kernel: Box<dyn Fn(f32) -> f32 + 'a>,
+    pub(crate) kernel: Box<dyn Fn(f32) -> f32 + 'a>,
 
     /// The window on which this filter operates.
-    pub support: f32,
+    pub(crate) support: f32,
 }
 
 // sinc function: the ideal sampling filter.
@@ -80,30 +80,30 @@ fn bc_cubic_spline(x: f32, b: f32, c: f32) -> f32 {
 
 /// The Gaussian Function.
 /// ```r``` is the standard deviation.
-pub fn gaussian(x: f32, r: f32) -> f32 {
+pub(crate) fn gaussian(x: f32, r: f32) -> f32 {
     ((2.0 * f32::consts::PI).sqrt() * r).recip() * (-x.powi(2) / (2.0 * r.powi(2))).exp()
 }
 
 /// Calculate the lanczos kernel with a window of 3
-pub fn lanczos3_kernel(x: f32) -> f32 {
+pub(crate) fn lanczos3_kernel(x: f32) -> f32 {
     lanczos(x, 3.0)
 }
 
 /// Calculate the gaussian function with a
 /// standard deviation of 0.5
-pub fn gaussian_kernel(x: f32) -> f32 {
+pub(crate) fn gaussian_kernel(x: f32) -> f32 {
     gaussian(x, 0.5)
 }
 
 /// Calculate the Catmull-Rom cubic spline.
 /// Also known as a form of `BiCubic` sampling in two dimensions.
-pub fn catmullrom_kernel(x: f32) -> f32 {
+pub(crate) fn catmullrom_kernel(x: f32) -> f32 {
     bc_cubic_spline(x, 0.0, 0.5)
 }
 
 /// Calculate the triangle function.
 /// Also known as `BiLinear` sampling in two dimensions.
-pub fn triangle_kernel(x: f32) -> f32 {
+pub(crate) fn triangle_kernel(x: f32) -> f32 {
     if x.abs() < 1.0 {
         1.0 - x.abs()
     } else {
@@ -114,7 +114,7 @@ pub fn triangle_kernel(x: f32) -> f32 {
 /// Calculate the box kernel.
 /// Only pixels inside the box should be considered, and those
 /// contribute equally.  So this method simply returns 1.
-pub fn box_kernel(_x: f32) -> f32 {
+pub(crate) fn box_kernel(_x: f32) -> f32 {
     1.0
 }
 

--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -157,7 +157,7 @@ struct Component {
     _dc_pred: i32,
 }
 
-pub struct BitWriter<'a, W: 'a> {
+pub(crate) struct BitWriter<'a, W: 'a> {
     w: &'a mut W,
     accumulator: u32,
     nbits: u8,

--- a/src/jpeg/entropy.rs
+++ b/src/jpeg/entropy.rs
@@ -49,7 +49,7 @@ fn derive_codes_and_sizes(bits: &[u8]) -> (Vec<u8>, Vec<u16>) {
     (huffsize, huffcode)
 }
 
-pub fn build_huff_lut(bits: &[u8], huffval: &[u8]) -> Vec<(u8, u16)> {
+pub(crate) fn build_huff_lut(bits: &[u8], huffval: &[u8]) -> Vec<(u8, u16)> {
     let mut lut = vec![(17u8, 0u16); 256];
     let (huffsize, huffcode) = derive_codes_and_sizes(bits);
 

--- a/src/jpeg/transform.rs
+++ b/src/jpeg/transform.rs
@@ -67,7 +67,7 @@ static FIX_2_053119869: i32 = 16_819;
 static FIX_2_562915447: i32 = 20_995;
 static FIX_3_072711026: i32 = 25_172;
 
-pub fn fdct(samples: &[u8], coeffs: &mut [i32]) {
+pub(crate) fn fdct(samples: &[u8], coeffs: &mut [i32]) {
     // Pass 1: process rows.
     // Results are scaled by sqrt(8) compared to a true DCT
     // furthermore we scale the results by 2**PASS1_BITS

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 
 #![warn(missing_docs)]
 #![warn(unused_qualifications)]
+#![deny(unreachable_pub)]
 #![deny(missing_copy_implementations)]
 #![cfg_attr(all(test, feature = "benchmarks"), feature(test))]
 // it's a bit of a pain otherwise

--- a/src/pnm/autobreak.rs
+++ b/src/pnm/autobreak.rs
@@ -4,7 +4,7 @@ use std::io;
 // The pnm standard says to insert line breaks after 70 characters. Assumes that no line breaks
 // are actually written. We have to be careful to fully commit buffers or not commit them at all,
 // otherwise we might insert a newline in the middle of a token.
-pub struct AutoBreak<W: io::Write> {
+pub(crate) struct AutoBreak<W: io::Write> {
     wrapped: W,
     line_capacity: usize,
     line: Vec<u8>,

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -127,7 +127,7 @@ struct ColorMap {
 }
 
 impl ColorMap {
-    pub fn from_reader(
+    pub(crate) fn from_reader(
         r: &mut dyn Read,
         start_offset: u16,
         num_entries: u16,
@@ -146,7 +146,7 @@ impl ColorMap {
     }
 
     /// Get one entry from the color map
-    pub fn get(&self, index: usize) -> &[u8] {
+    pub(crate) fn get(&self, index: usize) -> &[u8] {
         let entry = self.start_offset + self.entry_size * index;
         &self.bytes[entry..entry + self.entry_size]
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,7 +6,7 @@ use std::mem;
 use std::iter::repeat;
 
 #[inline(always)]
-pub fn expand_packed<F>(buf: &mut [u8], channels: usize, bit_depth: u8, mut func: F)
+pub(crate) fn expand_packed<F>(buf: &mut [u8], channels: usize, bit_depth: u8, mut func: F)
 where
     F: FnMut(u8, &mut [u8]),
 {
@@ -34,12 +34,12 @@ where
     }
 }
 
-pub fn vec_u16_into_u8(vec: Vec<u16>) -> Vec<u8> {
+pub(crate) fn vec_u16_into_u8(vec: Vec<u16>) -> Vec<u8> {
     // Do this way until we find a way to not alloc/dealloc but get llvm to realloc instead.
     vec_u16_copy_u8(&vec)
 }
 
-pub fn vec_u16_copy_u8(vec: &[u16]) -> Vec<u8> {
+pub(crate) fn vec_u16_copy_u8(vec: &[u16]) -> Vec<u8> {
     let mut new = vec![0; vec.len() * mem::size_of::<u16>()];
     NativeEndian::write_u16_into(&vec[..], &mut new[..]);
     new

--- a/src/webp/transform.rs
+++ b/src/webp/transform.rs
@@ -1,7 +1,7 @@
 static CONST1: i64 = 20091;
 static CONST2: i64 = 35468;
 
-pub fn idct4x4(block: &mut [i32]) {
+pub(crate) fn idct4x4(block: &mut [i32]) {
     // The intermediate results may overflow the types, so we stretch the type.
     fn fetch(block: &mut [i32], idx: usize) -> i64 {
         i64::from(block[idx])
@@ -45,7 +45,7 @@ pub fn idct4x4(block: &mut [i32]) {
 }
 
 // 14.3
-pub fn iwht4x4(block: &mut [i32]) {
+pub(crate) fn iwht4x4(block: &mut [i32]) {
     for i in 0usize..4 {
         let a1 = block[i] + block[12 + i];
         let b1 = block[4 + i] + block[8 + i];

--- a/src/webp/vp8.rs
+++ b/src/webp/vp8.rs
@@ -672,7 +672,7 @@ struct BoolReader {
 }
 
 impl BoolReader {
-    pub fn new() -> BoolReader {
+    pub(crate) fn new() -> BoolReader {
         BoolReader {
             buf: Vec::new(),
             range: 0,
@@ -682,7 +682,7 @@ impl BoolReader {
         }
     }
 
-    pub fn init(&mut self, buf: Vec<u8>) -> ImageResult<()> {
+    pub(crate) fn init(&mut self, buf: Vec<u8>) -> ImageResult<()> {
         if buf.len() < 2 {
             return Err(ImageError::FormatError(
                 "Expected at least 2 bytes of decoder initialization data".into()));
@@ -698,7 +698,7 @@ impl BoolReader {
         Ok(())
     }
 
-    pub fn read_bool(&mut self, probability: u8) -> bool {
+    pub(crate) fn read_bool(&mut self, probability: u8) -> bool {
         let split = 1 + (((self.range - 1) * u32::from(probability)) >> 8);
         let bigsplit = split << 8;
 
@@ -731,7 +731,7 @@ impl BoolReader {
         retval
     }
 
-    pub fn read_literal(&mut self, n: u8) -> u8 {
+    pub(crate) fn read_literal(&mut self, n: u8) -> u8 {
         let mut v = 0u8;
         let mut n = n;
 
@@ -743,7 +743,7 @@ impl BoolReader {
         v
     }
 
-    pub fn read_magnitude_and_sign(&mut self, n: u8) -> i32 {
+    pub(crate) fn read_magnitude_and_sign(&mut self, n: u8) -> i32 {
         let magnitude = self.read_literal(n);
         let sign = self.read_literal(1);
 
@@ -754,7 +754,7 @@ impl BoolReader {
         }
     }
 
-    pub fn read_with_tree(&mut self, tree: &[i8], probs: &[Prob], start: isize) -> i8 {
+    pub(crate) fn read_with_tree(&mut self, tree: &[i8], probs: &[Prob], start: isize) -> i8 {
         let mut index = start;
 
         loop {
@@ -770,7 +770,7 @@ impl BoolReader {
         -index as i8
     }
 
-    pub fn read_flag(&mut self) -> bool {
+    pub(crate) fn read_flag(&mut self) -> bool {
         0 != self.read_literal(1)
     }
 }


### PR DESCRIPTION
Also adds `#![deny(unreachable_pub)]` to enforce more clarity in visibility qualifiers. This was maybe the root cause why this function was not added in the first place.

Closes: #978 