### PR TITLE
Add _imm versions of  DynImage:: and imageops::crop(). Fix function links in toplevel doc

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -298,9 +298,17 @@ impl DynamicImage {
         }
     }
 
-    /// Return a cut out of this image delimited by the bounding rectangle.
+    /// Return a cut-out of this image delimited by the bounding rectangle.
+    ///
+    /// Note: this method does *not* modify the object,
+    /// and its signature will be replaced with `crop_imm()`'s in the 0.24 release
     pub fn crop(&mut self, x: u32, y: u32, width: u32, height: u32) -> DynamicImage {
         dynamic_map!(*self, ref mut p => imageops::crop(p, x, y, width, height).to_image())
+    }
+
+    /// Return a cut-out of this image delimited by the bounding rectangle.
+    pub fn crop_imm(&self, x: u32, y: u32, width: u32, height: u32) -> DynamicImage {
+        dynamic_map!(*self, ref p => imageops::crop_imm(p, x, y, width, height).to_image())
     }
 
     /// Return a reference to an 8bit RGB image

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -35,6 +35,29 @@ pub fn crop<I: GenericImageView>(
     width: u32,
     height: u32,
 ) -> SubImage<&mut I> {
+    let (x, y, width, height) = crop_dimms(image, x, y, width, height);
+    SubImage::new(image, x, y, width, height)
+}
+
+/// Return an immutable view into an image
+pub fn crop_imm<I: GenericImageView>(
+    image: &I,
+    x: u32,
+    y: u32,
+    width: u32,
+    height: u32,
+) -> SubImage<&I> {
+    let (x, y, width, height) = crop_dimms(image, x, y, width, height);
+    SubImage::new(image, x, y, width, height)
+}
+
+fn crop_dimms<I: GenericImageView>(
+    image: &I,
+    x: u32,
+    y: u32,
+    width: u32,
+    height: u32,
+) -> (u32, u32, u32, u32) {
     let (iwidth, iheight) = image.dimensions();
 
     let x = cmp::min(x, iwidth);
@@ -43,7 +66,7 @@ pub fn crop<I: GenericImageView>(
     let height = cmp::min(height, iheight - y);
     let width = cmp::min(width, iwidth - x);
 
-    SubImage::new(image, x, y, width, height)
+    (x, y, width, height)
 }
 
 /// Calculate the region that can be copied from top to bottom.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! functions.
 //!
 //! Additional documentation can currently also be found in the
-//! [README.md file which is most easily viewed on github](https://github.com/image-rs/image/blob/master/README.md). 
+//! [README.md file which is most easily viewed on github](https://github.com/image-rs/image/blob/master/README.md).
 //!
 //! [Jump forward to crate content](#reexports)
 //!
@@ -48,9 +48,9 @@
 //! * [`DynamicImage::from_decoder`] can be used for creating a buffer from a single specific or
 //!   any custom decoder implementing the [`ImageDecoder`] trait.
 //!
-//! [`open`]: #fn.open.html
-//! [`load_from_memory`]: #fn.load_from_memory.html
-//! [`load_from_memory_with_format`]: #fn.load_from_memory_with_format.html
+//! [`open`]: fn.open.html
+//! [`load_from_memory`]: fn.load_from_memory.html
+//! [`load_from_memory_with_format`]: fn.load_from_memory_with_format.html
 //! [`io::Reader`]: io/struct.Reader.html
 //! [`DynamicImage::from_decoder`]: enum.DynamicImage.html#method.from_decoder
 //! [`ImageDecoder`]: trait.ImageDecoder.html


### PR DESCRIPTION
The links, as [seen](https://docs.rs/image/0.23.3/image/#fn.open.html) on docs.rs don't actually go anywhere right now.

Ref: #1199