### PR TITLE
Simplify Pixel trait

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -86,9 +86,6 @@ pub trait Pixel: Copy + Clone {
     /// that the slice is long enough to present panics if the pixel is used later on.
     fn from_slice_mut(slice: &mut [Self::Subpixel]) -> &mut Self;
 
-    /// Convert this pixel to RGB
-    fn to_rgb(&self) -> Rgb<Self::Subpixel>;
-
     /// Convert this pixel to RGB with an alpha channel
     fn to_rgba(&self) -> Rgba<Self::Subpixel>;
 
@@ -97,12 +94,6 @@ pub trait Pixel: Copy + Clone {
 
     /// Convert this pixel to luma with an alpha channel
     fn to_luma_alpha(&self) -> LumaA<Self::Subpixel>;
-
-    /// Convert this pixel to BGR
-    fn to_bgr(&self) -> Bgr<Self::Subpixel>;
-
-    /// Convert this pixel to BGR with an alpha channel
-    fn to_bgra(&self) -> Bgra<Self::Subpixel>;
 
     /// Apply the function ```f``` to each channel of this pixel.
     fn map<F>(&self, f: F) -> Self

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -89,9 +89,6 @@ pub trait Pixel: Copy + Clone {
     /// Convert this pixel to RGB with an alpha channel
     fn to_rgba(&self) -> Rgba<Self::Subpixel>;
 
-    /// Convert this pixel to luma
-    fn to_luma(&self) -> Luma<Self::Subpixel>;
-
     /// Convert this pixel to luma with an alpha channel
     fn to_luma_alpha(&self) -> LumaA<Self::Subpixel>;
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -147,9 +147,6 @@ pub trait Pixel: Copy + Clone {
     where
         F: FnMut(Self::Subpixel, Self::Subpixel) -> Self::Subpixel;
 
-    /// Invert this pixel
-    fn invert(&mut self);
-
     /// Blend the color of a given pixel into ourself, taking into account alpha channels
     fn blend(&mut self, other: &Self);
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -268,10 +268,6 @@ impl<T: Primitive + 'static> Pixel for $ident<T> {
         }
     }
 
-    fn invert(&mut self) {
-        Invert::invert(self)
-    }
-
     fn blend(&mut self, other: &$ident<T>) {
         Blend::blend(self, other)
     }
@@ -989,83 +985,6 @@ impl<T: Primitive> Blend for Rgb<T> {
 impl<T: Primitive> Blend for Bgr<T> {
     fn blend(&mut self, other: &Bgr<T>) {
         *self = *other
-    }
-}
-
-
-/// Invert a color
-pub(crate) trait Invert {
-    /// Inverts a color in-place.
-    fn invert(&mut self);
-}
-
-impl<T: Primitive> Invert for LumaA<T> {
-    fn invert(&mut self) {
-        let l = self.0;
-        let max = T::max_value();
-
-        *self = LumaA([max - l[0], l[1]])
-    }
-}
-
-impl<T: Primitive> Invert for Luma<T> {
-    fn invert(&mut self) {
-        let l = self.0;
-
-        let max = T::max_value();
-        let l1 = max - l[0];
-
-        *self = Luma([l1])
-    }
-}
-
-impl<T: Primitive> Invert for Rgba<T> {
-    fn invert(&mut self) {
-        let rgba = self.0;
-
-        let max = T::max_value();
-
-        *self = Rgba([max - rgba[0], max - rgba[1], max - rgba[2], rgba[3]])
-    }
-}
-
-
-impl<T: Primitive> Invert for Bgra<T> {
-    fn invert(&mut self) {
-        let bgra = self.0;
-
-        let max = T::max_value();
-
-        *self = Bgra([max - bgra[2], max - bgra[1], max - bgra[0], bgra[3]])
-    }
-}
-
-
-impl<T: Primitive> Invert for Rgb<T> {
-    fn invert(&mut self) {
-        let rgb = self.0;
-
-        let max = T::max_value();
-
-        let r1 = max - rgb[0];
-        let g1 = max - rgb[1];
-        let b1 = max - rgb[2];
-
-        *self = Rgb([r1, g1, b1])
-    }
-}
-
-impl<T: Primitive> Invert for Bgr<T> {
-    fn invert(&mut self) {
-        let bgr = self.0;
-
-        let max = T::max_value();
-
-        let r1 = max - bgr[2];
-        let g1 = max - bgr[1];
-        let b1 = max - bgr[0];
-
-        *self = Bgr([b1, g1, r1])
     }
 }
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -214,26 +214,8 @@ impl<T: Primitive + 'static> Pixel for $ident<T> {
         unsafe { &mut *(slice.as_ptr() as *mut $ident<T>) }
     }
 
-    fn to_rgb(&self) -> Rgb<T> {
-        let mut pix = Rgb([Zero::zero(), Zero::zero(), Zero::zero()]);
-        pix.from_color(self);
-        pix
-    }
-
-    fn to_bgr(&self) -> Bgr<T> {
-        let mut pix = Bgr([Zero::zero(), Zero::zero(), Zero::zero()]);
-        pix.from_color(self);
-        pix
-    }
-
     fn to_rgba(&self) -> Rgba<T> {
         let mut pix = Rgba([Zero::zero(), Zero::zero(), Zero::zero(), Zero::zero()]);
-        pix.from_color(self);
-        pix
-    }
-
-    fn to_bgra(&self) -> Bgra<T> {
-        let mut pix = Bgra([Zero::zero(), Zero::zero(), Zero::zero(), Zero::zero()]);
         pix.from_color(self);
         pix
     }

--- a/src/color.rs
+++ b/src/color.rs
@@ -220,12 +220,6 @@ impl<T: Primitive + 'static> Pixel for $ident<T> {
         pix
     }
 
-    fn to_luma(&self) -> Luma<T> {
-        let mut pix = Luma([Zero::zero()]);
-        pix.from_color(self);
-        pix
-    }
-
     fn to_luma_alpha(&self) -> LumaA<T> {
         let mut pix = LumaA([Zero::zero(), Zero::zero()]);
         pix.from_color(self);

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -750,14 +750,19 @@ impl GenericImage for DynamicImage {
         let color::Rgba([r, g, b, a]) = pixel;
         let (r16, g16, b16, a16) = (r as u16 * 257, b as u16 * 257, g as u16 * 257, a as u16 * 257);
         match *self {
-            DynamicImage::ImageLuma8(ref mut p) => p.put_pixel(x, y, pixel.to_luma()),
+            DynamicImage::ImageLuma8(ref mut p) => {
+                let color::LumaA([l, _]) = pixel.to_luma_alpha();
+                p.put_pixel(x, y, color::Luma([l]))
+            }
             DynamicImage::ImageLumaA8(ref mut p) => p.put_pixel(x, y, pixel.to_luma_alpha()),
             DynamicImage::ImageRgb8(ref mut p) => p.put_pixel(x, y, color::Rgb([r, g, b])),
             DynamicImage::ImageRgba8(ref mut p) => p.put_pixel(x, y, pixel),
             DynamicImage::ImageBgr8(ref mut p) => p.put_pixel(x, y, color::Bgr([b, g, r])),
             DynamicImage::ImageBgra8(ref mut p) => p.put_pixel(x, y, color::Bgra([b, g, r, a])),
-            DynamicImage::ImageLuma16(ref mut p) =>
-                p.put_pixel(x, y, color::Rgb([r16, g16, b16]).to_luma()),
+            DynamicImage::ImageLuma16(ref mut p) =>{
+                let color::LumaA([l, _]) = color::Rgb([r16, g16, b16]).to_luma_alpha();
+                p.put_pixel(x, y, color::Luma([l]))
+            }
             DynamicImage::ImageLumaA16(ref mut p) =>
                 p.put_pixel(x, y, color::Rgba([r16, g16, b16, a16]).to_luma_alpha()),
             DynamicImage::ImageRgb16(ref mut p) =>
@@ -771,7 +776,10 @@ impl GenericImage for DynamicImage {
         let color::Rgba([r, g, b, a]) = pixel;
         let (r16, g16, b16, a16) = (r as u16 * 257, b as u16 * 257, g as u16 * 257, a as u16 * 257);
         match *self {
-            DynamicImage::ImageLuma8(ref mut p) => p.blend_pixel(x, y, pixel.to_luma()),
+            DynamicImage::ImageLuma8(ref mut p) => {
+                let color::LumaA([l, _]) = pixel.to_luma_alpha();
+                p.blend_pixel(x, y, color::Luma([l]))
+            }
             DynamicImage::ImageLumaA8(ref mut p) => p.blend_pixel(x, y, pixel.to_luma_alpha()),
             DynamicImage::ImageRgb8(ref mut p) => p.blend_pixel(x, y, color::Rgb([r, g, b])),
             DynamicImage::ImageRgba8(ref mut p) => p.blend_pixel(x, y, pixel),
@@ -781,8 +789,10 @@ impl GenericImage for DynamicImage {
                 p.blend_pixel(x, y, color::Rgb([r16, g16, b16])),
             DynamicImage::ImageRgba16(ref mut p) =>
                 p.blend_pixel(x, y, color::Rgba([r16, g16, b16, a16])),
-            DynamicImage::ImageLuma16(ref mut p) =>
-                p.blend_pixel(x, y, color::Rgb([r16, g16, b16]).to_luma()),
+            DynamicImage::ImageLuma16(ref mut p) =>{
+                let color::LumaA([l, _]) = color::Rgb([r16, g16, b16]).to_luma_alpha();
+                p.blend_pixel(x, y, color::Luma([l]))
+            }
             DynamicImage::ImageLumaA16(ref mut p) =>
                 p.blend_pixel(x, y, color::Rgba([r16, g16, b16, a16]).to_luma_alpha()),
         }

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -747,32 +747,44 @@ impl GenericImage for DynamicImage {
     type InnerImage = DynamicImage;
 
     fn put_pixel(&mut self, x: u32, y: u32, pixel: color::Rgba<u8>) {
+        let color::Rgba([r, g, b, a]) = pixel;
+        let (r16, g16, b16, a16) = (r as u16 * 257, b as u16 * 257, g as u16 * 257, a as u16 * 257);
         match *self {
             DynamicImage::ImageLuma8(ref mut p) => p.put_pixel(x, y, pixel.to_luma()),
             DynamicImage::ImageLumaA8(ref mut p) => p.put_pixel(x, y, pixel.to_luma_alpha()),
-            DynamicImage::ImageRgb8(ref mut p) => p.put_pixel(x, y, pixel.to_rgb()),
+            DynamicImage::ImageRgb8(ref mut p) => p.put_pixel(x, y, color::Rgb([r, g, b])),
             DynamicImage::ImageRgba8(ref mut p) => p.put_pixel(x, y, pixel),
-            DynamicImage::ImageBgr8(ref mut p) => p.put_pixel(x, y, pixel.to_bgr()),
-            DynamicImage::ImageBgra8(ref mut p) => p.put_pixel(x, y, pixel.to_bgra()),
-            DynamicImage::ImageLuma16(ref mut p) => p.put_pixel(x, y, pixel.to_luma().into_color()),
-            DynamicImage::ImageLumaA16(ref mut p) => p.put_pixel(x, y, pixel.to_luma_alpha().into_color()),
-            DynamicImage::ImageRgb16(ref mut p) => p.put_pixel(x, y, pixel.to_rgb().into_color()),
-            DynamicImage::ImageRgba16(ref mut p) => p.put_pixel(x, y, pixel.into_color()),
+            DynamicImage::ImageBgr8(ref mut p) => p.put_pixel(x, y, color::Bgr([b, g, r])),
+            DynamicImage::ImageBgra8(ref mut p) => p.put_pixel(x, y, color::Bgra([b, g, r, a])),
+            DynamicImage::ImageLuma16(ref mut p) =>
+                p.put_pixel(x, y, color::Rgb([r16, g16, b16]).to_luma()),
+            DynamicImage::ImageLumaA16(ref mut p) =>
+                p.put_pixel(x, y, color::Rgba([r16, g16, b16, a16]).to_luma_alpha()),
+            DynamicImage::ImageRgb16(ref mut p) =>
+                p.put_pixel(x, y, color::Rgb([r16, g16, b16])),
+            DynamicImage::ImageRgba16(ref mut p) =>
+                p.put_pixel(x, y, color::Rgba([r16, g16, b16, a16])),
         }
     }
     /// DEPRECATED: Use iterator `pixels_mut` to blend the pixels directly.
     fn blend_pixel(&mut self, x: u32, y: u32, pixel: color::Rgba<u8>) {
+        let color::Rgba([r, g, b, a]) = pixel;
+        let (r16, g16, b16, a16) = (r as u16 * 257, b as u16 * 257, g as u16 * 257, a as u16 * 257);
         match *self {
             DynamicImage::ImageLuma8(ref mut p) => p.blend_pixel(x, y, pixel.to_luma()),
             DynamicImage::ImageLumaA8(ref mut p) => p.blend_pixel(x, y, pixel.to_luma_alpha()),
-            DynamicImage::ImageRgb8(ref mut p) => p.blend_pixel(x, y, pixel.to_rgb()),
+            DynamicImage::ImageRgb8(ref mut p) => p.blend_pixel(x, y, color::Rgb([r, g, b])),
             DynamicImage::ImageRgba8(ref mut p) => p.blend_pixel(x, y, pixel),
-            DynamicImage::ImageBgr8(ref mut p) => p.blend_pixel(x, y, pixel.to_bgr()),
-            DynamicImage::ImageBgra8(ref mut p) => p.blend_pixel(x, y, pixel.to_bgra()),
-            DynamicImage::ImageLuma16(ref mut p) => p.blend_pixel(x, y, pixel.to_luma().into_color()),
-            DynamicImage::ImageLumaA16(ref mut p) => p.blend_pixel(x, y, pixel.to_luma_alpha().into_color()),
-            DynamicImage::ImageRgb16(ref mut p) => p.blend_pixel(x, y, pixel.to_rgb().into_color()),
-            DynamicImage::ImageRgba16(ref mut p) => p.blend_pixel(x, y, pixel.into_color()),
+            DynamicImage::ImageBgr8(ref mut p) => p.blend_pixel(x, y, color::Bgr([b, g, r])),
+            DynamicImage::ImageBgra8(ref mut p) => p.blend_pixel(x, y, color::Bgra([b, g, r, a])),
+            DynamicImage::ImageRgb16(ref mut p) =>
+                p.blend_pixel(x, y, color::Rgb([r16, g16, b16])),
+            DynamicImage::ImageRgba16(ref mut p) =>
+                p.blend_pixel(x, y, color::Rgba([r16, g16, b16, a16])),
+            DynamicImage::ImageLuma16(ref mut p) =>
+                p.blend_pixel(x, y, color::Rgb([r16, g16, b16]).to_luma()),
+            DynamicImage::ImageLumaA16(ref mut p) =>
+                p.blend_pixel(x, y, color::Rgba([r16, g16, b16, a16]).to_luma_alpha()),
         }
     }
 

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -457,7 +457,12 @@ impl DynamicImage {
     /// Invert the colors of this image.
     /// This method operates inplace.
     pub fn invert(&mut self) {
-        dynamic_map!(*self, ref mut p -> imageops::invert(p))
+        use traits::Primitive;
+        fn invert_pixel<T: Primitive>(p: &mut impl Pixel<Subpixel = T>) {
+            p.apply_with_alpha(|c|T::max_value() - c, |a|a);
+        }
+
+        dynamic_map!(*self, ref mut img -> img.pixels_mut().for_each(invert_pixel))
     }
 
     /// Resize this image using the specified filter algorithm.

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -2,7 +2,7 @@
 
 use buffer::{ImageBuffer, Pixel};
 use color::{Luma, LumaA, Rgba};
-use image::{GenericImage, GenericImageView};
+use image::GenericImageView;
 use math::nq;
 use math::utils::clamp;
 use num_traits::{Num, NumCast};
@@ -30,21 +30,6 @@ where
     }
 
     out
-}
-
-/// Invert each pixel within the supplied image.
-/// This function operates in place.
-pub fn invert<I: GenericImage>(image: &mut I) {
-    let (width, height) = image.dimensions();
-
-    for y in 0..height {
-        for x in 0..width {
-            let mut p = image.get_pixel(x, y);
-            p.invert();
-
-            image.put_pixel(x, y, p);
-        }
-    }
 }
 
 /// Adjust the contrast of the supplied image.

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -1,7 +1,7 @@
 //! Functions for altering and converting the color of pixelbufs
 
 use buffer::{ImageBuffer, Pixel};
-use color::{Luma, Rgba};
+use color::{Luma, LumaA, Rgba};
 use image::{GenericImage, GenericImageView};
 use math::nq;
 use math::utils::clamp;
@@ -24,8 +24,8 @@ where
 
     for y in 0..height {
         for x in 0..width {
-            let p = image.get_pixel(x, y).to_luma();
-            out.put_pixel(x, y, p);
+            let LumaA([l, _]) = image.get_pixel(x, y).to_luma_alpha();
+            out.put_pixel(x, y, Luma([l]));
         }
     }
 

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -16,7 +16,7 @@ pub use self::affine::{flip_horizontal, flip_vertical, rotate180, rotate270, rot
 pub use self::sample::{blur, filter3x3, resize, thumbnail, unsharpen};
 
 /// Color operations
-pub use self::colorops::{brighten, contrast, dither, grayscale, huerotate, index_colors, invert,
+pub use self::colorops::{brighten, contrast, dither, grayscale, huerotate, index_colors,
                          BiLevel, ColorMap};
 
 mod affine;


### PR DESCRIPTION
The trait has lots of methods that aren't especially useful, yet have to be implemented by every pixel struct. This PR attempts to make things better by removing a bunch of methods.