### PR TITLE
Align travis build to actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,11 @@ env:
     - FEATURES='tiff'
     - FEATURES='webp'
     - FEATURES='hdr'
+    - DEFAULT_FEATURES='yes'
 matrix:
   allow_failures:
     - name: "Clippy"
+    - rust: nightly
   include:
     - os: osx
       rust: 1.34.2
@@ -50,13 +52,11 @@ matrix:
         - rustup component add clippy
         - cargo clippy
 script:
-  - if [ -z "$FEATURES" ]; then
-      cargo build -v &&
-      if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then cargo test -v; fi &&
-      cargo doc -v;
-    else
+  - if [ -n "$FEATURES" ]; then
       cargo build -v --no-default-features --features "$FEATURES" &&
-      if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then cargo test -v --no-default-features --features "$FEATURES"; fi &&
+      cargo test -v --no-default-features --features "$FEATURES" &&
       cargo doc -v --no-default-features --features "$FEATURES";
     fi
-  - cargo test --no-default-features
+  - if [ -n "$DEFAULT_FEATURES" ]; then
+      cargo test -v;
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   global:
     - secure: "WI/r7hbDhenb7zPXht8J0mhcx5aUgY22cCrwYmNksMmgIK9hYfPjZ68XzaQ7+Ity8b12TlHM8lGRN9bIsyAZEiRIkxkZAArY9bXAOExJaAT+yOyxhEs/QdrGB6iRhC6FTxPwgUH82j0nFL1UI7HqBnOy3g3tv23jq1AlD9N3t0k="
   matrix:
+    - DEFAULT_FEATURES='yes'
     - FEATURES=''
     - FEATURES='gif_codec'
     - FEATURES='jpeg'
@@ -27,7 +28,6 @@ env:
     - FEATURES='tiff'
     - FEATURES='webp'
     - FEATURES='hdr'
-    - DEFAULT_FEATURES='yes'
 matrix:
   allow_failures:
     - name: "Clippy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,11 +52,11 @@ matrix:
         - rustup component add clippy
         - cargo clippy
 script:
-  - if [ -n "$FEATURES" ]; then
+  - if [ -n "${FEATURES+exists}" ]; then
       cargo build -v --no-default-features --features "$FEATURES" &&
       cargo test -v --no-default-features --features "$FEATURES" &&
       cargo doc -v --no-default-features --features "$FEATURES";
     fi
-  - if [ -n "$DEFAULT_FEATURES" ]; then
+  - if [ -n "${DEFAULT_FEATURES+exists}" ]; then
       cargo test -v;
     fi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 #![warn(missing_docs)]
 #![warn(unused_qualifications)]
 #![deny(unreachable_pub)]
+#![deny(deprecated)]
 #![deny(missing_copy_implementations)]
 #![cfg_attr(all(test, feature = "benchmarks"), feature(test))]
 // it's a bit of a pain otherwise


### PR DESCRIPTION
Failure that occurs only on nightly seems to be more often due to Rust
breakage than a bug. Take deprecation warnings more serious by actively
denying them which warns us of incompatible future versions as nightly
would.
  Note: May remove this again in the future if it doesn't help. We've
  already had the case where the rustc version commitment left us
  without a proper replacement for a while since that had only been
  introduce shortly before deprecation.

Also ensures that tests are ran on all relevant builds instead of only
on nightly.

Closes: #1043
