### PR TITLE
Deprecate and remove ImageEnd error constructor

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -118,13 +118,15 @@ pub struct ParameterError {
 /// Details how a parameter is malformed.
 #[derive(Clone, Debug, Hash, PartialEq)]
 pub enum ParameterErrorKind {
-    /// Repeated an operation for which error that could not be cloned was emitted already.
-    FailedAlready,
     /// The dimensions passed are wrong.
     DimensionMismatch,
+    /// Repeated an operation for which error that could not be cloned was emitted already.
+    FailedAlready,
     /// A string describing the parameter.
     /// This is discouraged and is likely to get deprecated (but not removed).
     Generic(String),
+    /// The end of the image has been reached.
+    NoMoreData,
     #[doc(hidden)]
     /// Do not use this, not part of stability guarantees.
     __NonExhaustive(NonExhaustiveMarker),
@@ -202,12 +204,6 @@ impl ImageError {
     pub(crate) const DimensionError: Self =
         ImageError::Parameter(ParameterError {
             kind: ParameterErrorKind::DimensionMismatch,
-            underlying: None,
-        });
-
-    pub(crate) const ImageEnd: Self =
-        ImageError::Parameter(ParameterError {
-            kind: ParameterErrorKind::FailedAlready,
             underlying: None,
         });
 
@@ -495,6 +491,10 @@ impl fmt::Display for ParameterError {
                 fmt,
                 "The parameter is malformed: {}",
                 message,
+            ),
+            ParameterErrorKind::NoMoreData => write!(
+                fmt,
+                "The end of the image has been reached",
             ),
             ParameterErrorKind::__NonExhaustive(marker) => match marker._private {},
         }?;

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -41,7 +41,7 @@ use num_rational::Ratio;
 use crate::animation;
 use crate::buffer::{ImageBuffer, Pixel};
 use crate::color::{ColorType, Rgba};
-use crate::error::{ImageError, ImageResult};
+use crate::error::{ImageError, ImageResult, ParameterError, ParameterErrorKind};
 use crate::image::{self, AnimationDecoder, ImageDecoder};
 
 /// GIF decoder
@@ -103,7 +103,9 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for GifDecoder<R> {
             f_width = u32::from(frame.width);
             f_height = u32::from(frame.height);
         } else {
-            return Err(ImageError::ImageEnd);
+            return Err(ImageError::Parameter(
+                ParameterError::from_kind(ParameterErrorKind::NoMoreData)
+            ));
         }
 
         self.reader.read_into_buffer(buf).map_err(ImageError::from_gif)?;

--- a/src/hdr/decoder.rs
+++ b/src/hdr/decoder.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use crate::Primitive;
 
 use crate::color::{ColorType, Rgb};
-use crate::error::{ImageError, ImageResult};
+use crate::error::{ImageError, ImageResult, ParameterError, ParameterErrorKind};
 use crate::image::{self, ImageDecoder, ImageDecoderExt, Progress};
 
 /// Adapter to conform to ```ImageDecoder``` trait
@@ -55,7 +55,9 @@ impl<R: BufRead> HDRAdapter<R> {
 
                 Ok(())
             }
-            None => Err(ImageError::ImageEnd),
+            None => Err(ImageError::Parameter(
+                ParameterError::from_kind(ParameterErrorKind::NoMoreData)
+            )),
         }
     }
 }
@@ -418,7 +420,9 @@ impl<R: BufRead> Iterator for HDRImageDecoderIterator<R> {
                 self.advance();
                 // Error was encountered. Keep producing errors.
                 // ImageError can't implement Clone, so just dump some error
-                return Some(Err(ImageError::ImageEnd));
+                return Some(Err(ImageError::Parameter(
+                    ParameterError::from_kind(ParameterErrorKind::FailedAlready)
+                )));
             } // no else
             if self.col == 0 {
                 // fill scanline buffer


### PR DESCRIPTION
This constructor has previously been used for at least three different purposes:

* To signal that an image has already been read from a stream.
* As a decoding error when some provided data was shorter than expected.
* An non-recoverable error has been produced already in a stream of images.