### PR TITLE
Cleanup internal benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ env:
 matrix:
   allow_failures:
     - name: "Clippy"
+    - name: "Public private dependencies"
     - rust: nightly
   include:
     - os: osx
@@ -47,6 +48,10 @@ matrix:
       rust: nightly
     - os: windows
       rust: nightly
+    - os: linux
+      rust: nightly
+      name: "Internal benchmarks"
+      env: BENCHMARKS='yes'
     - os: linux
       rust: stable
       name: "Clippy"
@@ -80,7 +85,6 @@ script:
   - if [ -n "${DEFAULT_FEATURES+exists}" ]; then
       cargo test -v;
     fi
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ] && [ -n "${DEFAULT_FEATURES+exists}" ]; then
-      cargo build -v --features=benchmarks &&
+  - if [ -n "${BENCHMARKS+exists}" ]; then
       cargo build -v --benches --features=benchmarks;
     fi

--- a/src/bmp/encoder.rs
+++ b/src/bmp/encoder.rs
@@ -256,11 +256,6 @@ mod tests {
     use crate::image::ImageDecoder;
     use std::io::Cursor;
 
-    #[cfg(feature = "benchmarks")]
-    use test::{Bencher};
-//     #[cfg(feature = "benchmarks")]
-//     use std::fs::File;
-
     fn round_trip_image(image: &[u8], width: u32, height: u32, c: ColorType) -> Vec<u8> {
         let mut encoded_data = Vec::new();
         {
@@ -276,74 +271,6 @@ mod tests {
         decoder.read_image(&mut buf).expect("failed to decode");
         buf
     }
-
-    #[cfg(feature = "benchmarks")]
-    #[bench]
-    fn bench_encode_rgb(b: &mut Bencher) {
-        let mut v= Vec::with_capacity(2000 * 2000);
-        let mut x = BMPEncoder::new(&mut v);
-        let mut im = vec![0; 2000 * 2000];
-        b.iter(|| {
-            x.encode_rgb(&mut im, 500, 2000, 0, 4);
-        });
-    }
-
-    #[cfg(feature = "benchmarks")]
-    #[bench]
-    fn bench_encode_rgba(b: &mut Bencher) {
-        let mut v= Vec::with_capacity(2000 * 2000);
-        let mut x = BMPEncoder::new(&mut v);
-        let mut im = vec![0; 2000 * 2000];
-        b.iter(|| {
-            x.encode_rgba(&mut im, 500, 2000, 0, 4);
-        });
-    }
-
-    #[cfg(feature = "benchmarks")]
-    #[bench]
-    fn bench_encode_gray(b: &mut Bencher) {
-        let mut v: Vec<u8> = Vec::with_capacity(2000 * 2000);
-        let mut x = BMPEncoder::new(& mut v);
-        let mut im = vec![0; 2000 * 2000];
-        b.iter(|| {
-            x.encode_gray(&mut im, 500, 2000, 0, 4);
-        });
-    }
-
-    #[cfg(feature = "benchmarks")]
-    #[bench]
-    fn bench_encode_gray_buf(b: &mut Bencher) {
-        let mut u: Vec<u8> = Vec::with_capacity(2000 * 2000);
-        let mut v= BufWriter::new(&mut u);
-        let mut x = BMPEncoder::new(& mut v);
-        let mut im = vec![0; 2000 * 2000];
-        b.iter(|| {
-            x.encode_gray(&mut im, 500, 2000, 0, 4);
-        });
-    }
-
-//     #[cfg(feature = "benchmarks")]
-//     #[bench]
-//     fn bench_encode_gray_buf_file(b: &mut Bencher) {
-//         let mut file = File::create("temp.bmp").unwrap();
-//         let mut v= BufWriter::new(&mut file);
-//         let mut x = BMPEncoder::new(& mut v);
-//         let mut im = vec![0; 2000 * 2000];
-//         b.iter(|| {
-//             x.encode_gray(&mut im, 500, 2000, 0, 4);
-//         });
-//     }
-
-//     #[cfg(feature = "benchmarks")]
-//     #[bench]
-//     fn bench_encode_gray_file(b: &mut Bencher) {
-//         let mut file = File::create("temp.bmp").unwrap();
-//         let mut x = BMPEncoder::new(& mut file);
-//         let mut im = vec![0; 2000 * 2000];
-//         b.iter(|| {
-//             x.encode_gray(&mut im, 500, 2000, 0, 4);
-//         });
-//     }
 
     #[test]
     fn round_trip_single_pixel_rgb() {

--- a/src/webp/vp8.rs
+++ b/src/webp/vp8.rs
@@ -2021,11 +2021,16 @@ mod test {
     extern crate test;
     use super::{top_pixels, edge_pixels, avg2, avg3, predict_bvepred, predict_brdpred, predict_bldpred, predict_bhepred, add_residue};
     #[cfg(feature = "benchmarks")]
+    use super::{IntraMode, predict_4x4};
+    #[cfg(feature = "benchmarks")]
     use test::{Bencher, black_box};
 
+    #[cfg(feature = "benchmarks")]
     const W: usize = 256;
+    #[cfg(feature = "benchmarks")]
     const H: usize = 256;
 
+    #[cfg(feature = "benchmarks")]
     fn make_sample_image() -> Vec<u8> {
         let mut v = Vec::with_capacity((W * H * 4) as usize);
         for c in 0u8..=255 {


### PR DESCRIPTION
Removes bmp benchmarks that have been implemented as integration
benchmarks. Fixes the compilation of vp8 benchmarks that test some
implementation methods.
