### PR TITLE
(Internally) restructure the buffer module

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use num_rational::Ratio;
 
-use crate::buffer::RgbaImage;
+use crate::RgbaImage;
 use crate::error::ImageResult;
 
 /// An implementation dependent iterator, reading the frames as requested

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,172 +1,18 @@
+//! Contains the generic `ImageBuffer` struct.
 use num_traits::Zero;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut, Index, IndexMut, Range};
 use std::path::Path;
 use std::slice::{Chunks, ChunksMut};
 
-use crate::color::{ColorType, FromColor, Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
+use crate::color::{FromColor, Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
 use crate::flat::{FlatSamples, SampleLayout};
 use crate::dynimage::{save_buffer, save_buffer_with_format};
 use crate::error::ImageResult;
 use crate::image::{GenericImage, GenericImageView, ImageFormat};
 use crate::math::Rect;
-use crate::traits::{EncodableLayout, Primitive};
+use crate::traits::{EncodableLayout, Pixel};
 use crate::utils::expand_packed;
-
-/// A generalized pixel.
-///
-/// A pixel object is usually not used standalone but as a view into an image buffer.
-pub trait Pixel: Copy + Clone {
-    /// The underlying subpixel type.
-    type Subpixel: Primitive;
-
-    /// The number of channels of this pixel type.
-    const CHANNEL_COUNT: u8;
-    /// Returns the number of channels of this pixel type.
-    #[deprecated(note="please use CHANNEL_COUNT associated constant")]
-    fn channel_count() -> u8 {
-        Self::CHANNEL_COUNT
-    }
-
-    /// Returns the components as a slice.
-    fn channels(&self) -> &[Self::Subpixel];
-
-    /// Returns the components as a mutable slice
-    fn channels_mut(&mut self) -> &mut [Self::Subpixel];
-
-    /// A string that can help to interpret the meaning each channel
-    /// See [gimp babl](http://gegl.org/babl/).
-    const COLOR_MODEL: &'static str;
-    /// Returns a string that can help to interpret the meaning each channel
-    /// See [gimp babl](http://gegl.org/babl/).
-    #[deprecated(note="please use COLOR_MODEL associated constant")]
-    fn color_model() -> &'static str {
-        Self::COLOR_MODEL
-    }
-
-    /// ColorType for this pixel format
-    const COLOR_TYPE: ColorType;
-    /// Returns the ColorType for this pixel format
-    #[deprecated(note="please use COLOR_TYPE associated constant")]
-    fn color_type() -> ColorType {
-        Self::COLOR_TYPE
-    }
-
-    /// Returns the channels of this pixel as a 4 tuple. If the pixel
-    /// has less than 4 channels the remainder is filled with the maximum value
-    ///
-    /// TODO deprecate
-    fn channels4(
-        &self,
-    ) -> (
-        Self::Subpixel,
-        Self::Subpixel,
-        Self::Subpixel,
-        Self::Subpixel,
-    );
-
-    /// Construct a pixel from the 4 channels a, b, c and d.
-    /// If the pixel does not contain 4 channels the extra are ignored.
-    ///
-    /// TODO deprecate
-    fn from_channels(
-        a: Self::Subpixel,
-        b: Self::Subpixel,
-        c: Self::Subpixel,
-        d: Self::Subpixel,
-    ) -> Self;
-
-    /// Returns a view into a slice.
-    ///
-    /// Note: The slice length is not checked on creation. Thus the caller has to ensure
-    /// that the slice is long enough to present panics if the pixel is used later on.
-    fn from_slice(slice: &[Self::Subpixel]) -> &Self;
-
-    /// Returns mutable view into a mutable slice.
-    ///
-    /// Note: The slice length is not checked on creation. Thus the caller has to ensure
-    /// that the slice is long enough to present panics if the pixel is used later on.
-    fn from_slice_mut(slice: &mut [Self::Subpixel]) -> &mut Self;
-
-    /// Convert this pixel to RGB
-    fn to_rgb(&self) -> Rgb<Self::Subpixel>;
-
-    /// Convert this pixel to RGB with an alpha channel
-    fn to_rgba(&self) -> Rgba<Self::Subpixel>;
-
-    /// Convert this pixel to luma
-    fn to_luma(&self) -> Luma<Self::Subpixel>;
-
-    /// Convert this pixel to luma with an alpha channel
-    fn to_luma_alpha(&self) -> LumaA<Self::Subpixel>;
-
-    /// Convert this pixel to BGR
-    fn to_bgr(&self) -> Bgr<Self::Subpixel>;
-
-    /// Convert this pixel to BGR with an alpha channel
-    fn to_bgra(&self) -> Bgra<Self::Subpixel>;
-
-    /// Apply the function ```f``` to each channel of this pixel.
-    fn map<F>(&self, f: F) -> Self
-    where
-        F: FnMut(Self::Subpixel) -> Self::Subpixel;
-
-    /// Apply the function ```f``` to each channel of this pixel.
-    fn apply<F>(&mut self, f: F)
-    where
-        F: FnMut(Self::Subpixel) -> Self::Subpixel;
-
-    /// Apply the function ```f``` to each channel except the alpha channel.
-    /// Apply the function ```g``` to the alpha channel.
-    fn map_with_alpha<F, G>(&self, f: F, g: G) -> Self
-    where
-        F: FnMut(Self::Subpixel) -> Self::Subpixel,
-        G: FnMut(Self::Subpixel) -> Self::Subpixel;
-
-    /// Apply the function ```f``` to each channel except the alpha channel.
-    /// Apply the function ```g``` to the alpha channel. Works in-place.
-    fn apply_with_alpha<F, G>(&mut self, f: F, g: G)
-    where
-        F: FnMut(Self::Subpixel) -> Self::Subpixel,
-        G: FnMut(Self::Subpixel) -> Self::Subpixel;
-
-    /// Apply the function ```f``` to each channel except the alpha channel.
-    fn map_without_alpha<F>(&self, f: F) -> Self
-    where
-        F: FnMut(Self::Subpixel) -> Self::Subpixel,
-    {
-        let mut this = *self;
-        this.apply_with_alpha(f, |x| x);
-        this
-    }
-
-    /// Apply the function ```f``` to each channel except the alpha channel.
-    /// Works in place.
-    fn apply_without_alpha<F>(&mut self, f: F)
-    where
-        F: FnMut(Self::Subpixel) -> Self::Subpixel,
-    {
-        self.apply_with_alpha(f, |x| x);
-    }
-
-    /// Apply the function ```f``` to each channel of this pixel and
-    /// ```other``` pairwise.
-    fn map2<F>(&self, other: &Self, f: F) -> Self
-    where
-        F: FnMut(Self::Subpixel, Self::Subpixel) -> Self::Subpixel;
-
-    /// Apply the function ```f``` to each channel of this pixel and
-    /// ```other``` pairwise. Works in-place.
-    fn apply2<F>(&mut self, other: &Self, f: F)
-    where
-        F: FnMut(Self::Subpixel, Self::Subpixel) -> Self::Subpixel;
-
-    /// Invert this pixel
-    fn invert(&mut self);
-
-    /// Blend the color of a given pixel into ourself, taking into account alpha channels
-    fn blend(&mut self, other: &Self);
-}
 
 /// Iterate over pixel refs.
 pub struct Pixels<'a, P: Pixel + 'a>

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,8 +1,7 @@
 use num_traits::{NumCast, ToPrimitive, Zero};
 use std::ops::{Index, IndexMut};
 
-use crate::buffer::Pixel;
-use crate::traits::Primitive;
+use crate::traits::{Pixel, Primitive};
 
 /// An enumeration over supported color types and bit depths
 #[derive(Copy, PartialEq, Eq, Debug, Clone, Hash)]

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -18,10 +18,10 @@ use crate::pnm;
 #[cfg(feature = "farbfeld")]
 use crate::farbfeld;
 
-use crate::buffer::{
+use crate::buffer_::{
     BgrImage, BgraImage, ConvertBuffer, GrayAlphaImage, GrayAlpha16Image,
-    GrayImage, Gray16Image, ImageBuffer, Pixel, RgbImage, Rgb16Image,
-    RgbaImage, Rgba16Image,
+    GrayImage, Gray16Image, ImageBuffer, RgbImage, Rgb16Image, RgbaImage,
+    Rgba16Image,
 };
 use crate::color::{self, IntoColor};
 use crate::error::{ImageError, ImageResult};
@@ -30,6 +30,7 @@ use crate::image;
 use crate::image::{GenericImage, GenericImageView, ImageEncoder, ImageDecoder, ImageFormat, ImageOutputFormat};
 use crate::io::free_functions;
 use crate::imageops;
+use crate::traits::Pixel;
 
 /// A Dynamic Image
 #[derive(Clone)]

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -47,10 +47,11 @@ use std::marker::PhantomData;
 
 use num_traits::Zero;
 
-use crate::buffer::{ImageBuffer, Pixel};
+use crate::ImageBuffer;
 use crate::color::ColorType;
 use crate::error::ImageError;
 use crate::image::{GenericImage, GenericImageView};
+use crate::traits::Pixel;
 
 /// A flat buffer over a (multi channel) image.
 ///
@@ -1419,7 +1420,7 @@ impl PartialOrd for NormalForm {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::buffer::GrayAlphaImage;
+    use crate::buffer_::GrayAlphaImage;
     use crate::color::{LumaA, Rgb};
 
     #[test]

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -39,10 +39,11 @@ use gif::{DisposalMethod, Frame};
 use num_rational::Ratio;
 
 use crate::animation;
-use crate::buffer::{ImageBuffer, Pixel};
+use crate::ImageBuffer;
 use crate::color::{ColorType, Rgba};
 use crate::error::{ImageError, ImageResult, ParameterError, ParameterErrorKind};
 use crate::image::{self, AnimationDecoder, ImageDecoder};
+use crate::traits::Pixel;
 
 /// GIF decoder
 pub struct GifDecoder<R: Read> {

--- a/src/image.rs
+++ b/src/image.rs
@@ -5,10 +5,11 @@ use std::io::Read;
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
 
-use crate::buffer::{ImageBuffer, Pixel};
+use crate::ImageBuffer;
 use crate::color::{ColorType, ExtendedColorType};
 use crate::error::{ImageError, ImageResult};
 use crate::math::Rect;
+use crate::traits::Pixel;
 
 use crate::animation::Frames;
 
@@ -846,7 +847,7 @@ mod tests {
     use std::path::Path;
 
     use super::{ColorType, ImageDecoder, ImageResult, GenericImage, GenericImageView, load_rect, ImageFormat};
-    use crate::buffer::{GrayImage, ImageBuffer};
+    use crate::{GrayImage, ImageBuffer};
     use crate::color::Rgba;
     use crate::math::Rect;
 

--- a/src/imageops/affine.rs
+++ b/src/imageops/affine.rs
@@ -1,7 +1,8 @@
 //! Functions for performing affine transformations.
 
-use crate::buffer::{ImageBuffer, Pixel};
+use crate::ImageBuffer;
 use crate::image::{GenericImage, GenericImageView};
+use crate::traits::Pixel;
 
 /// Rotate an image 90 degrees clockwise.
 pub fn rotate90<I: GenericImageView>(
@@ -245,8 +246,9 @@ mod test {
         flip_horizontal, flip_horizontal_in_place, flip_vertical, flip_vertical_in_place,
         rotate180, rotate180_in_place, rotate270, rotate90,
     };
-    use crate::buffer::{GrayImage, ImageBuffer, Pixel};
+    use crate::{GrayImage, ImageBuffer};
     use crate::image::GenericImage;
+    use crate::traits::Pixel;
 
     macro_rules! assert_pixels_eq {
         ($actual:expr, $expected:expr) => {{

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -1,13 +1,14 @@
 //! Functions for altering and converting the color of pixelbufs
 
-use crate::buffer::{ImageBuffer, Pixel};
+use num_traits::{Num, NumCast};
+use std::f64::consts::PI;
+
+use crate::ImageBuffer;
 use crate::color::{Luma, Rgba};
 use crate::image::{GenericImage, GenericImageView};
 use crate::math::nq;
 use crate::math::utils::clamp;
-use num_traits::{Num, NumCast};
-use std::f64::consts::PI;
-use crate::traits::Primitive;
+use crate::traits::{Pixel, Primitive};
 
 type Subpixel<I> = <<I as GenericImageView>::Pixel as Pixel>::Subpixel;
 

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -2,8 +2,7 @@
 use std::cmp;
 
 use crate::image::{GenericImage, GenericImageView, SubImage};
-
-use crate::buffer::Pixel;
+use crate::traits::Pixel;
 
 pub use self::sample::FilterType;
 
@@ -166,7 +165,7 @@ where
 mod tests {
 
     use super::overlay;
-    use crate::buffer::ImageBuffer;
+    use crate::ImageBuffer;
     use crate::color::Rgb;
 
     #[test]

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -7,10 +7,10 @@ use std::f32;
 
 use num_traits::{NumCast, ToPrimitive, Zero};
 
-use crate::buffer::{ImageBuffer, Pixel};
+use crate::ImageBuffer;
 use crate::image::GenericImageView;
 use crate::math::utils::clamp;
-use crate::traits::{Enlargeable, Primitive};
+use crate::traits::{Enlargeable, Pixel, Primitive};
 
 /// Available Sampling Filters.
 ///
@@ -817,7 +817,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::{resize, FilterType};
-    use crate::buffer::{ImageBuffer, RgbImage};
+    use crate::{ImageBuffer, RgbImage};
     #[cfg(feature = "benchmarks")]
     use test;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,20 +39,18 @@ pub use crate::image::{AnimationDecoder,
                 Pixels,
                 SubImage};
 
-pub use crate::buffer::{ConvertBuffer,
+pub use crate::buffer_::{
                  GrayAlphaImage,
                  GrayImage,
                  // Image types
                  ImageBuffer,
-                 Pixel,
                  RgbImage,
-                 RgbaImage,
-                 };
+                 RgbaImage};
 
 pub use crate::flat::FlatSamples;
 
 // Traits
-pub use crate::traits::Primitive;
+pub use crate::traits::{Primitive, Pixel};
 
 // Opening and loading images
 pub use crate::io::free_functions::{guess_format, load};
@@ -65,6 +63,22 @@ pub use crate::animation::{Delay, Frame, Frames};
 
 // More detailed error type
 pub mod error;
+
+/// Iterators and other auxiliary structure for the `ImageBuffer` type.
+pub mod buffer {
+    // Only those not exported at the top-level
+    pub use crate::buffer_::{
+        ConvertBuffer,
+        EnumeratePixels,
+        EnumeratePixelsMut,
+        EnumerateRows,
+        EnumerateRowsMut,
+        Pixels,
+        PixelsMut,
+        Rows,
+        RowsMut,
+    };
+}
 
 // Math utils
 pub mod math;
@@ -107,7 +121,8 @@ pub mod webp;
 pub mod farbfeld;
 
 mod animation;
-mod buffer;
+#[path = "buffer.rs"]
+mod buffer_;
 mod color;
 mod dynimage;
 mod image;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -5,6 +5,8 @@
 use num_traits::{Bounded, Num, NumCast};
 use std::ops::AddAssign;
 
+use crate::color::{ColorType, Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
+
 /// Types which are safe to treat as an immutable byte slice in a pixel layout
 /// for image encoding.
 pub trait EncodableLayout: seals::EncodableLayout {
@@ -65,6 +67,160 @@ impl Enlargeable for u32 {
     type Larger = u64;
 }
 
+/// A generalized pixel.
+///
+/// A pixel object is usually not used standalone but as a view into an image buffer.
+pub trait Pixel: Copy + Clone {
+    /// The underlying subpixel type.
+    type Subpixel: Primitive;
+
+    /// The number of channels of this pixel type.
+    const CHANNEL_COUNT: u8;
+    /// Returns the number of channels of this pixel type.
+    #[deprecated(note="please use CHANNEL_COUNT associated constant")]
+    fn channel_count() -> u8 {
+        Self::CHANNEL_COUNT
+    }
+
+    /// Returns the components as a slice.
+    fn channels(&self) -> &[Self::Subpixel];
+
+    /// Returns the components as a mutable slice
+    fn channels_mut(&mut self) -> &mut [Self::Subpixel];
+
+    /// A string that can help to interpret the meaning each channel
+    /// See [gimp babl](http://gegl.org/babl/).
+    const COLOR_MODEL: &'static str;
+    /// Returns a string that can help to interpret the meaning each channel
+    /// See [gimp babl](http://gegl.org/babl/).
+    #[deprecated(note="please use COLOR_MODEL associated constant")]
+    fn color_model() -> &'static str {
+        Self::COLOR_MODEL
+    }
+
+    /// ColorType for this pixel format
+    const COLOR_TYPE: ColorType;
+    /// Returns the ColorType for this pixel format
+    #[deprecated(note="please use COLOR_TYPE associated constant")]
+    fn color_type() -> ColorType {
+        Self::COLOR_TYPE
+    }
+
+    /// Returns the channels of this pixel as a 4 tuple. If the pixel
+    /// has less than 4 channels the remainder is filled with the maximum value
+    ///
+    /// TODO deprecate
+    fn channels4(
+        &self,
+    ) -> (
+        Self::Subpixel,
+        Self::Subpixel,
+        Self::Subpixel,
+        Self::Subpixel,
+    );
+
+    /// Construct a pixel from the 4 channels a, b, c and d.
+    /// If the pixel does not contain 4 channels the extra are ignored.
+    ///
+    /// TODO deprecate
+    fn from_channels(
+        a: Self::Subpixel,
+        b: Self::Subpixel,
+        c: Self::Subpixel,
+        d: Self::Subpixel,
+    ) -> Self;
+
+    /// Returns a view into a slice.
+    ///
+    /// Note: The slice length is not checked on creation. Thus the caller has to ensure
+    /// that the slice is long enough to present panics if the pixel is used later on.
+    fn from_slice(slice: &[Self::Subpixel]) -> &Self;
+
+    /// Returns mutable view into a mutable slice.
+    ///
+    /// Note: The slice length is not checked on creation. Thus the caller has to ensure
+    /// that the slice is long enough to present panics if the pixel is used later on.
+    fn from_slice_mut(slice: &mut [Self::Subpixel]) -> &mut Self;
+
+    /// Convert this pixel to RGB
+    fn to_rgb(&self) -> Rgb<Self::Subpixel>;
+
+    /// Convert this pixel to RGB with an alpha channel
+    fn to_rgba(&self) -> Rgba<Self::Subpixel>;
+
+    /// Convert this pixel to luma
+    fn to_luma(&self) -> Luma<Self::Subpixel>;
+
+    /// Convert this pixel to luma with an alpha channel
+    fn to_luma_alpha(&self) -> LumaA<Self::Subpixel>;
+
+    /// Convert this pixel to BGR
+    fn to_bgr(&self) -> Bgr<Self::Subpixel>;
+
+    /// Convert this pixel to BGR with an alpha channel
+    fn to_bgra(&self) -> Bgra<Self::Subpixel>;
+
+    /// Apply the function ```f``` to each channel of this pixel.
+    fn map<F>(&self, f: F) -> Self
+    where
+        F: FnMut(Self::Subpixel) -> Self::Subpixel;
+
+    /// Apply the function ```f``` to each channel of this pixel.
+    fn apply<F>(&mut self, f: F)
+    where
+        F: FnMut(Self::Subpixel) -> Self::Subpixel;
+
+    /// Apply the function ```f``` to each channel except the alpha channel.
+    /// Apply the function ```g``` to the alpha channel.
+    fn map_with_alpha<F, G>(&self, f: F, g: G) -> Self
+    where
+        F: FnMut(Self::Subpixel) -> Self::Subpixel,
+        G: FnMut(Self::Subpixel) -> Self::Subpixel;
+
+    /// Apply the function ```f``` to each channel except the alpha channel.
+    /// Apply the function ```g``` to the alpha channel. Works in-place.
+    fn apply_with_alpha<F, G>(&mut self, f: F, g: G)
+    where
+        F: FnMut(Self::Subpixel) -> Self::Subpixel,
+        G: FnMut(Self::Subpixel) -> Self::Subpixel;
+
+    /// Apply the function ```f``` to each channel except the alpha channel.
+    fn map_without_alpha<F>(&self, f: F) -> Self
+    where
+        F: FnMut(Self::Subpixel) -> Self::Subpixel,
+    {
+        let mut this = *self;
+        this.apply_with_alpha(f, |x| x);
+        this
+    }
+
+    /// Apply the function ```f``` to each channel except the alpha channel.
+    /// Works in place.
+    fn apply_without_alpha<F>(&mut self, f: F)
+    where
+        F: FnMut(Self::Subpixel) -> Self::Subpixel,
+    {
+        self.apply_with_alpha(f, |x| x);
+    }
+
+    /// Apply the function ```f``` to each channel of this pixel and
+    /// ```other``` pairwise.
+    fn map2<F>(&self, other: &Self, f: F) -> Self
+    where
+        F: FnMut(Self::Subpixel, Self::Subpixel) -> Self::Subpixel;
+
+    /// Apply the function ```f``` to each channel of this pixel and
+    /// ```other``` pairwise. Works in-place.
+    fn apply2<F>(&mut self, other: &Self, f: F)
+    where
+        F: FnMut(Self::Subpixel, Self::Subpixel) -> Self::Subpixel;
+
+    /// Invert this pixel
+    fn invert(&mut self);
+
+    /// Blend the color of a given pixel into ourself, taking into account alpha channels
+    fn blend(&mut self, other: &Self);
+}
 
 /// Private module for supertraits of sealed traits.
 mod seals {


### PR DESCRIPTION
Moves `Pixel` into the trait module. Exposes a public `buffer` module where iterators and other auxiliary definitions relating to the `ImageBuffer` are exported. The main `ImageBuffer` is _not_ re-exported within that module, for now. At some point we might want to make the type less special and then change the structure further and deprecate old export points.

Closes: #1069 
Closes: #549 (which apparently was either re-broken or never fixed)

