### PR TITLE
Add missing feature requirement dxt for dds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ webp = []
 bmp = []
 hdr = ["scoped_threadpool"]
 dxt = []
-dds = []
+dds = ["dxt"]
 jpeg_rayon = ["jpeg/rayon"]
 
 benchmarks = []


### PR DESCRIPTION
Missed that since the PR build of #1121 didn't trigger after a rebase. Fairly straightforward as the feature depends on the dxt decoder internally.