### PR TITLE
Disable test execution on old Rust version in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,10 @@ matrix:
 script:
   - if [ -n "${FEATURES+exists}" ]; then
       cargo build -v --no-default-features --features "$FEATURES" &&
-      cargo test -v --no-default-features --features "$FEATURES" &&
+      if [ "$(cargo --version)" != "cargo 1.34"* ]; then
+        # Tests (rather the criterion dev-dependency) relies on rayon, which uses Rust 1.36
+        cargo test -v --no-default-features --features "$FEATURES";
+      fi &&
       cargo doc -v --no-default-features --features "$FEATURES";
     fi
   - if [ -n "${DEFAULT_FEATURES+exists}" ]; then


### PR DESCRIPTION
Addresses the CI portion of #1240, until we have either reached a definitive decision or the next MSRV bump.
