### PR TITLE
Proper capitalization for decoder struct names

### DIFF
--- a/src/bmp/decoder.rs
+++ b/src/bmp/decoder.rs
@@ -425,7 +425,7 @@ impl Bitfields {
 }
 
 /// A bmp decoder
-pub struct BMPDecoder<R> {
+pub struct BmpDecoder<R> {
     reader: R,
 
     bmp_header_type: BMPHeaderType,
@@ -510,10 +510,10 @@ impl<'a, R: Read> Iterator for RLEInsnIterator<'a, R> {
     }
 }
 
-impl<R: Read + Seek> BMPDecoder<R> {
+impl<R: Read + Seek> BmpDecoder<R> {
     /// Create a new decoder that decodes from the stream ```r```
-    pub fn new(reader: R) -> ImageResult<BMPDecoder<R>> {
-        let mut decoder = BMPDecoder {
+    pub fn new(reader: R) -> ImageResult<BmpDecoder<R>> {
+        let mut decoder = BmpDecoder {
             reader,
 
             bmp_header_type: BMPHeaderType::Info,
@@ -538,8 +538,8 @@ impl<R: Read + Seek> BMPDecoder<R> {
     }
 
     #[cfg(feature = "ico")]
-    pub(crate) fn new_with_ico_format(reader: R) -> ImageResult<BMPDecoder<R>> {
-        let mut decoder = BMPDecoder {
+    pub(crate) fn new_with_ico_format(reader: R) -> ImageResult<BmpDecoder<R>> {
+        let mut decoder = BmpDecoder {
             reader,
 
             bmp_header_type: BMPHeaderType::Info,
@@ -1298,7 +1298,7 @@ impl<R> Read for BmpReader<R> {
     }
 }
 
-impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for BMPDecoder<R> {
+impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for BmpDecoder<R> {
     type Reader = BmpReader<R>;
 
     fn dimensions(&self) -> (u64, u64) {
@@ -1322,7 +1322,7 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for BMPDecoder<R> {
     }
 }
 
-impl<'a, R: 'a + Read + Seek> ImageDecoderExt<'a> for BMPDecoder<R> {
+impl<'a, R: 'a + Read + Seek> ImageDecoderExt<'a> for BmpDecoder<R> {
     fn read_rect_with_progress<F: Fn(Progress)>(
         &mut self,
         x: u64,

--- a/src/bmp/encoder.rs
+++ b/src/bmp/encoder.rs
@@ -239,7 +239,7 @@ fn get_pixel_info(c: color::ColorType) -> io::Result<(u32, u32, u32)> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::BMPDecoder;
+    use super::super::BmpDecoder;
     use super::BMPEncoder;
     use color::ColorType;
     use image::ImageDecoder;
@@ -254,7 +254,7 @@ mod tests {
                 .expect("could not encode image");
         }
 
-        let decoder = BMPDecoder::new(Cursor::new(&encoded_data)).expect("failed to decode");
+        let decoder = BmpDecoder::new(Cursor::new(&encoded_data)).expect("failed to decode");
         decoder.read_image().expect("failed to decode")
     }
 

--- a/src/bmp/mod.rs
+++ b/src/bmp/mod.rs
@@ -7,7 +7,7 @@
 //!  * <https://en.wikipedia.org/wiki/BMP_file_format>
 //!
 
-pub use self::decoder::BMPDecoder;
+pub use self::decoder::BmpDecoder;
 pub use self::encoder::BMPEncoder;
 
 mod decoder;

--- a/src/dxt.rs
+++ b/src/dxt.rs
@@ -56,7 +56,7 @@ impl DXTVariant {
 }
 
 /// DXT decoder
-pub struct DXTDecoder<R: Read> {
+pub struct DxtDecoder<R: Read> {
     inner: R,
     width_blocks: u32,
     height_blocks: u32,
@@ -64,7 +64,7 @@ pub struct DXTDecoder<R: Read> {
     row: u32,
 }
 
-impl<R: Read> DXTDecoder<R> {
+impl<R: Read> DxtDecoder<R> {
     /// Create a new DXT decoder that decodes from the stream ```r```.
     /// As DXT is often stored as raw buffers with the width/height
     /// somewhere else the width and height of the image need
@@ -77,13 +77,13 @@ impl<R: Read> DXTDecoder<R> {
         width: u32,
         height: u32,
         variant: DXTVariant,
-    ) -> Result<DXTDecoder<R>, ImageError> {
+    ) -> Result<DxtDecoder<R>, ImageError> {
         if width % 4 != 0 || height % 4 != 0 {
             return Err(ImageError::DimensionError);
         }
         let width_blocks = width / 4;
         let height_blocks = height / 4;
-        Ok(DXTDecoder {
+        Ok(DxtDecoder {
             inner: r,
             width_blocks,
             height_blocks,
@@ -110,7 +110,7 @@ impl<R: Read> DXTDecoder<R> {
 
 // Note that, due to the way that DXT compression works, a scanline is considered to consist out of
 // 4 lines of pixels.
-impl<'a, R: 'a + Read> ImageDecoder<'a> for DXTDecoder<R> {
+impl<'a, R: 'a + Read> ImageDecoder<'a> for DxtDecoder<R> {
     type Reader = DXTReader<R>;
 
     fn dimensions(&self) -> (u64, u64) {
@@ -149,7 +149,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for DXTDecoder<R> {
     }
 }
 
-impl<'a, R: 'a + Read + Seek> ImageDecoderExt<'a> for DXTDecoder<R> {
+impl<'a, R: 'a + Read + Seek> ImageDecoderExt<'a> for DxtDecoder<R> {
     fn read_rect_with_progress<F: Fn(Progress)>(
         &mut self,
         x: u64,
@@ -177,7 +177,7 @@ impl<'a, R: 'a + Read + Seek> ImageDecoderExt<'a> for DXTDecoder<R> {
 /// DXT reader
 pub struct DXTReader<R: Read> {
     buffer: ImageReadBuffer,
-    decoder: DXTDecoder<R>,
+    decoder: DxtDecoder<R>,
 }
 impl<R: Read> Read for DXTReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -7,13 +7,13 @@
 //!
 //! # Examples
 //! ```rust,no_run
-//! use image::gif::{Decoder, Encoder};
+//! use image::gif::{GifDecoder, Encoder};
 //! use image::{ImageDecoder, AnimationDecoder};
 //! use std::fs::File;
 //! # fn main() -> std::io::Result<()> {
 //! // Decode a gif into frames
 //! let file_in = File::open("foo.gif")?;
-//! let mut decoder = Decoder::new(file_in).unwrap();
+//! let mut decoder = GifDecoder::new(file_in).unwrap();
 //! let frames = decoder.into_frames();
 //! let frames = frames.collect_frames().expect("error decoding gif");
 //!
@@ -46,17 +46,17 @@ use image::{AnimationDecoder, ImageDecoder, ImageError, ImageResult};
 use num_rational::Ratio;
 
 /// GIF decoder
-pub struct Decoder<R: Read> {
+pub struct GifDecoder<R: Read> {
     reader: gif::Reader<R>,
 }
 
-impl<R: Read> Decoder<R> {
+impl<R: Read> GifDecoder<R> {
     /// Creates a new decoder that decodes the input steam ```r```
-    pub fn new(r: R) -> ImageResult<Decoder<R>> {
+    pub fn new(r: R) -> ImageResult<GifDecoder<R>> {
         let mut decoder = gif::Decoder::new(r);
         decoder.set(ColorOutput::RGBA);
 
-        Ok(Decoder {
+        Ok(GifDecoder {
             reader: decoder.read_info()?,
         })
     }
@@ -78,7 +78,7 @@ impl<R> Read for GifReader<R> {
     }
 }
 
-impl<'a, R: 'a + Read> ImageDecoder<'a> for Decoder<R> {
+impl<'a, R: 'a + Read> ImageDecoder<'a> for GifDecoder<R> {
     type Reader = GifReader<R>;
 
     fn dimensions(&self) -> (u64, u64) {
@@ -133,7 +133,7 @@ struct GifFrameIterator<R: Read> {
 
 
 impl<R: Read> GifFrameIterator<R> {
-    fn new(decoder: Decoder<R>) -> GifFrameIterator<R> {
+    fn new(decoder: GifDecoder<R>) -> GifFrameIterator<R> {
         let (width, height) = decoder.dimensions();
 
         // TODO: Avoid this cast
@@ -282,7 +282,7 @@ fn full_image_from_frame(
     }
 }
 
-impl<'a, R: Read + 'a> AnimationDecoder<'a> for Decoder<R> {
+impl<'a, R: Read + 'a> AnimationDecoder<'a> for GifDecoder<R> {
     fn into_frames(self) -> animation::Frames<'a> {
         animation::Frames::new(Box::new(GifFrameIterator::new(self)))
     }

--- a/src/hdr/decoder.rs
+++ b/src/hdr/decoder.rs
@@ -16,7 +16,7 @@ use image::{self, ImageDecoder, ImageDecoderExt, ImageError, ImageResult, Progre
 /// Adapter to conform to ```ImageDecoder``` trait
 #[derive(Debug)]
 pub struct HDRAdapter<R: BufRead> {
-    inner: Option<HDRDecoder<R>>,
+    inner: Option<HdrDecoder<R>>,
     data: Option<Vec<u8>>,
     meta: HDRMetadata,
 }
@@ -24,7 +24,7 @@ pub struct HDRAdapter<R: BufRead> {
 impl<R: BufRead> HDRAdapter<R> {
     /// Creates adapter
     pub fn new(r: R) -> ImageResult<HDRAdapter<R>> {
-        let decoder = HDRDecoder::new(r)?;
+        let decoder = HdrDecoder::new(r)?;
         let meta = decoder.metadata();
         Ok(HDRAdapter {
             inner: Some(decoder),
@@ -35,7 +35,7 @@ impl<R: BufRead> HDRAdapter<R> {
 
     /// Allows reading old Radiance HDR images
     pub fn new_nonstrict(r: R) -> ImageResult<HDRAdapter<R>> {
-        let decoder = HDRDecoder::with_strictness(r, false)?;
+        let decoder = HdrDecoder::with_strictness(r, false)?;
         let meta = decoder.metadata();
         Ok(HDRAdapter {
             inner: Some(decoder),
@@ -143,7 +143,7 @@ const SIGNATURE_LENGTH: usize = 10;
 
 /// An Radiance HDR decoder
 #[derive(Debug)]
-pub struct HDRDecoder<R> {
+pub struct HdrDecoder<R> {
     r: R,
     width: u32,
     height: u32,
@@ -230,22 +230,22 @@ impl RGBE8Pixel {
     }
 }
 
-impl<R: BufRead> HDRDecoder<R> {
+impl<R: BufRead> HdrDecoder<R> {
     /// Reads Radiance HDR image header from stream ```r```
-    /// if the header is valid, creates HDRDecoder
+    /// if the header is valid, creates HdrDecoder
     /// strict mode is enabled
-    pub fn new(reader: R) -> ImageResult<HDRDecoder<R>> {
-        HDRDecoder::with_strictness(reader, true)
+    pub fn new(reader: R) -> ImageResult<HdrDecoder<R>> {
+        HdrDecoder::with_strictness(reader, true)
     }
 
     /// Reads Radiance HDR image header from stream ```reader```,
-    /// if the header is valid, creates ```HDRDecoder```.
+    /// if the header is valid, creates ```HdrDecoder```.
     ///
     /// strict enables strict mode
     ///
     /// Warning! Reading wrong file in non-strict mode
     ///   could consume file size worth of memory in the process.
-    pub fn with_strictness(mut reader: R, strict: bool) -> ImageResult<HDRDecoder<R>> {
+    pub fn with_strictness(mut reader: R, strict: bool) -> ImageResult<HdrDecoder<R>> {
         let mut attributes = HDRMetadata::new();
 
         {
@@ -300,7 +300,7 @@ impl<R: BufRead> HDRDecoder<R> {
             }
         };
 
-        Ok(HDRDecoder {
+        Ok(HdrDecoder {
             r: reader,
 
             width,
@@ -385,7 +385,7 @@ impl<R: BufRead> HDRDecoder<R> {
     }
 }
 
-impl<R: BufRead> IntoIterator for HDRDecoder<R> {
+impl<R: BufRead> IntoIterator for HdrDecoder<R> {
     type Item = ImageResult<RGBE8Pixel>;
     type IntoIter = HDRImageDecoderIterator<R>;
 

--- a/src/ico/decoder.rs
+++ b/src/ico/decoder.rs
@@ -7,22 +7,22 @@ use color::ColorType;
 use image::{ImageDecoder, ImageError, ImageResult};
 
 use self::InnerDecoder::*;
-use bmp::BMPDecoder;
-use png::PNGDecoder;
+use bmp::BmpDecoder;
+use png::PngDecoder;
 
 // http://www.w3.org/TR/PNG-Structure.html
 // The first eight bytes of a PNG file always contain the following (decimal) values:
 const PNG_SIGNATURE: [u8; 8] = [137, 80, 78, 71, 13, 10, 26, 10];
 
 /// An ico decoder
-pub struct ICODecoder<R: Read> {
+pub struct IcoDecoder<R: Read> {
     selected_entry: DirEntry,
     inner_decoder: InnerDecoder<R>,
 }
 
 enum InnerDecoder<R: Read> {
-    BMP(BMPDecoder<R>),
-    PNG(PNGDecoder<R>),
+    BMP(BmpDecoder<R>),
+    PNG(PngDecoder<R>),
 }
 
 #[derive(Clone, Copy, Default)]
@@ -39,14 +39,14 @@ struct DirEntry {
     image_offset: u32,
 }
 
-impl<R: Read + Seek> ICODecoder<R> {
+impl<R: Read + Seek> IcoDecoder<R> {
     /// Create a new decoder that decodes from the stream ```r```
-    pub fn new(mut r: R) -> ImageResult<ICODecoder<R>> {
+    pub fn new(mut r: R) -> ImageResult<IcoDecoder<R>> {
         let entries = read_entries(&mut r)?;
         let entry = best_entry(entries)?;
         let decoder = entry.decoder(r)?;
 
-        Ok(ICODecoder {
+        Ok(IcoDecoder {
             selected_entry: entry,
             inner_decoder: decoder,
         })
@@ -153,9 +153,9 @@ impl DirEntry {
         self.seek_to_start(&mut r)?;
 
         if is_png {
-            Ok(PNG(PNGDecoder::new(r)?))
+            Ok(PNG(PngDecoder::new(r)?))
         } else {
-            Ok(BMP(BMPDecoder::new_with_ico_format(r)?))
+            Ok(BMP(BmpDecoder::new_with_ico_format(r)?))
         }
     }
 }
@@ -176,7 +176,7 @@ impl<R> Read for IcoReader<R> {
     }
 }
 
-impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for ICODecoder<R> {
+impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for IcoDecoder<R> {
     type Reader = IcoReader<R>;
 
     fn dimensions(&self) -> (u64, u64) {

--- a/src/ico/mod.rs
+++ b/src/ico/mod.rs
@@ -6,7 +6,7 @@
 //!  * <https://msdn.microsoft.com/en-us/library/ms997538.aspx>
 //!  * <https://en.wikipedia.org/wiki/ICO_%28file_format%29>
 
-pub use self::decoder::ICODecoder;
+pub use self::decoder::IcoDecoder;
 pub use self::encoder::ICOEncoder;
 
 mod decoder;

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -60,25 +60,25 @@ pub fn load<R: BufRead + Seek>(r: R, format: ImageFormat) -> ImageResult<Dynamic
     // Default is unreachable if all features are supported.
     match format {
         #[cfg(feature = "png_codec")]
-        image::ImageFormat::Png => DynamicImage::from_decoder(png::PNGDecoder::new(r)?),
+        image::ImageFormat::Png => DynamicImage::from_decoder(png::PngDecoder::new(r)?),
         #[cfg(feature = "gif_codec")]
-        image::ImageFormat::Gif => DynamicImage::from_decoder(gif::Decoder::new(r)?),
+        image::ImageFormat::Gif => DynamicImage::from_decoder(gif::GifDecoder::new(r)?),
         #[cfg(feature = "jpeg")]
-        image::ImageFormat::Jpeg => DynamicImage::from_decoder(jpeg::JPEGDecoder::new(r)?),
+        image::ImageFormat::Jpeg => DynamicImage::from_decoder(jpeg::JpegDecoder::new(r)?),
         #[cfg(feature = "webp")]
-        image::ImageFormat::WebP => DynamicImage::from_decoder(webp::WebpDecoder::new(r)?),
+        image::ImageFormat::WebP => DynamicImage::from_decoder(webp::WebPDecoder::new(r)?),
         #[cfg(feature = "tiff")]
-        image::ImageFormat::Tiff => DynamicImage::from_decoder(tiff::TIFFDecoder::new(r)?),
+        image::ImageFormat::Tiff => DynamicImage::from_decoder(tiff::TiffDecoder::new(r)?),
         #[cfg(feature = "tga")]
-        image::ImageFormat::Tga => DynamicImage::from_decoder(tga::TGADecoder::new(r)?),
+        image::ImageFormat::Tga => DynamicImage::from_decoder(tga::TgaDecoder::new(r)?),
         #[cfg(feature = "bmp")]
-        image::ImageFormat::Bmp => DynamicImage::from_decoder(bmp::BMPDecoder::new(r)?),
+        image::ImageFormat::Bmp => DynamicImage::from_decoder(bmp::BmpDecoder::new(r)?),
         #[cfg(feature = "ico")]
-        image::ImageFormat::Ico => DynamicImage::from_decoder(ico::ICODecoder::new(r)?),
+        image::ImageFormat::Ico => DynamicImage::from_decoder(ico::IcoDecoder::new(r)?),
         #[cfg(feature = "hdr")]
         image::ImageFormat::Hdr => DynamicImage::from_decoder(hdr::HDRAdapter::new(BufReader::new(r))?),
         #[cfg(feature = "pnm")]
-        image::ImageFormat::Pnm => DynamicImage::from_decoder(pnm::PNMDecoder::new(BufReader::new(r))?),
+        image::ImageFormat::Pnm => DynamicImage::from_decoder(pnm::PnmDecoder::new(BufReader::new(r))?),
         _ => Err(image::ImageError::UnsupportedError(format!(
             "A decoder for {:?} is not available.",
             format
@@ -102,26 +102,26 @@ pub(crate) fn image_dimensions_with_format_impl<R: BufRead + Seek>(fin: R, forma
     // Default is unreachable if all features are supported.
     let (w, h): (u64, u64) = match format {
         #[cfg(feature = "jpeg")]
-        image::ImageFormat::Jpeg => jpeg::JPEGDecoder::new(fin)?.dimensions(),
+        image::ImageFormat::Jpeg => jpeg::JpegDecoder::new(fin)?.dimensions(),
         #[cfg(feature = "png_codec")]
-        image::ImageFormat::Png => png::PNGDecoder::new(fin)?.dimensions(),
+        image::ImageFormat::Png => png::PngDecoder::new(fin)?.dimensions(),
         #[cfg(feature = "gif_codec")]
-        image::ImageFormat::Gif => gif::Decoder::new(fin)?.dimensions(),
+        image::ImageFormat::Gif => gif::GifDecoder::new(fin)?.dimensions(),
         #[cfg(feature = "webp")]
-        image::ImageFormat::WebP => webp::WebpDecoder::new(fin)?.dimensions(),
+        image::ImageFormat::WebP => webp::WebPDecoder::new(fin)?.dimensions(),
         #[cfg(feature = "tiff")]
-        image::ImageFormat::Tiff => tiff::TIFFDecoder::new(fin)?.dimensions(),
+        image::ImageFormat::Tiff => tiff::TiffDecoder::new(fin)?.dimensions(),
         #[cfg(feature = "tga")]
-        image::ImageFormat::Tga => tga::TGADecoder::new(fin)?.dimensions(),
+        image::ImageFormat::Tga => tga::TgaDecoder::new(fin)?.dimensions(),
         #[cfg(feature = "bmp")]
-        image::ImageFormat::Bmp => bmp::BMPDecoder::new(fin)?.dimensions(),
+        image::ImageFormat::Bmp => bmp::BmpDecoder::new(fin)?.dimensions(),
         #[cfg(feature = "ico")]
-        image::ImageFormat::Ico => ico::ICODecoder::new(fin)?.dimensions(),
+        image::ImageFormat::Ico => ico::IcoDecoder::new(fin)?.dimensions(),
         #[cfg(feature = "hdr")]
         image::ImageFormat::Hdr => hdr::HDRAdapter::new(fin)?.dimensions(),
         #[cfg(feature = "pnm")]
         image::ImageFormat::Pnm => {
-            pnm::PNMDecoder::new(fin)?.dimensions()
+            pnm::PnmDecoder::new(fin)?.dimensions()
         }
         format => return Err(image::ImageError::UnsupportedError(format!(
             "Image format image/{:?} is not supported.",

--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -8,14 +8,14 @@ use color::ColorType;
 use image::{ImageDecoder, ImageError, ImageResult};
 
 /// JPEG decoder
-pub struct JPEGDecoder<R> {
+pub struct JpegDecoder<R> {
     decoder: jpeg_decoder::Decoder<R>,
     metadata: jpeg_decoder::ImageInfo,
 }
 
-impl<R: Read> JPEGDecoder<R> {
+impl<R: Read> JpegDecoder<R> {
     /// Create a new decoder that decodes from the stream ```r```
-    pub fn new(r: R) -> ImageResult<JPEGDecoder<R>> {
+    pub fn new(r: R) -> ImageResult<JpegDecoder<R>> {
         let mut decoder = jpeg_decoder::Decoder::new(r);
 
         decoder.read_info()?;
@@ -26,7 +26,7 @@ impl<R: Read> JPEGDecoder<R> {
             metadata.pixel_format = jpeg_decoder::PixelFormat::RGB24;
         }
 
-        Ok(JPEGDecoder {
+        Ok(JpegDecoder {
             decoder,
             metadata,
         })
@@ -49,7 +49,7 @@ impl<R> Read for JpegReader<R> {
     }
 }
 
-impl<'a, R: 'a + Read> ImageDecoder<'a> for JPEGDecoder<R> {
+impl<'a, R: 'a + Read> ImageDecoder<'a> for JpegDecoder<R> {
     type Reader = JpegReader<R>;
 
     fn dimensions(&self) -> (u64, u64) {

--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -756,7 +756,7 @@ fn copy_blocks_gray(
 
 #[cfg(test)]
 mod tests {
-    use super::super::JPEGDecoder;
+    use super::super::JpegDecoder;
     use super::JPEGEncoder;
     use color::ColorType;
     use image::ImageDecoder;
@@ -778,7 +778,7 @@ mod tests {
 
         // decode it from the memory buffer
         {
-            let decoder = JPEGDecoder::new(Cursor::new(&encoded_img))
+            let decoder = JpegDecoder::new(Cursor::new(&encoded_img))
                 .expect("Could not decode image");
             let decoded = decoder.read_image().expect("Could not decode image");
             // note that, even with the encode quality set to 100, we do not get the same image
@@ -806,7 +806,7 @@ mod tests {
 
         // decode it from the memory buffer
         {
-            let decoder = JPEGDecoder::new(Cursor::new(&encoded_img))
+            let decoder = JpegDecoder::new(Cursor::new(&encoded_img))
                 .expect("Could not decode image");
             let decoded = decoder.read_image().expect("Could not decode image");
             // note that, even with the encode quality set to 100, we do not get the same image

--- a/src/jpeg/mod.rs
+++ b/src/jpeg/mod.rs
@@ -7,7 +7,7 @@
 //! * <http://www.w3.org/Graphics/JPEG/itu-t81.pdf> - The JPEG specification
 //!
 
-pub use self::decoder::JPEGDecoder;
+pub use self::decoder::JpegDecoder;
 pub use self::encoder::JPEGEncoder;
 
 mod decoder;

--- a/src/png.rs
+++ b/src/png.rs
@@ -89,14 +89,14 @@ impl<R: Read> Read for PNGReader<R> {
 }
 
 /// PNG decoder
-pub struct PNGDecoder<R: Read> {
+pub struct PngDecoder<R: Read> {
     color_type: ColorType,
     reader: png::Reader<R>,
 }
 
-impl<R: Read> PNGDecoder<R> {
+impl<R: Read> PngDecoder<R> {
     /// Creates a new decoder that decodes from the stream ```r```
-    pub fn new(r: R) -> ImageResult<PNGDecoder<R>> {
+    pub fn new(r: R) -> ImageResult<PngDecoder<R>> {
         let limits = png::Limits {
             bytes: usize::max_value(),
         };
@@ -144,11 +144,11 @@ impl<R: Read> PNGDecoder<R> {
                 return Err(ImageError::UnsupportedColor(ExtendedColorType::Unknown(bits as u8))),
         };
 
-        Ok(PNGDecoder { color_type, reader })
+        Ok(PngDecoder { color_type, reader })
     }
 }
 
-impl<'a, R: 'a + Read> ImageDecoder<'a> for PNGDecoder<R> {
+impl<'a, R: 'a + Read> ImageDecoder<'a> for PngDecoder<R> {
     type Reader = PNGReader<R>;
 
     fn dimensions(&self) -> (u64, u64) {
@@ -240,7 +240,7 @@ mod tests {
 
     #[test]
     fn ensure_no_decoder_off_by_one() {
-        let dec = PNGDecoder::new(std::fs::File::open("tests/images/png/bugfixes/debug_triangle_corners_widescreen.png").unwrap())
+        let dec = PngDecoder::new(std::fs::File::open("tests/images/png/bugfixes/debug_triangle_corners_widescreen.png").unwrap())
             .expect("Unable to read PNG file (does it exist?)");
 
         assert_eq![(2000, 1000), dec.dimensions()];

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -44,15 +44,15 @@ trait DecodableImageHeader {
 }
 
 /// PNM decoder
-pub struct PNMDecoder<R> {
+pub struct PnmDecoder<R> {
     reader: BufReader<R>,
     header: PNMHeader,
     tuple: TupleType,
 }
 
-impl<R: Read> PNMDecoder<R> {
+impl<R: Read> PnmDecoder<R> {
     /// Create a new decoder that decodes from the stream ```read```
-    pub fn new(read: R) -> ImageResult<PNMDecoder<R>> {
+    pub fn new(read: R) -> ImageResult<PnmDecoder<R>> {
         let mut buf = BufReader::new(read);
         let magic = buf.read_magic_constant()?;
         if magic[0] != b'P' {
@@ -77,10 +77,10 @@ impl<R: Read> PNMDecoder<R> {
         };
 
         match subtype {
-            PNMSubtype::Bitmap(enc) => PNMDecoder::read_bitmap_header(buf, enc),
-            PNMSubtype::Graymap(enc) => PNMDecoder::read_graymap_header(buf, enc),
-            PNMSubtype::Pixmap(enc) => PNMDecoder::read_pixmap_header(buf, enc),
-            PNMSubtype::ArbitraryMap => PNMDecoder::read_arbitrary_header(buf),
+            PNMSubtype::Bitmap(enc) => PnmDecoder::read_bitmap_header(buf, enc),
+            PNMSubtype::Graymap(enc) => PnmDecoder::read_graymap_header(buf, enc),
+            PNMSubtype::Pixmap(enc) => PnmDecoder::read_pixmap_header(buf, enc),
+            PNMSubtype::ArbitraryMap => PnmDecoder::read_arbitrary_header(buf),
         }
     }
 
@@ -92,9 +92,9 @@ impl<R: Read> PNMDecoder<R> {
     fn read_bitmap_header(
         mut reader: BufReader<R>,
         encoding: SampleEncoding,
-    ) -> ImageResult<PNMDecoder<R>> {
+    ) -> ImageResult<PnmDecoder<R>> {
         let header = reader.read_bitmap_header(encoding)?;
-        Ok(PNMDecoder {
+        Ok(PnmDecoder {
             reader,
             tuple: TupleType::PbmBit,
             header: PNMHeader {
@@ -107,10 +107,10 @@ impl<R: Read> PNMDecoder<R> {
     fn read_graymap_header(
         mut reader: BufReader<R>,
         encoding: SampleEncoding,
-    ) -> ImageResult<PNMDecoder<R>> {
+    ) -> ImageResult<PnmDecoder<R>> {
         let header = reader.read_graymap_header(encoding)?;
         let tuple_type = header.tuple_type()?;
-        Ok(PNMDecoder {
+        Ok(PnmDecoder {
             reader,
             tuple: tuple_type,
             header: PNMHeader {
@@ -123,10 +123,10 @@ impl<R: Read> PNMDecoder<R> {
     fn read_pixmap_header(
         mut reader: BufReader<R>,
         encoding: SampleEncoding,
-    ) -> ImageResult<PNMDecoder<R>> {
+    ) -> ImageResult<PnmDecoder<R>> {
         let header = reader.read_pixmap_header(encoding)?;
         let tuple_type = header.tuple_type()?;
-        Ok(PNMDecoder {
+        Ok(PnmDecoder {
             reader,
             tuple: tuple_type,
             header: PNMHeader {
@@ -136,10 +136,10 @@ impl<R: Read> PNMDecoder<R> {
         })
     }
 
-    fn read_arbitrary_header(mut reader: BufReader<R>) -> ImageResult<PNMDecoder<R>> {
+    fn read_arbitrary_header(mut reader: BufReader<R>) -> ImageResult<PnmDecoder<R>> {
         let header = reader.read_arbitrary_header()?;
         let tuple_type = header.tuple_type()?;
-        Ok(PNMDecoder {
+        Ok(PnmDecoder {
             reader,
             tuple: tuple_type,
             header: PNMHeader {
@@ -425,7 +425,7 @@ impl<R> Read for PnmReader<R> {
     }
 }
 
-impl<'a, R: 'a + Read> ImageDecoder<'a> for PNMDecoder<R> {
+impl<'a, R: 'a + Read> ImageDecoder<'a> for PnmDecoder<R> {
     type Reader = PnmReader<R>;
 
     fn dimensions(&self) -> (u64, u64) {
@@ -463,7 +463,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for PNMDecoder<R> {
     }
 }
 
-impl<R: Read> PNMDecoder<R> {
+impl<R: Read> PnmDecoder<R> {
     fn read(&mut self) -> ImageResult<Vec<u8>> {
         match self.tuple {
             TupleType::PbmBit => self.read_samples::<PbmBit>(1),
@@ -783,7 +783,7 @@ TUPLTYPE BLACKANDWHITE
 # Comment line
 ENDHDR
 \x01\x00\x00\x01\x01\x00\x00\x01\x01\x00\x00\x01\x01\x00\x00\x01";
-        let decoder = PNMDecoder::new(&pamdata[..]).unwrap();
+        let decoder = PnmDecoder::new(&pamdata[..]).unwrap();
         assert_eq!(decoder.color_type(), ColorType::L8);
         assert_eq!(decoder.original_color_type(), ExtendedColorType::L1);
         assert_eq!(decoder.dimensions(), (4, 4));
@@ -794,7 +794,7 @@ ENDHDR
             vec![0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00,
                  0x00, 0x01]
         );
-        match PNMDecoder::new(&pamdata[..]).unwrap().into_inner() {
+        match PnmDecoder::new(&pamdata[..]).unwrap().into_inner() {
             (
                 _,
                 PNMHeader {
@@ -825,7 +825,7 @@ TUPLTYPE GRAYSCALE
 # Comment line
 ENDHDR
 \xde\xad\xbe\xef\xde\xad\xbe\xef\xde\xad\xbe\xef\xde\xad\xbe\xef";
-        let decoder = PNMDecoder::new(&pamdata[..]).unwrap();
+        let decoder = PnmDecoder::new(&pamdata[..]).unwrap();
         assert_eq!(decoder.color_type(), ColorType::L8);
         assert_eq!(decoder.dimensions(), (4, 4));
         assert_eq!(decoder.subtype(), PNMSubtype::ArbitraryMap);
@@ -834,7 +834,7 @@ ENDHDR
             vec![0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad,
                  0xbe, 0xef]
         );
-        match PNMDecoder::new(&pamdata[..]).unwrap().into_inner() {
+        match PnmDecoder::new(&pamdata[..]).unwrap().into_inner() {
             (
                 _,
                 PNMHeader {
@@ -865,14 +865,14 @@ WIDTH 2
 HEIGHT 2
 ENDHDR
 \xde\xad\xbe\xef\xde\xad\xbe\xef\xde\xad\xbe\xef";
-        let decoder = PNMDecoder::new(&pamdata[..]).unwrap();
+        let decoder = PnmDecoder::new(&pamdata[..]).unwrap();
         assert_eq!(decoder.color_type(), ColorType::Rgb8);
         assert_eq!(decoder.dimensions(), (2, 2));
         assert_eq!(decoder.subtype(), PNMSubtype::ArbitraryMap);
 
         assert_eq!(decoder.read_image().unwrap(),
                    vec![0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef]);
-        match PNMDecoder::new(&pamdata[..]).unwrap().into_inner() {
+        match PnmDecoder::new(&pamdata[..]).unwrap().into_inner() {
             (
                 _,
                 PNMHeader {
@@ -896,7 +896,7 @@ ENDHDR
         // The data contains two rows of the image (each line is padded to the full byte). For
         // comments on its format, see documentation of `impl SampleType for PbmBit`.
         let pbmbinary = [&b"P4 6 2\n"[..], &[0b01101100 as u8, 0b10110111]].concat();
-        let decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
+        let decoder = PnmDecoder::new(&pbmbinary[..]).unwrap();
         assert_eq!(decoder.color_type(), ColorType::L8);
         assert_eq!(decoder.original_color_type(), ExtendedColorType::L1);
         assert_eq!(decoder.dimensions(), (6, 2));
@@ -905,7 +905,7 @@ ENDHDR
             PNMSubtype::Bitmap(SampleEncoding::Binary)
         );
         assert_eq!(decoder.read_image().unwrap(), vec![255, 0, 0, 255, 0, 0, 0, 255, 0, 0, 255, 0]);
-        match PNMDecoder::new(&pbmbinary[..]).unwrap().into_inner() {
+        match PnmDecoder::new(&pbmbinary[..]).unwrap().into_inner() {
             (
                 _,
                 PNMHeader {
@@ -942,7 +942,7 @@ ENDHDR
 
         let pbmbinary = FailRead(Cursor::new(b"P1 1 1\n"));
 
-        PNMDecoder::new(pbmbinary).unwrap()
+        PnmDecoder::new(pbmbinary).unwrap()
             .read_image().expect_err("Image is malformed");
     }
 
@@ -952,13 +952,13 @@ ENDHDR
         // comments on its format, see documentation of `impl SampleType for PbmBit`.  Tests all
         // whitespace characters that should be allowed (the 6 characters according to POSIX).
         let pbmbinary = b"P1 6 2\n 0 1 1 0 1 1\n1 0 1 1 0\t\n\x0b\x0c\r1";
-        let decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
+        let decoder = PnmDecoder::new(&pbmbinary[..]).unwrap();
         assert_eq!(decoder.color_type(), ColorType::L8);
         assert_eq!(decoder.original_color_type(), ExtendedColorType::L1);
         assert_eq!(decoder.dimensions(), (6, 2));
         assert_eq!(decoder.subtype(), PNMSubtype::Bitmap(SampleEncoding::Ascii));
         assert_eq!(decoder.read_image().unwrap(), vec![1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0]);
-        match PNMDecoder::new(&pbmbinary[..]).unwrap().into_inner() {
+        match PnmDecoder::new(&pbmbinary[..]).unwrap().into_inner() {
             (
                 _,
                 PNMHeader {
@@ -981,13 +981,13 @@ ENDHDR
         // it is completely within specification for the ascii data not to contain separating
         // whitespace for the pbm format or any mix.
         let pbmbinary = b"P1 6 2\n011011101101";
-        let decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
+        let decoder = PnmDecoder::new(&pbmbinary[..]).unwrap();
         assert_eq!(decoder.color_type(), ColorType::L8);
         assert_eq!(decoder.original_color_type(), ExtendedColorType::L1);
         assert_eq!(decoder.dimensions(), (6, 2));
         assert_eq!(decoder.subtype(), PNMSubtype::Bitmap(SampleEncoding::Ascii));
         assert_eq!(decoder.read_image().unwrap(), vec![1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0]);
-        match PNMDecoder::new(&pbmbinary[..]).unwrap().into_inner() {
+        match PnmDecoder::new(&pbmbinary[..]).unwrap().into_inner() {
             (
                 _,
                 PNMHeader {
@@ -1010,7 +1010,7 @@ ENDHDR
         // comments on its format, see documentation of `impl SampleType for PbmBit`.
         let elements = (0..16).collect::<Vec<_>>();
         let pbmbinary = [&b"P5 4 4 255\n"[..], &elements].concat();
-        let decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
+        let decoder = PnmDecoder::new(&pbmbinary[..]).unwrap();
         assert_eq!(decoder.color_type(), ColorType::L8);
         assert_eq!(decoder.dimensions(), (4, 4));
         assert_eq!(
@@ -1018,7 +1018,7 @@ ENDHDR
             PNMSubtype::Graymap(SampleEncoding::Binary)
         );
         assert_eq!(decoder.read_image().unwrap(), elements);
-        match PNMDecoder::new(&pbmbinary[..]).unwrap().into_inner() {
+        match PnmDecoder::new(&pbmbinary[..]).unwrap().into_inner() {
             (
                 _,
                 PNMHeader {
@@ -1041,7 +1041,7 @@ ENDHDR
         // The data contains two rows of the image (each line is padded to the full byte). For
         // comments on its format, see documentation of `impl SampleType for PbmBit`.
         let pbmbinary = b"P2 4 4 255\n 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15";
-        let decoder = PNMDecoder::new(&pbmbinary[..]).unwrap();
+        let decoder = PnmDecoder::new(&pbmbinary[..]).unwrap();
         assert_eq!(decoder.color_type(), ColorType::L8);
         assert_eq!(decoder.dimensions(), (4, 4));
         assert_eq!(
@@ -1049,7 +1049,7 @@ ENDHDR
             PNMSubtype::Graymap(SampleEncoding::Ascii)
         );
         assert_eq!(decoder.read_image().unwrap(), (0..16).collect::<Vec<_>>());
-        match PNMDecoder::new(&pbmbinary[..]).unwrap().into_inner() {
+        match PnmDecoder::new(&pbmbinary[..]).unwrap().into_inner() {
             (
                 _,
                 PNMHeader {

--- a/src/pnm/mod.rs
+++ b/src/pnm/mod.rs
@@ -4,7 +4,7 @@
 //! `BLACKANDWHITE`, `GRAYSCALE` and `RGB` and explicitely recognizes but rejects their `_ALPHA`
 //! variants for now as alpha color types are unsupported.
 use self::autobreak::AutoBreak;
-pub use self::decoder::PNMDecoder;
+pub use self::decoder::PnmDecoder;
 pub use self::encoder::PNMEncoder;
 use self::header::HeaderRecord;
 pub use self::header::{ArbitraryHeader, ArbitraryTuplType, BitmapHeader, GraymapHeader,
@@ -34,10 +34,10 @@ mod tests {
         }
 
         let (header, loaded_color, loaded_image) = {
-            let decoder = PNMDecoder::new(&encoded_buffer[..]).unwrap();
+            let decoder = PnmDecoder::new(&encoded_buffer[..]).unwrap();
             let color_type = decoder.color_type();
             let image = decoder.read_image().expect("Failed to decode the image");
-            let (_, header) = PNMDecoder::new(&encoded_buffer[..]).unwrap().into_inner();
+            let (_, header) = PnmDecoder::new(&encoded_buffer[..]).unwrap().into_inner();
             (header, color_type, image)
         };
 
@@ -64,10 +64,10 @@ mod tests {
         }
 
         let (header, loaded_color, loaded_image) = {
-            let decoder = PNMDecoder::new(&encoded_buffer[..]).unwrap();
+            let decoder = PnmDecoder::new(&encoded_buffer[..]).unwrap();
             let color_type = decoder.color_type();
             let image = decoder.read_image().expect("Failed to decode the image");
-            let (_, header) = PNMDecoder::new(&encoded_buffer[..]).unwrap().into_inner();
+            let (_, header) = PnmDecoder::new(&encoded_buffer[..]).unwrap().into_inner();
             (header, color_type, image)
         };
 
@@ -89,10 +89,10 @@ mod tests {
         }
 
         let (header, loaded_color, loaded_image) = {
-            let decoder = PNMDecoder::new(&encoded_buffer[..]).unwrap();
+            let decoder = PnmDecoder::new(&encoded_buffer[..]).unwrap();
             let color_type = decoder.color_type();
             let image = decoder.read_image().expect("Failed to decode the image");
-            let (_, header) = PNMDecoder::new(&encoded_buffer[..]).unwrap().into_inner();
+            let (_, header) = PnmDecoder::new(&encoded_buffer[..]).unwrap().into_inner();
             (header, color_type, image)
         };
 

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -153,7 +153,7 @@ impl ColorMap {
 }
 
 /// The representation of a TGA decoder
-pub struct TGADecoder<R> {
+pub struct TgaDecoder<R> {
     r: R,
 
     width: usize,
@@ -172,10 +172,10 @@ pub struct TGADecoder<R> {
     line_remain_buff: Vec<u8>,
 }
 
-impl<R: Read + Seek> TGADecoder<R> {
+impl<R: Read + Seek> TgaDecoder<R> {
     /// Create a new decoder that decodes from the stream `r`
-    pub fn new(r: R) -> ImageResult<TGADecoder<R>> {
-        let mut decoder = TGADecoder {
+    pub fn new(r: R) -> ImageResult<TgaDecoder<R>> {
+        let mut decoder = TgaDecoder {
             r,
 
             width: 0,
@@ -250,7 +250,7 @@ impl<R: Read + Seek> TGADecoder<R> {
 
         match (num_alpha_bits, other_channel_bits, color) {
             // really, the encoding is BGR and BGRA, this is fixed
-            // up with `TGADecoder::reverse_encoding`.
+            // up with `TgaDecoder::reverse_encoding`.
             (0, 32, true) => self.color_type = ColorType::Rgba8,
             (8, 24, true) => self.color_type = ColorType::Rgba8,
             (0, 24, true) => self.color_type = ColorType::Rgb8,
@@ -490,7 +490,7 @@ impl<R: Read + Seek> TGADecoder<R> {
     }
 }
 
-impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for TGADecoder<R> {
+impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for TgaDecoder<R> {
     type Reader = TGAReader<R>;
 
     fn dimensions(&self) -> (u64, u64) {
@@ -528,7 +528,7 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for TGADecoder<R> {
 
 pub struct TGAReader<R> {
     buffer: ImageReadBuffer,
-    decoder: TGADecoder<R>,
+    decoder: TgaDecoder<R>,
 }
 impl<R: Read + Seek> Read for TGAReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {

--- a/src/tga/mod.rs
+++ b/src/tga/mod.rs
@@ -6,7 +6,7 @@
 /// A decoder for TGA images
 ///
 /// Currently this decoder does not support 8, 15 and 16 bit color images.
-pub use self::decoder::TGADecoder;
+pub use self::decoder::TgaDecoder;
 
 //TODO add 8, 15, 16 bit color support
 

--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -17,7 +17,7 @@ use image::{ImageDecoder, ImageResult, ImageError};
 use utils::vec_u16_into_u8;
 
 /// Decoder for TIFF images.
-pub struct TIFFDecoder<R>
+pub struct TiffDecoder<R>
     where R: Read + Seek
 {
     dimensions: (u32, u32),
@@ -25,11 +25,11 @@ pub struct TIFFDecoder<R>
     inner: tiff::decoder::Decoder<R>,
 }
 
-impl<R> TIFFDecoder<R>
+impl<R> TiffDecoder<R>
     where R: Read + Seek
 {
-    /// Create a new TIFFDecoder.
-    pub fn new(r: R) -> Result<TIFFDecoder<R>, ImageError> {
+    /// Create a new TiffDecoder.
+    pub fn new(r: R) -> Result<TiffDecoder<R>, ImageError> {
         let mut inner = tiff::decoder::Decoder::new(r)?;
         let dimensions = inner.dimensions()?;
         let color_type = match inner.colortype()? {
@@ -52,7 +52,7 @@ impl<R> TIFFDecoder<R>
                 return Err(ImageError::UnsupportedColor(ExtendedColorType::Unknown(n*4))),
         };
 
-        Ok(TIFFDecoder {
+        Ok(TiffDecoder {
             dimensions,
             color_type,
             inner,
@@ -87,7 +87,7 @@ impl<R> Read for TiffReader<R> {
     }
 }
 
-impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for TIFFDecoder<R> {
+impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for TiffDecoder<R> {
     type Reader = TiffReader<R>;
 
     fn dimensions(&self) -> (u64, u64) {

--- a/src/webp/decoder.rs
+++ b/src/webp/decoder.rs
@@ -11,23 +11,23 @@ use image::ImageResult;
 use color;
 
 use super::vp8::Frame;
-use super::vp8::VP8Decoder;
+use super::vp8::Vp8Decoder;
 
 /// WebP Image format decoder. Currently only supportes the luma channel (meaning that decoded
 /// images will be grayscale).
-pub struct WebpDecoder<R> {
+pub struct WebPDecoder<R> {
     r: R,
     frame: Frame,
     have_frame: bool,
 }
 
-impl<R: Read> WebpDecoder<R> {
-    /// Create a new WebpDecoder from the Reader ```r```.
+impl<R: Read> WebPDecoder<R> {
+    /// Create a new WebPDecoder from the Reader ```r```.
     /// This function takes ownership of the Reader.
-    pub fn new(r: R) -> ImageResult<WebpDecoder<R>> {
+    pub fn new(r: R) -> ImageResult<WebPDecoder<R>> {
         let f: Frame = Default::default();
 
-        let mut decoder = WebpDecoder {
+        let mut decoder = WebPDecoder {
             r,
             have_frame: false,
             frame: f,
@@ -78,7 +78,7 @@ impl<R: Read> WebpDecoder<R> {
         self.r.read_to_end(&mut framedata)?;
         let m = io::Cursor::new(framedata);
 
-        let mut v = VP8Decoder::new(m);
+        let mut v = Vp8Decoder::new(m);
         let frame = v.decode_frame()?;
 
         self.frame = frame.clone();
@@ -115,7 +115,7 @@ impl<R> Read for WebpReader<R> {
     }
 }
 
-impl<'a, R: 'a + Read> ImageDecoder<'a> for WebpDecoder<R> {
+impl<'a, R: 'a + Read> ImageDecoder<'a> for WebPDecoder<R> {
     type Reader = WebpReader<R>;
 
     fn dimensions(&self) -> (u64, u64) {

--- a/src/webp/mod.rs
+++ b/src/webp/mod.rs
@@ -1,6 +1,6 @@
 //! Decoding of WebP Images
 
-pub use self::decoder::WebpDecoder;
+pub use self::decoder::WebPDecoder;
 
 mod decoder;
 mod transform;

--- a/src/webp/vp8.rs
+++ b/src/webp/vp8.rs
@@ -835,7 +835,7 @@ struct Segment {
 /// VP8 Decoder
 ///
 /// Only decodes keyframes
-pub struct VP8Decoder<R> {
+pub struct Vp8Decoder<R> {
     r: R,
     b: BoolReader,
 
@@ -867,15 +867,15 @@ pub struct VP8Decoder<R> {
     left_border: Vec<u8>,
 }
 
-impl<R: Read> VP8Decoder<R> {
+impl<R: Read> Vp8Decoder<R> {
     /// Create a new decoder.
     /// The reader must present a raw vp8 bitstream to the decoder
-    pub fn new(r: R) -> VP8Decoder<R> {
+    pub fn new(r: R) -> Vp8Decoder<R> {
         let f = Frame::default();
         let s = Segment::default();
         let m = MacroBlock::default();
 
-        VP8Decoder {
+        Vp8Decoder {
             r,
             b: BoolReader::new(),
 

--- a/tests/reference_images.rs
+++ b/tests/reference_images.rs
@@ -190,7 +190,7 @@ fn check_references() {
                     // Interpret the input file as an animation file
                     use image::AnimationDecoder;
                     let stream = io::BufReader::new(fs::File::open(&img_path).unwrap());
-                    let decoder = match image::gif::Decoder::new(stream) {
+                    let decoder = match image::gif::GifDecoder::new(stream) {
                         Ok(decoder) => decoder,
                         Err(image::ImageError::UnsupportedError(_)) => return,
                         Err(err) => {
@@ -284,7 +284,7 @@ fn check_hdr_references() {
         ref_path.set_extension("raw");
         println!("{}", ref_path.display());
         println!("{}", path.display());
-        let decoder = image::hdr::HDRDecoder::new(io::BufReader::new(
+        let decoder = image::hdr::HdrDecoder::new(io::BufReader::new(
             fs::File::open(&path).unwrap(),
         )).unwrap();
         let decoded = decoder.read_image_hdr().unwrap();


### PR DESCRIPTION
Also rename gif::Decoder to be consistent with the other decoder names.