### PR TITLE
Move error types to seperate module

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -3,7 +3,7 @@ use std::iter::Iterator;
 use num_rational::Ratio;
 
 use crate::buffer::RgbaImage;
-use crate::image::ImageResult;
+use crate::error::ImageResult;
 
 /// An implementation dependent iterator, reading the frames as requested
 pub struct Frames<'a> {

--- a/src/bmp/decoder.rs
+++ b/src/bmp/decoder.rs
@@ -9,7 +9,8 @@ use std::cmp::Ordering;
 use byteorder::{LittleEndian, ReadBytesExt};
 
 use crate::color::ColorType;
-use crate::image::{self, ImageDecoder, ImageDecoderExt, ImageError, ImageResult, Progress};
+use crate::error::{ImageError, ImageResult};
+use crate::image::{self, ImageDecoder, ImageDecoderExt, Progress};
 
 const BITMAPCOREHEADER_SIZE: u32 = 12;
 const BITMAPINFOHEADER_SIZE: u32 = 40;

--- a/src/bmp/encoder.rs
+++ b/src/bmp/encoder.rs
@@ -2,7 +2,8 @@ use byteorder::{LittleEndian, WriteBytesExt};
 use std::io::{self, Write};
 
 use crate::color;
-use crate::image::{ImageEncoder, ImageError, ImageResult};
+use crate::error::{ImageError, ImageResult};
+use crate::image::ImageEncoder;
 
 const BITMAPFILEHEADER_SIZE: u32 = 14;
 const BITMAPINFOHEADER_SIZE: u32 = 40;

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -7,7 +7,8 @@ use std::slice::{Chunks, ChunksMut};
 use crate::color::{ColorType, FromColor, Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
 use crate::flat::{FlatSamples, SampleLayout};
 use crate::dynimage::{save_buffer, save_buffer_with_format};
-use crate::image::{GenericImage, GenericImageView, ImageFormat, ImageResult};
+use crate::error::ImageResult;
+use crate::image::{GenericImage, GenericImageView, ImageFormat};
 use crate::traits::{EncodableLayout, Primitive};
 use crate::utils::expand_packed;
 

--- a/src/dxt.rs
+++ b/src/dxt.rs
@@ -11,7 +11,8 @@ use std::convert::TryFrom;
 use std::io::{self, Read, Seek, SeekFrom, Write};
 
 use crate::color::ColorType;
-use crate::image::{self, ImageDecoder, ImageDecoderExt, ImageError, ImageReadBuffer, ImageResult, Progress};
+use crate::error::{ImageError, ImageResult};
+use crate::image::{self, ImageDecoder, ImageDecoderExt, ImageReadBuffer, Progress};
 
 /// What version of DXT compression are we using?
 /// Note that DXT2 and DXT4 are left away as they're

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -22,11 +22,10 @@ use crate::buffer::{
     RgbaImage, Rgba16Image,
 };
 use crate::color::{self, IntoColor};
+use crate::error::{ImageError, ImageResult};
 use crate::flat::FlatSamples;
 use crate::image;
-use crate::image::{
-    GenericImage, GenericImageView, ImageDecoder, ImageError, ImageFormat, ImageOutputFormat, ImageResult,
-};
+use crate::image::{GenericImage, GenericImageView, ImageDecoder, ImageFormat, ImageOutputFormat};
 use crate::io::free_functions;
 use crate::imageops;
 
@@ -688,7 +687,7 @@ impl DynamicImage {
             }
 
             image::ImageOutputFormat::Unsupported(msg) => {
-                Err(image::ImageError::UnsupportedError(msg))
+                Err(ImageError::UnsupportedError(msg))
             }
         }
     }
@@ -836,7 +835,6 @@ fn decoder_to_image<'a, I: ImageDecoder<'a>>(decoder: I) -> ImageResult<DynamicI
             let buf = image::decoder_to_vec(decoder)?;
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLuma16)
         }
-
         color::ColorType::La16 => {
             let buf = image::decoder_to_vec(decoder)?;
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLumaA16)

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,98 @@
+use std::error::Error;
+use std::fmt;
+use std::io;
+use crate::color::ExtendedColorType;
+
+/// An enumeration of Image errors
+#[derive(Debug)]
+pub enum ImageError {
+    /// The Image is not formatted properly
+    FormatError(String),
+
+    /// The Image's dimensions are either too small or too large
+    DimensionError,
+
+    /// The Decoder does not support this image format
+    UnsupportedError(String),
+
+    /// The Decoder does not support this color type
+    UnsupportedColor(ExtendedColorType),
+
+    /// Not enough data was provided to the Decoder
+    /// to decode the image
+    NotEnoughData,
+
+    /// An I/O Error occurred while decoding the image
+    IoError(io::Error),
+
+    /// The end of the image has been reached
+    ImageEnd,
+
+    /// There is not enough memory to complete the given operation
+    InsufficientMemory,
+}
+
+impl fmt::Display for ImageError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            ImageError::FormatError(ref e) => write!(fmt, "Format error: {}", e),
+            ImageError::DimensionError => write!(
+                fmt,
+                "The Image's dimensions are either too \
+                 small or too large"
+            ),
+            ImageError::UnsupportedError(ref f) => write!(
+                fmt,
+                "The Decoder does not support the \
+                 image format `{}`",
+                f
+            ),
+            ImageError::UnsupportedColor(ref c) => write!(
+                fmt,
+                "The decoder does not support \
+                 the color type `{:?}`",
+                c
+            ),
+            ImageError::NotEnoughData => write!(
+                fmt,
+                "Not enough data was provided to the \
+                 Decoder to decode the image"
+            ),
+            ImageError::IoError(ref e) => e.fmt(fmt),
+            ImageError::ImageEnd => write!(fmt, "The end of the image has been reached"),
+            ImageError::InsufficientMemory => write!(fmt, "Insufficient memory"),
+        }
+    }
+}
+
+impl Error for ImageError {
+    fn description(&self) -> &str {
+        match *self {
+            ImageError::FormatError(..) => "Format error",
+            ImageError::DimensionError => "Dimension error",
+            ImageError::UnsupportedError(..) => "Unsupported error",
+            ImageError::UnsupportedColor(..) => "Unsupported color",
+            ImageError::NotEnoughData => "Not enough data",
+            ImageError::IoError(..) => "IO error",
+            ImageError::ImageEnd => "Image end",
+            ImageError::InsufficientMemory => "Insufficient memory",
+        }
+    }
+
+    // TODO: use `Error::source` when minimal rust version is updated
+    fn cause(&self) -> Option<&dyn Error> {
+        match *self {
+            ImageError::IoError(ref e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<io::Error> for ImageError {
+    fn from(err: io::Error) -> ImageError {
+        ImageError::IoError(err)
+    }
+}
+
+/// Result of an image decoding/encoding process
+pub type ImageResult<T> = Result<T, ImageError>;

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -49,7 +49,8 @@ use num_traits::Zero;
 
 use crate::buffer::{ImageBuffer, Pixel};
 use crate::color::ColorType;
-use crate::image::{GenericImage, GenericImageView, ImageError};
+use crate::error::ImageError;
+use crate::image::{GenericImage, GenericImageView};
 
 /// A flat buffer over a (multi channel) image.
 ///

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -43,7 +43,8 @@ pub use self::gif::{DisposalMethod, Frame};
 use crate::animation;
 use crate::buffer::{ImageBuffer, Pixel};
 use crate::color::{self, Rgba};
-use crate::image::{self, AnimationDecoder, ImageDecoder, ImageError, ImageResult};
+use crate::error::{ImageError, ImageResult};
+use crate::image::{self, AnimationDecoder, ImageDecoder};
 use num_rational::Ratio;
 
 /// GIF decoder

--- a/src/hdr/decoder.rs
+++ b/src/hdr/decoder.rs
@@ -12,7 +12,8 @@ use std::path::Path;
 use crate::Primitive;
 
 use crate::color::{ColorType, Rgb};
-use crate::image::{self, ImageDecoder, ImageDecoderExt, ImageError, ImageResult, Progress};
+use crate::error::{ImageError, ImageResult};
+use crate::image::{self, ImageDecoder, ImageDecoderExt, Progress};
 
 /// Adapter to conform to ```ImageDecoder``` trait
 #[derive(Debug)]

--- a/src/hdr/encoder.rs
+++ b/src/hdr/encoder.rs
@@ -1,7 +1,7 @@
 use crate::color::Rgb;
+use crate::error::ImageResult;
 use crate::hdr::{rgbe8, RGBE8Pixel, SIGNATURE};
 use std::io::{Result, Write};
-use crate::image::ImageResult;
 use std::cmp::Ordering;
 
 /// Radiance HDR encoder

--- a/src/ico/decoder.rs
+++ b/src/ico/decoder.rs
@@ -5,7 +5,8 @@ use std::marker::PhantomData;
 use std::mem;
 
 use crate::color::ColorType;
-use crate::image::{self, ImageDecoder, ImageError, ImageResult};
+use crate::error::{ImageError, ImageResult};
+use crate::image::{self, ImageDecoder};
 
 use self::InnerDecoder::*;
 use crate::bmp::BmpDecoder;

--- a/src/ico/encoder.rs
+++ b/src/ico/encoder.rs
@@ -2,7 +2,8 @@ use byteorder::{LittleEndian, WriteBytesExt};
 use std::io::{self, Write};
 
 use crate::color::ColorType;
-use crate::image::{ImageEncoder, ImageResult};
+use crate::error::ImageResult;
+use crate::image::ImageEncoder;
 
 use crate::png::PNGEncoder;
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,8 +1,5 @@
 #![allow(clippy::too_many_arguments)]
-
 use std::convert::TryFrom;
-use std::error::Error;
-use std::fmt;
 use std::io;
 use std::io::Read;
 use std::path::Path;
@@ -10,104 +7,12 @@ use std::ops::{Deref, DerefMut};
 
 use crate::buffer::{ImageBuffer, Pixel};
 use crate::color::{ColorType, ExtendedColorType};
+use crate::error::{ImageError, ImageResult};
 
 use crate::animation::Frames;
 
 #[cfg(feature = "pnm")]
 use crate::pnm::PNMSubtype;
-
-/// An enumeration of Image errors
-#[derive(Debug)]
-pub enum ImageError {
-    /// The Image is not formatted properly
-    FormatError(String),
-
-    /// The Image's dimensions are either too small or too large
-    DimensionError,
-
-    /// The Decoder does not support this image format
-    UnsupportedError(String),
-
-    /// The Decoder does not support this color type
-    UnsupportedColor(ExtendedColorType),
-
-    /// Not enough data was provided to the Decoder
-    /// to decode the image
-    NotEnoughData,
-
-    /// An I/O Error occurred while decoding the image
-    IoError(io::Error),
-
-    /// The end of the image has been reached
-    ImageEnd,
-
-    /// There is not enough memory to complete the given operation
-    InsufficientMemory,
-}
-
-impl fmt::Display for ImageError {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        match *self {
-            ImageError::FormatError(ref e) => write!(fmt, "Format error: {}", e),
-            ImageError::DimensionError => write!(
-                fmt,
-                "The Image's dimensions are either too \
-                 small or too large"
-            ),
-            ImageError::UnsupportedError(ref f) => write!(
-                fmt,
-                "The Decoder does not support the \
-                 image format `{}`",
-                f
-            ),
-            ImageError::UnsupportedColor(ref c) => write!(
-                fmt,
-                "The decoder does not support \
-                 the color type `{:?}`",
-                c
-            ),
-            ImageError::NotEnoughData => write!(
-                fmt,
-                "Not enough data was provided to the \
-                 Decoder to decode the image"
-            ),
-            ImageError::IoError(ref e) => e.fmt(fmt),
-            ImageError::ImageEnd => write!(fmt, "The end of the image has been reached"),
-            ImageError::InsufficientMemory => write!(fmt, "Insufficient memory"),
-        }
-    }
-}
-
-impl Error for ImageError {
-    fn description(&self) -> &str {
-        match *self {
-            ImageError::FormatError(..) => "Format error",
-            ImageError::DimensionError => "Dimension error",
-            ImageError::UnsupportedError(..) => "Unsupported error",
-            ImageError::UnsupportedColor(..) => "Unsupported color",
-            ImageError::NotEnoughData => "Not enough data",
-            ImageError::IoError(..) => "IO error",
-            ImageError::ImageEnd => "Image end",
-            ImageError::InsufficientMemory => "Insufficient memory",
-        }
-    }
-
-    fn cause(&self) -> Option<&dyn Error> {
-        match *self {
-            ImageError::IoError(ref e) => Some(e),
-            _ => None,
-        }
-    }
-}
-
-impl From<io::Error> for ImageError {
-    fn from(err: io::Error) -> ImageError {
-        ImageError::IoError(err)
-    }
-}
-
-/// Result of an image decoding/encoding process
-pub type ImageResult<T> = Result<T, ImageError>;
 
 /// An enumeration of supported image formats.
 /// Not all formats support both encoding and decoding.

--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -6,7 +6,8 @@ use std::marker::PhantomData;
 use std::mem;
 
 use crate::color::ColorType;
-use crate::image::{ImageDecoder, ImageError, ImageResult};
+use crate::image::ImageDecoder;
+use crate::error::{ImageError, ImageResult};
 
 /// JPEG decoder
 pub struct JpegDecoder<R> {

--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::too_many_arguments)]
 
 use byteorder::{BigEndian, WriteBytesExt};
-use crate::image::{ImageError, ImageResult};
+use crate::error::{ImageError, ImageResult};
 use crate::math::utils::clamp;
 use num_iter::range_step;
 use std::io::{self, Write};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,16 +31,16 @@ pub use crate::color::{ColorType, ExtendedColorType};
 
 pub use crate::color::{Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
 
+pub use crate::error::{ImageError, ImageResult};
+
 pub use crate::image::{AnimationDecoder,
                 GenericImage,
                 GenericImageView,
                 ImageDecoder,
                 ImageDecoderExt,
                 ImageEncoder,
-                ImageError,
                 ImageFormat,
                 ImageOutputFormat,
-                ImageResult,
                 Progress,
                 // Iterators
                 Pixels,
@@ -106,6 +106,7 @@ pub mod tiff;
 #[cfg(feature = "webp")]
 pub mod webp;
 
+mod error;
 mod animation;
 mod buffer;
 mod color;

--- a/src/png.rs
+++ b/src/png.rs
@@ -12,7 +12,8 @@ use std::convert::TryFrom;
 use std::io::{self, Read, Write};
 
 use crate::color::{ColorType, ExtendedColorType};
-use crate::image::{ImageDecoder, ImageEncoder, ImageError, ImageResult};
+use crate::error::{ImageError, ImageResult};
+use crate::image::{ImageDecoder, ImageEncoder};
 
 /// PNG Reader
 ///

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -8,7 +8,8 @@ use std::mem;
 use super::{ArbitraryHeader, ArbitraryTuplType, BitmapHeader, GraymapHeader, PixmapHeader};
 use super::{HeaderRecord, PNMHeader, PNMSubtype, SampleEncoding};
 use crate::color::{ColorType, ExtendedColorType};
-use crate::image::{self, ImageDecoder, ImageError, ImageResult};
+use crate::error::{ImageError, ImageResult};
+use crate::image::{self, ImageDecoder};
 use crate::utils;
 
 use byteorder::{BigEndian, ByteOrder, NativeEndian};

--- a/src/pnm/encoder.rs
+++ b/src/pnm/encoder.rs
@@ -8,7 +8,8 @@ use super::AutoBreak;
 use super::{ArbitraryHeader, ArbitraryTuplType, BitmapHeader, GraymapHeader, PixmapHeader};
 use super::{HeaderRecord, PNMHeader, PNMSubtype, SampleEncoding};
 use crate::color::{ColorType, ExtendedColorType};
-use crate::image::{ImageEncoder, ImageError, ImageResult};
+use crate::error::{ImageError, ImageResult};
+use crate::image::ImageEncoder;
 
 use byteorder::{BigEndian, WriteBytesExt};
 

--- a/src/tga/decoder.rs
+++ b/src/tga/decoder.rs
@@ -4,7 +4,8 @@ use std::io;
 use std::io::{Read, Seek};
 
 use crate::color::ColorType;
-use crate::image::{ImageDecoder, ImageError, ImageReadBuffer, ImageResult};
+use crate::error::{ImageError, ImageResult};
+use crate::image::{ImageDecoder, ImageReadBuffer};
 
 enum ImageType {
     NoImageData = 0,

--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -16,7 +16,8 @@ use std::mem;
 use byteorder::{NativeEndian, ByteOrder};
 
 use crate::color::{ColorType, ExtendedColorType};
-use crate::image::{ImageDecoder, ImageEncoder, ImageResult, ImageError};
+use crate::error::{ImageError, ImageResult};
+use crate::image::{ImageDecoder, ImageEncoder};
 use crate::utils::vec_u16_into_u8;
 
 /// Decoder for TIFF images.

--- a/src/webp/decoder.rs
+++ b/src/webp/decoder.rs
@@ -5,9 +5,8 @@ use std::io::{self, Cursor, Read};
 use std::marker::PhantomData;
 use std::mem;
 
-use crate::image;
 use crate::image::ImageDecoder;
-use crate::image::ImageResult;
+use crate::error::{ImageError, ImageResult};
 
 use crate::color;
 
@@ -45,13 +44,13 @@ impl<R: Read> WebPDecoder<R> {
         self.r.by_ref().take(4).read_to_end(&mut webp)?;
 
         if &*riff != b"RIFF" {
-            return Err(image::ImageError::FormatError(
+            return Err(ImageError::FormatError(
                 "Invalid RIFF signature.".to_string(),
             ));
         }
 
         if &*webp != b"WEBP" {
-            return Err(image::ImageError::FormatError(
+            return Err(ImageError::FormatError(
                 "Invalid WEBP signature.".to_string(),
             ));
         }
@@ -64,7 +63,7 @@ impl<R: Read> WebPDecoder<R> {
         self.r.by_ref().take(4).read_to_end(&mut vp8)?;
 
         if &*vp8 != b"VP8 " {
-            return Err(image::ImageError::FormatError(
+            return Err(ImageError::FormatError(
                 "Invalid VP8 signature.".to_string(),
             ));
         }


### PR DESCRIPTION
This resolves a few rebasing issues that came up while rebasing #928.

At least it is supposed to. I'm expecting a few pushes.