### PR TITLE
Add more crate documentation

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -343,6 +343,54 @@ where
 }
 
 /// Generic image buffer
+///
+/// This is an image parameterised by its Pixel types, represented by a width and height and a
+/// container of channel data. It provides direct access to its pixels and implements the
+/// [`GenericImageView`] and [`GenericImage`] traits. In many ways, this is the standard buffer
+/// implementing those traits. Using this concrete type instead of a generic type parameter has
+/// been shown to improve performance.
+///
+/// The crate defines a few type aliases with regularly used pixel types for your convenience, such
+/// as `RgbImage`, `GrayImage` etc.
+///
+/// [`GenericImage`]: trait.GenericImage.html
+/// [`GenericImageView`]: trait.GenericImageView.html
+/// [`RgbImage`]: type.RgbImage.html
+/// [`GrayImage`]: type.GrayImage.html
+///
+/// ## Examples
+///
+/// Create a simple canvas and paint a small cross.
+///
+/// ```
+/// use image::{RgbImage, Rgb};
+///
+/// let mut img = RgbImage::new(32, 32);
+///
+/// for x in 15..=17 {
+///     for y in 8..24 {
+///         img.put_pixel(x, y, Rgb([255, 0, 0]));
+///         img.put_pixel(y, x, Rgb([255, 0, 0]));
+///     }
+/// }
+/// ```
+///
+/// Overlays an image on top of a larger background raster.
+///
+/// ```no_run
+/// use image::{GenericImage, GenericImageView, ImageBuffer, open};
+///
+/// let on_top = open("path/to/some.png").unwrap().into_rgb();
+/// let mut img = ImageBuffer::from_fn(512, 512, |x, y| {
+///     if (x + y) % 2 == 0 {
+///         image::Rgb([0, 0, 0])
+///     } else {
+///         image::Rgb([255, 255, 255])
+///     }
+/// });
+///
+/// image::imageops::overlay(&mut img, &on_top, 128, 128);
+/// ```
 #[derive(Debug)]
 pub struct ImageBuffer<P: Pixel, Container> {
     width: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,99 @@
 //! image encoders and decoders and basic image manipulation
 //! functions.
 //!
-//! Additional documentation can currently be found in the
-//! [README.md file which is most easily viewed on github](https://github.com/image-rs/image/blob/master/README.md).
+//! Additional documentation can currently also be found in the
+//! [README.md file which is most easily viewed on github](https://github.com/image-rs/image/blob/master/README.md). 
+//!
+//! [Jump forward to crate content](#reexports)
+//!
+//! # Overview
+//!
+//! There are two core problems for this library provides solutions: a unified interface for images
+//! encodings and simple generic buffers for their content. It's possible to use either feature
+//! without the other. The focus is on small and stable set of common operations that can be
+//! supplemented by other specialized crates. The library also prefers safe solutions with few
+//! dependencies.
+//!
+//! | Format | Decoding | Encoding |
+//! | ------ | -------- | -------- |
+//! | PNG    | All supported color types | Same as decoding |
+//! | JPEG   | Baseline and progressive | Baseline JPEG |
+//! | GIF    | Yes | Yes |
+//! | BMP    | Yes | RGB(8), RGBA(8), Gray(8), GrayA(8) |
+//! | ICO    | Yes | Yes |
+//! | TIFF   | Baseline(no fax support) + LZW + PackBits | RGB(8), RGBA(8), Gray(8) |
+//! | WebP   | Lossy(Luma channel only) | No |
+//! | PNM    | PBM, PGM, PPM, standard PAM | Yes |
+//! | DDS    | DXT1, DXT3, DXT5 | No |
+//! | TGA    | Yes | No |
+//! | farbfeld | Yes | Yes |
+//!
+//! ## Using images decoders
+//!
+//! There exists a huge variety of image formats that are concerned with efficiently encoding image
+//! pixel data and auxiliary meta data for many different purposes. The `image` library provides
+//! decoders for many common formats, depending on the active features. The best way to use them
+//! depends on your use case.
+//!
+//! * [`open`] is a very simple way to load images from the file system, automatically deducing the
+//!   format but offering little customization.
+//! * [`load_from_memory`], [`load_from_memory_with_format`] present a similar interface for images
+//!   whose encoded data is already present in memory.
+//! * [`io::Reader`] is a builder providing a superset of the functions. It offers both
+//!   customization and auto-deduction but is slightly more involved. The main benefit is that the
+//!   interface is easier to evolve.
+//! * [`ImageDecoder`] is a trait for querying meta data and reading image pixels into a generic
+//!   byte buffer. It also contains a `Read` adaptor for stream reading the pixels.
+//! * [`DynamicImage::from_decoder`] can be used for creating a buffer from a single specific or
+//!   any custom decoder implementing the [`ImageDecoder`] trait.
+//!
+//! [`open`]: #fn.open.html
+//! [`load_from_memory`]: #fn.load_from_memory.html
+//! [`load_from_memory_with_format`]: #fn.load_from_memory_with_format.html
+//! [`io::Reader`]: io/struct.Reader.html
+//! [`DynamicImage::from_decoder`]: enum.DynamicImage.html#method.from_decoder
+//! [`ImageDecoder`]: trait.ImageDecoder.html
+//!
+//! ## Using image encoders
+//!
+//! Encoding pixel data is supported for the majority of formats but not quite as broadly.
+//!
+//! * [`DynamicImage::save`] is converse of `open` and stores a `DynamicImage`.
+//! * [`DynamicImage::write_to`] can be used to encode an image into any writer, for example into a
+//!   vector of bytes in memory.
+//! * [`save_buffer`], [`save_buffer_with_format`] are a low-level interface for saving an image
+//!   in the file system where the library initializes the chosen encoder.
+//! * [`ImageEncoder`] is a trait for encoding a byte buffer of image data and the inverse of the
+//!   `ImageDecoder` interface.
+//!
+//! [`save_buffer`]: #fn.save_buffer.html
+//! [`save_buffer_with_format`]: #fn.save_buffer_with_format.html
+//! [`DynamicImage::save`]: enum.DynamicImage.html#method.save
+//! [`DynamicImage::write_to`]: enum.DynamicImage.html#method.write_to
+//! [`ImageEncoder`]: trait.ImageEncoder.html
+//!
+//! ## Image buffers
+//!
+//! The library adds containers for channel data which together form some representation of a 2D
+//! matrix of pixels. These are all statically typed to avoid misinterpretation of byte data (and
+//! since Rust has no standard safe encapsulation for reinterpreting byte slices as another type).
+//! The main traits [`GenericImageView`] and [`GenericImage`] model a view on a 2D-matrix of
+//! addressable pixels and a buffer of independently accessible pixels respectively.
+//!
+//! The two main types for owning pixel data are [`ImageBuffer`] and [`DynamicImage`]. Note that
+//! the latter is an enum over well-supported pixel types that also offers conversion
+//! functionality.
+//!
+//! Additionally, the [`flat`] module contains items for interoperability with generic channel
+//! matrices and foreign interface. While still strict typed these dynamically validate length and
+//! other layout assumptions required to provide the trait interface. While quite generic You
+//! should be prepared for a bit of boilerplate when using these types.
+//!
+//! [`GenericImageView`]: trait.GenericImageView.html
+//! [`GenericImage`]: trait.GenericImage.html
+//! [`ImageBuffer`]: struct.ImageBuffer.html
+//! [`DynamicImage`]: enum.DynamicImage.html
+//! [`flat`]: flat/index.html
 
 #![warn(missing_docs)]
 #![warn(unused_qualifications)]


### PR DESCRIPTION
Adds more documentation that addresses some of #1182. This does not yet remove those sections from the Readme, it's also a slight rewrite of the relevant sections or purely new documentation especially on how and when to use the different decoders.