### PR TITLE
Implement copy_within for GenericImage

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -644,7 +644,9 @@ pub trait GenericImage: GenericImageView {
     fn copy_within(&mut self, from: (u32, u32), to: (u32, u32), width: u32, height: u32) -> bool {
         let (fx, fy) = from;
         let (tx, ty) = to;
-        if tx.max(fx) + width > self.width() || ty.max(fy) + height > self.height() {
+        assert!(fx < self.width() && tx < self.width()); 
+        assert!(fy < self.height() && ty < self.height());
+        if self.width() - tx.max(fx) < width || self.height() - ty.max(fy) < height  {
             return false;
         }
         // since `.rev()` creates a new type we would either have to go with dynamic dispatch for the ranges

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -1,3 +1,6 @@
 //! Mathematical helper functions and types.
 pub mod nq;
 pub mod utils;
+
+mod rect;
+pub use self::rect::Rect;

--- a/src/math/rect.rs
+++ b/src/math/rect.rs
@@ -1,0 +1,12 @@
+/// A Rectangle defined by its top left corner, width and height.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Rect {
+    /// The x coordinate of the top left corner.
+    pub x: u32,
+    /// The y coordinate of the top left corner.
+    pub y: u32,
+    /// The rectangle's width.
+    pub width: u32,
+    /// The rectangle's height.
+    pub height: u32,
+}


### PR DESCRIPTION
Attempts to implement #987 with a specialized version for `ImageBuffer`

I unfortunately couldn't come up with a way of implementing this without basically copy pasting the copy logic 4 times while still using static dispatch due to there being 4 different cases to handle that determine in what order to copy the pixels. Hence I wrote a small macro to make the implementation more readable(even though macro normally does the opposite). If you got any ideas for how to improve this I'd be happy to change this.

Regarding the the function signature I currently chose to use a tuple for the two corners of the source and destination rectangles with a width and height parameter, this should obviously thought about a bit more. The other alternatives being two tuples one describing the source rectangle and the other describing the top left corner of the destination rectangle or instead of tuples using proper rectangle structs for the source rectangle.

Sample on how those signatures would look like when calling them:
```rust
image.copy_within((0, 0), (1, 1), 20, 13);
image.copy_within((0, 0, 20, 13), (1, 1));
image.copy_within(Rect { x: 0, y: 0, width: 20, height: 13) }, (1, 1));
```

I also made it return a bool since thats what `copy_from` currently does(https://github.com/image-rs/image/issues/901).

Edit: I forgot that [`slice::copy_within`](https://doc.rust-lang.org/std/primitive.slice.html#method.copy_within) became stable on 1.37, so assuming that this crate has MSRV 1.34 the specialized version of `ImageBuffer` has to be changed first, the only efficient way that comes to mind right now would be `ptr::copy`(given thats how copy_within is implemented), but given it's an unsafe operation I dont know how well received that would be.