### PR TITLE
Fix potential overflow in GIF decoding

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -36,8 +36,8 @@ impl<'a> Iterator for Frames<'a> {
 /// A single animation frame
 #[derive(Clone)]
 pub struct Frame {
-    /// Delay between the frames in s
-    delay: Ratio<u16>,
+    /// Delay between the frames in milliseconds
+    delay_ms: Ratio<u32>,
     /// x offset
     left: u32,
     /// y offset
@@ -49,7 +49,7 @@ impl Frame {
     /// Contructs a new frame
     pub fn new(buffer: RgbaImage) -> Frame {
         Frame {
-            delay: Ratio::from_integer(0),
+            delay_ms: Ratio::from_integer(0),
             left: 0,
             top: 0,
             buffer,
@@ -57,9 +57,9 @@ impl Frame {
     }
 
     /// Contructs a new frame
-    pub fn from_parts(buffer: RgbaImage, left: u32, top: u32, delay: Ratio<u16>) -> Frame {
+    pub fn from_parts(buffer: RgbaImage, left: u32, top: u32, delay_ms: Ratio<u32>) -> Frame {
         Frame {
-            delay,
+            delay_ms,
             left,
             top,
             buffer,
@@ -67,8 +67,8 @@ impl Frame {
     }
 
     /// Delay of this frame
-    pub fn delay(&self) -> Ratio<u16> {
-        self.delay
+    pub fn delay_ms(&self) -> Ratio<u32> {
+        self.delay_ms
     }
 
     /// Returns the image buffer


### PR DESCRIPTION
Fixes: #877 

That issue was caused by an overflow in the "frame delay" field between individual frames of the GIF frames when expressed in milliseconds. This translates to highly unrealistic frame rates of greater than 65 seconds per frame (i.e. over 1000x slower than a normal monitor refresh rate), but ideally should still not result in panics. This PR switches to using u32's to prevent the possibility of overflow while still allowing all delay values expressible by GIF images.

At the same time I noticed that there was some confusion about the actual units used to store frame delays in various places. I've renamed a bunch of places to "delay_ms" to be clear when milliseconds are in use.

**Open questions**: Is num_rational::Ratio<u32> really the right type to express the delay in milliseconds between frames of an animation?