### PR TITLE
Make ImageFormat related enums non-exhaustive

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -31,7 +31,7 @@ pub enum ColorType {
     Bgra8,
 
     #[doc(hidden)]
-    __Nonexhaustive,
+    __NonExhaustive(crate::utils::NonExhaustiveMarker),
 }
 
 impl ColorType {
@@ -44,7 +44,7 @@ impl ColorType {
             ColorType::Rgba8 | ColorType::Bgra8 | ColorType::La16 => 4,
             ColorType::Rgb16 => 6,
             ColorType::Rgba16 => 8,
-            ColorType::__Nonexhaustive => unreachable!(),
+            ColorType::__NonExhaustive(marker) => match marker._private {},
         }
     }
 
@@ -100,7 +100,7 @@ pub enum ExtendedColorType {
     Unknown(u8),
 
     #[doc(hidden)]
-    __Nonexhaustive,
+    __NonExhaustive(crate::utils::NonExhaustiveMarker),
 }
 
 impl ExtendedColorType {
@@ -133,7 +133,7 @@ impl ExtendedColorType {
             ExtendedColorType::Rgba8 |
             ExtendedColorType::Rgba16 |
             ExtendedColorType::Bgra8 => 4,
-            ExtendedColorType::__Nonexhaustive => unreachable!(),
+            ExtendedColorType::__NonExhaustive(marker) => match marker._private {},
         }
     }
 }
@@ -150,7 +150,7 @@ impl From<ColorType> for ExtendedColorType {
             ColorType::Rgba16 => ExtendedColorType::Rgba16,
             ColorType::Bgr8 => ExtendedColorType::Bgr8,
             ColorType::Bgra8 => ExtendedColorType::Bgra8,
-            ColorType::__Nonexhaustive => unreachable!(),
+            ColorType::__NonExhaustive(marker) => match marker._private {},
         }
     }
 }

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -688,7 +688,9 @@ impl DynamicImage {
 
             image::ImageOutputFormat::Unsupported(msg) => {
                 Err(ImageError::UnsupportedError(msg))
-            }
+            },
+
+            image::ImageOutputFormat::__NonExhaustive(marker) => match marker._private {},
         }
     }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -47,6 +47,9 @@ pub enum ImageFormat {
 
     /// An Image in Radiance HDR Format
     Hdr,
+
+    #[doc(hidden)]
+    __NonExhaustive(crate::utils::NonExhaustiveMarker),
 }
 
 impl ImageFormat {
@@ -89,6 +92,9 @@ pub enum ImageOutputFormat {
     // Note: When TryFrom is stabilized, this value should not be needed, and
     // a TryInto<ImageOutputFormat> should be used instead of an Into<ImageOutputFormat>.
     Unsupported(String),
+
+    #[doc(hidden)]
+    __NonExhaustive(crate::utils::NonExhaustiveMarker),
 }
 
 impl From<ImageFormat> for ImageOutputFormat {

--- a/src/pnm/encoder.rs
+++ b/src/pnm/encoder.rs
@@ -448,7 +448,7 @@ impl<'a> CheckedHeaderColor<'a> {
             | ExtendedColorType::Rgb16
             | ExtendedColorType::Rgba16
                 => 0xffff,
-            ExtendedColorType::__Nonexhaustive => unreachable!(),
+            ExtendedColorType::__NonExhaustive(marker) => match marker._private {},
             _ => {
                 return Err(ImageError::IoError(io::Error::new(
                     io::ErrorKind::InvalidInput,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -74,6 +74,26 @@ pub(crate) fn vec_u16_copy_u8(vec: &[u16]) -> Vec<u8> {
     new
 }
 
+
+/// A marker struct for __NonExhaustive enums.
+///
+/// This is an empty type that can not be constructed. When an enum contains a tuple variant that
+/// includes this type the optimizer can statically determined tha the branch is never taken while
+/// at the same time the matching of the branch is required.
+///
+/// The effect is thus very similar to the actual `#[non_exhaustive]` attribute with no runtime
+/// costs. Also note that we use a dirty trick to not only hide this type from the doc but make it
+/// inaccessible. The visibility in this module is pub but the module itself is not and the
+/// top-level crate never exports the type.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct NonExhaustiveMarker {
+    /// Allows this crate, and this crate only, to match on the impossibility of this variant.
+    pub(crate) _private: Empty,
+}
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum Empty { }
+
 #[cfg(test)]
 mod test {
     #[test]


### PR DESCRIPTION
Future compatibility change to allow PRs such as #1121 without a 
breaking change.

Also note the curious and complicated but clever way of statically
eliminating the actual branch in matchings, and avoid the need for
unreachable markers within the crate. This has been ported to the other
uses of non-exhaustive enumerations.

