### PR TITLE
tiff: don't apply decoding_buffer_size limit

### DIFF
--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -33,7 +33,12 @@ impl<R> TiffDecoder<R>
 {
     /// Create a new TiffDecoder.
     pub fn new(r: R) -> Result<TiffDecoder<R>, ImageError> {
-        let mut inner = tiff::decoder::Decoder::new(r).map_err(ImageError::from_tiff)?;
+        let mut limits = tiff::decoder::Limits::default();
+        limits.decoding_buffer_size = usize::max_value();
+
+        let mut inner = tiff::decoder::Decoder::new(r)
+            .map_err(ImageError::from_tiff)?
+            .with_limits(limits);
         let dimensions = inner.dimensions().map_err(ImageError::from_tiff)?;
         let color_type = match inner.colortype().map_err(ImageError::from_tiff)? {
             tiff::ColorType::Gray(8) => ColorType::L8,


### PR DESCRIPTION
In the image::Decoder API, the user supplies the buffer to decode into. Since we aren't the ones allocating the buffer, we as a library don't need to worry about denial of service from allocating too much memory. TiffDecoder does not currently have any way to set the limits on the underlying tiff::decoder::Decoder, so this patch is necessary to load Tiff files > 256MB at all.