### PR TITLE
Adding  gif format to `save_buffer`

### DIFF
--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -25,8 +25,6 @@ use tga;
 use tiff;
 #[cfg(feature = "webp")]
 use webp;
-#[cfg(feature = "dxt")]
-use dxt;
 
 use color;
 use image;
@@ -149,9 +147,6 @@ pub(crate) fn save_buffer_impl(
         .map_or("".to_string(), |s| s.to_ascii_lowercase());
 
     match &*ext {
-        #[cfg(feature = "dxt")]
-        "dxt" => dxt::DXTEncoder::new(fout).encode(&buf, width, height, dxt::DXTVariant::DXT1)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, Box::new(e))), // FIXME: see https://github.com/image-rs/image/issues/921
         #[cfg(feature = "gif_codec")]
         "gif" => gif::Encoder::new(fout).encode(&gif::Frame::from_rgb(width as u16, height as u16, &buf))
             .map_err(|e| io::Error::new(io::ErrorKind::Other, Box::new(e))), // FIXME: see https://github.com/image-rs/image/issues/921


### PR DESCRIPTION
I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.


WIP for issue #927 

I have the basics down for `gif` and `dxt` in `save_buffer`, and `gif` for `save_buffer_with_format_impl`. I just would to check a few things:

- [x] Will a `gif` type have all `frame`s in a single `&[u8]` for the `buf` parameter? 
- [x] How should we map `dxt::DXTVariant` to `color::ColorType`? 
- [x] Should we add a `image::ImageFormat::DXT` for a `dxt` `save_buffer_with_format_impl`?

