### PR TITLE
gitignore: ignore target as a symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@
 /bin/test-internal
 /bin/test-external
 /doc/
-/target/
+/target
 /build/
 /.rust/
 rusti.sh


### PR DESCRIPTION
---
I've contributed before, but don't remember this, so while I'm at it:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.