### PR TITLE
Add TGA to list of Supported Image Formats in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ https://docs.rs/image
 | WebP   | Lossy(Luma channel only) | No |
 | PNM    | PBM, PGM, PPM, standard PAM | Yes |
 | DDS    | DXT1, DXT3, DXT5 | No |
+| TGA    | Yes | No |
 
 ### 2.2 The `ImageDecoder` and `ImageDecoderExt` Traits
 


### PR DESCRIPTION
TGA is missing from the list of supported image formats