### PR TITLE
Simplify cargo toml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ env:
   matrix:
     - DEFAULT_FEATURES='yes'
     - FEATURES=''
-    - FEATURES='gif_codec'
+    - FEATURES='gif'
     - FEATURES='jpeg'
-    - FEATURES='png_codec'
+    - FEATURES='png'
     - FEATURES='pnm'
     - FEATURES='tga'
     - FEATURES='tiff'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,12 +37,10 @@ glob = "0.3"
 quickcheck = "0.6.2"
 
 [features]
-default = ["gif_codec", "jpeg", "ico", "png_codec", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "jpeg_rayon"]
+default = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "jpeg_rayon"]
 
-gif_codec = ["gif"]
-ico = ["bmp", "png_codec"]
+ico = ["bmp", "png"]
 jpeg = ["jpeg-decoder"]
-png_codec = ["png"]
 pnm = []
 tga = []
 webp = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ num-iter = "0.1.32"
 num-rational = { version = "0.2.1", default-features = false }
 num-traits = "0.2.0"
 gif = { version = "0.10.0", optional = true }
-jpeg-decoder = { version = "0.1", default-features = false, optional = true }
+jpeg = { package = "jpeg-decoder", version = "0.1", default-features = false, optional = true }
 png = { version = "0.15", optional = true }
 scoped_threadpool = { version = "0.1", optional = true }
 tiff = { version = "0.4.0", optional = true }
@@ -40,13 +40,12 @@ quickcheck = "0.6.2"
 default = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "jpeg_rayon"]
 
 ico = ["bmp", "png"]
-jpeg = ["jpeg-decoder"]
 pnm = []
 tga = []
 webp = []
 bmp = []
 hdr = ["scoped_threadpool"]
 dxt = []
-jpeg_rayon = ["jpeg-decoder/rayon"]
+jpeg_rayon = ["jpeg/rayon"]
 
 benchmarks = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,27 +33,11 @@ byteorder = "1.2.1"
 num-iter = "0.1.32"
 num-rational = { version = "0.2.1", default-features = false }
 num-traits = "0.2.0"
-
-[dependencies.gif]
-version = "0.10.0"
-optional = true
-
-[dependencies.jpeg-decoder]
-version = "0.1"
-default-features = false
-optional = true
-
-[dependencies.png]
-version = "0.15"
-optional = true
-
-[dependencies.scoped_threadpool]
-version = "0.1"
-optional = true
-
-[dependencies.tiff]
-version = "0.4.0"
-optional = true
+gif = { version = "0.10.0", optional = true }
+jpeg-decoder = { version = "0.1", default-features = false, optional = true }
+png = { version = "0.15", optional = true }
+scoped_threadpool = { version = "0.1", optional = true }
+tiff = { version = "0.4.0", optional = true }
 
 [dev-dependencies]
 crc32fast = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,19 +3,10 @@ name = "image"
 version = "0.23.0-preview.0"
 license = "MIT"
 description = "Imaging library written in Rust. Provides basic filters and decoders for the most common image formats."
-authors = [
-    "ccgn",
-    "bvssvni <bvssvni@gmail.com>",
-    "nwin",
-    "TyOverby <ty@pre-alpha.com>",
-    "HeroicKatora",
-    "Calum",
-    "CensoredUsername <cens.username@gmail.com>",
-    "fintelia <fintelia@gmail.com>"
-]
+authors = ["The image-rs Developers"]
 readme = "README.md"
 documentation = "https://docs.rs/image"
-repository = "https://github.com/image-rs/image.git"
+repository = "https://github.com/image-rs/image"
 homepage = "https://github.com/image-rs/image"
 categories = ["multimedia::images", "multimedia::encoding"]
 exclude = [

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -5,13 +5,13 @@ use std::u32;
 
 #[cfg(feature = "bmp")]
 use bmp;
-#[cfg(feature = "gif_codec")]
+#[cfg(feature = "gif")]
 use gif;
 #[cfg(feature = "ico")]
 use ico;
 #[cfg(feature = "jpeg")]
 use jpeg;
-#[cfg(feature = "png_codec")]
+#[cfg(feature = "png")]
 use png;
 #[cfg(feature = "pnm")]
 use pnm;
@@ -477,7 +477,7 @@ impl DynamicImage {
 
         #[allow(deprecated)]
         match format {
-            #[cfg(feature = "png_codec")]
+            #[cfg(feature = "png")]
             image::ImageOutputFormat::Png => {
                 let p = png::PNGEncoder::new(w);
                 match *self {
@@ -519,7 +519,7 @@ impl DynamicImage {
                 Ok(())
             }
 
-            #[cfg(feature = "gif_codec")]
+            #[cfg(feature = "gif")]
             image::ImageOutputFormat::Gif => {
                 let mut g = gif::Encoder::new(w);
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -156,7 +156,7 @@ impl ImageFormat {
 /// An enumeration of supported image formats for encoding.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum ImageOutputFormat {
-    #[cfg(feature = "png_codec")]
+    #[cfg(feature = "png")]
     /// An Image in PNG Format
     Png,
 
@@ -168,7 +168,7 @@ pub enum ImageOutputFormat {
     /// An Image in one of the PNM Formats
     Pnm(PNMSubtype),
 
-    #[cfg(feature = "gif_codec")]
+    #[cfg(feature = "gif")]
     /// An Image in GIF Format
     Gif,
 
@@ -189,13 +189,13 @@ pub enum ImageOutputFormat {
 impl From<ImageFormat> for ImageOutputFormat {
     fn from(fmt: ImageFormat) -> Self {
         match fmt {
-            #[cfg(feature = "png_codec")]
+            #[cfg(feature = "png")]
             ImageFormat::Png => ImageOutputFormat::Png,
             #[cfg(feature = "jpeg")]
             ImageFormat::Jpeg => ImageOutputFormat::Jpeg(75),
             #[cfg(feature = "pnm")]
             ImageFormat::Pnm => ImageOutputFormat::Pnm(PNMSubtype::ArbitraryMap),
-            #[cfg(feature = "gif_codec")]
+            #[cfg(feature = "gif")]
             ImageFormat::Gif => ImageOutputFormat::Gif,
             #[cfg(feature = "ico")]
             ImageFormat::Ico => ImageOutputFormat::Ico,

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -757,7 +757,7 @@ mod tests {
     use test;
 
     #[bench]
-    #[cfg(all(feature = "benchmarks", feature = "png_codec"))]
+    #[cfg(all(feature = "benchmarks", feature = "png"))]
     fn bench_resize(b: &mut test::Bencher) {
         use std::path::Path;
         let img = ::open(&Path::new("./examples/fractal.png")).unwrap();

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -6,7 +6,7 @@ use std::u32;
 
 #[cfg(feature = "bmp")]
 use bmp;
-#[cfg(feature = "gif_codec")]
+#[cfg(feature = "gif")]
 use gif;
 #[cfg(feature = "hdr")]
 use hdr;
@@ -14,7 +14,7 @@ use hdr;
 use ico;
 #[cfg(feature = "jpeg")]
 use jpeg;
-#[cfg(feature = "png_codec")]
+#[cfg(feature = "png")]
 use png;
 #[cfg(feature = "pnm")]
 use pnm;
@@ -57,9 +57,9 @@ pub fn load<R: BufRead + Seek>(r: R, format: ImageFormat) -> ImageResult<Dynamic
     #[allow(deprecated, unreachable_patterns)]
     // Default is unreachable if all features are supported.
     match format {
-        #[cfg(feature = "png_codec")]
+        #[cfg(feature = "png")]
         image::ImageFormat::Png => DynamicImage::from_decoder(png::PngDecoder::new(r)?),
-        #[cfg(feature = "gif_codec")]
+        #[cfg(feature = "gif")]
         image::ImageFormat::Gif => DynamicImage::from_decoder(gif::GifDecoder::new(r)?),
         #[cfg(feature = "jpeg")]
         image::ImageFormat::Jpeg => DynamicImage::from_decoder(jpeg::JpegDecoder::new(r)?),
@@ -101,9 +101,9 @@ pub(crate) fn image_dimensions_with_format_impl<R: BufRead + Seek>(fin: R, forma
     Ok(match format {
         #[cfg(feature = "jpeg")]
         image::ImageFormat::Jpeg => jpeg::JpegDecoder::new(fin)?.dimensions(),
-        #[cfg(feature = "png_codec")]
+        #[cfg(feature = "png")]
         image::ImageFormat::Png => png::PngDecoder::new(fin)?.dimensions(),
-        #[cfg(feature = "gif_codec")]
+        #[cfg(feature = "gif")]
         image::ImageFormat::Gif => gif::GifDecoder::new(fin)?.dimensions(),
         #[cfg(feature = "webp")]
         image::ImageFormat::WebP => webp::WebPDecoder::new(fin)?.dimensions(),
@@ -145,7 +145,7 @@ pub(crate) fn save_buffer_impl(
         "ico" => ico::ICOEncoder::new(fout).encode(buf, width, height, color),
         #[cfg(feature = "jpeg")]
         "jpg" | "jpeg" => jpeg::JPEGEncoder::new(fout).encode(buf, width, height, color),
-        #[cfg(feature = "png_codec")]
+        #[cfg(feature = "png")]
         "png" => png::PNGEncoder::new(fout).encode(buf, width, height, color),
         #[cfg(feature = "pnm")]
         "pbm" => pnm::PNMEncoder::new(fout)
@@ -185,7 +185,7 @@ pub(crate) fn save_buffer_with_format_impl(
         image::ImageFormat::Ico => ico::ICOEncoder::new(fout).encode(buf, width, height, color),
         #[cfg(feature = "jpeg")]
         image::ImageFormat::Jpeg => jpeg::JPEGEncoder::new(fout).encode(buf, width, height, color),
-        #[cfg(feature = "png_codec")]
+        #[cfg(feature = "png")]
         image::ImageFormat::Png => png::PNGEncoder::new(fout).encode(buf, width, height, color),
         #[cfg(feature = "bmp")]
         image::ImageFormat::Bmp => bmp::BMPEncoder::new(fout).encode(buf, width, height, color),

--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -1,4 +1,4 @@
-extern crate jpeg_decoder;
+extern crate jpeg;
 
 use std::convert::TryFrom;
 use std::io::{self, Cursor, Read};
@@ -10,21 +10,21 @@ use image::{ImageDecoder, ImageError, ImageResult};
 
 /// JPEG decoder
 pub struct JpegDecoder<R> {
-    decoder: jpeg_decoder::Decoder<R>,
-    metadata: jpeg_decoder::ImageInfo,
+    decoder: jpeg::Decoder<R>,
+    metadata: jpeg::ImageInfo,
 }
 
 impl<R: Read> JpegDecoder<R> {
     /// Create a new decoder that decodes from the stream ```r```
     pub fn new(r: R) -> ImageResult<JpegDecoder<R>> {
-        let mut decoder = jpeg_decoder::Decoder::new(r);
+        let mut decoder = jpeg::Decoder::new(r);
 
         decoder.read_info()?;
         let mut metadata = decoder.info().unwrap();
 
         // We convert CMYK data to RGB before returning it to the user.
-        if metadata.pixel_format == jpeg_decoder::PixelFormat::CMYK32 {
-            metadata.pixel_format = jpeg_decoder::PixelFormat::RGB24;
+        if metadata.pixel_format == jpeg::PixelFormat::CMYK32 {
+            metadata.pixel_format = jpeg::PixelFormat::RGB24;
         }
 
         Ok(JpegDecoder {
@@ -64,7 +64,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for JpegDecoder<R> {
     fn into_reader(mut self) -> ImageResult<Self::Reader> {
         let mut data = self.decoder.decode()?;
         data = match self.decoder.info().unwrap().pixel_format {
-            jpeg_decoder::PixelFormat::CMYK32 => cmyk_to_rgb(&data),
+            jpeg::PixelFormat::CMYK32 => cmyk_to_rgb(&data),
             _ => data,
         };
 
@@ -76,7 +76,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for JpegDecoder<R> {
 
         let mut data = self.decoder.decode()?;
         data = match self.decoder.info().unwrap().pixel_format {
-            jpeg_decoder::PixelFormat::CMYK32 => cmyk_to_rgb(&data),
+            jpeg::PixelFormat::CMYK32 => cmyk_to_rgb(&data),
             _ => data,
         };
 
@@ -113,9 +113,9 @@ fn cmyk_to_rgb(input: &[u8]) -> Vec<u8> {
     output
 }
 
-impl From<jpeg_decoder::PixelFormat> for ColorType {
-    fn from(pixel_format: jpeg_decoder::PixelFormat) -> ColorType {
-        use self::jpeg_decoder::PixelFormat::*;
+impl From<jpeg::PixelFormat> for ColorType {
+    fn from(pixel_format: jpeg::PixelFormat) -> ColorType {
+        use self::jpeg::PixelFormat::*;
         match pixel_format {
             L8 => ColorType::L8,
             RGB24 => ColorType::Rgb8,
@@ -124,9 +124,9 @@ impl From<jpeg_decoder::PixelFormat> for ColorType {
     }
 }
 
-impl From<jpeg_decoder::Error> for ImageError {
-    fn from(err: jpeg_decoder::Error) -> ImageError {
-        use self::jpeg_decoder::Error::*;
+impl From<jpeg::Error> for ImageError {
+    fn from(err: jpeg::Error) -> ImageError {
+        use self::jpeg::Error::*;
         match err {
             Format(desc) => ImageError::FormatError(desc),
             Unsupported(desc) => ImageError::UnsupportedError(format!("{:?}", desc)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ pub mod flat;
 pub mod bmp;
 #[cfg(feature = "dxt")]
 pub mod dxt;
-#[cfg(feature = "gif_codec")]
+#[cfg(feature = "gif")]
 pub mod gif;
 #[cfg(feature = "hdr")]
 pub mod hdr;
@@ -92,7 +92,7 @@ pub mod hdr;
 pub mod ico;
 #[cfg(feature = "jpeg")]
 pub mod jpeg;
-#[cfg(feature = "png_codec")]
+#[cfg(feature = "png")]
 pub mod png;
 #[cfg(feature = "pnm")]
 pub mod pnm;

--- a/tests/reference_images.rs
+++ b/tests/reference_images.rs
@@ -185,7 +185,7 @@ fn check_references() {
 
         match case.kind {
             ReferenceTestKind::AnimatedGifFrame { frame: frame_num } => {
-                #[cfg(feature = "gif_codec")]
+                #[cfg(feature = "gif")]
                 {
                     // Interpret the input file as an animation file
                     use image::AnimationDecoder;
@@ -214,7 +214,7 @@ fn check_references() {
                     test_img = frame.into_buffer();
                 }
 
-                #[cfg(not(feature = "gif_codec"))]
+                #[cfg(not(feature = "gif"))]
                 {
                     println!("Skipping - GIF codec is not enabled");
                     return;


### PR DESCRIPTION
This series of patches makes the Cargo.toml more concise, updates it in a few places, and removes the "gif_codec" and "png_codec" features in favor of just referring to them via "gif" and "png" respectively.

The first two items should have no end user impact, but renaming features represents a breaking change. 