### PR TITLE
Berid of most (all?) warnings

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -80,27 +80,49 @@ impl ColorType {
 /// decoding from and encoding to such an image format.
 #[derive(Copy, PartialEq, Eq, Debug, Clone, Hash)]
 pub enum ExtendedColorType {
+    /// Pixel is 1-bit luminance
     L1,
+    /// Pixel is 1-bit luminance with an alpha channel
     La1,
+    /// Pixel contains 1-bit R, G and B channels
     Rgb1,
+    /// Pixel is 1-bit RGB with an alpha channel
     Rgba1,
+    /// Pixel is 2-bit luminance
     L2,
+    /// Pixel is 2-bit luminance with an alpha channel
     La2,
+    /// Pixel contains 2-bit R, G and B channels
     Rgb2,
+    /// Pixel is 2-bit RGB with an alpha channel
     Rgba2,
+    /// Pixel is 4-bit luminance
     L4,
+    /// Pixel is 4-bit luminance with an alpha channel
     La4,
+    /// Pixel contains 4-bit R, G and B channels
     Rgb4,
+    /// Pixel is 4-bit RGB with an alpha channel
     Rgba4,
+    /// Pixel is 8-bit luminance
     L8,
+    /// Pixel is 8-bit luminance with an alpha channel
     La8,
+    /// Pixel contains 8-bit R, G and B channels
     Rgb8,
+    /// Pixel is 8-bit RGB with an alpha channel
     Rgba8,
+    /// Pixel is 16-bit luminance
     L16,
+    /// Pixel is 16-bit luminance with an alpha channel
     La16,
+    /// Pixel contains 16-bit R, G and B channels
     Rgb16,
+    /// Pixel is 16-bit RGB with an alpha channel
     Rgba16,
+    /// Pixel contains 8-bit B, G and R channels
     Bgr8,
+    /// Pixel is 8-bit BGR with an alpha channel
     Bgra8,
 
     /// Pixel is of unknown color type with the specified bits per pixel. This can apply to pixels

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -689,8 +689,14 @@ impl DynamicImage {
         w: &mut W,
         format: F,
     ) -> ImageResult<()> {
+        #[allow(unused_variables)]
+        // When no features are supported
+        let w = w;
+        #[allow(unused_variables,unused_mut)]
         let mut bytes = self.to_bytes();
+        #[allow(unused_variables)]
         let (width, height) = self.dimensions();
+        #[allow(unused_variables,unused_mut)]
         let mut color = self.color();
         let format = format.into();
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -135,6 +135,8 @@ impl From<ImageFormat> for ImageOutputFormat {
 
 // This struct manages buffering associated with implementing `Read` and `Seek` on decoders that can
 // must decode ranges of bytes at a time.
+#[allow(dead_code)]
+// When no image formats that use it are enabled
 pub(crate) struct ImageReadBuffer {
     scanline_bytes: usize,
     buffer: Vec<u8>,
@@ -149,6 +151,8 @@ impl ImageReadBuffer {
     /// Panics if scanline_bytes doesn't fit into a usize, because that would mean reading anything
     /// from the image would take more RAM than the entire virtual address space. In other words,
     /// actually using this struct would instantly OOM so just get it out of the way now.
+    #[allow(dead_code)]
+    // When no image formats that use it are enabled
     pub(crate) fn new(scanline_bytes: u64, total_bytes: u64) -> Self {
         Self {
             scanline_bytes: usize::try_from(scanline_bytes).unwrap(),
@@ -159,6 +163,8 @@ impl ImageReadBuffer {
         }
     }
 
+    #[allow(dead_code)]
+    // When no image formats that use it are enabled
     pub(crate) fn read<F>(&mut self, buf: &mut [u8], mut read_scanline: F) -> io::Result<usize>
     where
         F: FnMut(&mut [u8]) -> io::Result<usize>,
@@ -204,6 +210,8 @@ impl ImageReadBuffer {
 
 /// Decodes a specific region of the image, represented by the rectangle
 /// starting from ```x``` and ```y``` and having ```length``` and ```width```
+#[allow(dead_code)]
+// When no image formats that use it are enabled
 pub(crate) fn load_rect<'a, D, F, F1, F2, E>(x: u32, y: u32, width: u32, height: u32, buf: &mut [u8],
                                           progress_callback: F,
                                           decoder: &mut D,

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -33,7 +33,9 @@ use crate::color;
 use crate::image;
 use crate::dynimage::DynamicImage;
 use crate::error::{ImageError, ImageFormatHint, ImageResult};
-use crate::image::{ImageDecoder, ImageEncoder, ImageFormat};
+use crate::image::ImageFormat;
+#[allow(unused_imports)]  // When no features are supported
+use crate::image::{ImageDecoder, ImageEncoder};
 
 /// Internal error type for guessing format from path.
 pub(crate) enum PathError {
@@ -58,8 +60,10 @@ pub(crate) fn open_impl(path: &Path) -> ImageResult<DynamicImage> {
 /// Try [`io::Reader`] for more advanced uses.
 ///
 /// [`io::Reader`]: io/struct.Reader.html
+#[allow(unused_variables)]
+// r is unused if no features are supported.
 pub fn load<R: BufRead + Seek>(r: R, format: ImageFormat) -> ImageResult<DynamicImage> {
-    #[allow(deprecated, unreachable_patterns)]
+    #[allow(unreachable_patterns)]
     // Default is unreachable if all features are supported.
     match format {
         #[cfg(feature = "png")]
@@ -99,11 +103,14 @@ pub(crate) fn image_dimensions_impl(path: &Path) -> ImageResult<(u32, u32)> {
     image_dimensions_with_format_impl(fin, format)
 }
 
+#[allow(unused_variables)]
+// fin is unused if no features are supported.
 pub(crate) fn image_dimensions_with_format_impl<R: BufRead + Seek>(fin: R, format: ImageFormat)
     -> ImageResult<(u32, u32)>
 {
-    #[allow(unreachable_patterns)]
+    #[allow(unreachable_patterns,unreachable_code)]
     // Default is unreachable if all features are supported.
+    // Code after the match is unreachable if none are.
     Ok(match format {
         #[cfg(feature = "jpeg")]
         image::ImageFormat::Jpeg => jpeg::JpegDecoder::new(fin)?.dimensions(),
@@ -133,6 +140,8 @@ pub(crate) fn image_dimensions_with_format_impl<R: BufRead + Seek>(fin: R, forma
     })
 }
 
+#[allow(unused_variables)]
+// Most variables when no features are supported
 pub(crate) fn save_buffer_impl(
     path: &Path,
     buf: &[u8],
@@ -177,6 +186,8 @@ pub(crate) fn save_buffer_impl(
     }
 }
 
+#[allow(unused_variables)]
+// Most variables when no features are supported
 pub(crate) fn save_buffer_with_format_impl(
     path: &Path,
     buf: &[u8],

--- a/src/jpeg/decoder.rs
+++ b/src/jpeg/decoder.rs
@@ -150,7 +150,9 @@ mod tests {
     #[cfg(feature = "benchmarks")]
     use test::Bencher;
 
+    #[cfg(feature = "benchmarks")]
     const W: usize = 256;
+    #[cfg(feature = "benchmarks")]
     const H: usize = 256;
 
     #[test]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -36,6 +36,8 @@ where
 
 /// Expand a buffer of packed 1, 2, or 4 bits integers into u8's. Assumes that
 /// every `row_size` entries there are padding bits up to the next byte boundry.
+#[allow(dead_code)]
+// When no image formats that use it are enabled
 pub(crate) fn expand_bits(bit_depth: u8, row_size: u32, buf: &[u8]) -> Vec<u8> {
     // Note: this conversion assumes that the scanlines begin on byte boundaries
     let mask = (1u8 << bit_depth as usize) - 1;
@@ -63,11 +65,15 @@ pub(crate) fn expand_bits(bit_depth: u8, row_size: u32, buf: &[u8]) -> Vec<u8> {
     p
 }
 
+#[allow(dead_code)]
+// When no image formats that use it are enabled
 pub(crate) fn vec_u16_into_u8(vec: Vec<u16>) -> Vec<u8> {
     // Do this way until we find a way to not alloc/dealloc but get llvm to realloc instead.
     vec_u16_copy_u8(&vec)
 }
 
+#[allow(dead_code)]
+// When no image formats that use it are enabled
 pub(crate) fn vec_u16_copy_u8(vec: &[u16]) -> Vec<u8> {
     let mut new = vec![0; vec.len() * mem::size_of::<u16>()];
     NativeEndian::write_u16_into(&vec[..], &mut new[..]);


### PR DESCRIPTION
Mainly the vomit from `ExtendedColorType` in each and every build, but tested with no features, one feature at a time, and all features, all of which have just the two warnings fixed by #1205.