### PR TITLE
Interface restrictions for gif and jpeg

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -728,12 +728,7 @@ impl DynamicImage {
             #[cfg(feature = "gif")]
             image::ImageOutputFormat::Gif => {
                 let mut g = gif::Encoder::new(w);
-
-                g.encode(&gif::Frame::from_rgba(
-                    width as u16,
-                    height as u16,
-                    &mut *self.to_rgba().iter().cloned().collect::<Vec<u8>>(),
-                ))?;
+                g.encode_frame(crate::animation::Frame::new(self.to_rgba()))?;
                 Ok(())
             }
 

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -26,9 +26,6 @@
 //! ```
 #![allow(clippy::while_let_loop)]
 
-extern crate gif;
-extern crate num_rational;
-
 use std::clone::Clone;
 use std::convert::TryInto;
 use std::cmp::min;
@@ -37,15 +34,16 @@ use std::io::{self, Cursor, Read, Write};
 use std::marker::PhantomData;
 use std::mem;
 
-use self::gif::{ColorOutput, SetParameter};
-pub use self::gif::{DisposalMethod, Frame};
+use gif::{ColorOutput, SetParameter};
+use gif::DisposalMethod;
+pub(crate) use gif::Frame;
+use num_rational::Ratio;
 
 use crate::animation;
 use crate::buffer::{ImageBuffer, Pixel};
 use crate::color::{self, Rgba};
 use crate::error::{ImageError, ImageResult};
 use crate::image::{self, AnimationDecoder, ImageDecoder};
-use num_rational::Ratio;
 
 /// GIF decoder
 pub struct GifDecoder<R: Read> {
@@ -325,7 +323,7 @@ impl<W: Write> Encoder<W> {
         }
     }
     /// Encodes a frame.
-    pub fn encode(&mut self, frame: &Frame) -> ImageResult<()> {
+    pub(crate) fn encode(&mut self, frame: &Frame) -> ImageResult<()> {
         let result;
         if let Some(ref mut encoder) = self.gif_encoder {
             result = encoder.write_frame(frame).map_err(|err| err.into());
@@ -340,7 +338,7 @@ impl<W: Write> Encoder<W> {
 
     /// Encodes Frames.
     /// Consider using `try_encode_frames` instead to encode an `animation::Frames` like iterator.
-    pub fn encode_frames<F>(&mut self, frames: F) -> ImageResult<()>
+    pub(crate) fn encode_frames<F>(&mut self, frames: F) -> ImageResult<()>
     where
         F: IntoIterator<Item = animation::Frame>
     {
@@ -353,7 +351,7 @@ impl<W: Write> Encoder<W> {
     /// Try to encode a collection of `ImageResult<animation::Frame>` objects.
     /// Use this function to encode an `animation::Frames` like iterator.
     /// Whenever an `Err` item is encountered, that value is returned without further actions.
-    pub fn try_encode_frames<F>(&mut self, frames: F) -> ImageResult<()>
+    pub(crate) fn try_encode_frames<F>(&mut self, frames: F) -> ImageResult<()>
     where
         F: IntoIterator<Item = ImageResult<animation::Frame>>
     {
@@ -380,7 +378,7 @@ impl<W: Write> Encoder<W> {
 
 impl ImageError {
     fn from_gif(err: gif::DecodingError) -> ImageError {
-        use self::gif::DecodingError::*;
+        use gif::DecodingError::*;
         match err {
             Format(desc) | Internal(desc) => ImageError::FormatError(desc.into()),
             Io(io_err) => ImageError::IoError(io_err),

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -143,7 +143,7 @@ pub(crate) fn save_buffer_impl(
 
     match &*ext {
         #[cfg(feature = "gif")]
-        "gif" => gif::Encoder::new(fout).encode(&gif::Frame::from_rgb(width as u16, height as u16, &buf)),
+        "gif" => gif::Encoder::new(fout).encode(buf, width, height, color),
         #[cfg(feature = "ico")]
         "ico" => ico::ICOEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "jpeg")]
@@ -185,8 +185,7 @@ pub(crate) fn save_buffer_with_format_impl(
 
     match format {
         #[cfg(feature = "gif")]
-        image::ImageFormat::Gif => gif::Encoder::new(fout)
-            .encode(&gif::Frame::from_rgb(width as u16, height as u16, &buf)),
+        image::ImageFormat::Gif => gif::Encoder::new(fout).encode(buf, width, height, color),
         #[cfg(feature = "ico")]
         image::ImageFormat::Ico => ico::ICOEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "jpeg")]

--- a/src/png.rs
+++ b/src/png.rs
@@ -6,8 +6,6 @@
 //! * <http://www.w3.org/TR/PNG/> - The PNG Specification
 //!
 
-extern crate png;
-
 use std::convert::TryFrom;
 use std::io::{self, Read, Write};
 
@@ -265,7 +263,7 @@ impl<W: Write> ImageEncoder for PNGEncoder<W> {
 
 impl ImageError {
     fn from_png(err: png::DecodingError) -> ImageError {
-        use self::png::DecodingError::*;
+        use png::DecodingError::*;
         match err {
             IoError(err) => ImageError::IoError(err),
             Format(message) => ImageError::Decoding(DecodingError::with_message(


### PR DESCRIPTION
Hide some public interface dependencies on gif and jpeg. Note that frame
oriented functions are now unused and will likely be brought back in a
(slightly less generic) manner that is more uniform over other multi
frame formats as well.

