### PR TITLE
Fix cmyk_to_rgb causing off by one rounding errors.

### DIFF
--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -89,20 +89,18 @@ fn cmyk_to_rgb(input: &[u8]) -> Vec<u8> {
     let mut output = Vec::with_capacity(size);
 
     for pixel in input.chunks(4) {
-        let c = f32::from(pixel[0]) / 255.0;
-        let m = f32::from(pixel[1]) / 255.0;
-        let y = f32::from(pixel[2]) / 255.0;
-        let k = f32::from(pixel[3]) / 255.0;
+        let c = f32::from(pixel[0]);
+        let m = f32::from(pixel[1]);
+        let y = f32::from(pixel[2]);
+        let k = 255.0 - f32::from(pixel[3]);
 
-        // CMYK -> CMY
-        let c = c * (1.0 - k) + k;
-        let m = m * (1.0 - k) + k;
-        let y = y * (1.0 - k) + k;
+        let k_sub = k / 255.0;
 
         // CMY -> RGB
-        let r = (1.0 - c) * 255.0;
-        let g = (1.0 - m) * 255.0;
-        let b = (1.0 - y) * 255.0;
+        let r = k - c * k_sub;
+        let g = k - m * k_sub;
+        let b = k - y * k_sub;
+
 
         output.push(r as u8);
         output.push(g as u8);


### PR DESCRIPTION
Running cmyk_to_rgb(&[0, 0, 0, 254]) produces the RGB color [0, 0, 0] when it should in fact produce RGB [1, 1, 1]:
R = 255 * (1 - C/255) * (1-K/255) 
R = 255 * (1-0/255) * (1-254/255)
R = 255 * 1 * 1/ 255 = 1.

This bug occurs with a range of other values as well - 159 / 255 of the values [0, 0, 0, 0..255] are affected.
The fix involves reducing the number of multiplications and divisions, and also yields a ~15-25% speedup (results are from randomly generated images, using `cargo build --release`). 

```
250 px
Orig took 0.0000020s
Fast took 0.0000015s
2500 px
Orig took 0.0000154s
Fast took 0.0000121s
25000 px
Orig took 0.0002961s
Fast took 0.0002334s
250000 px
Orig took 0.0017928s
Fast took 0.0014527s
2500000 px
Orig took 0.0255831s
Fast took 0.0213677s
```

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.