### PR TITLE
Opinionated changes to ImageDecoder

### DIFF
--- a/src/bmp/decoder.rs
+++ b/src/bmp/decoder.rs
@@ -1317,14 +1317,7 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for BmpDecoder<R> {
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
-        if self.total_bytes() > usize::max_value() as u64 {
-            return Err(ImageError::InsufficientMemory);
-        }
-
-        let mut buf = vec![0; self.total_bytes() as usize];
-        self.read_image(&mut buf)?;
-
-        Ok(BmpReader(Cursor::new(buf), PhantomData))
+        Ok(BmpReader(Cursor::new(image::decoder_to_vec(self)?), PhantomData))
     }
 
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {

--- a/src/bmp/decoder.rs
+++ b/src/bmp/decoder.rs
@@ -1,3 +1,4 @@
+use std::convert::TryFrom;
 use std::io::{self, Cursor, Read, Seek, SeekFrom};
 use std::iter::{repeat, Iterator, Rev};
 use std::marker::PhantomData;
@@ -1321,7 +1322,7 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for BmpDecoder<R> {
     }
 
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
-        assert!(buf.len() as u64 == self.total_bytes());
+        assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
         self.read_image_data(buf)
     }
 }

--- a/src/bmp/encoder.rs
+++ b/src/bmp/encoder.rs
@@ -255,7 +255,10 @@ mod tests {
         }
 
         let decoder = BmpDecoder::new(Cursor::new(&encoded_data)).expect("failed to decode");
-        decoder.read_image().expect("failed to decode")
+
+        let mut buf = vec![0; decoder.total_bytes() as usize];
+        decoder.read_image(&mut buf).expect("failed to decode");
+        buf
     }
 
     #[test]

--- a/src/dxt.rs
+++ b/src/dxt.rs
@@ -127,12 +127,8 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for DxtDecoder<R> {
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
-        if self.total_bytes() > usize::max_value() as u64 {
-            return Err(ImageError::InsufficientMemory);
-        }
-
         Ok(DXTReader {
-            buffer: ImageReadBuffer::new(self.scanline_bytes() as usize, self.total_bytes() as usize),
+            buffer: ImageReadBuffer::new(self.scanline_bytes(), self.total_bytes()),
             decoder: self,
         })
     }

--- a/src/dxt.rs
+++ b/src/dxt.rs
@@ -113,8 +113,8 @@ impl<R: Read> DxtDecoder<R> {
 impl<'a, R: 'a + Read> ImageDecoder<'a> for DxtDecoder<R> {
     type Reader = DXTReader<R>;
 
-    fn dimensions(&self) -> (u64, u64) {
-        (u64::from(self.width_blocks) * 4, u64::from(self.height_blocks) * 4)
+    fn dimensions(&self) -> (u32, u32) {
+        (self.width_blocks * 4, self.height_blocks * 4)
     }
 
     fn color_type(&self) -> ColorType {
@@ -136,16 +136,13 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for DxtDecoder<R> {
         })
     }
 
-    fn read_image(mut self) -> ImageResult<Vec<u8>> {
-        if self.total_bytes() > usize::max_value() as u64 {
-            return Err(ImageError::InsufficientMemory);
-        }
+    fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
+        assert!(buf.len() as u64 == self.total_bytes());
 
-        let mut dest = vec![0u8; self.total_bytes() as usize];
-        for chunk in dest.chunks_mut(self.scanline_bytes() as usize) {
+        for chunk in buf.chunks_mut(self.scanline_bytes() as usize) {
             self.read_scanline(chunk)?;
         }
-        Ok(dest)
+        Ok(())
     }
 }
 

--- a/src/dxt.rs
+++ b/src/dxt.rs
@@ -7,6 +7,7 @@
 //!
 //!  Note: this module only implements bare DXT encoding/decoding, it does not parse formats that can contain DXT files like .dds
 
+use std::convert::TryFrom;
 use std::io::{self, Read, Seek, SeekFrom, Write};
 
 use color::ColorType;
@@ -93,7 +94,7 @@ impl<R: Read> DxtDecoder<R> {
     }
 
     fn read_scanline(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        assert_eq!(buf.len() as u64, self.scanline_bytes());
+        assert_eq!(u64::try_from(buf.len()), Ok(self.scanline_bytes()));
 
         let mut src =
             vec![0u8; self.variant.encoded_bytes_per_block() * self.width_blocks as usize];
@@ -137,7 +138,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for DxtDecoder<R> {
     }
 
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
-        assert!(buf.len() as u64 == self.total_bytes());
+        assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
 
         for chunk in buf.chunks_mut(self.scanline_bytes() as usize) {
             self.read_scanline(chunk)?;

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -640,16 +640,9 @@ impl GenericImage for DynamicImage {
 
 /// Decodes an image and stores it into a dynamic image
 fn decoder_to_image<'a, I: ImageDecoder<'a>>(decoder: I) -> ImageResult<DynamicImage> {
-    let color_type = decoder.color_type();
     let (w, h) = decoder.dimensions();
-    let total_bytes = decoder.total_bytes();
-
-    if total_bytes > usize::max_value() as u64 {
-        return Err(ImageError::InsufficientMemory);
-    }
-
-    let mut buf = vec![0; total_bytes as usize];
-    decoder.read_image(&mut buf)?;
+    let color_type = decoder.color_type();
+    let buf = image::decoder_to_vec(decoder)?;
 
     let image = match color_type {
         color::ColorType::Rgb8 => {

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -40,9 +40,8 @@ pub use self::gif::{DisposalMethod, Frame};
 
 use animation;
 use buffer::{ImageBuffer, Pixel};
-use color;
-use color::Rgba;
-use image::{AnimationDecoder, ImageDecoder, ImageError, ImageResult};
+use color::{self, Rgba};
+use image::{self, AnimationDecoder, ImageDecoder, ImageError, ImageResult};
 use num_rational::Ratio;
 
 /// GIF decoder
@@ -90,14 +89,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for GifDecoder<R> {
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
-        if self.total_bytes() > usize::max_value() as u64 {
-            return Err(ImageError::InsufficientMemory);
-        }
-
-        let mut buf = vec![0; self.total_bytes() as usize];
-        self.read_image(&mut buf)?;
-
-        Ok(GifReader(Cursor::new(buf), PhantomData))
+        Ok(GifReader(Cursor::new(image::decoder_to_vec(self)?), PhantomData))
     }
 
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -111,7 +111,12 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for GifDecoder<R> {
 
         let (width, height) = (u32::from(self.reader.width()), u32::from(self.reader.height()));
         if (left, top) != (0, 0) || (width, height) != (f_width, f_height) {
-            // TODO: Avoid unnecessary allocation here.
+            // This is somewhat of an annoying case. The image we read into `buf` doesn't take up
+            // the whole buffer and now we need to properly insert borders. For simplicity this code
+            // currently takes advantage of the `ImageBuffer::from_fn` function to make a second
+            // ImageBuffer that is properly positioned, and then copies it back into `buf`.
+            //
+            // TODO: Implement this without any allocation.
 
             // See the comments inside `<GifFrameIterator as Iterator>::next` about
             // the error handling of `from_raw`.

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -31,6 +31,7 @@ extern crate num_rational;
 
 use std::clone::Clone;
 use std::cmp::min;
+use std::convert::TryFrom;
 use std::io::{self, Cursor, Read, Write};
 use std::marker::PhantomData;
 use std::mem;
@@ -93,7 +94,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for GifDecoder<R> {
     }
 
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
-        assert!(buf.len() as u64 == self.total_bytes());
+        assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
 
         let (f_width, f_height, left, top);
 

--- a/src/hdr/decoder.rs
+++ b/src/hdr/decoder.rs
@@ -2,6 +2,7 @@ use num_traits::identities::Zero;
 use scoped_threadpool::Pool;
 #[cfg(test)]
 use std::borrow::Cow;
+use std::convert::TryFrom;
 use std::error::Error;
 use std::io::{self, BufRead, Cursor, Read, Seek};
 use std::iter::Iterator;
@@ -44,6 +45,7 @@ impl<R: BufRead> HDRAdapter<R> {
 
     /// Read the actual data of the image, and store it in Self::data.
     fn read_image_data(&mut self, buf: &mut [u8]) -> ImageResult<()> {
+        assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
         match self.inner.take() {
             Some(decoder) => {
                 let img: Vec<Rgb<u8>> = decoder.read_image_ldr()?;

--- a/src/hdr/decoder.rs
+++ b/src/hdr/decoder.rs
@@ -86,14 +86,7 @@ impl<'a, R: 'a + BufRead> ImageDecoder<'a> for HDRAdapter<R> {
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
-        if self.total_bytes() > usize::max_value() as u64 {
-            return Err(ImageError::InsufficientMemory);
-        }
-
-        let mut buf = vec![0; self.total_bytes() as usize];
-        self.read_image(&mut buf)?;
-
-        Ok(HdrReader(Cursor::new(buf), PhantomData))
+        Ok(HdrReader(Cursor::new(image::decoder_to_vec(self)?), PhantomData))
     }
 
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {

--- a/src/ico/decoder.rs
+++ b/src/ico/decoder.rs
@@ -1,4 +1,5 @@
 use byteorder::{LittleEndian, ReadBytesExt};
+use std::convert::TryFrom;
 use std::io::{self, Cursor, Read, Seek, SeekFrom};
 use std::marker::PhantomData;
 use std::mem;
@@ -198,6 +199,7 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for IcoDecoder<R> {
     }
 
     fn read_image(self, buf: &mut [u8]) -> ImageResult<()> {
+        assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
         match self.inner_decoder {
             PNG(decoder) => {
                 if self.selected_entry.image_length < PNG_SIGNATURE.len() as u32 {

--- a/src/ico/decoder.rs
+++ b/src/ico/decoder.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 use std::mem;
 
 use color::ColorType;
-use image::{ImageDecoder, ImageError, ImageResult};
+use image::{self, ImageDecoder, ImageError, ImageResult};
 
 use self::InnerDecoder::*;
 use bmp::BmpDecoder;
@@ -194,14 +194,7 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for IcoDecoder<R> {
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
-        if self.total_bytes() > usize::max_value() as u64 {
-            return Err(ImageError::InsufficientMemory);
-        }
-
-        let mut buf = vec![0; self.total_bytes() as usize];
-        self.read_image(&mut buf)?;
-
-        Ok(IcoReader(Cursor::new(buf), PhantomData))
+        Ok(IcoReader(Cursor::new(image::decoder_to_vec(self)?), PhantomData))
     }
 
     fn read_image(self, buf: &mut [u8]) -> ImageResult<()> {

--- a/src/image.rs
+++ b/src/image.rs
@@ -403,9 +403,9 @@ pub trait ImageDecoder<'a>: Sized {
 
     /// Returns all the bytes in the image.
     ///
-    /// This function takes a slices of bytes and writes the pixel data of the image into it.
+    /// This function takes a slice of bytes and writes the pixel data of the image into it.
     /// Although not required, for certain color types callers may want to pass buffers which are
-    /// aligned to 2 or 4 byte boundries to the slice can be cast to a [u16] or [u32]. To accommodate
+    /// aligned to 2 or 4 byte boundaries to the slice can be cast to a [u16] or [u32]. To accommodate
     /// such casts, the returned contents will always be in native endian.
     ///
     /// # Panics

--- a/src/image.rs
+++ b/src/image.rs
@@ -388,7 +388,7 @@ pub trait ImageDecoder<'a>: Sized {
     /// Returns the total number of bytes in the decoded image.
     ///
     /// This is the size of the buffer that must be passed to `read_image` or
-    /// `read_image_with_progress`. It is possible that the returned value exceeds usize::MAX, in
+    /// `read_image_with_progress`. The returned value may exceed usize::MAX, in
     /// which case it isn't actually possible to construct a buffer to decode all the image data
     /// into.
     fn total_bytes(&self) -> u64 {

--- a/src/image.rs
+++ b/src/image.rs
@@ -408,7 +408,11 @@ pub trait ImageDecoder<'a>: Sized {
     /// aligned to 2 or 4 byte boundries to the slice can be cast to a [u16] or [u32]. To accommodate
     /// such casts, the returned contents will always be in native endian.
     ///
-    /// For example, using the `zerocopy` crate:
+    /// # Panics
+    ///
+    /// This function panics if buf.len() != self.total_bytes().
+    ///
+    /// # Examples
     ///
     /// ```no_run
     /// use zerocopy::{AsBytes, FromBytes};

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::too_many_arguments)]
 
+use std::convert::TryFrom;
 use std::error::Error;
 use std::fmt;
 use std::io;
@@ -447,12 +448,9 @@ pub trait ImageDecoder<'a>: Sized {
         buf: &mut [u8],
         progress_callback: F,
     ) -> ImageResult<()> {
-        let total_bytes = self.total_bytes();
-        if total_bytes > usize::max_value() as u64 {
-            return Err(ImageError::InsufficientMemory);
-        }
+        assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
 
-        let total_bytes = total_bytes as usize;
+        let total_bytes = self.total_bytes() as usize;
         let scanline_bytes = self.scanline_bytes() as usize;
         let target_read_size = if scanline_bytes < 4096 {
             (4096 / scanline_bytes) * scanline_bytes

--- a/src/image.rs
+++ b/src/image.rs
@@ -358,6 +358,19 @@ pub(crate) fn load_rect<'a, D, F, F1, F2, E>(x: u64, y: u64, width: u64, height:
     Ok(seek_scanline(decoder, 0)?)
 }
 
+/// Reads all of the bytes of a decoder into a Vec<u8>. No particular alignment
+/// of the output buffer is guaranteed.
+pub(crate) fn decoder_to_vec<'a>(decoder: impl ImageDecoder<'a>) -> ImageResult<Vec<u8>> {
+    let total_bytes = decoder.total_bytes();
+    if total_bytes > isize::max_value() as u64 {
+        return Err(ImageError::InsufficientMemory);
+    }
+
+    let mut buf = vec![0; total_bytes as usize];
+    decoder.read_image(&mut buf)?;
+    Ok(buf)
+}
+
 /// Represents the progress of an image operation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Progress {

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -100,7 +100,7 @@ pub(crate) fn image_dimensions_with_format_impl<R: BufRead + Seek>(fin: R, forma
 {
     #[allow(unreachable_patterns)]
     // Default is unreachable if all features are supported.
-    let (w, h): (u64, u64) = match format {
+    Ok(match format {
         #[cfg(feature = "jpeg")]
         image::ImageFormat::Jpeg => jpeg::JpegDecoder::new(fin)?.dimensions(),
         #[cfg(feature = "png_codec")]
@@ -127,11 +127,7 @@ pub(crate) fn image_dimensions_with_format_impl<R: BufRead + Seek>(fin: R, forma
             "Image format image/{:?} is not supported.",
             format
         ))),
-    };
-    if w >= u64::from(u32::MAX) || h >= u64::from(u32::MAX) {
-        return Err(image::ImageError::DimensionError);
-    }
-    Ok((w as u32, h as u32))
+    })
 }
 
 pub(crate) fn save_buffer_impl(

--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -1,5 +1,6 @@
 extern crate jpeg_decoder;
 
+use std::convert::TryFrom;
 use std::io::{self, Cursor, Read};
 use std::marker::PhantomData;
 use std::mem;
@@ -71,7 +72,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for JpegDecoder<R> {
     }
 
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
-        assert!(buf.len() as u64 == self.total_bytes());
+        assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
 
         let mut data = self.decoder.decode()?;
         data = match self.decoder.info().unwrap().pixel_format {

--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -762,6 +762,15 @@ mod tests {
     use image::ImageDecoder;
     use std::io::Cursor;
 
+    fn decode(encoded: &[u8]) -> Vec<u8> {
+        let decoder = JpegDecoder::new(Cursor::new(encoded))
+            .expect("Could not decode image");
+
+        let mut decoded = vec![0; decoder.total_bytes() as usize];
+        decoder.read_image(&mut decoded).expect("Could not decode image");
+        decoded
+    }
+
     #[test]
     fn roundtrip_sanity_check() {
         // create a 1x1 8-bit image buffer containing a single red pixel
@@ -778,9 +787,7 @@ mod tests {
 
         // decode it from the memory buffer
         {
-            let decoder = JpegDecoder::new(Cursor::new(&encoded_img))
-                .expect("Could not decode image");
-            let decoded = decoder.read_image().expect("Could not decode image");
+            let decoded = decode(&encoded_img);
             // note that, even with the encode quality set to 100, we do not get the same image
             // back. Therefore, we're going to assert that it's at least red-ish:
             assert_eq!(3, decoded.len());
@@ -806,9 +813,7 @@ mod tests {
 
         // decode it from the memory buffer
         {
-            let decoder = JpegDecoder::new(Cursor::new(&encoded_img))
-                .expect("Could not decode image");
-            let decoded = decoder.read_image().expect("Could not decode image");
+            let decoded = decode(&encoded_img);
             // note that, even with the encode quality set to 100, we do not get the same image
             // back. Therefore, we're going to assert that the diagonal is at least white-ish:
             assert_eq!(4, decoded.len());

--- a/src/png.rs
+++ b/src/png.rs
@@ -151,9 +151,8 @@ impl<R: Read> PngDecoder<R> {
 impl<'a, R: 'a + Read> ImageDecoder<'a> for PngDecoder<R> {
     type Reader = PNGReader<R>;
 
-    fn dimensions(&self) -> (u64, u64) {
-        let (w, h) = self.reader.info().size();
-        (u64::from(w), u64::from(h))
+    fn dimensions(&self) -> (u32, u32) {
+        self.reader.info().size()
     }
 
     fn color_type(&self) -> ColorType {
@@ -164,11 +163,10 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for PngDecoder<R> {
         PNGReader::new(self.reader)
     }
 
-    fn read_image(mut self) -> ImageResult<Vec<u8>> {
-        // This should be slightly faster than the default implementation
-        let mut data = vec![0; self.reader.output_buffer_size()];
-        self.reader.next_frame(&mut data)?;
-        Ok(data)
+    fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
+        assert!(buf.len() as u64 == self.total_bytes());
+        self.reader.next_frame(buf)?;
+        Ok(())
     }
 
     fn scanline_bytes(&self) -> u64 {

--- a/src/png.rs
+++ b/src/png.rs
@@ -8,6 +8,7 @@
 
 extern crate png;
 
+use std::convert::TryFrom;
 use std::io::{self, Read, Write};
 
 use color::{ColorType, ExtendedColorType};
@@ -164,7 +165,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for PngDecoder<R> {
     }
 
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
-        assert!(buf.len() as u64 == self.total_bytes());
+        assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
         self.reader.next_frame(buf)?;
         Ok(())
     }

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -1,3 +1,4 @@
+use std::convert::TryFrom;
 use std::io::{self, BufRead, BufReader, Cursor, Read};
 use std::str::{self, FromStr};
 use std::fmt::Display;
@@ -459,7 +460,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for PnmDecoder<R> {
     }
 
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
-        assert!(buf.len() as u64 == self.total_bytes());
+        assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
         buf.copy_from_slice(&match self.tuple {
             TupleType::PbmBit => self.read_samples::<PbmBit>(1),
             TupleType::BWBit => self.read_samples::<BWBit>(1),

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -7,7 +7,7 @@ use std::mem;
 use super::{ArbitraryHeader, ArbitraryTuplType, BitmapHeader, GraymapHeader, PixmapHeader};
 use super::{HeaderRecord, PNMHeader, PNMSubtype, SampleEncoding};
 use color::{ColorType, ExtendedColorType};
-use image::{ImageDecoder, ImageError, ImageResult};
+use image::{self, ImageDecoder, ImageError, ImageResult};
 use utils;
 
 use byteorder::{BigEndian, ByteOrder, NativeEndian};
@@ -455,14 +455,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for PnmDecoder<R> {
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
-        if self.total_bytes() > usize::max_value() as u64 {
-            return Err(ImageError::InsufficientMemory);
-        }
-
-        let mut buf = vec![0; self.total_bytes() as usize];
-        self.read_image(&mut buf)?;
-
-        Ok(PnmReader(Cursor::new(buf), PhantomData))
+        Ok(PnmReader(Cursor::new(image::decoder_to_vec(self)?), PhantomData))
     }
 
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -428,8 +428,8 @@ impl<R> Read for PnmReader<R> {
 impl<'a, R: 'a + Read> ImageDecoder<'a> for PnmDecoder<R> {
     type Reader = PnmReader<R>;
 
-    fn dimensions(&self) -> (u64, u64) {
-        (u64::from(self.header.width()), u64::from(self.header.height()))
+    fn dimensions(&self) -> (u32, u32) {
+        (self.header.width(), self.header.height())
     }
 
     fn color_type(&self) -> ColorType {
@@ -455,26 +455,31 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for PnmDecoder<R> {
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
-        Ok(PnmReader(Cursor::new(self.read_image()?), PhantomData))
+        if self.total_bytes() > usize::max_value() as u64 {
+            return Err(ImageError::InsufficientMemory);
+        }
+
+        let mut buf = vec![0; self.total_bytes() as usize];
+        self.read_image(&mut buf)?;
+
+        Ok(PnmReader(Cursor::new(buf), PhantomData))
     }
 
-    fn read_image(mut self) -> ImageResult<Vec<u8>> {
-        self.read()
-    }
-}
-
-impl<R: Read> PnmDecoder<R> {
-    fn read(&mut self) -> ImageResult<Vec<u8>> {
-        match self.tuple {
+    fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
+        assert!(buf.len() as u64 == self.total_bytes());
+        buf.copy_from_slice(&match self.tuple {
             TupleType::PbmBit => self.read_samples::<PbmBit>(1),
             TupleType::BWBit => self.read_samples::<BWBit>(1),
             TupleType::RGBU8 => self.read_samples::<U8>(3),
             TupleType::RGBU16 => self.read_samples::<U16>(3),
             TupleType::GrayU8 => self.read_samples::<U8>(1),
             TupleType::GrayU16 => self.read_samples::<U16>(1),
-        }
+        }?);
+        Ok(())
     }
+}
 
+impl<R: Read> PnmDecoder<R> {
     fn read_samples<S: Sample>(&mut self, components: u32) -> ImageResult<Vec<u8>> {
         match self.subtype().sample_encoding() {
             SampleEncoding::Binary => {
@@ -789,8 +794,10 @@ ENDHDR
         assert_eq!(decoder.dimensions(), (4, 4));
         assert_eq!(decoder.subtype(), PNMSubtype::ArbitraryMap);
 
+        let mut image = vec![0; decoder.total_bytes() as usize];
+        decoder.read_image(&mut image).unwrap();
         assert_eq!(
-            decoder.read_image().unwrap(),
+            image,
             vec![0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00,
                  0x00, 0x01]
         );
@@ -829,8 +836,11 @@ ENDHDR
         assert_eq!(decoder.color_type(), ColorType::L8);
         assert_eq!(decoder.dimensions(), (4, 4));
         assert_eq!(decoder.subtype(), PNMSubtype::ArbitraryMap);
+
+        let mut image = vec![0; decoder.total_bytes() as usize];
+        decoder.read_image(&mut image).unwrap();
         assert_eq!(
-            decoder.read_image().unwrap(),
+            image,
             vec![0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad,
                  0xbe, 0xef]
         );
@@ -870,7 +880,9 @@ ENDHDR
         assert_eq!(decoder.dimensions(), (2, 2));
         assert_eq!(decoder.subtype(), PNMSubtype::ArbitraryMap);
 
-        assert_eq!(decoder.read_image().unwrap(),
+        let mut image = vec![0; decoder.total_bytes() as usize];
+        decoder.read_image(&mut image).unwrap();
+        assert_eq!(image,
                    vec![0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef]);
         match PnmDecoder::new(&pamdata[..]).unwrap().into_inner() {
             (
@@ -904,7 +916,9 @@ ENDHDR
             decoder.subtype(),
             PNMSubtype::Bitmap(SampleEncoding::Binary)
         );
-        assert_eq!(decoder.read_image().unwrap(), vec![255, 0, 0, 255, 0, 0, 0, 255, 0, 0, 255, 0]);
+        let mut image = vec![0; decoder.total_bytes() as usize];
+        decoder.read_image(&mut image).unwrap();
+        assert_eq!(image, vec![255, 0, 0, 255, 0, 0, 0, 255, 0, 0, 255, 0]);
         match PnmDecoder::new(&pbmbinary[..]).unwrap().into_inner() {
             (
                 _,
@@ -942,8 +956,9 @@ ENDHDR
 
         let pbmbinary = FailRead(Cursor::new(b"P1 1 1\n"));
 
-        PnmDecoder::new(pbmbinary).unwrap()
-            .read_image().expect_err("Image is malformed");
+        let decoder = PnmDecoder::new(pbmbinary).unwrap();
+        let mut image = vec![0; decoder.total_bytes() as usize];
+        decoder.read_image(&mut image).expect_err("Image is malformed");
     }
 
     #[test]
@@ -957,7 +972,10 @@ ENDHDR
         assert_eq!(decoder.original_color_type(), ExtendedColorType::L1);
         assert_eq!(decoder.dimensions(), (6, 2));
         assert_eq!(decoder.subtype(), PNMSubtype::Bitmap(SampleEncoding::Ascii));
-        assert_eq!(decoder.read_image().unwrap(), vec![1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0]);
+
+        let mut image = vec![0; decoder.total_bytes() as usize];
+        decoder.read_image(&mut image).unwrap();
+        assert_eq!(image, vec![1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0]);
         match PnmDecoder::new(&pbmbinary[..]).unwrap().into_inner() {
             (
                 _,
@@ -986,7 +1004,10 @@ ENDHDR
         assert_eq!(decoder.original_color_type(), ExtendedColorType::L1);
         assert_eq!(decoder.dimensions(), (6, 2));
         assert_eq!(decoder.subtype(), PNMSubtype::Bitmap(SampleEncoding::Ascii));
-        assert_eq!(decoder.read_image().unwrap(), vec![1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0]);
+
+        let mut image = vec![0; decoder.total_bytes() as usize];
+        decoder.read_image(&mut image).unwrap();
+        assert_eq!(image, vec![1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0]);
         match PnmDecoder::new(&pbmbinary[..]).unwrap().into_inner() {
             (
                 _,
@@ -1017,7 +1038,9 @@ ENDHDR
             decoder.subtype(),
             PNMSubtype::Graymap(SampleEncoding::Binary)
         );
-        assert_eq!(decoder.read_image().unwrap(), elements);
+        let mut image = vec![0; decoder.total_bytes() as usize];
+        decoder.read_image(&mut image).unwrap();
+        assert_eq!(image, elements);
         match PnmDecoder::new(&pbmbinary[..]).unwrap().into_inner() {
             (
                 _,
@@ -1048,7 +1071,9 @@ ENDHDR
             decoder.subtype(),
             PNMSubtype::Graymap(SampleEncoding::Ascii)
         );
-        assert_eq!(decoder.read_image().unwrap(), (0..16).collect::<Vec<_>>());
+        let mut image = vec![0; decoder.total_bytes() as usize];
+        decoder.read_image(&mut image).unwrap();
+        assert_eq!(image, (0..16).collect::<Vec<_>>());
         match PnmDecoder::new(&pbmbinary[..]).unwrap().into_inner() {
             (
                 _,

--- a/src/pnm/mod.rs
+++ b/src/pnm/mod.rs
@@ -36,7 +36,8 @@ mod tests {
         let (header, loaded_color, loaded_image) = {
             let decoder = PnmDecoder::new(&encoded_buffer[..]).unwrap();
             let color_type = decoder.color_type();
-            let image = decoder.read_image().expect("Failed to decode the image");
+            let mut image = vec![0; decoder.total_bytes() as usize];
+            decoder.read_image(&mut image).expect("Failed to decode the image");
             let (_, header) = PnmDecoder::new(&encoded_buffer[..]).unwrap().into_inner();
             (header, color_type, image)
         };
@@ -66,7 +67,8 @@ mod tests {
         let (header, loaded_color, loaded_image) = {
             let decoder = PnmDecoder::new(&encoded_buffer[..]).unwrap();
             let color_type = decoder.color_type();
-            let image = decoder.read_image().expect("Failed to decode the image");
+            let mut image = vec![0; decoder.total_bytes() as usize];
+            decoder.read_image(&mut image).expect("Failed to decode the image");
             let (_, header) = PnmDecoder::new(&encoded_buffer[..]).unwrap().into_inner();
             (header, color_type, image)
         };
@@ -91,7 +93,8 @@ mod tests {
         let (header, loaded_color, loaded_image) = {
             let decoder = PnmDecoder::new(&encoded_buffer[..]).unwrap();
             let color_type = decoder.color_type();
-            let image = decoder.read_image().expect("Failed to decode the image");
+            let mut image = vec![0; decoder.total_bytes() as usize];
+            decoder.read_image(&mut image).expect("Failed to decode the image");
             let (_, header) = PnmDecoder::new(&encoded_buffer[..]).unwrap().into_inner();
             (header, color_type, image)
         };

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -483,15 +483,8 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for TgaDecoder<R> {
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
-        if self.total_bytes() > usize::max_value() as u64 {
-            return Err(ImageError::InsufficientMemory);
-        }
-
         Ok(TGAReader {
-            buffer: ImageReadBuffer::new(
-                self.scanline_bytes() as usize,
-                self.total_bytes() as usize,
-            ),
+            buffer: ImageReadBuffer::new(self.scanline_bytes(), self.total_bytes()),
             decoder: self,
         })
     }

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -1,4 +1,5 @@
 use byteorder::{LittleEndian, ReadBytesExt};
+use std::convert::TryFrom;
 use std::io;
 use std::io::{Read, Seek};
 
@@ -496,7 +497,7 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for TgaDecoder<R> {
     }
 
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
-        assert!(buf.len() as u64 == self.total_bytes());
+        assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
 
         // read the pixels from the data region
         let len = if self.image_type.is_encoded() {

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -302,10 +302,7 @@ impl<R: Read + Seek> TgaDecoder<R> {
         let bytes_per_entry = (self.header.map_entry_size as usize + 7) / 8;
         let mut result = Vec::with_capacity(self.width * self.height * bytes_per_entry);
 
-        let color_map = match self.color_map {
-            Some(ref color_map) => color_map,
-            None => unreachable!(),
-        };
+        let color_map = self.color_map.as_ref().unwrap();
 
         for chunk in pixel_data.chunks(self.bytes_per_pixel) {
             let index = bytes_to_index(chunk);
@@ -313,29 +310,6 @@ impl<R: Read + Seek> TgaDecoder<R> {
         }
 
         result
-    }
-
-    fn read_image_data(&mut self) -> ImageResult<Vec<u8>> {
-        // read the pixels from the data region
-        let mut pixel_data = if self.image_type.is_encoded() {
-            self.read_all_encoded_data()?
-        } else {
-            let num_raw_bytes = self.width * self.height * self.bytes_per_pixel;
-            let mut buf = vec![0; num_raw_bytes];
-            self.r.by_ref().read_exact(&mut buf)?;
-            buf
-        };
-
-        // expand the indices using the color map if necessary
-        if self.image_type.is_color_mapped() {
-            pixel_data = self.expand_color_map(&pixel_data)
-        }
-
-        self.reverse_encoding(&mut pixel_data);
-
-        self.flip_vertically(&mut pixel_data);
-
-        Ok(pixel_data)
     }
 
     /// Reads a run length encoded data for given number of bytes
@@ -493,8 +467,8 @@ impl<R: Read + Seek> TgaDecoder<R> {
 impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for TgaDecoder<R> {
     type Reader = TGAReader<R>;
 
-    fn dimensions(&self) -> (u64, u64) {
-        (self.width as u64, self.height as u64)
+    fn dimensions(&self) -> (u32, u32) {
+        (self.width as u32, self.height as u32)
     }
 
     fn color_type(&self) -> ColorType {
@@ -521,8 +495,31 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for TgaDecoder<R> {
         })
     }
 
-    fn read_image(mut self) -> ImageResult<Vec<u8>> {
-        self.read_image_data()
+    fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
+        assert!(buf.len() as u64 == self.total_bytes());
+
+        // read the pixels from the data region
+        let len = if self.image_type.is_encoded() {
+            let pixel_data = self.read_all_encoded_data()?;
+            buf[0..pixel_data.len()].copy_from_slice(&pixel_data);
+            pixel_data.len()
+        } else {
+            let num_raw_bytes = self.width * self.height * self.bytes_per_pixel;
+            self.r.by_ref().read_exact(&mut buf[0..num_raw_bytes])?;
+            num_raw_bytes
+        };
+
+        // expand the indices using the color map if necessary
+        if self.image_type.is_color_mapped() {
+            let pixel_data = self.expand_color_map(&buf[0..len]);
+            buf.copy_from_slice(&pixel_data);
+        }
+
+        self.reverse_encoding(buf);
+
+        self.flip_vertically(buf);
+
+        Ok(())
     }
 }
 

--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -8,6 +8,7 @@
 
 extern crate tiff;
 
+use std::convert::TryFrom;
 use std::io::{self, Cursor, Read, Write, Seek};
 use std::marker::PhantomData;
 use std::mem;
@@ -110,6 +111,7 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for TiffDecoder<R> {
     }
 
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
+        assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
         match self.inner.read_image()? {
             tiff::decoder::DecodingResult::U8(v) => {
                 buf.copy_from_slice(&v);

--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -12,6 +12,8 @@ use std::io::{self, Cursor, Read, Write, Seek};
 use std::marker::PhantomData;
 use std::mem;
 
+use byteorder::{NativeEndian, ByteOrder};
+
 use color::{ColorType, ExtendedColorType};
 use image::{ImageDecoder, ImageResult, ImageError};
 use utils::vec_u16_into_u8;
@@ -90,23 +92,33 @@ impl<R> Read for TiffReader<R> {
 impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for TiffDecoder<R> {
     type Reader = TiffReader<R>;
 
-    fn dimensions(&self) -> (u64, u64) {
-        (u64::from(self.dimensions.0), u64::from(self.dimensions.1))
+    fn dimensions(&self) -> (u32, u32) {
+        self.dimensions
     }
 
     fn color_type(&self) -> ColorType {
         self.color_type
     }
 
-    fn into_reader(self) -> ImageResult<Self::Reader> {
-        Ok(TiffReader(Cursor::new(self.read_image()?), PhantomData))
+    fn into_reader(mut self) -> ImageResult<Self::Reader> {
+        let buf = match self.inner.read_image()? {
+            tiff::decoder::DecodingResult::U8(v) => v,
+            tiff::decoder::DecodingResult::U16(v) => vec_u16_into_u8(v),
+        };
+
+        Ok(TiffReader(Cursor::new(buf), PhantomData))
     }
 
-    fn read_image(mut self) -> ImageResult<Vec<u8>> {
+    fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
         match self.inner.read_image()? {
-            tiff::decoder::DecodingResult::U8(v) => Ok(v),
-            tiff::decoder::DecodingResult::U16(v) => Ok(vec_u16_into_u8(v)),
+            tiff::decoder::DecodingResult::U8(v) => {
+                buf.copy_from_slice(&v);
+            }
+            tiff::decoder::DecodingResult::U16(v) => {
+                NativeEndian::write_u16_into(&v, buf);
+            }
         }
+        Ok(())
     }
 }
 

--- a/src/webp/decoder.rs
+++ b/src/webp/decoder.rs
@@ -118,8 +118,8 @@ impl<R> Read for WebpReader<R> {
 impl<'a, R: 'a + Read> ImageDecoder<'a> for WebPDecoder<R> {
     type Reader = WebpReader<R>;
 
-    fn dimensions(&self) -> (u64, u64) {
-        (u64::from(self.frame.width), u64::from(self.frame.height))
+    fn dimensions(&self) -> (u32, u32) {
+        (u32::from(self.frame.width), u32::from(self.frame.height))
     }
 
     fn color_type(&self) -> color::ColorType {
@@ -130,7 +130,8 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for WebPDecoder<R> {
         Ok(WebpReader(Cursor::new(self.frame.ybuf), PhantomData))
     }
 
-    fn read_image(self) -> ImageResult<Vec<u8>> {
-        Ok(self.frame.ybuf)
+    fn read_image(self, buf: &mut [u8]) -> ImageResult<()> {
+        buf.copy_from_slice(&self.frame.ybuf);
+        Ok(())
     }
 }

--- a/src/webp/decoder.rs
+++ b/src/webp/decoder.rs
@@ -1,4 +1,5 @@
 use byteorder::{LittleEndian, ReadBytesExt};
+use std::convert::TryFrom;
 use std::default::Default;
 use std::io::{self, Cursor, Read};
 use std::marker::PhantomData;
@@ -131,6 +132,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for WebPDecoder<R> {
     }
 
     fn read_image(self, buf: &mut [u8]) -> ImageResult<()> {
+        assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
         buf.copy_from_slice(&self.frame.ybuf);
         Ok(())
     }


### PR DESCRIPTION
This PR makes breaking changes to the ImageDecoder trait. Now is a good time to do these because the next branch already has a bunch of breaking changes queued and the longer we wait the more code will be written against the current interfaces.

#### _read_image()_ and _read_image_ with_progress()_ now take `&mut [u8]`'s 
Alignment issues make returning a Vec awkward, and this seems like the simplest way of avoiding that. If the interface proves annoying to use we can always add helper functions or higher level abstractions. One possible future path would be to have image-canvas be an optional dependency of image-core so that there could be a function like `ImageDecoder::read_to_canvas(self) -> ImageResult<Canvas>` or similar.

#### _dimensions()_ now returns `u32`'s instead of `u64`'s
I initially picked u64's for consistency with the *__bytes_ functions + forward compatibility. However I've since realized that image formats generally don't support dimensions over 2^32 and there really aren't images in the wild within several orders of magnitude of hitting that limit. Not to mention almost the entire rest of the library / Rust image ecosystem uses u32's for sizes.

For now, I've only the trait definition has been updated but if other people are on board I'll make a pass updating the rest of the code.

Fixes #1029