### PR TITLE
add flip and rotate in destination operations

### DIFF
--- a/src/imageops/affine.rs
+++ b/src/imageops/affine.rs
@@ -189,7 +189,8 @@ pub fn rotate180_in_place<I: GenericImage>(image: &mut I) {
             let x2 = width - x - 1;
             let y2 = height - y - 1;
 
-            image.put_pixel(x, y, image.get_pixel(x2, y2));
+            let p2 = image.get_pixel(x2, y2);
+            image.put_pixel(x, y, p2);
             image.put_pixel(x2, y2, p);
         }
     }
@@ -201,7 +202,8 @@ pub fn rotate180_in_place<I: GenericImage>(image: &mut I) {
             let p = image.get_pixel(x, middle);
             let x2 = width - x - 1;
 
-            image.put_pixel(x, middle, image.get_pixel(x2, middle));
+            let p2 = image.get_pixel(x2, middle);
+            image.put_pixel(x, middle, p2);
             image.put_pixel(x2, middle, p);
         }
     }
@@ -215,7 +217,8 @@ pub fn flip_horizontal_in_place<I: GenericImage>(image: &mut I) {
         for x in 0..width / 2 {
             let x2 = width - x - 1;
             let p2 = image.get_pixel(x2, y);
-            image.put_pixel(x2, y, image.get_pixel(x, y));
+            let p = image.get_pixel(x, y);
+            image.put_pixel(x2, y, p);
             image.put_pixel(x, y, p2);
         }
     }
@@ -229,7 +232,8 @@ pub fn flip_vertical_in_place<I: GenericImage>(image: &mut I) {
         for x in 0..width {
             let y2 = height - y - 1;
             let p2 = image.get_pixel(x, y2);
-            image.put_pixel(x, y2, image.get_pixel(x, y));
+            let p = image.get_pixel(x, y);
+            image.put_pixel(x, y2, p);
             image.put_pixel(x, y, p2);
         }
     }

--- a/src/imageops/affine.rs
+++ b/src/imageops/affine.rs
@@ -1,7 +1,7 @@
 //! Functions for performing affine transformations.
 
 use buffer::{ImageBuffer, Pixel};
-use image::GenericImageView;
+use image::{GenericImage, GenericImageView};
 
 /// Rotate an image 90 degrees clockwise.
 pub fn rotate90<I: GenericImageView>(
@@ -11,14 +11,7 @@ pub fn rotate90<I: GenericImageView>(
 {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(height, width);
-
-    for y in 0..height {
-        for x in 0..width {
-            let p = image.get_pixel(x, y);
-            out.put_pixel(height - 1 - y, x, p);
-        }
-    }
-
+    let _ = rotate90_in(image, &mut out);
     out
 }
 
@@ -30,14 +23,7 @@ pub fn rotate180<I: GenericImageView>(
 {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
-
-    for y in 0..height {
-        for x in 0..width {
-            let p = image.get_pixel(x, y);
-            out.put_pixel(width - 1 - x, height - 1 - y, p);
-        }
-    }
-
+    let _ = rotate180_in(image, &mut out);
     out
 }
 
@@ -49,15 +35,77 @@ pub fn rotate270<I: GenericImageView>(
 {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(height, width);
+    let _ = rotate270_in(image, &mut out);
+    out
+}
 
-    for y in 0..height {
-        for x in 0..width {
-            let p = image.get_pixel(x, y);
-            out.put_pixel(y, width - 1 - x, p);
-        }
+/// Rotate an image 90 degrees clockwise and put the result into the destination [`ImageBuffer`].
+pub fn rotate90_in<I, Container>(
+    image: &I,
+    destination: &mut ImageBuffer<I::Pixel, Container>
+) -> crate::ImageResult<()> where
+    I: GenericImageView,
+    I::Pixel: 'static, 
+    Container: std::ops::DerefMut<Target = [<I::Pixel as Pixel>::Subpixel]> 
+{
+    let ((w0, h0), (w1, h1)) = (image.dimensions(), destination.dimensions());
+    if w0 != h1 || h0 != w1 {
+        return Err(crate::ImageError::DimensionError);
     }
 
-    out
+    for y in 0..h0 {
+        for x in 0..w0 {
+            let p = image.get_pixel(x, y);
+            destination.put_pixel(h0 - y - 1, x, p);
+        }
+    }
+    Ok(())
+}
+
+/// Rotate an image 180 degrees clockwise and put the result into the destination [`ImageBuffer`].
+pub fn rotate180_in<I, Container>(
+    image: &I,
+    destination: &mut ImageBuffer<I::Pixel, Container>
+) -> crate::ImageResult<()> where
+    I: GenericImageView,
+    I::Pixel: 'static, 
+    Container: std::ops::DerefMut<Target = [<I::Pixel as Pixel>::Subpixel]> 
+{
+    let ((w0, h0), (w1, h1)) = (image.dimensions(), destination.dimensions());
+    if w0 != w1 || h0 != h1 {
+        return Err(crate::ImageError::DimensionError);
+    }
+
+    for y in 0..h0 {
+        for x in 0..w0 {
+            let p = image.get_pixel(x, y);
+            destination.put_pixel(w0 - x - 1, h0 - y - 1, p);
+        }
+    }
+    Ok(())
+}
+
+/// Rotate an image 270 degrees clockwise and put the result into the destination [`ImageBuffer`].
+pub fn rotate270_in<I, Container>(
+    image: &I,
+    destination: &mut ImageBuffer<I::Pixel, Container>
+) -> crate::ImageResult<()> where
+    I: GenericImageView,
+    I::Pixel: 'static, 
+    Container: std::ops::DerefMut<Target = [<I::Pixel as Pixel>::Subpixel]> 
+{
+    let ((w0, h0), (w1, h1)) = (image.dimensions(), destination.dimensions());
+    if w0 != h1 || h0 != w1 {
+        return Err(crate::ImageError::DimensionError);
+    }
+
+    for y in 0..h0 {
+        for x in 0..w0 {
+            let p = image.get_pixel(x, y);
+            destination.put_pixel(y, w0 - x - 1, p);
+        }
+    }
+    Ok(())
 }
 
 /// Flip an image horizontally
@@ -68,14 +116,7 @@ pub fn flip_horizontal<I: GenericImageView>(
 {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
-
-    for y in 0..height {
-        for x in 0..width {
-            let p = image.get_pixel(x, y);
-            out.put_pixel(width - 1 - x, y, p);
-        }
-    }
-
+    let _ = flip_horizontal_in(image, &mut out);
     out
 }
 
@@ -87,20 +128,119 @@ pub fn flip_vertical<I: GenericImageView>(
 {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(width, height);
+    let _ = flip_vertical_in(image, &mut out);
+    out
+}
 
-    for y in 0..height {
+/// Flip an image horizontally and put the result into the destination [`ImageBuffer`].
+pub fn flip_horizontal_in<I, Container>(
+    image: &I,
+    destination: &mut ImageBuffer<I::Pixel, Container>
+) -> crate::ImageResult<()> where
+    I: GenericImageView,
+    I::Pixel: 'static, 
+    Container: std::ops::DerefMut<Target = [<I::Pixel as Pixel>::Subpixel]> 
+{
+    let ((w0, h0), (w1, h1)) = (image.dimensions(), destination.dimensions());
+    if w0 != w1 || h0 != h1 {
+        return Err(crate::ImageError::DimensionError);
+    }
+
+    for y in 0..h0 {
+        for x in 0..w0 {
+            let p = image.get_pixel(x, y);
+            destination.put_pixel(w0 - x - 1, y, p);
+        }
+    }
+    Ok(())
+}
+
+/// Flip an image vertically and put the result into the destination [`ImageBuffer`].
+pub fn flip_vertical_in<I, Container>(
+    image: &I,
+    destination: &mut ImageBuffer<I::Pixel, Container>
+) -> crate::ImageResult<()> where
+    I: GenericImageView,
+    I::Pixel: 'static, 
+    Container: std::ops::DerefMut<Target = [<I::Pixel as Pixel>::Subpixel]> 
+{
+    let ((w0, h0), (w1, h1)) = (image.dimensions(), destination.dimensions());
+    if w0 != w1 || h0 != h1 {
+        return Err(crate::ImageError::DimensionError);
+    }
+
+    for y in 0..h0 {
+        for x in 0..w0 {
+            let p = image.get_pixel(x, y);
+            destination.put_pixel(x, h0 - 1 - y, p);
+        }
+    }
+    Ok(())
+}
+
+/// Rotate an image 180 degrees clockwise in place.
+pub fn rotate180_in_place<I: GenericImage>(image: &mut I) {
+    let (width, height) = image.dimensions();
+
+    for y in 0..height / 2 {
         for x in 0..width {
             let p = image.get_pixel(x, y);
-            out.put_pixel(x, height - 1 - y, p);
+
+            let x2 = width - x - 1;
+            let y2 = height - y - 1;
+
+            image.put_pixel(x, y, image.get_pixel(x2, y2));
+            image.put_pixel(x2, y2, p);
         }
     }
 
-    out
+    if height % 2 != 0 {
+        let middle = height / 2;
+
+        for x in 0..width / 2 {
+            let p = image.get_pixel(x, middle);
+            let x2 = width - x - 1;
+
+            image.put_pixel(x, middle, image.get_pixel(x2, middle));
+            image.put_pixel(x2, middle, p);
+        }
+    }
+}
+
+/// Flip an image horizontally in place.
+pub fn flip_horizontal_in_place<I: GenericImage>(image: &mut I) {
+    let (width, height) = image.dimensions();
+
+    for y in 0..height {
+        for x in 0..width / 2 {
+            let x2 = width - x - 1;
+            let p2 = image.get_pixel(x2, y);
+            image.put_pixel(x2, y, image.get_pixel(x, y));
+            image.put_pixel(x, y, p2);
+        }
+    }
+}
+
+/// Flip an image vertically in place.
+pub fn flip_vertical_in_place<I: GenericImage>(image: &mut I) {
+    let (width, height) = image.dimensions();
+
+    for y in 0..height / 2 {
+        for x in 0..width {
+            let y2 = height - y - 1;
+            let p2 = image.get_pixel(x, y2);
+            image.put_pixel(x, y2, image.get_pixel(x, y));
+            image.put_pixel(x, y, p2);
+        }
+    }
 }
 
 #[cfg(test)]
 mod test {
-    use super::{flip_horizontal, flip_vertical, rotate180, rotate270, rotate90};
+    use super::{
+        flip_horizontal, flip_horizontal_in_place, flip_vertical, flip_vertical_in_place,
+        rotate180, rotate180_in_place, rotate270, rotate90,
+    };
     use buffer::{GrayImage, ImageBuffer, Pixel};
     use image::GenericImage;
 
@@ -169,6 +309,19 @@ mod test {
     }
 
     #[test]
+    fn test_rotate180_in_place() {
+        let mut image: GrayImage =
+            ImageBuffer::from_raw(3, 2, vec![00u8, 01u8, 02u8, 10u8, 11u8, 12u8]).unwrap();
+
+        let expected: GrayImage =
+            ImageBuffer::from_raw(3, 2, vec![12u8, 11u8, 10u8, 02u8, 01u8, 00u8]).unwrap();
+
+        rotate180_in_place(&mut image);
+
+        assert_pixels_eq!(&image, &expected);
+    }
+
+    #[test]
     fn test_flip_horizontal() {
         let image: GrayImage =
             ImageBuffer::from_raw(3, 2, vec![00u8, 01u8, 02u8, 10u8, 11u8, 12u8]).unwrap();
@@ -188,6 +341,32 @@ mod test {
             ImageBuffer::from_raw(3, 2, vec![10u8, 11u8, 12u8, 00u8, 01u8, 02u8]).unwrap();
 
         assert_pixels_eq!(&flip_vertical(&image), &expected);
+    }
+
+    #[test]
+    fn test_flip_horizontal_in_place() {
+        let mut image: GrayImage =
+            ImageBuffer::from_raw(3, 2, vec![00u8, 01u8, 02u8, 10u8, 11u8, 12u8]).unwrap();
+
+        let expected: GrayImage =
+            ImageBuffer::from_raw(3, 2, vec![02u8, 01u8, 00u8, 12u8, 11u8, 10u8]).unwrap();
+
+        flip_horizontal_in_place(&mut image);
+
+        assert_pixels_eq!(&image, &expected);
+    }
+
+    #[test]
+    fn test_flip_vertical_in_place() {
+        let mut image: GrayImage =
+            ImageBuffer::from_raw(3, 2, vec![00u8, 01u8, 02u8, 10u8, 11u8, 12u8]).unwrap();
+
+        let expected: GrayImage =
+            ImageBuffer::from_raw(3, 2, vec![10u8, 11u8, 12u8, 00u8, 01u8, 02u8]).unwrap();
+
+        flip_vertical_in_place(&mut image);
+
+        assert_pixels_eq!(&image, &expected);
     }
 
     fn pixel_diffs<I, J, P>(left: &I, right: &J) -> Vec<((u32, u32, P), (u32, u32, P))>

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -10,7 +10,10 @@ pub use self::sample::FilterType;
 pub use self::sample::FilterType::{CatmullRom, Gaussian, Lanczos3, Nearest, Triangle};
 
 /// Affine transformations
-pub use self::affine::{flip_horizontal, flip_vertical, rotate180, rotate270, rotate90};
+pub use self::affine::{
+    flip_horizontal, flip_horizontal_in_place, flip_vertical, flip_vertical_in_place, rotate180,
+    rotate180_in_place, rotate270, rotate90, rotate180_in, rotate90_in, rotate270_in, flip_horizontal_in, flip_vertical_in
+};
 
 /// Image sampling
 pub use self::sample::{blur, filter3x3, resize, thumbnail, unsharpen};


### PR DESCRIPTION
This PR implements the rotate{90, 180, 270} (and flip_{vertical,horizontal}) functions with a destination buffer argument as described in #1082 as new functions with an `_in` suffix. It also implements an `in_place` version for the flip functions as well as for `rotate180` since implementing those was rather straightforward. The previous functions have been reimplemented by using the new `_in` version to avoid code duplication.

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

