### PR TITLE
Remove comment, which might mess up the travis parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,13 +80,15 @@ matrix:
 script:
   - if [ -n "${FEATURES+exists}" ]; then
       cargo build -v --no-default-features --features "$FEATURES" &&
-      if [ "$(cargo --version)" != "cargo 1.34"* ]; then
-        cargo test -v --no-default-features --features "$FEATURES";
-      fi &&
-      cargo doc -v --no-default-features --features "$FEATURES";
+      if [[ "$(cargo --version)" != "cargo 1.34"* ]]; then
+        cargo test -v --no-default-features --features "$FEATURES" &&
+        cargo doc -v --no-default-features --features "$FEATURES";
+      fi
     fi
   - if [ -n "${DEFAULT_FEATURES+exists}" ]; then
-      cargo test -v;
+      if [[ "$(cargo --version)" != "cargo 1.34"* ]]; then
+        cargo test -v;
+      fi
     fi
   - if [ -n "${BENCHMARKS+exists}" ]; then
       cargo build -v --benches --features=benchmarks;

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,6 @@ script:
   - if [ -n "${FEATURES+exists}" ]; then
       cargo build -v --no-default-features --features "$FEATURES" &&
       if [ "$(cargo --version)" != "cargo 1.34"* ]; then
-        # Tests (rather the criterion dev-dependency) relies on rayon, which uses Rust 1.36
         cargo test -v --no-default-features --features "$FEATURES";
       fi &&
       cargo doc -v --no-default-features --features "$FEATURES";


### PR DESCRIPTION
This was visible after trying to manually trigger a build which redirected to the otherwise invisible tab on travis: https://travis-ci.com/github/image-rs/image/requests This finally shows the error message that it is unable to parse the file. (Edit: Travis show the request for this PR as received).