### PR TITLE
Remove deprecated Error::description

### DIFF
--- a/src/hdr/decoder.rs
+++ b/src/hdr/decoder.rs
@@ -3,7 +3,6 @@ use num_traits::identities::Zero;
 use scoped_threadpool::Pool;
 #[cfg(test)]
 use std::borrow::Cow;
-use std::error::Error;
 use std::io::{self, BufRead, Cursor, Read, Seek};
 use std::iter::Iterator;
 use std::marker::PhantomData;
@@ -707,7 +706,7 @@ impl HDRMetadata {
                         if strict {
                             return Err(ImageError::FormatError(format!(
                                 "Cannot parse EXPOSURE value: {}",
-                                parse_error.description()
+                                parse_error
                             )));
                         } // no else, skip this line in non-strict mode
                     }
@@ -723,7 +722,7 @@ impl HDRMetadata {
                         if strict {
                             return Err(ImageError::FormatError(format!(
                                 "Cannot parse PIXASPECT value: {}",
-                                parse_error.description()
+                                parse_error
                             )));
                         } // no else, skip this line in non-strict mode
                     }
@@ -771,7 +770,7 @@ fn parse_space_separated_f32(line: &str, vals: &mut [f32], name: &str) -> ImageR
                     return Err(ImageError::FormatError(format!(
                         "f32 parse error in {}: {}",
                         name,
-                        err.description()
+                        err
                     )));
                 }
             }
@@ -832,7 +831,7 @@ trait IntoImageError<T> {
 impl<T> IntoImageError<T> for ::std::result::Result<T, ::std::num::ParseFloatError> {
     fn into_image_error(self, description: &str) -> ImageResult<T> {
         self.map_err(|err| {
-            ImageError::FormatError(format!("{} {}", description, err.description()))
+            ImageError::FormatError(format!("{} {}", description, err))
         })
     }
 }
@@ -840,7 +839,7 @@ impl<T> IntoImageError<T> for ::std::result::Result<T, ::std::num::ParseFloatErr
 impl<T> IntoImageError<T> for ::std::result::Result<T, ::std::num::ParseIntError> {
     fn into_image_error(self, description: &str) -> ImageResult<T> {
         self.map_err(|err| {
-            ImageError::FormatError(format!("{} {}", description, err.description()))
+            ImageError::FormatError(format!("{} {}", description, err))
         })
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -79,20 +79,7 @@ impl fmt::Display for ImageError {
 }
 
 impl Error for ImageError {
-    fn description(&self) -> &str {
-        match *self {
-            ImageError::FormatError(..) => "Format error",
-            ImageError::DimensionError => "Dimension error",
-            ImageError::UnsupportedError(..) => "Unsupported error",
-            ImageError::UnsupportedColor(..) => "Unsupported color",
-            ImageError::NotEnoughData => "Not enough data",
-            ImageError::IoError(..) => "IO error",
-            ImageError::ImageEnd => "Image end",
-            ImageError::InsufficientMemory => "Insufficient memory",
-        }
-    }
-
-    fn cause(&self) -> Option<&dyn Error> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         match *self {
             ImageError::IoError(ref e) => Some(e),
             _ => None,

--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -121,7 +121,7 @@ impl From<jpeg_decoder::Error> for ImageError {
             Format(desc) => ImageError::FormatError(desc),
             Unsupported(desc) => ImageError::UnsupportedError(format!("{:?}", desc)),
             Io(err) => ImageError::IoError(err),
-            Internal(err) => ImageError::FormatError(err.description().to_owned()),
+            Internal(err) => ImageError::FormatError(err.to_string()),
         }
     }
 }


### PR DESCRIPTION
Rust is about to hard-deprecate Error::description, which has been soft deprecated for over a year.

Also switches `cause` to the newer `source` (requires 1.30.0).