### PR TITLE
Less in root

### DIFF
--- a/examples/scaledown/main.rs
+++ b/examples/scaledown/main.rs
@@ -1,6 +1,7 @@
 extern crate image;
 
-use image::{FilterType, ImageFormat};
+use image::ImageFormat;
+use image::imageops::FilterType;
 use std::fmt;
 use std::fs::File;
 use std::time::{Duration, Instant};

--- a/examples/scaleup/main.rs
+++ b/examples/scaleup/main.rs
@@ -1,6 +1,7 @@
 extern crate image;
 
-use image::{FilterType, ImageFormat};
+use image::ImageFormat;
+use image::imageops::FilterType;
 use std::fmt;
 use std::fs::File;
 use std::time::{Duration, Instant};

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -1076,7 +1076,8 @@ where
     /// `self.into_inner().as_view_mut()` and keeps the `View` alive on failure.
     ///
     /// ```
-    /// # use image::{Rgb, RgbImage};
+    /// # use image::RgbImage;
+    /// # use image::Rgb;
     /// let mut buffer = RgbImage::new(480, 640).into_flat_samples();
     /// let view = buffer.as_view_with_mut_samples::<Rgb<u8>>().unwrap();
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,9 +41,7 @@ pub use image::{AnimationDecoder,
                 Pixels,
                 SubImage};
 
-pub use imageops::FilterType::{self, CatmullRom, Gaussian, Lanczos3, Nearest, Triangle};
-
-pub use image::ImageFormat::{self, Bmp, Gif, Ico, Jpeg, Png, Pnm, WebP};
+pub use image::ImageFormat;
 
 pub use image::ImageOutputFormat;
 
@@ -56,7 +54,7 @@ pub use buffer::{ConvertBuffer,
                  RgbImage,
                  RgbaImage};
 
-pub use flat::{FlatSamples};
+pub use flat::FlatSamples;
 
 // Traits
 pub use traits::Primitive;
@@ -66,7 +64,7 @@ pub use io::free_functions::{guess_format, load};
 pub use dynimage::{load_from_memory, load_from_memory_with_format, open,
                    save_buffer, save_buffer_with_format, image_dimensions};
 
-pub use dynimage::DynamicImage::{self, ImageLuma8, ImageLumaA8, ImageRgb8, ImageRgba8, ImageBgr8, ImageBgra8};
+pub use dynimage::DynamicImage;
 
 pub use animation::{Frame, Frames};
 


### PR DESCRIPTION
There are a bunch of types are structs that are exported from the crate root but don't need to be. Not having them makes the documentation less cluttered.