### PR TITLE
farbfeld followup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ quickcheck = "0.9"
 criterion = "0.3"
 
 [features]
-default = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "dds", "jpeg_rayon"]
+default = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "dds", "farbfeld", "jpeg_rayon"]
 
 ico = ["bmp", "png"]
 pnm = []

--- a/src/bmp/decoder.rs
+++ b/src/bmp/decoder.rs
@@ -1427,7 +1427,7 @@ impl<'a, R: 'a + Read + Seek> ImageDecoderExt<'a> for BmpDecoder<R> {
     ) -> ImageResult<()> {
         let start = self.reader.seek(SeekFrom::Current(0))?;
         image::load_rect(x, y, width, height, buf, progress_callback, self, |_, _| unreachable!(),
-                         |s, buf| { s.read_image_data(buf).map(|_| buf.len()) })?;
+                         |s, buf| s.read_image_data(buf))?;
         self.reader.seek(SeekFrom::Start(start))?;
         Ok(())
     }

--- a/src/dxt.rs
+++ b/src/dxt.rs
@@ -165,7 +165,7 @@ impl<'a, R: 'a + Read + Seek> ImageDecoderExt<'a> for DxtDecoder<R> {
                              s.inner.seek(SeekFrom::Start(start + scanline * encoded_scanline_bytes))?;
                              Ok(())
                          },
-                         |s, buf| s.read_scanline(buf))?;
+                         |s, buf| s.read_scanline(buf).map(|_| ()))?;
         self.inner.seek(SeekFrom::Start(start))?;
         Ok(())
     }

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -27,7 +27,9 @@ use crate::color::{self, IntoColor};
 use crate::error::{ImageError, ImageResult};
 use crate::flat::FlatSamples;
 use crate::image;
-use crate::image::{GenericImage, GenericImageView, ImageEncoder, ImageDecoder, ImageFormat, ImageOutputFormat};
+use crate::image::{GenericImage, GenericImageView, ImageDecoder, ImageFormat, ImageOutputFormat};
+#[cfg(feature = "farbfeld")]
+use crate::image::ImageEncoder;
 use crate::io::free_functions;
 use crate::imageops;
 

--- a/src/farbfeld.rs
+++ b/src/farbfeld.rs
@@ -206,7 +206,7 @@ impl<'a, R: 'a + Read + Seek> ImageDecoderExt<'a> for FarbfeldDecoder<R> {
         let start = self.reader.seek(SeekFrom::Current(0))?;
         image::load_rect(x, y, width, height, buf, progress_callback, self,
                          |s, scanline| s.reader.seek(SeekFrom::Start(scanline * 2)).map(|_| ()),
-                         |s, buf| s.reader.read_exact(buf).map(|()| buf.len()))?;
+                         |s, buf| s.reader.read_exact(buf))?;
         self.reader.seek(SeekFrom::Start(start))?;
         Ok(())
     }

--- a/src/hdr/decoder.rs
+++ b/src/hdr/decoder.rs
@@ -109,7 +109,7 @@ impl<'a, R: 'a + BufRead + Seek> ImageDecoderExt<'a> for HDRAdapter<R> {
         progress_callback: F,
     ) -> ImageResult<()> {
         image::load_rect(x, y, width, height, buf, progress_callback, self, |_, _| unreachable!(),
-                         |s, buf| s.read_image_data(buf).map(|_| buf.len()))
+                         |s, buf| s.read_image_data(buf))
     }
 }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -214,7 +214,7 @@ pub(crate) fn load_rect<'a, D, F, F1, F2, E>(x: u32, y: u32, width: u32, height:
     where D: ImageDecoder<'a>,
           F: Fn(Progress),
           F1: FnMut(&mut D, u64) -> io::Result<()>,
-          F2: FnMut(&mut D, &mut [u8]) -> Result<usize, E>,
+          F2: FnMut(&mut D, &mut [u8]) -> Result<(), E>,
           ImageError: From<E>,
 {
     let (x, y, width, height) = (u64::from(x), u64::from(y), u64::from(width), u64::from(height));
@@ -943,16 +943,16 @@ mod tests {
             m.scanline_number = n;
             Ok(())
         }
-        fn read_scanline(m: &mut MockDecoder, buf: &mut [u8]) -> io::Result<usize> {
+        fn read_scanline(m: &mut MockDecoder, buf: &mut [u8]) -> io::Result<()> {
             let bytes_read = m.scanline_number * m.scanline_bytes;
             if bytes_read >= 25 {
-                return Ok(0);
+                return Ok(());
             }
 
             let len = m.scanline_bytes.min(25 - bytes_read);
             buf[..(len as usize)].copy_from_slice(&DATA[(bytes_read as usize)..][..(len as usize)]);
             m.scanline_number += 1;
-            Ok(len as usize)
+            Ok(())
         }
 
         for scanline_bytes in 1..30 {

--- a/src/image.rs
+++ b/src/image.rs
@@ -4,6 +4,7 @@ use std::io;
 use std::io::Read;
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
+use std::usize;
 
 use crate::buffer::{ImageBuffer, Pixel};
 use crate::color::{ColorType, ExtendedColorType};
@@ -223,6 +224,10 @@ pub(crate) fn load_rect<'a, D, F, F1, F2, E>(x: u32, y: u32, width: u32, height:
     let scanline_bytes = decoder.scanline_bytes();
     let total_bytes = width * height * bytes_per_pixel;
 
+    if buf.len() < usize::try_from(total_bytes).unwrap_or(usize::MAX) {
+        panic!("output buffer too short\n expected `{}`, provided `{}`", total_bytes, buf.len());
+    }
+
     let mut bytes_read = 0u64;
     let mut current_scanline = 0;
     let mut tmp = Vec::new();
@@ -264,7 +269,7 @@ pub(crate) fn load_rect<'a, D, F, F1, F2, E>(x: u32, y: u32, width: u32, height:
             Ok(())
         };
 
-        if x + width > u64::from(dimensions.0) || y + height > u64::from(dimensions.0)
+        if x + width > u64::from(dimensions.0) || y + height > u64::from(dimensions.1)
             || width == 0 || height == 0 {
                 return Err(ImageError::DimensionError);
             }


### PR DESCRIPTION
Marked as draft since I can't get `load_rect()` to stop panicking in code I don't understand; see commit marked [WIP], particularly the diff with `read_scanline()`.

`cargo test --features farbfeld farbfeld`:
```
running 1 test
test farbfeld::tests::read_rect ... FAILED

failures:

---- farbfeld::tests::read_rect stdout ----
inner
magic = [102, 97, 114, 98, 102, 101, 108, 100]
magic ok
[src\farbfeld.rs:66] read_dimm(&mut inner) = Ok(
    2,
)
[src\farbfeld.rs:67] read_dimm(&mut inner) = Ok(
    3,
)
rrwp(1, 1, 1, 2)
start = 16
we in this
Progress { current: 0, total: 16 }
|s, scanline=12|
[src\image.rs:244] bytes_read = 0
[src\image.rs:244] &mut buf[(dbg!(bytes_read) as usize)..] = [
    0,
    64,
]
[src\image.rs:244] &mut dbg!(& mut buf
          [(dbg ! (bytes_read) as usize) ..])[..(scanline_bytes as usize)] = [
    0,
    64,
]
|s, buf=[00, 40]|
Progress { current: 2, total: 16 }
[src\image.rs:244] bytes_read = 2
[src\image.rs:244] &mut buf[(dbg!(bytes_read) as usize)..] = []
thread 'farbfeld::tests::read_rect' panicked at 'index 2 out of range for slice of length 0', src\libcore\slice\mod.rs:2674:5
stack backtrace:
   0:           0xd369ab - backtrace::backtrace::dbghelp::trace::h2c26bcbdf690198b
                               at C:\Users\VssAdministrator\.cargo\registry\src\github.com-1ecc6299db9ec823\backtrace-0.3.40\src\backtrace/dbghelp.rs:88
   1:           0xd369ab - backtrace::backtrace::trace_unsynchronized::h5cce0bcde2e3f784
                               at C:\Users\VssAdministrator\.cargo\registry\src\github.com-1ecc6299db9ec823\backtrace-0.3.40\src\backtrace/mod.rs:66
   2:           0xd369ab - std::sys_common::backtrace::_print_fmt::ha46fdf8ef77a98a0
                               at src\libstd\sys_common/backtrace.rs:84
   3:           0xd369ab - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h75ab5013ba686b22
                               at src\libstd\sys_common/backtrace.rs:61
   4:           0xd63b8b - core::fmt::write::hd635a12733f6f15d
                               at src\libcore\fmt/mod.rs:1025
   5:           0x6fd3b5 - std::io::Write::write_fmt::hcfbafa1fecf5fde0
                               at /rustc/f3e1a954d2ead4e2fc197c7da7d71e6c61bad196\src\libstd\io/mod.rs:1426
   6:           0xd26668 - std::io::impls::<impl std::io::Write for alloc::boxed::Box<W>>::write_fmt::h8188fab2d09208df
                               at src\libstd\io/impls.rs:156
   7:           0xd3a8da - std::sys_common::backtrace::_print::h1c91521169f60228
                               at src\libstd\sys_common/backtrace.rs:65
   8:           0xd3a8da - std::sys_common::backtrace::print::hc35a9a96041cb5d9
                               at src\libstd\sys_common/backtrace.rs:50
   9:           0xd3a8da - std::panicking::default_hook::{{closure}}::hd13b5f894afbe914
                               at src\libstd/panicking.rs:193
  10:           0xd3a507 - std::panicking::default_hook::h96527dcae48a6c68
                               at src\libstd/panicking.rs:207
  11:           0xd3ae87 - std::panicking::rust_panic_with_hook::h05d6b37476184f50
                               at src\libstd/panicking.rs:471
  12:           0xd3ab14 - rust_begin_unwind
                               at src\libstd/panicking.rs:375
  13:           0xd5cfcd - core::panicking::panic_fmt::hd3376e66e4519b18
                               at src\libcore/panicking.rs:84
  14:           0xd5d5cb - core::slice::slice_index_len_fail::h6a80c843fd413bf0
                               at src\libcore\slice/mod.rs:2674
  15:           0x790dc9 - <core::ops::range::Range<usize> as core::slice::SliceIndex<[T]>>::index_mut::hce4dfba5d66fc8dd
                               at /rustc/f3e1a954d2ead4e2fc197c7da7d71e6c61bad196\src\libcore\slice/mod.rs:2869
  16:           0x78f4ef - <core::ops::range::RangeTo<usize> as core::slice::SliceIndex<[T]>>::index_mut::h0dd6175ada979267
                               at /rustc/f3e1a954d2ead4e2fc197c7da7d71e6c61bad196\src\libcore\slice/mod.rs:2908
  17:           0x770477 - core::slice::<impl core::ops::index::IndexMut<I> for [T]>::index_mut::h48a9c86ec993bfdb
                               at /rustc/f3e1a954d2ead4e2fc197c7da7d71e6c61bad196\src\libcore\slice/mod.rs:2667
  18:           0x5f4eae - image::image::load_rect::{{closure}}::hfabd9a2a40f7c4b5
                               at src/image.rs:244
  19:           0x5eaf47 - image::image::load_rect::h041ba2aecfeb2741
                               at src/image.rs:285
  20:           0x4f8bd8 - <image::farbfeld::FarbfeldDecoder<R> as image::image::ImageDecoderExt>::read_rect_with_progress::h57fa45efd5e6f7d5
                               at src/farbfeld.rs:161
  21:           0x4c586b - image::farbfeld::tests::read_rect::h1e428e41618b4aaa
                               at src/farbfeld.rs:248
  22:           0x62010e - image::farbfeld::tests::read_rect::{{closure}}::hd2016b03e64bb60b
                               at src/farbfeld.rs:236
  23:           0x514eee - core::ops::function::FnOnce::call_once::hff541ae2429b8b6a
                               at /rustc/f3e1a954d2ead4e2fc197c7da7d71e6c61bad196\src\libcore\ops/function.rs:232
  24:           0x709086 - <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once::hd3e8c16ba5ec20b1
                               at /rustc/f3e1a954d2ead4e2fc197c7da7d71e6c61bad196\src\liballoc/boxed.rs:1022
  25:           0xd4bff9 - __rust_maybe_catch_panic
                               at src\libpanic_unwind/lib.rs:78
  26:           0x727264 - std::panicking::try::h3c074fb48fa145d0
                               at /rustc/f3e1a954d2ead4e2fc197c7da7d71e6c61bad196\src\libstd/panicking.rs:270
  27:           0x727264 - std::panic::catch_unwind::hc68f651c2fcaef9e
                               at /rustc/f3e1a954d2ead4e2fc197c7da7d71e6c61bad196\src\libstd/panic.rs:394
  28:           0x727264 - test::run_test_in_process::hca5f302cec41c050
                               at src\libtest/lib.rs:567
  29:           0x727264 - test::run_test::run_test_inner::{{closure}}::hd25abdd43a8d21a8
                               at src\libtest/lib.rs:474
  30:           0x6fcaa6 - std::sys_common::backtrace::__rust_begin_short_backtrace::h23b43e2eabce9ba3
                               at /rustc/f3e1a954d2ead4e2fc197c7da7d71e6c61bad196\src\libstd\sys_common/backtrace.rs:136
  31:           0x700f66 - std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}}::hae46c65b8d1f9212
                               at /rustc/f3e1a954d2ead4e2fc197c7da7d71e6c61bad196\src\libstd\thread/mod.rs:469
  32:           0x700f66 - <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once::h5e01109204b752e3
                               at /rustc/f3e1a954d2ead4e2fc197c7da7d71e6c61bad196\src\libstd/panic.rs:318
  33:           0x700f66 - std::panicking::try::do_call::h582b79f8e83aec34
                               at /rustc/f3e1a954d2ead4e2fc197c7da7d71e6c61bad196\src\libstd/panicking.rs:292
  34:           0xd4bff9 - __rust_maybe_catch_panic
                               at src\libpanic_unwind/lib.rs:78
  35:           0x7023b2 - std::panicking::try::hd1ab16165a21805b
                               at /rustc/f3e1a954d2ead4e2fc197c7da7d71e6c61bad196\src\libstd/panicking.rs:270
  36:           0x7023b2 - std::panic::catch_unwind::h693c15d43c580911
                               at /rustc/f3e1a954d2ead4e2fc197c7da7d71e6c61bad196\src\libstd/panic.rs:394
  37:           0x7023b2 - std::thread::Builder::spawn_unchecked::{{closure}}::hee9af0c11904f026
                               at /rustc/f3e1a954d2ead4e2fc197c7da7d71e6c61bad196\src\libstd\thread/mod.rs:468
  38:           0x7023b2 - core::ops::function::FnOnce::call_once{{vtable.shim}}::he9777495942f2df1
                               at /rustc/f3e1a954d2ead4e2fc197c7da7d71e6c61bad196\src\libcore\ops/function.rs:232
  39:           0xd1b9f6 - <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once::h4c59a6e6375e38e5
                               at /rustc/f3e1a954d2ead4e2fc197c7da7d71e6c61bad196\src\liballoc/boxed.rs:1022
  40:           0xd49657 - <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once::ha27f34c112a96d5b
                               at /rustc/f3e1a954d2ead4e2fc197c7da7d71e6c61bad196\src\liballoc/boxed.rs:1022
  41:           0xd49657 - std::sys_common::thread::start_thread::h963d76a11b016aac
                               at src\libstd\sys_common/thread.rs:13
  42:           0xd49657 - std::sys::windows::thread::Thread::new::thread_start::haa13ed8670bb07d8
                               at src\libstd\sys\windows/thread.rs:51
  43:     0x7ffde02d8364 - unit_addrs_search
  44:     0x7ffde03e70d1 - unit_addrs_search


failures:
    farbfeld::tests::read_rect
```

Also, should the final version of this PR enable farbfeld by default?