### PR TITLE
Remove redundant code

### DIFF
--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -242,7 +242,7 @@ pub(crate) fn guess_format_from_path_impl(path: &Path) -> Result<ImageFormat, Pa
     })
 }
 
-static MAGIC_BYTES: [(&'static [u8], ImageFormat); 17] = [
+static MAGIC_BYTES: [(&[u8], ImageFormat); 17] = [
     (b"\x89PNG\r\n\x1a\n", ImageFormat::PNG),
     (&[0xff, 0xd8, 0xff], ImageFormat::JPEG),
     (b"GIF89a", ImageFormat::GIF),

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -239,8 +239,7 @@ impl<R: Read + Seek> TGADecoder<R> {
         } else {
             if num_alpha_bits > self.header.pixel_depth {
                 return Err(ImageError::UnsupportedError(
-                    format!("Color format not supported. Alpha bits: {}", num_alpha_bits)
-                        .to_string(),
+                    format!("Color format not supported. Alpha bits: {}", num_alpha_bits),
                 ));
             }
 


### PR DESCRIPTION
explicit `'static` lifetime on static variable and `to_string` to `format!` are redundant.