### PR TITLE
Update tiff dependency to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ version = "0.1"
 optional = true
 
 [dependencies.tiff]
-version = "0.3.1"
+version = "0.4.0"
 optional = true
 
 [dev-dependencies]


### PR DESCRIPTION
tiff 0.3.1 pulls in num-derive 0.2.5 which pulls in old versions of syn/quote/proc-macro2. This increases compile times by quite a bit. tiff 0.4.0 seems to have removed that dependency entirely. Simply updating the crate version here is enough to make `cargo test` pass so hopefully this is an easy compile time win!

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

