### PR TITLE
Fix tiff magic bytes

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -951,8 +951,8 @@ static MAGIC_BYTES: [(&[u8], ImageFormat); 17] = [
     (b"GIF89a", ImageFormat::GIF),
     (b"GIF87a", ImageFormat::GIF),
     (b"RIFF", ImageFormat::WEBP), // TODO: better magic byte detection, see https://github.com/image-rs/image/issues/660
-    (b"MM.*", ImageFormat::TIFF),
-    (b"II*.", ImageFormat::TIFF),
+    (b"MM\x00*", ImageFormat::TIFF),
+    (b"II*\x00", ImageFormat::TIFF),
     (b"BM", ImageFormat::BMP),
     (&[0, 0, 1, 0], ImageFormat::ICO),
     (b"#?RADIANCE", ImageFormat::HDR),


### PR DESCRIPTION
Split from #933 as it doesn't require any interface design. It should really be 'authored-by martinlindhe' but that way the commit gets signed and it was what `cherry-pick` did automatically.

Co-authored-by: martinlindhe
