### PR TITLE
Remove `ImageError::UnsupportedColor`, improve readability of DecoderErrors

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -922,7 +922,10 @@ fn decoder_to_image<'a, I: ImageDecoder<'a>>(decoder: I) -> ImageResult<DynamicI
             let buf = image::decoder_to_vec(decoder)?;
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLumaA16)
         }
-        _ => return Err(ImageError::UnsupportedColor(color_type.into())),
+        _ => return Err(ImageError::Unsupported(UnsupportedError::from_format_and_kind(
+            ImageFormatHint::Unknown,
+            UnsupportedErrorKind::Color(color_type.into()),
+        ))),
     };
     match image {
         Some(image) => Ok(image),

--- a/src/farbfeld.rs
+++ b/src/farbfeld.rs
@@ -23,7 +23,7 @@ use std::io::{self, Seek, SeekFrom, Read, Write, BufReader, BufWriter};
 use byteorder::{BigEndian, ByteOrder, NativeEndian};
 
 use crate::color::ColorType;
-use crate::error::{EncodingError, DecodingError, ImageError, ImageResult};
+use crate::error::{EncodingError, DecodingError, ImageError, ImageResult, UnsupportedError, UnsupportedErrorKind};
 use crate::image::{self, ImageDecoder, ImageDecoderExt, ImageEncoder, ImageFormat, Progress};
 
 /// farbfeld Reader
@@ -261,7 +261,10 @@ impl<W: Write> ImageEncoder for FarbfeldEncoder<W> {
         color_type: ColorType,
     ) -> ImageResult<()> {
         if color_type != ColorType::Rgba16 {
-            return Err(ImageError::UnsupportedColor(color_type.into()));
+            return Err(ImageError::Unsupported(UnsupportedError::from_format_and_kind(
+                ImageFormat::Farbfeld.into(),
+                UnsupportedErrorKind::Color(color_type.into()),
+            )));
         }
 
         self.encode(buf, width, height)

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -49,7 +49,7 @@ use num_traits::Zero;
 
 use crate::ImageBuffer;
 use crate::color::ColorType;
-use crate::error::{ImageError, ParameterError, ParameterErrorKind};
+use crate::error::{ImageError, ImageFormatHint, ParameterError, ParameterErrorKind, UnsupportedError, UnsupportedErrorKind};
 use crate::image::{GenericImage, GenericImageView};
 use crate::traits::Pixel;
 
@@ -1379,9 +1379,11 @@ impl From<Error> for ImageError {
             Error::TooLarge => ImageError::Parameter(
                 ParameterError::from_kind(ParameterErrorKind::DimensionMismatch)
             ),
-            Error::WrongColor(color) => ImageError::UnsupportedColor(color.into()),
             Error::NormalFormRequired(form) => ImageError::FormatError(
                 format!("Required sample buffer in normal form {:?}", form)),
+            Error::WrongColor(color) => ImageError::Unsupported(UnsupportedError::from_format_and_kind(
+                ImageFormatHint::Unknown,
+                UnsupportedErrorKind::Color(color.into()))),
         }
     }
 }

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -41,7 +41,7 @@
 //! }
 //! ```
 //!
-use std::cmp;
+use std::{cmp, error, fmt};
 use std::ops::{Deref, Index, IndexMut};
 use std::marker::PhantomData;
 
@@ -49,7 +49,7 @@ use num_traits::Zero;
 
 use crate::ImageBuffer;
 use crate::color::ColorType;
-use crate::error::{ImageError, ImageFormatHint, ParameterError, ParameterErrorKind, UnsupportedError, UnsupportedErrorKind};
+use crate::error::{ImageError, ImageFormatHint, DecodingError, ParameterError, ParameterErrorKind, UnsupportedError, UnsupportedErrorKind};
 use crate::image::{GenericImage, GenericImageView};
 use crate::traits::Pixel;
 
@@ -1375,12 +1375,20 @@ impl<Buffer, P: Pixel> GenericImage for ViewMut<Buffer, P>
 
 impl From<Error> for ImageError {
     fn from(error: Error) -> ImageError {
+        #[derive(Debug)]
+        struct NormalFormRequiredError(NormalForm);
+        impl fmt::Display for NormalFormRequiredError {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "Required sample buffer in normal form {:?}", self.0)
+            }
+        }
+        impl error::Error for NormalFormRequiredError {}
+
         match error {
-            Error::TooLarge => ImageError::Parameter(
-                ParameterError::from_kind(ParameterErrorKind::DimensionMismatch)
-            ),
-            Error::NormalFormRequired(form) => ImageError::FormatError(
-                format!("Required sample buffer in normal form {:?}", form)),
+            Error::TooLarge => ImageError::Parameter(ParameterError::from_kind(ParameterErrorKind::DimensionMismatch)),
+            Error::NormalFormRequired(form) => ImageError::Decoding(DecodingError::new(
+                ImageFormatHint::Unknown,
+                NormalFormRequiredError(form))),
             Error::WrongColor(color) => ImageError::Unsupported(UnsupportedError::from_format_and_kind(
                 ImageFormatHint::Unknown,
                 UnsupportedErrorKind::Color(color.into()))),


### PR DESCRIPTION
Remove `ImageError::UnsupportedColor` usage from DynImage, farbfeld, flat, PNG and the constructor. Add `.into() -> ImageError` for the rest of *private* DecoderErrors.

Only TGA left, with #1145.

Part of #1134
Ref: #1203 