### PR TITLE
Optimize some functions in vp8.rs

### DIFF
--- a/src/webp/vp8.rs
+++ b/src/webp/vp8.rs
@@ -2097,7 +2097,7 @@ mod test {
 
     #[test]
     fn test_avg2_specific() {
-        assert_eq!(255, avg2(255, 255), "avg2(255, 255), expected 255, got {}.", avg2(2, 1));
+        assert_eq!(255, avg2(255, 255), "avg2(255, 255), expected 255, got {}.", avg2(255, 255));
         assert_eq!(1, avg2(1, 1), "avg2(1, 1), expected 1, got {}.", avg2(1, 1));
         assert_eq!(2, avg2(2, 1), "avg2(2, 1), expected 2, got {}.", avg2(2, 1));
     }

--- a/src/webp/vp8.rs
+++ b/src/webp/vp8.rs
@@ -1690,7 +1690,6 @@ fn predict_4x4(ws: &mut [u8], stride: usize, modes: &[IntraMode], resdata: &[i32
             let i = sbx + sby * 4;
             let y0 = sby * 4 + 1;
             let x0 = sbx * 4 + 1;
-            let rb = &resdata[i * 16..i * 16 + 16];
 
             match modes[i] {
                 IntraMode::TM => predict_tmpred(ws, 4, x0, y0, stride),


### PR DESCRIPTION
This uses slices to index into the relevant portions of the array for top_pixels and edge_pixels, which helps decrease runtime by ~100%, as seen below:

```
test webp::vp8::bench::bench_edge_pixels                       ... bench:           8 ns/iter (+/- 0)
test webp::vp8::bench::bench_edge_pixels_new                   ... bench:           0 ns/iter (+/- 0)
test webp::vp8::bench::bench_top_pixels                        ... bench:           5 ns/iter (+/- 0)
test webp::vp8::bench::bench_top_pixels_new                    ... bench:           0 ns/iter (+/- 0)
```

I also tweaked avg2 to avoid u16 conversions. 
I added tests to cover all changes made, (including tests which fully cover the output of avg2 and avg3 to ensure that they remain consistent). The tests for edge_pixels and top_pixels also help demonstrate how the functions work.