### PR TITLE
Document and expose all new pub structures

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -61,6 +61,14 @@ impl ColorType {
     }
 }
 
+/// An enumeration of color types encountered in image formats.
+///
+/// This is not exhaustive over all existing image formats but should be granular enough to allow
+/// round tripping of decoding and encoding as much as possible. The variants will be extended as
+/// necessary to enable this.
+///
+/// Another purpose is to advise users of a rough estimate of the accuracy and effort of the
+/// decoding from and encoding to such an image format.
 #[derive(Copy, PartialEq, Eq, Debug, Clone, Hash)]
 pub enum ExtendedColorType {
     L1,
@@ -96,6 +104,10 @@ pub enum ExtendedColorType {
 }
 
 impl ExtendedColorType {
+    /// Get the number of channels for colors of this type.
+    ///
+    /// Note that the `Unknown` variant returns a value of `1` since pixels can only be treated as
+    /// an opaque datum by the library.
     pub fn channel_count(self) -> u8 {
         match self {
             ExtendedColorType::L1 |

--- a/src/image.rs
+++ b/src/image.rs
@@ -379,8 +379,8 @@ pub(crate) fn decoder_to_vec<'a>(decoder: impl ImageDecoder<'a>) -> ImageResult<
 /// Represents the progress of an image operation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Progress {
-    current: u64,
-    total: u64,
+    pub current: u64,
+    pub total: u64,
 }
 
 /// The trait that all decoders implement

--- a/src/image.rs
+++ b/src/image.rs
@@ -383,15 +383,23 @@ pub(crate) fn decoder_to_vec<'a>(decoder: impl ImageDecoder<'a>) -> ImageResult<
 /// progress `(0, 0)` if progress is unknown, without violating the interface contract of the type.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Progress {
-    /// A measure of completed decoding.
-    pub current: u64,
-    /// A measure of all necessary decoding work.
-    ///
-    /// This is in general greater or equal than `current`.
-    pub total: u64,
+    current: u64,
+    total: u64,
 }
 
 impl Progress {
+    /// A measure of completed decoding.
+    pub fn current(self) -> u64 {
+        self.current
+    }
+
+    /// A measure of all necessary decoding work.
+    ///
+    /// This is in general greater or equal than `current`.
+    pub fn total(self) -> u64 {
+        self.total
+    }
+
     /// Calculate a measure for remaining decoding work.
     pub fn remaining(self) -> u64 {
         self.total.max(self.current) - self.current

--- a/src/image.rs
+++ b/src/image.rs
@@ -377,10 +377,25 @@ pub(crate) fn decoder_to_vec<'a>(decoder: impl ImageDecoder<'a>) -> ImageResult<
 }
 
 /// Represents the progress of an image operation.
+///
+/// Note that this is not necessarily accurate and no change to the values passed to the progress
+/// function during decoding will be considered breaking. A decoder could in theory report the
+/// progress `(0, 0)` if progress is unknown, without violating the interface contract of the type.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Progress {
+    /// A measure of completed decoding.
     pub current: u64,
+    /// A measure of all necessary decoding work.
+    ///
+    /// This is in general greater or equal than `current`.
     pub total: u64,
+}
+
+impl Progress {
+    /// Calculate a measure for remaining decoding work.
+    pub fn remaining(self) -> u64 {
+        self.total.max(self.current) - self.current
+    }
 }
 
 /// The trait that all decoders implement

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ extern crate quickcheck;
 
 use std::io::Write;
 
-pub use color::ColorType;
+pub use color::{ColorType, ExtendedColorType};
 
 pub use color::{Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
 
@@ -36,14 +36,13 @@ pub use image::{AnimationDecoder,
                 ImageDecoder,
                 ImageDecoderExt,
                 ImageError,
+                ImageFormat,
+                ImageOutputFormat,
                 ImageResult,
+                Progress,
                 // Iterators
                 Pixels,
                 SubImage};
-
-pub use image::ImageFormat;
-
-pub use image::ImageOutputFormat;
 
 pub use buffer::{ConvertBuffer,
                  GrayAlphaImage,


### PR DESCRIPTION
Of note, these were previously hidden despite `#[deny(unreachable_pub)]` because they were no completely unreachable, just unnamable. Note that the `ImageDecoder` utilizes them both in function signatures and through some trait trickery it was theoretically possible to type-def them (or so I think).

Also, `Progress` was completely opaque and missing any accessors, contrary to its use in the callback since it could not be inspected. Sorry :cry: .