### PR TITLE
Require jpeg-decoder >= 0.1.17 for Send + Sync error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ num-iter = "0.1.32"
 num-rational = { version = "0.2.1", default-features = false }
 num-traits = "0.2.0"
 gif = { version = "0.10.0", optional = true }
-jpeg = { package = "jpeg-decoder", version = "0.1", default-features = false, optional = true }
+jpeg = { package = "jpeg-decoder", version = "0.1.17", default-features = false, optional = true }
 png = { version = "0.16.0", optional = true }
 scoped_threadpool = { version = "0.1", optional = true }
 tiff = { version = "0.4.0", optional = true }


### PR DESCRIPTION
## Description

#1144 (image 0.23.1) requires https://github.com/image-rs/jpeg-decoder/pull/119 (jpeg-decoder 0.1.17) to compile, so clarify that in Cargo.toml.

## License

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.
