### PR TITLE
Fix a warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ optional = true
 crc32fast = "1.2.0"
 num-complex = "0.2.0"
 glob = "0.3"
-quickcheck = "0.6.2"
+quickcheck = "0.9"
 
 [features]
 default = ["gif_codec", "jpeg", "ico", "png_codec", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "jpeg_rayon"]

--- a/examples/scaledown/main.rs
+++ b/examples/scaledown/main.rs
@@ -33,7 +33,7 @@ fn main() {
         ("cmr", FilterType::CatmullRom),
         ("gauss", FilterType::Gaussian),
         ("lcz2", FilterType::Lanczos3),
-    ].into_iter()
+    ].iter()
     {
         let timer = Instant::now();
         let scaled = img.resize(400, 400, filter);

--- a/examples/scaleup/main.rs
+++ b/examples/scaleup/main.rs
@@ -33,7 +33,7 @@ fn main() {
         ("xcmr", FilterType::CatmullRom),
         ("ygauss", FilterType::Gaussian),
         ("zlcz2", FilterType::Lanczos3),
-    ].into_iter()
+    ].iter()
     {
         let timer = Instant::now();
         let scaled = tiny.resize(32, 32, filter);


### PR DESCRIPTION
The tiff dependency update is especially nice for compilation times because it removes the syn 0.15 dependency.