### PR TITLE
Add support for DDS files using DXT1, DXT3 or DXT5 compression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
     - FEATURES='png'
     - FEATURES='pnm'
     - FEATURES='tga'
+    - FEATURES='dds'
     - FEATURES='tiff'
     - FEATURES='webp'
     - FEATURES='hdr'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ glob = "0.3"
 quickcheck = "0.9"
 
 [features]
-default = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "jpeg_rayon"]
+default = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "dds", "jpeg_rayon"]
 
 ico = ["bmp", "png"]
 pnm = []
@@ -48,6 +48,7 @@ webp = []
 bmp = []
 hdr = ["scoped_threadpool"]
 dxt = []
+dds = []
 jpeg_rayon = ["jpeg/rayon"]
 
 benchmarks = []

--- a/src/dds.rs
+++ b/src/dds.rs
@@ -1,0 +1,170 @@
+//!  Decoding of DDS images
+//!
+//!  DDS (DirectDraw Surface) is a container format for storing DXT (S3TC) compressed images.
+//!
+//!  # Related Links
+//!  * <https://docs.microsoft.com/en-us/windows/win32/direct3ddds/dx-graphics-dds-pguide> - Description of the DDS format.
+
+use std::io::Read;
+
+use byteorder::{LittleEndian, ReadBytesExt};
+
+use crate::color::ColorType;
+use crate::dxt::{DxtDecoder, DXTReader, DXTVariant};
+use crate::error::{ImageError, ImageResult};
+use crate::image::ImageDecoder;
+
+
+/// Header used by DDS image files
+#[derive(Debug)]
+struct Header {
+    flags: u32,
+    height: u32,
+    width: u32,
+    pitch_or_linear_size: u32,
+    depth: u32,
+    mipmap_count: u32,
+    pixel_format: PixelFormat,
+    caps: u32,
+    caps2: u32,
+}
+
+/// DDS pixel format
+#[derive(Debug)]
+struct PixelFormat {
+    flags: u32,
+    fourcc: [u8; 4],
+    rgb_bit_count: u32,
+    r_bit_mask: u32,
+    g_bit_mask: u32,
+    b_bit_mask: u32,
+    a_bit_mask: u32,
+}
+
+impl PixelFormat {
+    fn from_reader(r: &mut dyn Read) -> ImageResult<Self> {
+        let size = r.read_u32::<LittleEndian>()?;
+        if size != 32 {
+            return Err(ImageError::FormatError("Invalid DDS PixelFormat size".to_string()))
+        }
+
+        Ok(Self {
+            flags: r.read_u32::<LittleEndian>()?,
+            fourcc: {
+                let mut v = [0; 4];
+                r.read_exact(&mut v)?;
+                v
+            },
+            rgb_bit_count: r.read_u32::<LittleEndian>()?,
+            r_bit_mask: r.read_u32::<LittleEndian>()?,
+            g_bit_mask: r.read_u32::<LittleEndian>()?,
+            b_bit_mask: r.read_u32::<LittleEndian>()?,
+            a_bit_mask: r.read_u32::<LittleEndian>()?,
+        })
+    }
+}
+
+impl Header {
+    fn from_reader(r: &mut dyn Read) -> ImageResult<Self> {
+        let size = r.read_u32::<LittleEndian>()?;
+        if size != 124 {
+            return Err(ImageError::FormatError("Invalid DDS header size".to_string()))
+        }
+
+        const REQUIRED_FLAGS: u32 = 0x1 | 0x2 | 0x4 | 0x1000;
+        const VALID_FLAGS: u32 = 0x1 | 0x2 | 0x4 | 0x8 | 0x1000 | 0x20000 | 0x80000 | 0x800000;
+        let flags = r.read_u32::<LittleEndian>()?;
+        if flags & (REQUIRED_FLAGS | !VALID_FLAGS) != REQUIRED_FLAGS {
+            return Err(ImageError::FormatError("Invalid DDS header flags".to_string()))
+        }
+
+        let height = r.read_u32::<LittleEndian>()?;
+        let width = r.read_u32::<LittleEndian>()?;
+        let pitch_or_linear_size = r.read_u32::<LittleEndian>()?;
+        let depth = r.read_u32::<LittleEndian>()?;
+        let mipmap_count = r.read_u32::<LittleEndian>()?;
+        // Skip `dwReserved1`
+        {
+            let mut skipped = [0; 4 * 11];
+            r.read_exact(&mut skipped)?;
+        }
+        let pixel_format = PixelFormat::from_reader(r)?;
+        let caps = r.read_u32::<LittleEndian>()?;
+        let caps2 = r.read_u32::<LittleEndian>()?;
+        // Skip `dwCaps3`, `dwCaps4`, `dwReserved2` (unused)
+        {
+            let mut skipped = [0; 4 + 4 + 4];
+            r.read_exact(&mut skipped)?;
+        }
+
+        Ok(Self {
+            flags,
+            height,
+            width,
+            pitch_or_linear_size,
+            depth,
+            mipmap_count,
+            pixel_format,
+            caps,
+            caps2,
+        })
+    }
+}
+
+
+/// The representation of a DDS decoder
+pub struct DdsDecoder<R: Read> {
+    inner: DxtDecoder<R>,
+}
+
+impl<R: Read> DdsDecoder<R> {
+    /// Create a new decoder that decodes from the stream `r`
+    pub fn new(mut r: R) -> ImageResult<Self> {
+        let mut magic = [0; 4];
+        r.read_exact(&mut magic)?;
+        if magic != b"DDS "[..] {
+            return Err(ImageError::FormatError("DDS signature not found".to_string()))
+        }
+
+        let header = Header::from_reader(&mut r)?;
+
+        if header.pixel_format.flags & 0x4 != 0 {
+            let variant = match &header.pixel_format.fourcc {
+                b"DXT1" => DXTVariant::DXT1,
+                b"DXT3" => DXTVariant::DXT3,
+                b"DXT5" => DXTVariant::DXT5,
+                _ => return Err(ImageError::FormatError("Unsupported DDS FourCC".to_string())),
+            };
+            let inner = DxtDecoder::new(r, header.width, header.height, variant)?;
+            Ok(Self { inner })
+        } else {
+            // For now, supports only DXT variants
+            Err(ImageError::FormatError("DDS format not supported".to_string()))
+        }
+    }
+}
+
+impl<'a, R: 'a + Read> ImageDecoder<'a> for DdsDecoder<R> {
+    type Reader = DXTReader<R>;
+
+    fn dimensions(&self) -> (u32, u32) {
+        self.inner.dimensions()
+    }
+
+    fn color_type(&self) -> ColorType {
+        self.inner.color_type()
+    }
+
+    fn scanline_bytes(&self) -> u64 {
+        self.inner.scanline_bytes()
+    }
+
+    fn into_reader(self) -> ImageResult<Self::Reader> {
+        self.inner.into_reader()
+    }
+
+    fn read_image(self, buf: &mut [u8]) -> ImageResult<()> {
+        self.inner.read_image(buf)
+    }
+}
+

--- a/src/image.rs
+++ b/src/image.rs
@@ -39,6 +39,9 @@ pub enum ImageFormat {
     /// An Image in TGA Format
     Tga,
 
+    /// An Image in DDS Format
+    Dds,
+
     /// An Image in BMP Format
     Bmp,
 
@@ -931,6 +934,7 @@ mod tests {
         assert_eq!(from_path("./a.tiFF").unwrap(), ImageFormat::Tiff);
         assert_eq!(from_path("./a.tif").unwrap(), ImageFormat::Tiff);
         assert_eq!(from_path("./a.tga").unwrap(), ImageFormat::Tga);
+        assert_eq!(from_path("./a.dds").unwrap(), ImageFormat::Dds);
         assert_eq!(from_path("./a.bmp").unwrap(), ImageFormat::Bmp);
         assert_eq!(from_path("./a.Ico").unwrap(), ImageFormat::Ico);
         assert_eq!(from_path("./a.hdr").unwrap(), ImageFormat::Hdr);

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -20,6 +20,8 @@ use crate::png;
 use crate::pnm;
 #[cfg(feature = "tga")]
 use crate::tga;
+#[cfg(feature = "dds")]
+use crate::dds;
 #[cfg(feature = "tiff")]
 use crate::tiff;
 #[cfg(feature = "webp")]
@@ -70,6 +72,8 @@ pub fn load<R: BufRead + Seek>(r: R, format: ImageFormat) -> ImageResult<Dynamic
         image::ImageFormat::Tiff => DynamicImage::from_decoder(tiff::TiffDecoder::new(r)?),
         #[cfg(feature = "tga")]
         image::ImageFormat::Tga => DynamicImage::from_decoder(tga::TgaDecoder::new(r)?),
+        #[cfg(feature = "dds")]
+        image::ImageFormat::Dds => DynamicImage::from_decoder(dds::DdsDecoder::new(r)?),
         #[cfg(feature = "bmp")]
         image::ImageFormat::Bmp => DynamicImage::from_decoder(bmp::BmpDecoder::new(r)?),
         #[cfg(feature = "ico")]
@@ -112,6 +116,8 @@ pub(crate) fn image_dimensions_with_format_impl<R: BufRead + Seek>(fin: R, forma
         image::ImageFormat::Tiff => tiff::TiffDecoder::new(fin)?.dimensions(),
         #[cfg(feature = "tga")]
         image::ImageFormat::Tga => tga::TgaDecoder::new(fin)?.dimensions(),
+        #[cfg(feature = "dds")]
+        image::ImageFormat::Dds => dds::DdsDecoder::new(fin)?.dimensions(),
         #[cfg(feature = "bmp")]
         image::ImageFormat::Bmp => bmp::BmpDecoder::new(fin)?.dimensions(),
         #[cfg(feature = "ico")]
@@ -223,6 +229,7 @@ pub(crate) fn guess_format_from_path_impl(path: &Path) -> Result<ImageFormat, Pa
         Some("webp") => image::ImageFormat::WebP,
         Some("tif") | Some("tiff") => image::ImageFormat::Tiff,
         Some("tga") => image::ImageFormat::Tga,
+        Some("dds") => image::ImageFormat::Dds,
         Some("bmp") => image::ImageFormat::Bmp,
         Some("ico") => image::ImageFormat::Ico,
         Some("hdr") => image::ImageFormat::Hdr,
@@ -235,7 +242,7 @@ pub(crate) fn guess_format_from_path_impl(path: &Path) -> Result<ImageFormat, Pa
     })
 }
 
-static MAGIC_BYTES: [(&'static [u8], ImageFormat); 17] = [
+static MAGIC_BYTES: [(&'static [u8], ImageFormat); 18] = [
     (b"\x89PNG\r\n\x1a\n", ImageFormat::Png),
     (&[0xff, 0xd8, 0xff], ImageFormat::Jpeg),
     (b"GIF89a", ImageFormat::Gif),
@@ -243,6 +250,7 @@ static MAGIC_BYTES: [(&'static [u8], ImageFormat); 17] = [
     (b"RIFF", ImageFormat::WebP), // TODO: better magic byte detection, see https://github.com/image-rs/image/issues/660
     (b"MM\x00*", ImageFormat::Tiff),
     (b"II*\x00", ImageFormat::Tiff),
+    (b"DDS ", ImageFormat::Dds),
     (b"BM", ImageFormat::Bmp),
     (&[0, 0, 1, 0], ImageFormat::Ico),
     (b"#?RADIANCE", ImageFormat::Hdr),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,8 @@ pub mod flat;
 // Image codecs
 #[cfg(feature = "bmp")]
 pub mod bmp;
+#[cfg(feature = "dds")]
+pub mod dds;
 #[cfg(feature = "dxt")]
 pub mod dxt;
 #[cfg(feature = "gif")]


### PR DESCRIPTION
Basically, the DDS decoder parses the DDS header to create a DXT decoder. `ImageDecoder` is implemented by forwarding calls to this inner DXT decoder.

The DDS header (which includes pixel format) is parsed, even if only few fields are used by the current code.
Full support would require to handle all kinds of DDS formats and provide an alternate `ImageDecoder` implementation for non-DXT formats.

This is a first step towards closing #621.