### PR TITLE
Add crosslink to github docs.

### DIFF
--- a/src/io/reader.rs
+++ b/src/io/reader.rs
@@ -149,7 +149,7 @@ impl<R: BufRead + Seek> Reader<R> {
     ///
     /// ## Usage
     ///
-    /// This supplements the path based type deduction from [`open`] with content based deduction.
+    /// This supplements the path based type deduction from [`open`](Reader::open) with content based deduction.
     /// This is more common in Linux and UNIX operating systems and also helpful if the path can
     /// not be directly controlled.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 //! This crate provides native rust implementations of
 //! image encoders and decoders and basic image manipulation
 //! functions.
+//!
+//! Additional documentation can currently be found in the
+//! [README.md file which is most easily viewed on github](https://github.com/image-rs/image/blob/master/README.md).
 
 #![warn(missing_docs)]
 #![warn(unused_qualifications)]


### PR DESCRIPTION
Per discussion on #1180 most of the documentation will remain in `README.md` for now. However, the first search engine hit when searching for "rust image" is the docs.rs version of `src/lib.rs`, so having a link through to `README.md` significantly helps with documentation discoverability.