### PR TITLE
Remove most ImageError::UnsupportedError usages. Destringrypify DDS decoder

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -24,7 +24,7 @@ use crate::buffer_::{
     Rgba16Image,
 };
 use crate::color::{self, IntoColor};
-use crate::error::{ImageError, ImageResult, ParameterError, ParameterErrorKind};
+use crate::error::{ImageError, ImageFormatHint, ImageResult, ParameterError, ParameterErrorKind, UnsupportedError, UnsupportedErrorKind};
 use crate::flat::FlatSamples;
 use crate::image;
 use crate::image::{GenericImage, GenericImageView, ImageDecoder, ImageFormat, ImageOutputFormat};
@@ -758,7 +758,9 @@ impl DynamicImage {
             }
 
             image::ImageOutputFormat::Unsupported(msg) => {
-                Err(ImageError::UnsupportedError(msg))
+                Err(ImageError::Unsupported(UnsupportedError::from_format_and_kind(
+                    ImageFormatHint::Unknown,
+                    UnsupportedErrorKind::Format(ImageFormatHint::Name(msg)))))
             },
 
             image::ImageOutputFormat::__NonExhaustive(marker) => match marker._private {},

--- a/src/image.rs
+++ b/src/image.rs
@@ -128,10 +128,7 @@ impl From<ImageFormat> for ImageOutputFormat {
             #[cfg(feature = "farbfeld")]
             ImageFormat::Farbfeld => ImageOutputFormat::Farbfeld,
 
-            f => ImageOutputFormat::Unsupported(format!(
-                "Image format {:?} not supported for encoding.",
-                f
-            )),
+            f => ImageOutputFormat::Unsupported(format!("{:?}", f)),
         }
     }
 }

--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -126,8 +126,8 @@ impl ImageError {
     fn from_jpeg(err: jpeg::Error) -> ImageError {
         use jpeg::Error::*;
         match err {
-            Format(desc) => {
-                ImageError::Decoding(DecodingError::with_message(ImageFormat::Jpeg.into(), desc))
+            err @ Format(_) => {
+                ImageError::Decoding(DecodingError::new(ImageFormat::Jpeg.into(), err))
             }
             Unsupported(desc) => ImageError::Unsupported(UnsupportedError::from_format_and_kind(
                 ImageFormat::Jpeg.into(),
@@ -145,7 +145,7 @@ impl ImageError {
 mod tests {
     #[cfg(feature = "benchmarks")]
     extern crate test;
-    
+
     use super::cmyk_to_rgb;
     #[cfg(feature = "benchmarks")]
     use test::Bencher;
@@ -190,7 +190,7 @@ mod tests {
             single_pix_correct(cmyk_pixel, rgb_pixel);
         }
     }
-    
+
     #[cfg(feature = "benchmarks")]
     #[bench]
     fn bench_cmyk_to_rgb(b: &mut Bencher) {
@@ -208,7 +208,7 @@ mod tests {
             cmyk_to_rgb(&v);
         });
     }
-    
+
     #[cfg(feature = "benchmarks")]
     #[bench]
     fn bench_cmyk_to_rgb_single(b: &mut Bencher) {

--- a/src/png.rs
+++ b/src/png.rs
@@ -268,9 +268,9 @@ impl ImageError {
         use png::DecodingError::*;
         match err {
             IoError(err) => ImageError::IoError(err),
-            Format(message) => ImageError::Decoding(DecodingError::with_message(
+            err @ Format(_) => ImageError::Decoding(DecodingError::new(
                 ImageFormat::Png.into(),
-                message,
+                err,
             )),
             LimitsExceeded => ImageError::Limits(LimitError::from_kind(
                 LimitErrorKind::InsufficientMemory,


### PR DESCRIPTION
Along with #1196 and #1145 this gets us to zero (ish) `ImageError::UnsupportedError` uses

Part of: #1134, #1195 