### PR TITLE
Fix the method reference to with_guessed_format

### DIFF
--- a/src/io/reader.rs
+++ b/src/io/reader.rs
@@ -69,9 +69,9 @@ impl<R: Read> Reader<R> {
     /// Create a new image reader without a preset format.
     ///
     /// It is possible to guess the format based on the content of the read object with
-    /// [`guess_format`], or to set the format directly with [`set_format`].
+    /// [`with_guessed_format`], or to set the format directly with [`set_format`].
     ///
-    /// [`guess_format`]: #method.guess_format
+    /// [`with_guessed_format`]: #method.with_guessed_format
     /// [`set_format`]: method.set_format
     pub fn new(reader: R) -> Self {
         Reader {
@@ -118,9 +118,9 @@ impl Reader<BufReader<File>> {
     /// This will not attempt any io operation on the opened file.
     ///
     /// If you want to inspect the content for a better guess on the format, which does not depend
-    /// on file extensions, follow this call with a call to [`guess_format`].
+    /// on file extensions, follow this call with a call to [`with_guessed_format`].
     ///
-    /// [`guess_format`]: #method.guess_format
+    /// [`with_guessed_format`]: #method.with_guessed_format
     pub fn open<P>(path: P) -> io::Result<Self> where P: AsRef<Path> {
         Self::open_impl(path.as_ref())
     }


### PR DESCRIPTION
The previous documentation links to a method that was ultimately made
private in a decision to make `Reader` behave like a builder style
struct, and prioritize chaining with `self` over `&mut self` as it
handles the non-Clone reader.

Fixes: #1231 

