### PR TITLE
Error rework

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -12,7 +12,7 @@ use crate::image::ImageFormat;
 /// This high level enum is allows, by variant matching, a rough separation of concerns between
 /// underlying IO, the caller, format specifications, and the `image` implementation.
 #[derive(Debug)]
-pub enum NewImageError {
+pub enum ImageError {
     /// An error was encountered while decoding.
     ///
     /// This means that the input data did not conform to the specification of some image format,
@@ -54,7 +54,7 @@ pub enum NewImageError {
 
 /// An enumeration of Image errors
 #[derive(Debug)]
-pub enum ImageError {
+pub enum OldImageError {
     /// The Image is not formatted properly
     FormatError(String),
 
@@ -176,37 +176,37 @@ pub enum ImageFormatHint {
 
 #[allow(non_upper_case_globals)]
 #[allow(non_snake_case)]
-impl NewImageError {
+impl ImageError {
     pub(crate) const InsufficientMemory: Self =
-        NewImageError::Limits(LimitError {
+        ImageError::Limits(LimitError {
             kind: LimitErrorKind::InsufficientMemory,
         });
 
     pub(crate) const DimensionError: Self =
-        NewImageError::Parameter(ParameterError {
+        ImageError::Parameter(ParameterError {
             kind: ParameterErrorKind::DimensionMismatch,
             underlying: None,
         });
 
     pub(crate) const ImageEnd: Self =
-        NewImageError::Parameter(ParameterError {
+        ImageError::Parameter(ParameterError {
             kind: ParameterErrorKind::FailedAlready,
             underlying: None,
         });
 
     pub(crate) fn UnsupportedError(message: String) -> Self {
-        NewImageError::Unsupported(UnsupportedError::legacy_from_string(message))
+        ImageError::Unsupported(UnsupportedError::legacy_from_string(message))
     }
 
     pub(crate) fn UnsupportedColor(color: ExtendedColorType) -> Self {
-        NewImageError::Unsupported(UnsupportedError::new(
+        ImageError::Unsupported(UnsupportedError::new(
             ImageFormatHint::Unknown,
             UnsupportedErrorKind::Color(color),
         ))
     }
 
     pub(crate) fn FormatError(message: String) -> Self {
-        NewImageError::Decoding(DecodingError::legacy_from_string(message))
+        ImageError::Decoding(DecodingError::legacy_from_string(message))
     }
 }
 
@@ -260,9 +260,9 @@ impl LimitError {
     }
 }
 
-impl From<io::Error> for NewImageError {
-    fn from(err: io::Error) -> NewImageError {
-        NewImageError::IoError(err)
+impl From<io::Error> for ImageError {
+    fn from(err: io::Error) -> ImageError {
+        ImageError::IoError(err)
     }
 }
 
@@ -290,69 +290,69 @@ impl From<ImageFormatHint> for UnsupportedError {
     }
 }
 
-impl fmt::Display for ImageError {
+impl fmt::Display for OldImageError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match *self {
-            ImageError::FormatError(ref e) => write!(fmt, "Format error: {}", e),
-            ImageError::DimensionError => write!(
+            OldImageError::FormatError(ref e) => write!(fmt, "Format error: {}", e),
+            OldImageError::DimensionError => write!(
                 fmt,
                 "The Image's dimensions are either too \
                  small or too large"
             ),
-            ImageError::UnsupportedError(ref f) => write!(
+            OldImageError::UnsupportedError(ref f) => write!(
                 fmt,
                 "The Decoder does not support the \
                  image format `{}`",
                 f
             ),
-            ImageError::UnsupportedColor(ref c) => write!(
+            OldImageError::UnsupportedColor(ref c) => write!(
                 fmt,
                 "The decoder does not support \
                  the color type `{:?}`",
                 c
             ),
-            ImageError::NotEnoughData => write!(
+            OldImageError::NotEnoughData => write!(
                 fmt,
                 "Not enough data was provided to the \
                  Decoder to decode the image"
             ),
-            ImageError::IoError(ref e) => e.fmt(fmt),
-            ImageError::ImageEnd => write!(fmt, "The end of the image has been reached"),
-            ImageError::InsufficientMemory => write!(fmt, "Insufficient memory"),
+            OldImageError::IoError(ref e) => e.fmt(fmt),
+            OldImageError::ImageEnd => write!(fmt, "The end of the image has been reached"),
+            OldImageError::InsufficientMemory => write!(fmt, "Insufficient memory"),
         }
     }
 }
 
-impl Error for ImageError {
+impl Error for OldImageError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match *self {
-            ImageError::IoError(ref e) => Some(e),
+            OldImageError::IoError(ref e) => Some(e),
             _ => None,
         }
     }
 }
 
-impl From<io::Error> for ImageError {
-    fn from(err: io::Error) -> ImageError {
-        ImageError::IoError(err)
+impl From<io::Error> for OldImageError {
+    fn from(err: io::Error) -> OldImageError {
+        OldImageError::IoError(err)
     }
 }
 
 /// Result of an image decoding/encoding process
-pub type ImageResult<T> = Result<T, ImageError>;
+pub type OldImageResult<T> = Result<T, OldImageError>;
 
 /// Result of an image decoding/encoding process
-pub(crate) type NewImageResult<T> = Result<T, NewImageError>;
+pub type ImageResult<T> = Result<T, ImageError>;
 
-impl fmt::Display for NewImageError {
+impl fmt::Display for ImageError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self {
-            NewImageError::IoError(err) => err.fmt(fmt),
-            NewImageError::Decoding(err) => err.fmt(fmt),
-            NewImageError::Encoding(err) => err.fmt(fmt),
-            NewImageError::Parameter(err) => err.fmt(fmt),
-            NewImageError::Limits(err) => err.fmt(fmt),
-            NewImageError::Unsupported(err) => err.fmt(fmt),
+            ImageError::IoError(err) => err.fmt(fmt),
+            ImageError::Decoding(err) => err.fmt(fmt),
+            ImageError::Encoding(err) => err.fmt(fmt),
+            ImageError::Parameter(err) => err.fmt(fmt),
+            ImageError::Limits(err) => err.fmt(fmt),
+            ImageError::Unsupported(err) => err.fmt(fmt),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,35 +52,6 @@ pub enum ImageError {
     IoError(io::Error),
 }
 
-/// An enumeration of Image errors
-#[derive(Debug)]
-pub enum OldImageError {
-    /// The Image is not formatted properly
-    FormatError(String),
-
-    /// The Image's dimensions are either too small or too large
-    DimensionError,
-
-    /// The Decoder does not support this image format
-    UnsupportedError(String),
-
-    /// The Decoder does not support this color type
-    UnsupportedColor(ExtendedColorType),
-
-    /// Not enough data was provided to the Decoder
-    /// to decode the image
-    NotEnoughData,
-
-    /// An I/O Error occurred while decoding the image
-    IoError(io::Error),
-
-    /// The end of the image has been reached
-    ImageEnd,
-
-    /// There is not enough memory to complete the given operation
-    InsufficientMemory,
-}
-
 /// The implementation for an operation was not provided.
 ///
 /// See the variant [`Unsupported`] for more documentation.
@@ -289,57 +260,6 @@ impl From<ImageFormatHint> for UnsupportedError {
         }
     }
 }
-
-impl fmt::Display for OldImageError {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        match *self {
-            OldImageError::FormatError(ref e) => write!(fmt, "Format error: {}", e),
-            OldImageError::DimensionError => write!(
-                fmt,
-                "The Image's dimensions are either too \
-                 small or too large"
-            ),
-            OldImageError::UnsupportedError(ref f) => write!(
-                fmt,
-                "The Decoder does not support the \
-                 image format `{}`",
-                f
-            ),
-            OldImageError::UnsupportedColor(ref c) => write!(
-                fmt,
-                "The decoder does not support \
-                 the color type `{:?}`",
-                c
-            ),
-            OldImageError::NotEnoughData => write!(
-                fmt,
-                "Not enough data was provided to the \
-                 Decoder to decode the image"
-            ),
-            OldImageError::IoError(ref e) => e.fmt(fmt),
-            OldImageError::ImageEnd => write!(fmt, "The end of the image has been reached"),
-            OldImageError::InsufficientMemory => write!(fmt, "Insufficient memory"),
-        }
-    }
-}
-
-impl Error for OldImageError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match *self {
-            OldImageError::IoError(ref e) => Some(e),
-            _ => None,
-        }
-    }
-}
-
-impl From<io::Error> for OldImageError {
-    fn from(err: io::Error) -> OldImageError {
-        OldImageError::IoError(err)
-    }
-}
-
-/// Result of an image decoding/encoding process
-pub type OldImageResult<T> = Result<T, OldImageError>;
 
 /// Result of an image decoding/encoding process
 pub type ImageResult<T> = Result<T, ImageError>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,7 @@
 //! Contains detailed error representation.
 
+use std::{fmt, io, mem};
 use std::error::Error;
-use std::fmt;
-use std::io;
 
 use crate::color::ExtendedColorType;
 use crate::image::ImageFormat;
@@ -145,6 +144,7 @@ pub enum ImageFormatHint {
     __NonExhaustive,
 }
 
+// Internal implementation block for ImageError.
 #[allow(non_upper_case_globals)]
 #[allow(non_snake_case)]
 impl ImageError {
@@ -511,5 +511,21 @@ impl fmt::Display for ImageFormatHint {
             ImageFormatHint::Unknown => write!(fmt, "`Unknown`"),
             ImageFormatHint::__NonExhaustive => unreachable!(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(dead_code)]
+    // This will fail to compile if the size of this type is large.
+    const ASSERT_SMALLISH: usize = [0][(mem::size_of::<ImageError>() >= 200) as usize];
+
+    #[test]
+    fn test_send_sync_stability() {
+        fn assert_send_sync<T: Send + Sync>() { }
+
+        assert_send_sync::<ImageError>();
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,17 @@
 //! Contains detailed error representation.
+//!
+//! See the main [`ImageError`] which contains a variant for each specialized error type. The
+//! subtypes used in each variant are opaque by design. They can be roughly inspected through their
+//! respective `kind` methods which work similar to `std::io::Error::kind`.
+//!
+//! The error interface makes it possible to inspect the error of an underlying decoder or encoder,
+//! through the `Error::source` method. Note that this is not part of the stable interface and you
+//! may not rely on a particular error value for a particular operation. This means mainly that
+//! `image` does not promise to remain on a particular version of its underlying decoders but if
+//! you ensure to use the same version of the dependency (or at least of the error type) through
+//! external means then you could inspect the error type in slightly more detail.
+//!
+//! [`ImageError`]: enum.ImageError.html
 
 use std::{fmt, io};
 use std::error::Error;
@@ -9,7 +22,7 @@ use crate::utils::NonExhaustiveMarker;
 
 /// The generic error type for image operations.
 ///
-/// This high level enum is allows, by variant matching, a rough separation of concerns between
+/// This high level enum allows, by variant matching, a rough separation of concerns between
 /// underlying IO, the caller, format specifications, and the `image` implementation.
 #[derive(Debug)]
 pub enum ImageError {
@@ -56,7 +69,7 @@ pub enum ImageError {
 ///
 /// See the variant [`Unsupported`] for more documentation.
 ///
-/// [`Unsupported`]: struct.ImageError.html#variant.Unsupported
+/// [`Unsupported`]: enum.ImageError.html#variant.Unsupported
 #[derive(Debug)]
 pub struct UnsupportedError {
     format: ImageFormatHint,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,56 @@
+//! Contains detailed error representation.
+
 use std::error::Error;
 use std::fmt;
 use std::io;
+
 use crate::color::ExtendedColorType;
+use crate::image::ImageFormat;
+
+/// The generic error type for image operations.
+///
+/// This high level enum is allows, by variant matching, a rough separation of concerns between
+/// underlying IO, the caller, format specifications, and the `image` implementation.
+#[derive(Debug)]
+pub enum NewImageError {
+    /// An error was encountered while decoding.
+    ///
+    /// This means that the input data did not conform to the specification of some image format,
+    /// or that no format could be determined, or that it did not match format specific
+    /// requirements set by the caller.
+    Decoding(DecodingError),
+
+    /// An error was encountered while encoding.
+    ///
+    /// The input image can not be encoded with the chosen format, for example because the
+    /// specification has no representation for its color space or because a necessary conversion
+    /// is ambiguous. In some cases it might also happen that the dimensions can not be used with
+    /// the format.
+    Encoding(EncodingError),
+
+    /// An error was encountered in inputs arguments.
+    ///
+    /// This is a catch-all case for strictly internal operations such as scaling, conversions,
+    /// etc. that involve no external format specifications.
+    Parameter(ParameterError),
+
+    /// Completing the operation would have required more resources than allowed.
+    ///
+    /// Errors of this type are limits set by the user or environment, *not* inherent in a specific
+    /// format or operation that was executed.
+    Limits(LimitError),
+
+    /// An operation can not be completed by the chosen abstraction.
+    ///
+    /// This means that it might be possible for the operation to succeed in general but
+    /// * it requires a disabled feature,
+    /// * the implementation does not yet exist, or
+    /// * no abstraction for a lower level could be found.
+    Unsupported(UnsupportedError),
+
+    /// An error occurred while interacting with the environment.
+    IoError(io::Error),
+}
 
 /// An enumeration of Image errors
 #[derive(Debug)]
@@ -30,6 +79,125 @@ pub enum ImageError {
 
     /// There is not enough memory to complete the given operation
     InsufficientMemory,
+}
+
+/// The implementation for an operation was not provided.
+///
+/// See the variant [`Unsupported`] for more documentation.
+///
+/// [`Unsupported`]: struct.ImageError.html#variant.Unsupported
+#[derive(Debug)]
+pub struct UnsupportedError {
+    format: ImageFormatHint,
+    kind: UnsupportedErrorKind,
+}
+
+/// Details what feature is not supported.
+#[derive(Clone, Debug, Hash, PartialEq)]
+pub enum UnsupportedErrorKind {
+    /// The required color type can not be handled.
+    Color(ExtendedColorType),
+    /// An image format is not supported.
+    Format(ImageFormatHint),
+    Feature,
+    #[doc(hidden)]
+    __NonExhaustive,
+}
+
+#[derive(Debug)]
+pub struct EncodingError {
+    format: ImageFormatHint,
+    message: String,
+    underlying: Option<Box<dyn Error>>,
+}
+
+#[derive(Debug)]
+pub struct ParameterError {
+    kind: ParameterErrorKind,
+    underlying: Option<Box<dyn Error>>,
+}
+
+/// Details how a parameter is malformed.
+#[derive(Clone, Debug, Hash, PartialEq)]
+pub enum ParameterErrorKind {
+    /// Repeated an operation for which error that could not be cloned was emitted already.
+    FailedAlready,
+    /// The dimensions passed are wrong.
+    DimensionMismatch,
+    /// A string describing the parameter.
+    /// This is discouraged and is likely to get deprecated (but not removed).
+    Generic(String),
+    #[doc(hidden)]
+    __NonExhaustive,
+}
+
+#[derive(Debug)]
+pub struct DecodingError {
+    format: ImageFormatHint,
+    message: String,
+    underlying: Option<Box<dyn Error>>,
+}
+
+#[derive(Debug)]
+pub struct LimitError {
+    kind: LimitErrorKind,
+    // do we need an underlying error?
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[allow(missing_copy_implementations)] // Might be non-Copy in the future.
+pub enum LimitErrorKind {
+    DimensionError,
+    InsufficientMemory,
+    #[doc(hidden)]
+    __NonExhaustive,
+}
+
+/// A best effort representation for image formats.
+#[derive(Clone, Debug, Hash, PartialEq)]
+pub enum ImageFormatHint {
+    /// The format is known exactly.
+    Exact(ImageFormat),
+
+    /// The format can be identified by a name.
+    Name(String),
+
+    /// A common path extension for the format is known.
+    PathExtension(std::path::PathBuf),
+
+    /// The format is not known or could not be determined.
+    Unknown,
+
+    #[doc(hidden)]
+    __NonExhaustive,
+}
+
+impl UnsupportedError {
+    pub fn kind(&self) -> UnsupportedErrorKind {
+        self.kind.clone()
+    }
+
+    pub fn format_hint(&self) -> ImageFormatHint {
+        self.format.clone()
+    }
+}
+
+impl DecodingError {
+    pub fn format_hint(&self) -> ImageFormatHint {
+        self.format.clone()
+    }
+}
+
+impl EncodingError {
+    pub fn format_hint(&self) -> ImageFormatHint {
+        self.format.clone()
+    }
+}
+
+impl LimitError {
+    pub fn kind(&self) -> LimitErrorKind {
+        self.kind.clone()
+    }
 }
 
 impl fmt::Display for ImageError {
@@ -82,3 +250,157 @@ impl From<io::Error> for ImageError {
 
 /// Result of an image decoding/encoding process
 pub type ImageResult<T> = Result<T, ImageError>;
+
+impl fmt::Display for NewImageError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self {
+            NewImageError::IoError(err) => err.fmt(fmt),
+            NewImageError::Decoding(err) => err.fmt(fmt),
+            NewImageError::Encoding(err) => err.fmt(fmt),
+            NewImageError::Parameter(err) => err.fmt(fmt),
+            NewImageError::Limits(err) => err.fmt(fmt),
+            NewImageError::Unsupported(err) => err.fmt(fmt),
+        }
+    }
+}
+
+impl fmt::Display for UnsupportedError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match &self.kind {
+            UnsupportedErrorKind::Format(ImageFormatHint::Unknown) => write!(
+                fmt,
+                "The image format could not be determined",
+            ),
+            UnsupportedErrorKind::Format(format @ ImageFormatHint::PathExtension(_)) => write!(
+                fmt,
+                "The file extension {} was not recognized as an image format",
+                format,
+            ),
+            UnsupportedErrorKind::Format(format) => write!(
+                fmt,
+                "The image format {} is not supported",
+                format,
+            ),
+            UnsupportedErrorKind::Color(color) => write!(
+                fmt,
+                "The decoder for {} does not support the color type `{:?}`",
+                self.format,
+                color,
+            ),
+            UnsupportedErrorKind::Feature => unimplemented!(),
+            UnsupportedErrorKind::__NonExhaustive => unreachable!()
+        }
+    }
+}
+
+impl Error for UnsupportedError { }
+
+impl fmt::Display for ParameterError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match &self.kind {
+            ParameterErrorKind::DimensionMismatch => write!(
+                fmt,
+                "The Image's dimensions are either too \
+                 small or too large"
+            ),
+            ParameterErrorKind::FailedAlready => write!(
+                fmt,
+                "The end the image stream has been reached due to a previous error"
+            ),
+            ParameterErrorKind::Generic(message) => write!(
+                fmt,
+                "The parameter is malformed: {}",
+                message,
+            ),
+            ParameterErrorKind::__NonExhaustive => unreachable!(),
+        }?;
+
+        if let Some(underlying) = &self.underlying {
+            write!(fmt, "\n{}", underlying)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Error for ParameterError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.underlying.as_ref().map(|b| &**b)
+    }
+}
+
+impl fmt::Display for EncodingError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match &self.underlying {
+            Some(underlying) => write!(
+                fmt,
+                "Format error encoding {}: {}\n{}",
+                self.format,
+                self.message,
+                underlying,
+            ),
+            None => write!(
+                fmt,
+                "Format error encoding {}: {}",
+                self.format,
+                self.message,
+            ),
+        }
+    }
+}
+
+impl Error for EncodingError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.underlying.as_ref().map(|b| &**b)
+    }
+}
+
+impl fmt::Display for DecodingError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match &self.underlying {
+            Some(underlying) => write!(
+                fmt,
+                "Format error decoding {}: {}\n{}",
+                self.format,
+                self.message,
+                underlying,
+            ),
+            None => write!(
+                fmt,
+                "Format error decoding {}: {}",
+                self.format,
+                self.message,
+            ),
+        }
+    }
+}
+
+impl Error for DecodingError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.underlying.as_ref().map(|b| &**b)
+    }
+}
+
+impl fmt::Display for LimitError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self.kind {
+            LimitErrorKind::InsufficientMemory => write!(fmt, "Insufficient memory"),
+            LimitErrorKind::DimensionError => write!(fmt, "Image is too large"),
+            LimitErrorKind::__NonExhaustive => unreachable!(),
+        }
+    }
+}
+
+impl Error for LimitError { }
+
+impl fmt::Display for ImageFormatHint {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self {
+            ImageFormatHint::Exact(format) => write!(fmt, "{:?}", format),
+            ImageFormatHint::Name(name) => write!(fmt, "`{}`", name),
+            ImageFormatHint::PathExtension(ext) => write!(fmt, "`.{:?}`", ext),
+            ImageFormatHint::Unknown => write!(fmt, "`Unknown`"),
+            ImageFormatHint::__NonExhaustive => unreachable!(),
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -125,7 +125,7 @@ pub enum ParameterErrorKind {
 #[derive(Debug)]
 pub struct DecodingError {
     format: ImageFormatHint,
-    message: Option<String>,
+    message: Option<Box<str>>,
     underlying: Option<Box<dyn Error + Send + Sync>>,
 }
 
@@ -277,7 +277,7 @@ impl DecodingError {
     pub(crate) fn legacy_from_string(message: String) -> Self {
         DecodingError {
             format: ImageFormatHint::Unknown,
-            message: Some(message),
+            message: Some(message.into_boxed_str()),
             underlying: None,
         }
     }
@@ -291,14 +291,14 @@ impl DecodingError {
     ) -> Self {
         DecodingError {
             format,
-            message: Some(message),
+            message: Some(message.into_boxed_str()),
             underlying: None,
         }
     }
 
     fn get_message_or_default(&self) -> &str {
-        match self.message {
-            Some(ref st) => st.as_str(),
+        match &self.message {
+            Some(st) => st,
             None => "",
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,7 @@ use std::error::Error;
 
 use crate::color::ExtendedColorType;
 use crate::image::ImageFormat;
+use crate::utils::NonExhaustiveMarker;
 
 /// The generic error type for image operations.
 ///
@@ -73,7 +74,7 @@ pub enum UnsupportedErrorKind {
     /// This is discouraged and is likely to get deprecated (but not removed).
     GenericFeature(String),
     #[doc(hidden)]
-    __NonExhaustive,
+    __NonExhaustive(NonExhaustiveMarker),
 }
 
 /// An error was encountered while encoding an image.
@@ -113,7 +114,7 @@ pub enum ParameterErrorKind {
     Generic(String),
     #[doc(hidden)]
     /// Do not use this, not part of stability guarantees.
-    __NonExhaustive,
+    __NonExhaustive(NonExhaustiveMarker),
 }
 
 /// An error was encountered while decoding an image.
@@ -154,7 +155,7 @@ pub enum LimitErrorKind {
     InsufficientMemory,
     #[doc(hidden)]
     /// Do not use this, not part of stability guarantees.
-    __NonExhaustive,
+    __NonExhaustive(NonExhaustiveMarker),
 }
 
 /// A best effort representation for image formats.
@@ -173,7 +174,7 @@ pub enum ImageFormatHint {
     Unknown,
 
     #[doc(hidden)]
-    __NonExhaustive,
+    __NonExhaustive(NonExhaustiveMarker),
 }
 
 // Internal implementation block for ImageError.
@@ -458,7 +459,7 @@ impl fmt::Display for UnsupportedError {
                     ),
                 }
             },
-            UnsupportedErrorKind::__NonExhaustive => unreachable!()
+            UnsupportedErrorKind::__NonExhaustive(marker) => match marker._private {},
         }
     }
 }
@@ -482,7 +483,7 @@ impl fmt::Display for ParameterError {
                 "The parameter is malformed: {}",
                 message,
             ),
-            ParameterErrorKind::__NonExhaustive => unreachable!(),
+            ParameterErrorKind::__NonExhaustive(marker) => match marker._private {},
         }?;
 
         if let Some(underlying) = &self.underlying {
@@ -570,7 +571,7 @@ impl fmt::Display for LimitError {
         match self.kind {
             LimitErrorKind::InsufficientMemory => write!(fmt, "Insufficient memory"),
             LimitErrorKind::DimensionError => write!(fmt, "Image is too large"),
-            LimitErrorKind::__NonExhaustive => unreachable!(),
+            LimitErrorKind::__NonExhaustive(marker) => match marker._private {},
         }
     }
 }
@@ -584,7 +585,7 @@ impl fmt::Display for ImageFormatHint {
             ImageFormatHint::Name(name) => write!(fmt, "`{}`", name),
             ImageFormatHint::PathExtension(ext) => write!(fmt, "`.{:?}`", ext),
             ImageFormatHint::Unknown => write!(fmt, "`Unknown`"),
-            ImageFormatHint::__NonExhaustive => unreachable!(),
+            ImageFormatHint::__NonExhaustive(marker) => match marker._private {},
         }
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -16,7 +16,7 @@ use crate::pnm::PNMSubtype;
 
 /// An enumeration of supported image formats.
 /// Not all formats support both encoding and decoding.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 pub enum ImageFormat {
     /// An Image in PNG Format
     Png,

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -169,7 +169,7 @@ pub(crate) fn save_buffer_impl(
         #[cfg(feature = "tiff")]
         "tif" | "tiff" => tiff::TiffEncoder::new(fout)
             .write_image(buf, width, height, color),
-        format => Err(ImageError::Unsupported(ImageFormatHint::from(path).into())),
+        _ => Err(ImageError::Unsupported(ImageFormatHint::from(path).into())),
     }
 }
 
@@ -229,7 +229,7 @@ pub(crate) fn guess_format_from_path_impl(path: &Path) -> Result<ImageFormat, Pa
         Some("hdr") => image::ImageFormat::Hdr,
         Some("pbm") | Some("pam") | Some("ppm") | Some("pgm") => image::ImageFormat::Pnm,
         // The original extension is used, instead of _format
-        _format => return match exact_ext {
+        _ => return match exact_ext {
             None => Err(PathError::NoExtension),
             Some(os) => Err(PathError::UnknownExtension(os.to_owned())),
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,9 @@ pub use crate::dynimage::DynamicImage;
 
 pub use crate::animation::{Frame, Frames};
 
+// More detailed error type
+pub mod error;
+
 // Math utils
 pub mod math;
 
@@ -108,7 +111,6 @@ pub mod tiff;
 #[cfg(feature = "webp")]
 pub mod webp;
 
-mod error;
 mod animation;
 mod buffer;
 mod color;

--- a/src/png.rs
+++ b/src/png.rs
@@ -274,13 +274,13 @@ impl ImageError {
             )),
             LimitsExceeded => ImageError::InsufficientMemory,
             // Other is used when the buffer to `Reader::next_frame` is too small.
-            Other(message) => ImageError::Parameter(ParameterError::new(
+            Other(message) => ImageError::Parameter(ParameterError::from_kind(
                 ParameterErrorKind::Generic(message.into_owned())
             )),
             err @ InvalidSignature
             | err @ CrcMismatch { .. }
             | err @ CorruptFlateStream => {
-                ImageError::Decoding(DecodingError::with_underlying(
+                ImageError::Decoding(DecodingError::new(
                     ImageFormat::Png.into(),
                     err,
                 ))

--- a/tests/reference_images.rs
+++ b/tests/reference_images.rs
@@ -50,7 +50,7 @@ fn render_images() {
             // Do not fail on unsupported error
             // This might happen because the testsuite contains unsupported images
             // or because a specific decoder included via a feature.
-            Err(image::ImageError::UnsupportedError(e)) => {
+            Err(image::ImageError::Unsupported(e)) => {
                 println!("UNSUPPORTED {}: {}", path.display(), e);
                 return;
             }
@@ -161,7 +161,7 @@ fn check_references() {
             // Do not fail on unsupported error
             // This might happen because the testsuite contains unsupported images
             // or because a specific decoder included via a feature.
-            Err(image::ImageError::UnsupportedError(_)) => return,
+            Err(image::ImageError::Unsupported(_)) => return,
             Err(err) => panic!(format!("{}", err)),
         };
 
@@ -192,7 +192,7 @@ fn check_references() {
                     let stream = io::BufReader::new(fs::File::open(&img_path).unwrap());
                     let decoder = match image::gif::GifDecoder::new(stream) {
                         Ok(decoder) => decoder,
-                        Err(image::ImageError::UnsupportedError(_)) => return,
+                        Err(image::ImageError::Unsupported(_)) => return,
                         Err(err) => {
                             panic!(format!("decoding of {:?} failed with: {}", img_path, err))
                         }
@@ -200,7 +200,7 @@ fn check_references() {
 
                     let mut frames = match decoder.into_frames().collect_frames() {
                         Ok(frames) => frames,
-                        Err(image::ImageError::UnsupportedError(_)) => return,
+                        Err(image::ImageError::Unsupported(_)) => return,
                         Err(err) => panic!(format!(
                             "collecting frames of {:?} failed with: {}",
                             img_path, err
@@ -228,7 +228,7 @@ fn check_references() {
                     // Do not fail on unsupported error
                     // This might happen because the testsuite contains unsupported images
                     // or because a specific decoder included via a feature.
-                    Err(image::ImageError::UnsupportedError(_)) => return,
+                    Err(image::ImageError::Unsupported(_)) => return,
                     Err(err) => panic!(format!("decoding of {:?} failed with: {}", img_path, err)),
                 };
             }


### PR DESCRIPTION
Moves away from a single, open representation of errors to an extensible and precise one. This considers a previously identified few issues (in #928):

* The new variants are somewhat actionable since they at least identify the
  cause more closely.
* They are extensible as most state is opaque to some degree and key
  enumerations are marked as non-exhaustive which allows us to extend
  it later, for example to capture the difference between dimension 
  mismatch errors.
* They are more precise as the opaque state allows storing specialized
  variants for supported formats while still maintaining a uniform
  interface and permitting extension formats outside the library.
* Handling of 'stringification' is more principled as error values can
  be stored as-is instead of converting them on the spot. This might
  also improve the performance when the conversion is not required.

Issues: #921, #938, #896, #823, #741, 
PRs: #1066, #928,

Closes: #928 