### PR TITLE
Add travis script and public dependency reference

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,14 @@ matrix:
       script:
         - rustup component add clippy
         - cargo clippy
+    - os: linux
+      rust: nightly
+      name: "Public private dependencies"
+      script:
+        - mv ./Cargo.toml.public-private-dependencies ./Cargo.toml
+        - echo "#![deny(exported_private_dependencies)]" | cat - src/lib.rs > src/lib.rs.0
+        - mv src/lib.rs.0 src/lib.rs
+        - cargo check
 script:
   - if [ -n "${FEATURES+exists}" ]; then
       cargo build -v --no-default-features --features "$FEATURES" &&

--- a/Cargo.toml.public-private-dependencies
+++ b/Cargo.toml.public-private-dependencies
@@ -1,0 +1,58 @@
+cargo-features = ["public-dependency"]
+
+[package]
+name = "image"
+version = "0.23.0-preview.0"
+edition = "2018"
+license = "MIT"
+description = "Imaging library written in Rust. Provides basic filters and decoders for the most common image formats."
+authors = ["The image-rs Developers"]
+readme = "README.md"
+documentation = "https://docs.rs/image"
+repository = "https://github.com/image-rs/image"
+homepage = "https://github.com/image-rs/image"
+categories = ["multimedia::images", "multimedia::encoding"]
+exclude = [
+    "src/png/testdata/*",
+    "examples/*",
+    "tests/*",
+]
+
+[lib]
+name = "image"
+path = "./src/lib.rs"
+
+[dependencies]
+# Not yet public.
+bytemuck = "1"
+byteorder = "1.3.2"
+num-iter = "0.1.32"
+num-rational = "0.2.1"
+# Public due to Pixel, otherwise quite useless.
+num-traits = { version = "0.2.0", public = true }
+gif = { version = "0.10.0", optional = true }
+jpeg = { package = "jpeg-decoder", version = "0.1", default-features = false, optional = true }
+png = { version = "0.15.2", optional = true }
+scoped_threadpool = { version = "0.1", optional = true }
+tiff = { version = "0.4.0", optional = true }
+
+[dev-dependencies]
+crc32fast = "1.2.0"
+num-complex = "0.2.0"
+glob = "0.3"
+quickcheck = "0.9"
+
+[features]
+default = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "dds", "jpeg_rayon"]
+
+ico = ["bmp", "png"]
+pnm = []
+tga = []
+webp = []
+bmp = []
+hdr = ["scoped_threadpool"]
+dxt = []
+dds = ["dxt"]
+jpeg_rayon = ["jpeg/rayon"]
+
+benchmarks = []


### PR DESCRIPTION
See the nightly feature [`public-dependency`](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#public-dependency), tracking issue: [#44663](https://github.com/rust-lang/rust/issues/44663). Very cool to check if we actually depend on anything publicly.

Based on local tests, this should currently fail with a dependency on `num-rational`. This is insofar suboptimal as they might bump version to `0.3` soon (last updated was a year ago, #809, also see #1036 where we had to manually adjust that public type).



