### PR TITLE
Update crate metadata for release 0.22.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,24 @@ Rust image aims to be a pure-Rust implementation of various popular image format
 
 ## Changes
 
+### Version 0.22.2
+
+- Undeprecate `unsafe` trait accessors. Further evaluation showed that their
+  deprecation should be delayed until trait `impl` specialization is available.
+- Fixed magic bytes used to detect `tiff` images.
+- Added `DynamicImage::from_decoder`.
+- Fixed a bug in the `PNGReader` that caused an infinite loop.
+- Added `ColorType::{bits_per_pixel, num_components}`.
+- Added `ImageFormat::from_path`, same format deduction as the `open` method.
+- Fixed a panic in the gif decoder.
+- Aligned background color handling of `gif` to web browser implementations.
+- Fixed handling of partial frames in animated `gif`.
+- Removed unused direct `lzw` dependency, an indirect dependency in `tiff`.
+
+### Version 0.22.1
+
+- Fixed build without no features enabled
+
 ### Version 0.22
 
 - The required Rust version is now `1.34.2`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "image"
-version = "0.22.1"
+version = "0.22.2"
 license = "MIT"
 description = "Imaging library written in Rust. Provides basic filters and decoders for the most common image formats."
 authors = [


### PR DESCRIPTION
Includes release notes for `0.22.1` which was a simple quickfix but nevertheless.

@fintelia 