### PR TITLE
Remove DimensionError constructor

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -24,7 +24,7 @@ use crate::buffer_::{
     Rgba16Image,
 };
 use crate::color::{self, IntoColor};
-use crate::error::{ImageError, ImageResult};
+use crate::error::{ImageError, ImageResult, ParameterError, ParameterErrorKind};
 use crate::flat::FlatSamples;
 use crate::image;
 use crate::image::{GenericImage, GenericImageView, ImageDecoder, ImageFormat, ImageOutputFormat};
@@ -916,7 +916,9 @@ fn decoder_to_image<'a, I: ImageDecoder<'a>>(decoder: I) -> ImageResult<DynamicI
     };
     match image {
         Some(image) => Ok(image),
-        None => Err(ImageError::DimensionError),
+        None => Err(ImageError::Parameter(
+            ParameterError::from_kind(ParameterErrorKind::DimensionMismatch)
+        ))
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -196,12 +196,6 @@ pub enum ImageFormatHint {
 #[allow(non_upper_case_globals)]
 #[allow(non_snake_case)]
 impl ImageError {
-    pub(crate) const DimensionError: Self =
-        ImageError::Parameter(ParameterError {
-            kind: ParameterErrorKind::DimensionMismatch,
-            underlying: None,
-        });
-
     pub(crate) fn UnsupportedError(message: String) -> Self {
         ImageError::Unsupported(UnsupportedError::legacy_from_string(message))
     }

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -49,7 +49,7 @@ use num_traits::Zero;
 
 use crate::ImageBuffer;
 use crate::color::ColorType;
-use crate::error::ImageError;
+use crate::error::{ImageError, ParameterError, ParameterErrorKind};
 use crate::image::{GenericImage, GenericImageView};
 use crate::traits::Pixel;
 
@@ -1376,7 +1376,9 @@ impl<Buffer, P: Pixel> GenericImage for ViewMut<Buffer, P>
 impl From<Error> for ImageError {
     fn from(error: Error) -> ImageError {
         match error {
-            Error::TooLarge => ImageError::DimensionError,
+            Error::TooLarge => ImageError::Parameter(
+                ParameterError::from_kind(ParameterErrorKind::DimensionMismatch)
+            ),
             Error::WrongColor(color) => ImageError::UnsupportedColor(color.into()),
             Error::NormalFormRequired(form) => ImageError::FormatError(
                 format!("Required sample buffer in normal form {:?}", form)),

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -387,13 +387,11 @@ impl<W: Write> Encoder<W> {
 
         // Create the gif::Frame from the animation::Frame
         let mut frame = Frame::from_rgba(width, height, &mut *rbga_frame);
-        frame.delay = (frame_delay / 10)
-            .try_into()
-            .map_err(|_| {
-                ImageError::Parameter(ParameterError::from_kind(
-                    ParameterErrorKind::DimensionMismatch
-                ))
-            })?;
+        // Saturate the conversion to u16::MAX instead of returning an error as that
+        // would require a new special cased variant in ParameterErrorKind which most
+        // likely couldn't be reused for other cases. This isn't a bad trade-off given
+        // that the current algorithm is already lossy.
+        frame.delay = (frame_delay / 10).try_into().unwrap_or(std::u16::MAX);
 
         Ok(frame)
     }

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -387,7 +387,13 @@ impl<W: Write> Encoder<W> {
 
         // Create the gif::Frame from the animation::Frame
         let mut frame = Frame::from_rgba(width, height, &mut *rbga_frame);
-        frame.delay = (frame_delay / 10).try_into().map_err(|_|ImageError::DimensionError)?;
+        frame.delay = (frame_delay / 10)
+            .try_into()
+            .map_err(|_| {
+                ImageError::Parameter(ParameterError::from_kind(
+                    ParameterErrorKind::DimensionMismatch
+                ))
+            })?;
 
         Ok(frame)
     }
@@ -399,7 +405,9 @@ impl<W: Write> Encoder<W> {
             Some((width, height))
         }
 
-        inner_dimensions(width, height).ok_or(ImageError::DimensionError)
+        inner_dimensions(width, height).ok_or(ImageError::Parameter(ParameterError::from_kind(
+            ParameterErrorKind::DimensionMismatch
+        )))
     }
 
     pub(crate) fn encode_gif(&mut self, frame: Frame) -> ImageResult<()> {

--- a/src/image.rs
+++ b/src/image.rs
@@ -8,7 +8,7 @@ use std::usize;
 
 use crate::ImageBuffer;
 use crate::color::{ColorType, ExtendedColorType};
-use crate::error::{ImageError, ImageResult, LimitError, LimitErrorKind};
+use crate::error::{ImageError, ImageResult, LimitError, LimitErrorKind, ParameterError, ParameterErrorKind};
 use crate::math::Rect;
 use crate::traits::Pixel;
 
@@ -272,7 +272,9 @@ pub(crate) fn load_rect<'a, D, F, F1, F2, E>(x: u32, y: u32, width: u32, height:
 
         if x + width > u64::from(dimensions.0) || y + height > u64::from(dimensions.1)
             || width == 0 || height == 0 {
-                return Err(ImageError::DimensionError);
+                return Err(ImageError::Parameter(ParameterError::from_kind(
+                    ParameterErrorKind::DimensionMismatch,
+                )));
             }
         if scanline_bytes > usize::max_value() as u64 {
             return Err(ImageError::Limits(LimitError::from_kind(
@@ -657,7 +659,9 @@ pub trait GenericImage: GenericImageView {
         // Do bounds checking here so we can use the non-bounds-checking
         // functions to copy pixels.
         if self.width() < other.width() + x || self.height() < other.height() + y {
-            return Err(ImageError::DimensionError);
+            return Err(ImageError::Parameter(ParameterError::from_kind(
+                ParameterErrorKind::DimensionMismatch,
+            )));
         }
 
         for i in 0..other.width() {

--- a/src/imageops/affine.rs
+++ b/src/imageops/affine.rs
@@ -2,6 +2,7 @@
 
 use crate::ImageBuffer;
 use crate::image::{GenericImage, GenericImageView};
+use crate::error::{ImageError, ParameterError, ParameterErrorKind};
 use crate::traits::Pixel;
 
 /// Rotate an image 90 degrees clockwise.
@@ -51,7 +52,9 @@ pub fn rotate90_in<I, Container>(
 {
     let ((w0, h0), (w1, h1)) = (image.dimensions(), destination.dimensions());
     if w0 != h1 || h0 != w1 {
-        return Err(crate::ImageError::DimensionError);
+        return Err(ImageError::Parameter(ParameterError::from_kind(
+            ParameterErrorKind::DimensionMismatch,
+        )));
     }
 
     for y in 0..h0 {
@@ -74,7 +77,9 @@ pub fn rotate180_in<I, Container>(
 {
     let ((w0, h0), (w1, h1)) = (image.dimensions(), destination.dimensions());
     if w0 != w1 || h0 != h1 {
-        return Err(crate::ImageError::DimensionError);
+        return Err(ImageError::Parameter(ParameterError::from_kind(
+            ParameterErrorKind::DimensionMismatch,
+        )));
     }
 
     for y in 0..h0 {
@@ -97,7 +102,9 @@ pub fn rotate270_in<I, Container>(
 {
     let ((w0, h0), (w1, h1)) = (image.dimensions(), destination.dimensions());
     if w0 != h1 || h0 != w1 {
-        return Err(crate::ImageError::DimensionError);
+        return Err(ImageError::Parameter(ParameterError::from_kind(
+            ParameterErrorKind::DimensionMismatch,
+        )));
     }
 
     for y in 0..h0 {
@@ -144,7 +151,9 @@ pub fn flip_horizontal_in<I, Container>(
 {
     let ((w0, h0), (w1, h1)) = (image.dimensions(), destination.dimensions());
     if w0 != w1 || h0 != h1 {
-        return Err(crate::ImageError::DimensionError);
+        return Err(ImageError::Parameter(ParameterError::from_kind(
+            ParameterErrorKind::DimensionMismatch,
+        )));
     }
 
     for y in 0..h0 {
@@ -167,7 +176,9 @@ pub fn flip_vertical_in<I, Container>(
 {
     let ((w0, h0), (w1, h1)) = (image.dimensions(), destination.dimensions());
     if w0 != w1 || h0 != h1 {
-        return Err(crate::ImageError::DimensionError);
+        return Err(ImageError::Parameter(ParameterError::from_kind(
+            ParameterErrorKind::DimensionMismatch,
+        )));
     }
 
     for y in 0..h0 {

--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::too_many_arguments)]
 
 use byteorder::{BigEndian, WriteBytesExt};
-use crate::error::{ImageError, ImageResult, UnsupportedError, UnsupportedErrorKind};
+use crate::error::{ImageError, ImageResult, ParameterError, ParameterErrorKind, UnsupportedError, UnsupportedErrorKind};
 use crate::math::utils::clamp;
 use num_iter::range_step;
 use std::io::{self, Write};
@@ -449,8 +449,16 @@ impl<'a, W: Write> JPEGEncoder<'a, W> {
         build_frame_header(
             &mut buf,
             8,
-            u16::try_from(width).map_err(|_| ImageError::DimensionError)?,
-            u16::try_from(height).map_err(|_| ImageError::DimensionError)?,
+            u16::try_from(width).map_err(|_| {
+                ImageError::Parameter(ParameterError::from_kind(
+                    ParameterErrorKind::DimensionMismatch,
+                ))
+            })?,
+            u16::try_from(height).map_err(|_| {
+                ImageError::Parameter(ParameterError::from_kind(
+                    ParameterErrorKind::DimensionMismatch,
+                ))
+            })?,
             &self.components[..num_components],
         );
         self.writer.write_segment(SOF0, Some(&buf))?;


### PR DESCRIPTION
Removal of the DimensionError constructor listed in #1134.

There is one instance where I don't think the error is fitting though I wasn't sure what to replace it with either which is in the gif module where it is being used for erroring on the `frame_delay` being bigger than a `u16`.