### PR TITLE
Add limits to decoder

### DIFF
--- a/src/gif.rs
+++ b/src/gif.rs
@@ -56,6 +56,8 @@ impl<R: Read> GifDecoder<R> {
     pub fn new(r: R) -> ImageResult<GifDecoder<R>> {
         Self::new_with_limits(r, DecodingLimits::default())
     }
+
+    /// Same as `new`, but allows you to set limits.
     pub fn new_with_limits(r: R, limits: DecodingLimits) -> ImageResult<GifDecoder<R>> {
         let gif_limits = gif::MemoryLimit(min(u32::max_value() as usize, limits.buffer_limit) as u32);
         let mut decoder = gif::Decoder::new(r);

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -43,6 +43,7 @@ use animation;
 use buffer::{ImageBuffer, Pixel};
 use color::{self, Rgba};
 use image::{self, AnimationDecoder, ImageDecoder, ImageError, ImageResult};
+use io::DecodingLimits;
 use num_rational::Ratio;
 
 /// GIF decoder
@@ -53,7 +54,12 @@ pub struct GifDecoder<R: Read> {
 impl<R: Read> GifDecoder<R> {
     /// Creates a new decoder that decodes the input steam ```r```
     pub fn new(r: R) -> ImageResult<GifDecoder<R>> {
+        Self::new_with_limits(r, DecodingLimits::default())
+    }
+    pub fn new_with_limits(r: R, limits: DecodingLimits) -> ImageResult<GifDecoder<R>> {
+        let gif_limits = gif::MemoryLimit(min(u32::max_value() as usize, limits.buffer_limit) as u32);
         let mut decoder = gif::Decoder::new(r);
+        decoder.set(gif_limits);
         decoder.set(ColorOutput::RGBA);
 
         Ok(GifDecoder {

--- a/src/image.rs
+++ b/src/image.rs
@@ -441,6 +441,7 @@ pub trait ImageDecoder<'a>: Sized {
     ///     decoder.read_image(buf.as_bytes());
     ///     buf
     /// }
+    /// ```
     fn read_image(self, buf: &mut [u8]) -> ImageResult<()> {
         self.read_image_with_progress(buf, |_| {})
     }

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -63,25 +63,25 @@ pub(crate) fn load_with_limits<R: BufRead + Seek>(r: R, format: ImageFormat, lim
     // Default is unreachable if all features are supported.
     match format {
         #[cfg(feature = "png_codec")]
-        image::ImageFormat::Png => DynamicImage::from_decoder(png::PngDecoder::new_with_limits(r, limits)?),
+        image::ImageFormat::Png => DynamicImage::from_decoder_limits(png::PngDecoder::new_with_limits(r, limits)?, limits),
         #[cfg(feature = "gif_codec")]
-        image::ImageFormat::Gif => DynamicImage::from_decoder(gif::GifDecoder::new_with_limits(r, limits)?),
+        image::ImageFormat::Gif => DynamicImage::from_decoder_limits(gif::GifDecoder::new_with_limits(r, limits)?, limits),
         #[cfg(feature = "jpeg")]
-        image::ImageFormat::Jpeg => DynamicImage::from_decoder(jpeg::JpegDecoder::new(r)?),
+        image::ImageFormat::Jpeg => DynamicImage::from_decoder_limits(jpeg::JpegDecoder::new(r)?, limits),
         #[cfg(feature = "webp")]
-        image::ImageFormat::WebP => DynamicImage::from_decoder(webp::WebPDecoder::new(r)?),
+        image::ImageFormat::WebP => DynamicImage::from_decoder_limits(webp::WebPDecoder::new(r)?, limits),
         #[cfg(feature = "tiff")]
-        image::ImageFormat::Tiff => DynamicImage::from_decoder(tiff::TiffDecoder::new_with_limits(r, limits)?),
+        image::ImageFormat::Tiff => DynamicImage::from_decoder_limits(tiff::TiffDecoder::new_with_limits(r, limits)?, limits),
         #[cfg(feature = "tga")]
-        image::ImageFormat::Tga => DynamicImage::from_decoder(tga::TgaDecoder::new(r)?),
+        image::ImageFormat::Tga => DynamicImage::from_decoder_limits(tga::TgaDecoder::new(r)?, limits),
         #[cfg(feature = "bmp")]
-        image::ImageFormat::Bmp => DynamicImage::from_decoder(bmp::BmpDecoder::new(r)?),
+        image::ImageFormat::Bmp => DynamicImage::from_decoder_limits(bmp::BmpDecoder::new(r)?, limits),
         #[cfg(feature = "ico")]
-        image::ImageFormat::Ico => DynamicImage::from_decoder(ico::IcoDecoder::new(r)?),
+        image::ImageFormat::Ico => DynamicImage::from_decoder_limits(ico::IcoDecoder::new(r)?, limits),
         #[cfg(feature = "hdr")]
-        image::ImageFormat::Hdr => DynamicImage::from_decoder(hdr::HDRAdapter::new(BufReader::new(r))?),
+        image::ImageFormat::Hdr => DynamicImage::from_decoder_limits(hdr::HDRAdapter::new(BufReader::new(r))?, limits),
         #[cfg(feature = "pnm")]
-        image::ImageFormat::Pnm => DynamicImage::from_decoder(pnm::PnmDecoder::new(BufReader::new(r))?),
+        image::ImageFormat::Pnm => DynamicImage::from_decoder_limits(pnm::PnmDecoder::new(BufReader::new(r))?, limits),
         _ => Err(image::ImageError::UnsupportedError(format!(
             "A decoder for {:?} is not available.",
             format

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -58,7 +58,7 @@ pub fn load<R: BufRead + Seek>(r: R, format: ImageFormat) -> ImageResult<Dynamic
     load_with_limits(r, format, DecodingLimits::default())
 }
 
-fn load_with_limits<R: BufRead + Seek>(r: R, format: ImageFormat, limits: DecodingLimits) -> ImageResult<DynamicImage> {
+pub(crate) fn load_with_limits<R: BufRead + Seek>(r: R, format: ImageFormat, limits: DecodingLimits) -> ImageResult<DynamicImage> {
     #[allow(deprecated, unreachable_patterns)]
     // Default is unreachable if all features are supported.
     match format {

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -29,6 +29,7 @@ use color;
 use image;
 use dynimage::DynamicImage;
 use image::{ImageDecoder, ImageFormat, ImageResult, ImageError};
+use super::DecodingLimits;
 
 /// Internal error type for guessing format from path.
 pub(crate) enum PathError {
@@ -54,19 +55,23 @@ pub(crate) fn open_impl(path: &Path) -> ImageResult<DynamicImage> {
 ///
 /// [`io::Reader`]: io/struct.Reader.html
 pub fn load<R: BufRead + Seek>(r: R, format: ImageFormat) -> ImageResult<DynamicImage> {
+    load_with_limits(r, format, DecodingLimits::default())
+}
+
+fn load_with_limits<R: BufRead + Seek>(r: R, format: ImageFormat, limits: DecodingLimits) -> ImageResult<DynamicImage> {
     #[allow(deprecated, unreachable_patterns)]
     // Default is unreachable if all features are supported.
     match format {
         #[cfg(feature = "png_codec")]
-        image::ImageFormat::Png => DynamicImage::from_decoder(png::PngDecoder::new(r)?),
+        image::ImageFormat::Png => DynamicImage::from_decoder(png::PngDecoder::new_with_limits(r, limits)?),
         #[cfg(feature = "gif_codec")]
-        image::ImageFormat::Gif => DynamicImage::from_decoder(gif::GifDecoder::new(r)?),
+        image::ImageFormat::Gif => DynamicImage::from_decoder(gif::GifDecoder::new_with_limits(r, limits)?),
         #[cfg(feature = "jpeg")]
         image::ImageFormat::Jpeg => DynamicImage::from_decoder(jpeg::JpegDecoder::new(r)?),
         #[cfg(feature = "webp")]
         image::ImageFormat::WebP => DynamicImage::from_decoder(webp::WebPDecoder::new(r)?),
         #[cfg(feature = "tiff")]
-        image::ImageFormat::Tiff => DynamicImage::from_decoder(tiff::TiffDecoder::new(r)?),
+        image::ImageFormat::Tiff => DynamicImage::from_decoder(tiff::TiffDecoder::new_with_limits(r, limits)?),
         #[cfg(feature = "tga")]
         image::ImageFormat::Tga => DynamicImage::from_decoder(tga::TgaDecoder::new(r)?),
         #[cfg(feature = "bmp")]

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -95,10 +95,10 @@ pub(crate) fn image_dimensions_impl(path: &Path) -> ImageResult<(u32, u32)> {
     let fin = File::open(path)?;
     let fin = BufReader::new(fin);
 
-    image_dimensions_with_format_impl(fin, format)
+    image_dimensions_with_format_impl(fin, format, DecodingLimits::default())
 }
 
-pub(crate) fn image_dimensions_with_format_impl<R: BufRead + Seek>(fin: R, format: ImageFormat)
+pub(crate) fn image_dimensions_with_format_impl<R: BufRead + Seek>(fin: R, format: ImageFormat, limits: DecodingLimits)
     -> ImageResult<(u32, u32)>
 {
     #[allow(unreachable_patterns)]
@@ -107,13 +107,13 @@ pub(crate) fn image_dimensions_with_format_impl<R: BufRead + Seek>(fin: R, forma
         #[cfg(feature = "jpeg")]
         image::ImageFormat::Jpeg => jpeg::JpegDecoder::new(fin)?.dimensions(),
         #[cfg(feature = "png_codec")]
-        image::ImageFormat::Png => png::PngDecoder::new(fin)?.dimensions(),
+        image::ImageFormat::Png => png::PngDecoder::new_with_limits(fin, limits)?.dimensions(),
         #[cfg(feature = "gif_codec")]
-        image::ImageFormat::Gif => gif::GifDecoder::new(fin)?.dimensions(),
+        image::ImageFormat::Gif => gif::GifDecoder::new_with_limits(fin, limits)?.dimensions(),
         #[cfg(feature = "webp")]
         image::ImageFormat::WebP => webp::WebPDecoder::new(fin)?.dimensions(),
         #[cfg(feature = "tiff")]
-        image::ImageFormat::Tiff => tiff::TiffDecoder::new(fin)?.dimensions(),
+        image::ImageFormat::Tiff => tiff::TiffDecoder::new_with_limits(fin, limits)?.dimensions(),
         #[cfg(feature = "tga")]
         image::ImageFormat::Tga => tga::TgaDecoder::new(fin)?.dimensions(),
         #[cfg(feature = "bmp")]

--- a/src/io/limits.rs
+++ b/src/io/limits.rs
@@ -1,0 +1,15 @@
+/// Limits on how much memory that can be used in the decoding process. These limits are "best
+/// effort" limits and there are no strict guarantees that they will be followed at all times.
+#[derive(Debug, Copy, Clone)]
+pub struct DecodingLimits {
+    /// A limit on how large buffers a decoder is allowed to allocate. The default is 512MiB.
+    pub buffer_limit: usize,
+}
+
+impl Default for DecodingLimits {
+    fn default() -> Self {
+        DecodingLimits {
+            buffer_limit: 512*1024*1024,
+        }
+    }
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,5 +1,7 @@
 //! Input and output of images.
 mod reader;
+mod limits;
 pub(crate) mod free_functions;
 
 pub use self::reader::Reader;
+pub use self::limits::DecodingLimits;

--- a/src/io/reader.rs
+++ b/src/io/reader.rs
@@ -6,7 +6,7 @@ use dynimage::DynamicImage;
 use image::ImageFormat;
 use {ImageError, ImageResult};
 
-use super::free_functions;
+use super::{free_functions, limits};
 
 /// A multi-format image reader.
 ///
@@ -62,6 +62,8 @@ pub struct Reader<R: Read> {
     inner: R,
     /// The format, if one has been set or deduced.
     format: Option<ImageFormat>,
+    /// Decoding limits.
+    limits: limits::DecodingLimits,
 }
 
 impl<R: Read> Reader<R> {
@@ -76,6 +78,7 @@ impl<R: Read> Reader<R> {
         Reader {
             inner: reader,
             format: None,
+            limits: limits::DecodingLimits::default(),
         }
     }
 
@@ -84,6 +87,7 @@ impl<R: Read> Reader<R> {
         Reader {
             inner: reader,
             format: Some(format),
+            limits: limits::DecodingLimits::default(),
         }
     }
 
@@ -103,6 +107,11 @@ impl<R: Read> Reader<R> {
     /// `ImageError::UnsupportedError` when the image format has not been set.
     pub fn clear_format(&mut self) {
         self.format = None;
+    }
+
+    /// Set the limits to use when decoding.
+    pub fn set_limits(&mut self, limits: limits::DecodingLimits) {
+        self.limits = limits;
     }
 
     /// Unwrap the reader.
@@ -129,6 +138,7 @@ impl Reader<BufReader<File>> {
         Ok(Reader {
             inner: BufReader::new(file),
             format: ImageFormat::from_path(path).ok(),
+            limits: limits::DecodingLimits::default(),
         })
     }
 }

--- a/src/io/reader.rs
+++ b/src/io/reader.rs
@@ -200,7 +200,7 @@ impl<R: BufRead + Seek> Reader<R> {
     /// If no format was determined, returns an `ImageError::UnsupportedError`.
     pub fn into_dimensions(mut self) -> ImageResult<(u32, u32)> {
         let format = self.require_format()?;
-        free_functions::image_dimensions_with_format_impl(self.inner, format)
+        free_functions::image_dimensions_with_format_impl(self.inner, format, self.limits)
     }
 
     /// Read the image (replaces `load`).

--- a/src/io/reader.rs
+++ b/src/io/reader.rs
@@ -210,7 +210,7 @@ impl<R: BufRead + Seek> Reader<R> {
     /// If no format was determined, returns an `ImageError::UnsupportedError`.
     pub fn decode(mut self) -> ImageResult<DynamicImage> {
         let format = self.require_format()?;
-        free_functions::load(self.inner, format)
+        free_functions::load_with_limits(self.inner, format, self.limits)
     }
 
     fn require_format(&mut self) -> ImageResult<ImageFormat> {

--- a/src/png.rs
+++ b/src/png.rs
@@ -13,6 +13,7 @@ use std::io::{self, Read, Write};
 
 use color::{ColorType, ExtendedColorType};
 use image::{ImageDecoder, ImageError, ImageResult};
+use io::DecodingLimits;
 
 /// PNG Reader
 ///
@@ -98,8 +99,13 @@ pub struct PngDecoder<R: Read> {
 impl<R: Read> PngDecoder<R> {
     /// Creates a new decoder that decodes from the stream ```r```
     pub fn new(r: R) -> ImageResult<PngDecoder<R>> {
+        Self::new_with_limits(r, DecodingLimits::default())
+    }
+
+    /// Same as `new`, but allows you to specify limits.
+    pub fn new_with_limits(r: R, limits: DecodingLimits) -> ImageResult<PngDecoder<R>> {
         let limits = png::Limits {
-            bytes: usize::max_value(),
+            bytes: limits.buffer_limit,
         };
         let decoder = png::Decoder::new_with_limits(r, limits);
         let (_, mut reader) = decoder.read_info().map_err(ImageError::from_png)?;

--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -37,6 +37,7 @@ impl<R> TiffDecoder<R>
         Self::new_with_limits(r, DecodingLimits::default())
     }
 
+    /// Same as `new`, but allows you to set limits.
     pub fn new_with_limits(r: R, limits: DecodingLimits) -> Result<TiffDecoder<R>, ImageError> {
         let mut tiff_limits = tiff::decoder::Limits::default();
         tiff_limits.decoding_buffer_size = limits.buffer_limit;


### PR DESCRIPTION
This PR adds limits to the decoders that support it and adds a method for setting these in the `io::Reader` interface.

This fixes #938 