### PR TITLE
Destringtypify PNM, WebP, WebP's VP8 decoders. Remove legacy constructor from PNM decoder. Add Error::source() to HDR's DecoderError. Remove ImageError::with_message(). Remove needless allocations from WebP decoder. Fix PNM header writing with custom TUPLTYPE

### DIFF
--- a/src/dds.rs
+++ b/src/dds.rs
@@ -39,7 +39,7 @@ impl fmt::Display for DecoderError {
             DecoderError::HeaderSizeInvalid(s) =>
                 f.write_fmt(format_args!("Invalid DDS header size: {}", s)),
             DecoderError::HeaderFlagsInvalid(fs) =>
-                f.write_fmt(format_args!("Invalid DDS header flags: {:#010x}", fs)),
+                f.write_fmt(format_args!("Invalid DDS header flags: {:#010X}", fs)),
             DecoderError::DdsSignatureInvalid =>
                 f.write_str("DDS signature not found"),
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -275,25 +275,9 @@ impl DecodingError {
 
     /// A shorthand for a string error without an image format.
     pub(crate) fn legacy_from_string(message: String) -> Self {
-        DecodingError::with_message(ImageFormatHint::Unknown, message)
-    }
-
-    /// Not quite legacy but also highly discouraged.
-    /// This is just since the string typing is prevalent in the `image` decoders...
-    pub(crate) fn with_message<M: Into<Cow<'static, str>>>(
-        format: ImageFormatHint,
-        message: M,
-    ) -> Self {
-        DecodingError::with_message_impl(format, message.into())
-    }
-
-    fn with_message_impl(
-        format: ImageFormatHint,
-        message: Cow<'static, str>,
-    ) -> Self {
         DecodingError {
-            format,
-            message: Some(message),
+            format: ImageFormatHint::Unknown,
+            message: Some(message.into()),
             underlying: None,
         }
     }

--- a/src/hdr/decoder.rs
+++ b/src/hdr/decoder.rs
@@ -75,7 +75,15 @@ impl fmt::Display for DecoderError {
     }
 }
 
-impl error::Error for DecoderError {}
+impl error::Error for DecoderError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            DecoderError::UnparsableF32(_, err) => Some(err),
+            DecoderError::UnparsableU32(_, err) => Some(err),
+            _ => None,
+        }
+    }
+}
 
 /// Lines which contain parsable data that can fail
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/src/webp/decoder.rs
+++ b/src/webp/decoder.rs
@@ -14,7 +14,7 @@ use super::vp8::Frame;
 use super::vp8::Vp8Decoder;
 
 /// All errors that can occur when attempting to parse a WEBP container
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 enum DecoderError {
     /// RIFF's "RIFF" signature not found or invalid
     RiffSignatureInvalid([u8; 4]),

--- a/src/webp/decoder.rs
+++ b/src/webp/decoder.rs
@@ -1,17 +1,52 @@
 use byteorder::{LittleEndian, ReadBytesExt};
 use std::convert::TryFrom;
 use std::default::Default;
+use std::{error, fmt, mem};
 use std::io::{self, Cursor, Read};
 use std::marker::PhantomData;
-use std::mem;
 
-use crate::error::{DecodingError, ImageError, ImageResult};
+use crate::error::{DecodingError, ImageError, ImageResult, UnsupportedError, UnsupportedErrorKind};
 use crate::image::{ImageDecoder, ImageFormat};
 
 use crate::color;
 
 use super::vp8::Frame;
 use super::vp8::Vp8Decoder;
+
+/// All errors that can occur when attempting to parse a WEBP container
+#[derive(Debug, Clone)]
+enum DecoderError {
+    /// RIFF's "RIFF" signature not found or invalid
+    RiffSignatureInvalid([u8; 4]),
+    /// WebP's "WEBP" signature not found or invalid
+    WebpSignatureInvalid([u8; 4]),
+}
+
+impl fmt::Display for DecoderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        struct SignatureWriter([u8; 4]);
+        impl fmt::Display for SignatureWriter {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "[{:#04X?}, {:#04X?}, {:#04X?}, {:#04X?}]", self.0[0], self.0[1], self.0[2], self.0[3])
+            }
+        }
+
+        match self {
+            DecoderError::RiffSignatureInvalid(riff) =>
+                f.write_fmt(format_args!("Invalid RIFF signature: {}", SignatureWriter(*riff))),
+            DecoderError::WebpSignatureInvalid(webp) =>
+                f.write_fmt(format_args!("Invalid WebP signature: {}", SignatureWriter(*webp))),
+        }
+    }
+}
+
+impl From<DecoderError> for ImageError {
+    fn from(e: DecoderError) -> ImageError {
+        ImageError::Decoding(DecodingError::new(ImageFormat::WebP.into(), e))
+    }
+}
+
+impl error::Error for DecoderError {}
 
 /// WebP Image format decoder. Currently only supportes the luma channel (meaning that decoded
 /// images will be grayscale).
@@ -37,24 +72,18 @@ impl<R: Read> WebPDecoder<R> {
     }
 
     fn read_riff_header(&mut self) -> ImageResult<u32> {
-        let mut riff = Vec::with_capacity(4);
-        self.r.by_ref().take(4).read_to_end(&mut riff)?;
-        let size = self.r.read_u32::<LittleEndian>()?;
-        let mut webp = Vec::with_capacity(4);
-        self.r.by_ref().take(4).read_to_end(&mut webp)?;
-
-        if &*riff != b"RIFF" {
-            return Err(ImageError::Decoding(DecodingError::with_message(
-                ImageFormat::WebP.into(),
-                "Invalid RIFF signature",
-            )));
+        let mut riff = [0; 4];
+        self.r.read_exact(&mut riff)?;
+        if &riff != b"RIFF" {
+            return Err(DecoderError::RiffSignatureInvalid(riff).into());
         }
 
-        if &*webp != b"WEBP" {
-            return Err(ImageError::Decoding(DecodingError::with_message(
-                ImageFormat::WebP.into(),
-                "Invalid WEBP signature",
-            )));
+        let size = self.r.read_u32::<LittleEndian>()?;
+
+        let mut webp = [0; 4];
+        self.r.read_exact(&mut webp)?;
+        if &webp != b"WEBP" {
+            return Err(DecoderError::WebpSignatureInvalid(webp).into());
         }
 
         Ok(size)
@@ -62,19 +91,19 @@ impl<R: Read> WebPDecoder<R> {
 
     fn read_vp8_header(&mut self) -> ImageResult<u32> {
         loop {
-            let mut chunk = Vec::with_capacity(4);
-            self.r.by_ref().take(4).read_to_end(&mut chunk)?;
+            let mut chunk = [0; 4];
+            self.r.read_exact(&mut chunk)?;
 
-            match &*chunk {
+            match &chunk {
                 b"VP8 " => {
                     let len = self.r.read_u32::<LittleEndian>()?;
                     return Ok(len);
                 }
                 b"ALPH" | b"VP8L" | b"ANIM" | b"ANMF" => {
                     // Alpha, Lossless and Animation isn't supported
-                    return Err(ImageError::Decoding(DecodingError::with_message(
+                    return Err(ImageError::Unsupported(UnsupportedError::from_format_and_kind(
                         ImageFormat::WebP.into(),
-                        "Unsupported WEBP feature.",
+                        UnsupportedErrorKind::GenericFeature(chunk.iter().map(|&b| b as char).collect()),
                     )));
                 }
                 _ => {

--- a/src/webp/vp8.rs
+++ b/src/webp/vp8.rs
@@ -666,7 +666,7 @@ static AC_QUANT: [i16; 128] = [
 static ZIGZAG: [u8; 16] = [0, 1, 4, 8, 5, 2, 3, 6, 9, 12, 13, 10, 7, 11, 14, 15];
 
 /// All errors that can occur when attempting to parse a VP8 codec inside WebP
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 enum DecoderError {
     /// VP8's `[0x9D, 0x01, 0x2A]` magic not found or invalid
     Vp8MagicInvalid([u8; 3]),


### PR DESCRIPTION
`ArbitraryTuplType::name()` – name? publicity?

Will go 'round the rest of `DecoderError`s and bring them back in line with the `Into<ImageError>` thing after this, it helps verbosity a lot.