### PR TITLE
Replace legacy error constructors in ICO decoder. Make DecodingError::message a Cow to reduce allocations

### DIFF
--- a/src/bmp/decoder.rs
+++ b/src/bmp/decoder.rs
@@ -117,7 +117,7 @@ fn check_for_overflow(width: i32, length: i32, channels: usize) -> ImageResult<(
         .ok_or_else(|| {
             ImageError::Decoding(DecodingError::with_message(
                 ImageFormat::Png.into(),
-                "Image would require a buffer that is too large to be represented!".to_owned(),
+                "Image would require a buffer that is too large to be represented!",
             ))
         })
 }
@@ -372,13 +372,13 @@ impl Bitfield {
         if len != mask.count_ones() {
             return Err(ImageError::Decoding(DecodingError::with_message(
                 ImageFormat::Bmp.into(),
-                "Non-contiguous bitfield mask".to_owned(),
+                "Non-contiguous bitfield mask",
             )));
         }
         if len + shift > max_len {
             return Err(ImageError::Decoding(DecodingError::with_message(
                 ImageFormat::Bmp.into(),
-                "Invalid bitfield mask".to_owned(),
+                "Invalid bitfield mask",
             )));
         }
         if len > 8 {
@@ -429,7 +429,7 @@ impl Bitfields {
         if bitfields.r.len == 0 || bitfields.g.len == 0 || bitfields.b.len == 0 {
             return Err(ImageError::Decoding(DecodingError::with_message(
                 ImageFormat::Bmp.into(),
-                "Missing bitfield mask".to_owned(),
+                "Missing bitfield mask",
             )));
         }
         Ok(bitfields)
@@ -590,7 +590,7 @@ impl<R: Read + Seek> BmpDecoder<R> {
         if signature != b"BM"[..] {
             return Err(ImageError::Decoding(DecodingError::with_message(
                 ImageFormat::Bmp.into(),
-                "BMP signature not found".to_owned(),
+                "BMP signature not found",
             )));
         }
 
@@ -619,7 +619,7 @@ impl<R: Read + Seek> BmpDecoder<R> {
         if self.reader.read_u16::<LittleEndian>()? != 1 {
             return Err(ImageError::Decoding(DecodingError::with_message(
                 ImageFormat::Bmp.into(),
-                "More than one plane".to_owned(),
+                "More than one plane",
             )));
         }
 
@@ -630,7 +630,7 @@ impl<R: Read + Seek> BmpDecoder<R> {
             _ => {
                 return Err(ImageError::Decoding(DecodingError::with_message(
                     ImageFormat::Bmp.into(),
-                    "Invalid bit count".to_owned(),
+                    "Invalid bit count",
                 )))
             }
         };
@@ -650,21 +650,21 @@ impl<R: Read + Seek> BmpDecoder<R> {
         if self.width < 0 {
             return Err(ImageError::Decoding(DecodingError::with_message(
                 ImageFormat::Bmp.into(),
-                "Negative width".to_owned(),
+                "Negative width",
             )));
         } else if self.width > MAX_WIDTH_HEIGHT || self.height > MAX_WIDTH_HEIGHT {
             // Limit very large image sizes to avoid OOM issues. Images with these sizes are
             // unlikely to be valid anyhow.
             return Err(ImageError::Decoding(DecodingError::with_message(
                 ImageFormat::Bmp.into(),
-                "Image too large".to_owned(),
+                "Image too large",
             )));
         }
 
         if self.height == i32::min_value() {
             return Err(ImageError::Decoding(DecodingError::with_message(
                 ImageFormat::Bmp.into(),
-                "Invalid height".to_owned(),
+                "Invalid height",
             )));
         }
 
@@ -680,7 +680,7 @@ impl<R: Read + Seek> BmpDecoder<R> {
         if self.reader.read_u16::<LittleEndian>()? != 1 {
             return Err(ImageError::Decoding(DecodingError::with_message(
                 ImageFormat::Bmp.into(),
-                "More than one plane".to_owned(),
+                "More than one plane",
             )));
         }
 
@@ -691,7 +691,7 @@ impl<R: Read + Seek> BmpDecoder<R> {
         if self.top_down && image_type_u32 != 0 && image_type_u32 != 3 {
             return Err(ImageError::Decoding(DecodingError::with_message(
                 ImageFormat::Bmp.into(),
-                "Invalid image type for top-down image.".to_owned(),
+                "Invalid image type for top-down image.",
             )));
         }
         self.image_type = match image_type_u32 {
@@ -713,7 +713,7 @@ impl<R: Read + Seek> BmpDecoder<R> {
                 _ => {
                     return Err(ImageError::Decoding(DecodingError::with_message(
                         ImageFormat::Bmp.into(),
-                        "Invalid RLE8 bit count".to_owned(),
+                        "Invalid RLE8 bit count",
                     )))
                 }
             },
@@ -722,7 +722,7 @@ impl<R: Read + Seek> BmpDecoder<R> {
                 _ => {
                     return Err(ImageError::Decoding(DecodingError::with_message(
                         ImageFormat::Bmp.into(),
-                        "Invalid RLE4 bit count".to_owned(),
+                        "Invalid RLE4 bit count",
                     )))
                 }
             },
@@ -732,7 +732,7 @@ impl<R: Read + Seek> BmpDecoder<R> {
                 _ => {
                     return Err(ImageError::Decoding(DecodingError::with_message(
                         ImageFormat::Bmp.into(),
-                        "Invalid bitfields bit count".to_owned(),
+                        "Invalid bitfields bit count",
                     )))
                 }
             },
@@ -836,7 +836,7 @@ impl<R: Read + Seek> BmpDecoder<R> {
                     // Size of any valid header types won't be smaller than core header type.
                     return Err(ImageError::Decoding(DecodingError::with_message(
                         ImageFormat::Bmp.into(),
-                        "Bitmap header is too small".to_owned(),
+                        "Bitmap header is too small",
                     )));
                 }
                 _ => {
@@ -1171,7 +1171,7 @@ impl<R: Read + Seek> BmpDecoder<R> {
             num_bytes(self.width, self.height, self.num_channels()).ok_or_else(|| {
                 ImageError::Decoding(DecodingError::with_message(
                     ImageFormat::Bmp.into(),
-                    "Image buffer would be too large!".to_owned(),
+                    "Image buffer would be too large!",
                 ))
             })?;
         let mut pixel_data = self.create_pixel_data();
@@ -1330,7 +1330,7 @@ impl<R: Read + Seek> BmpDecoder<R> {
                         // We ran out of data while we still had rows to fill in.
                         return Err(ImageError::Decoding(DecodingError::with_message(
                             ImageFormat::Bmp.into(),
-                            "Not enough RLE data".to_owned(),
+                            "Not enough RLE data",
                         )));
                     }
                 }
@@ -1354,7 +1354,7 @@ impl<R: Read + Seek> BmpDecoder<R> {
                 Some(_) => self.read_16_bit_pixel_data(None),
                 None => Err(ImageError::Decoding(DecodingError::with_message(
                     ImageFormat::Bmp.into(),
-                    "Missing 16-bit bitfield masks".to_owned(),
+                    "Missing 16-bit bitfield masks",
                 ))),
             },
             ImageType::Bitfields32 => match self.bitfields {
@@ -1364,7 +1364,7 @@ impl<R: Read + Seek> BmpDecoder<R> {
                 Some(_) => self.read_32_bit_pixel_data(),
                 None => Err(ImageError::Decoding(DecodingError::with_message(
                     ImageFormat::Bmp.into(),
-                    "Missing 32-bit bitfield masks".to_owned(),
+                    "Missing 32-bit bitfield masks",
                 ))),
             },
         }?;

--- a/src/dds.rs
+++ b/src/dds.rs
@@ -48,7 +48,7 @@ impl PixelFormat {
         if size != 32 {
             return Err(ImageError::Decoding(DecodingError::with_message(
                 ImageFormat::Dds.into(),
-                "Invalid DDS PixelFormat size".to_string(),
+                "Invalid DDS PixelFormat size",
             )));
         }
 
@@ -74,7 +74,7 @@ impl Header {
         if size != 124 {
             return Err(ImageError::Decoding(DecodingError::with_message(
                 ImageFormat::Dds.into(),
-                "Invalid DDS header size".to_string(),
+                "Invalid DDS header size",
             )));
         }
 
@@ -84,7 +84,7 @@ impl Header {
         if flags & (REQUIRED_FLAGS | !VALID_FLAGS) != REQUIRED_FLAGS {
             return Err(ImageError::Decoding(DecodingError::with_message(
                 ImageFormat::Dds.into(),
-                "Invalid DDS header flags".to_string(),
+                "Invalid DDS header flags",
             )));
         }
 

--- a/src/png.rs
+++ b/src/png.rs
@@ -270,7 +270,7 @@ impl ImageError {
             IoError(err) => ImageError::IoError(err),
             Format(message) => ImageError::Decoding(DecodingError::with_message(
                 ImageFormat::Png.into(),
-                message.into_owned(),
+                message,
             )),
             LimitsExceeded => ImageError::Limits(LimitError::from_kind(
                 LimitErrorKind::InsufficientMemory,

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -300,7 +300,7 @@ trait HeaderReader: BufRead {
             if len == 0 {
                 return Err(ImageError::Decoding(DecodingError::with_message(
                     ImageFormat::Pnm.into(),
-                    "Unexpected end of pnm header".to_string(),
+                    "Unexpected end of pnm header",
                 )));
             }
             if line.as_bytes()[0] == b'#' {
@@ -309,7 +309,7 @@ trait HeaderReader: BufRead {
             if !line.is_ascii() {
                 return Err(ImageError::Decoding(DecodingError::with_message(
                     ImageFormat::Pnm.into(),
-                    "Only ascii characters allowed in pam header".to_string(),
+                    "Only ascii characters allowed in pam header",
                 )));
             }
             #[allow(deprecated)]
@@ -321,7 +321,7 @@ trait HeaderReader: BufRead {
                     if height.is_some() {
                         return Err(ImageError::Decoding(DecodingError::with_message(
                             ImageFormat::Pnm.into(),
-                            "Duplicate HEIGHT line".to_string(),
+                            "Duplicate HEIGHT line",
                         )));
                     } else {
                         let h = rest
@@ -335,7 +335,7 @@ trait HeaderReader: BufRead {
                     if width.is_some() {
                         return Err(ImageError::Decoding(DecodingError::with_message(
                             ImageFormat::Pnm.into(),
-                            "Duplicate WIDTH line".to_string(),
+                            "Duplicate WIDTH line",
                         )));
                     } else {
                         let w = rest
@@ -349,7 +349,7 @@ trait HeaderReader: BufRead {
                     if depth.is_some() {
                         return Err(ImageError::Decoding(DecodingError::with_message(
                             ImageFormat::Pnm.into(),
-                            "Duplicate DEPTH line".to_string(),
+                            "Duplicate DEPTH line",
                         )));
                     } else {
                         let d = rest
@@ -363,7 +363,7 @@ trait HeaderReader: BufRead {
                     if maxval.is_some() {
                         return Err(ImageError::Decoding(DecodingError::with_message(
                             ImageFormat::Pnm.into(),
-                            "Duplicate MAXVAL line".to_string(),
+                            "Duplicate MAXVAL line",
                         )));
                     } else {
                         let m = rest
@@ -389,7 +389,7 @@ trait HeaderReader: BufRead {
                 _ => {
                     return Err(ImageError::Decoding(DecodingError::with_message(
                         ImageFormat::Pnm.into(),
-                        "Unknown header line".to_string(),
+                        "Unknown header line",
                     )))
                 }
             }
@@ -399,25 +399,25 @@ trait HeaderReader: BufRead {
             (None, _, _, _) => {
                 return Err(ImageError::Decoding(DecodingError::with_message(
                     ImageFormat::Pnm.into(),
-                    "Expected one HEIGHT line".to_string(),
+                    "Expected one HEIGHT line",
                 )))
             }
             (_, None, _, _) => {
                 return Err(ImageError::Decoding(DecodingError::with_message(
                     ImageFormat::Pnm.into(),
-                    "Expected one WIDTH line".to_string(),
+                    "Expected one WIDTH line",
                 )))
             }
             (_, _, None, _) => {
                 return Err(ImageError::Decoding(DecodingError::with_message(
                     ImageFormat::Pnm.into(),
-                    "Expected one DEPTH line".to_string(),
+                    "Expected one DEPTH line",
                 )))
             }
             (_, _, _, None) => {
                 return Err(ImageError::Decoding(DecodingError::with_message(
                     ImageFormat::Pnm.into(),
-                    "Expected one MAXVAL line".to_string(),
+                    "Expected one MAXVAL line",
                 )))
             }
             (Some(h), Some(w), Some(d), Some(m)) => (h, w, d, m),
@@ -514,7 +514,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for PnmDecoder<R> {
 fn err_input_is_too_short() -> ImageError {
     ImageError::Decoding(DecodingError::with_message(
         ImageFormat::Pnm.into(),
-        "Not enough data was provided to the Decoder to decode the image".to_string(),
+        "Not enough data was provided to the Decoder to decode the image",
     ))
 }
 
@@ -575,7 +575,7 @@ fn read_separated_ascii<T: FromStr<Err = ParseIntError>>(reader: &mut dyn Read) 
     if !token.is_ascii() {
         return Err(ImageError::Decoding(DecodingError::with_message(
             ImageFormat::Pnm.into(),
-            "Non ascii character where sample value was expected".to_string(),
+            "Non ascii character where sample value was expected",
         )));
     }
 
@@ -757,7 +757,7 @@ impl DecodableImageHeader for GraymapHeader {
             v if v <= 0xFFFF => Ok(TupleType::GrayU16),
             _ => Err(ImageError::Decoding(DecodingError::with_message(
                 ImageFormat::Pnm.into(),
-                "Image maxval is not less or equal to 65535".to_string(),
+                "Image maxval is not less or equal to 65535",
             ))),
         }
     }
@@ -770,7 +770,7 @@ impl DecodableImageHeader for PixmapHeader {
             v if v <= 0xFFFF => Ok(TupleType::RGBU16),
             _ => Err(ImageError::Decoding(DecodingError::with_message(
                 ImageFormat::Pnm.into(),
-                "Image maxval is not less or equal to 65535".to_string(),
+                "Image maxval is not less or equal to 65535",
             ))),
         }
     }
@@ -790,7 +790,7 @@ impl DecodableImageHeader for ArbitraryHeader {
             Some(ArbitraryTuplType::BlackAndWhite) => {
                 Err(ImageError::Decoding(DecodingError::with_message(
                     ImageFormat::Pnm.into(),
-                    "Invalid depth or maxval for tuple type BLACKANDWHITE".to_string(),
+                    "Invalid depth or maxval for tuple type BLACKANDWHITE",
                 )))
             }
 
@@ -803,7 +803,7 @@ impl DecodableImageHeader for ArbitraryHeader {
             Some(ArbitraryTuplType::Grayscale) => {
                 Err(ImageError::Decoding(DecodingError::with_message(
                     ImageFormat::Pnm.into(),
-                    "Invalid depth or maxval for tuple type GRAYSCALE".to_string(),
+                    "Invalid depth or maxval for tuple type GRAYSCALE",
                 )))
             }
 
@@ -815,13 +815,13 @@ impl DecodableImageHeader for ArbitraryHeader {
             }
             Some(ArbitraryTuplType::RGB) => Err(ImageError::Decoding(DecodingError::with_message(
                 ImageFormat::Pnm.into(),
-                "Invalid depth for tuple type RGB".to_string(),
+                "Invalid depth for tuple type RGB",
             ))),
 
             Some(ArbitraryTuplType::BlackAndWhiteAlpha) => {
                 Err(ImageError::Decoding(DecodingError::with_message(
                     ImageFormat::Pnm.into(),
-                    "Unsupported color type: BlackAndWhiteAlpha".to_string(),
+                    "Unsupported color type: BlackAndWhiteAlpha",
                 )))
             }
             Some(ArbitraryTuplType::GrayscaleAlpha) => Err(ImageError::Unsupported(
@@ -847,7 +847,7 @@ impl DecodableImageHeader for ArbitraryHeader {
             )),
             None => Err(ImageError::Decoding(DecodingError::with_message(
                 ImageFormat::Pnm.into(),
-                "Tuple type not recognized".to_string(),
+                "Tuple type not recognized",
             ))),
         }
     }

--- a/src/webp/decoder.rs
+++ b/src/webp/decoder.rs
@@ -46,14 +46,14 @@ impl<R: Read> WebPDecoder<R> {
         if &*riff != b"RIFF" {
             return Err(ImageError::Decoding(DecodingError::with_message(
                 ImageFormat::WebP.into(),
-                "Invalid RIFF signature".to_string(),
+                "Invalid RIFF signature",
             )));
         }
 
         if &*webp != b"WEBP" {
             return Err(ImageError::Decoding(DecodingError::with_message(
                 ImageFormat::WebP.into(),
-                "Invalid WEBP signature".to_string(),
+                "Invalid WEBP signature",
             )));
         }
 
@@ -74,7 +74,7 @@ impl<R: Read> WebPDecoder<R> {
                     // Alpha, Lossless and Animation isn't supported
                     return Err(ImageError::Decoding(DecodingError::with_message(
                         ImageFormat::WebP.into(),
-                        "Unsupported WEBP feature.".to_string(),
+                        "Unsupported WEBP feature.",
                     )));
                 }
                 _ => {

--- a/src/webp/vp8.rs
+++ b/src/webp/vp8.rs
@@ -689,7 +689,7 @@ impl BoolReader {
         if buf.len() < 2 {
             return Err(ImageError::Decoding(DecodingError::with_message(
                 ImageFormat::WebP.into(),
-                "Expected at least 2 bytes of decoder initialization data".to_owned(),
+                "Expected at least 2 bytes of decoder initialization data",
             )));
         }
 
@@ -1151,7 +1151,7 @@ impl<R: Read> Vp8Decoder<R> {
             if color_space != 0 {
                 return Err(ImageError::Decoding(DecodingError::with_message(
                     ImageFormat::WebP.into(),
-                    "Only YUV color space is specified.".to_string(),
+                    "Only YUV color space is specified.",
                 )));
             }
         }


### PR DESCRIPTION
Also fixes a formatting bug in what is now `ImageEntryDimensionMismatch` with `format: Bmp`.

This knocks off `ico` from the list in #1134 and gets rid of one simple inline TODO item