### PR TITLE
Add derives for `Hash`, `PartialEq` and `Eq`.

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -449,7 +449,7 @@ where
 ///
 /// image::imageops::overlay(&mut img, &on_top, 128, 128);
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Hash, PartialEq, Eq)]
 pub struct ImageBuffer<P: Pixel, Container> {
     width: u32,
     height: u32,


### PR DESCRIPTION
This provides a (very trivial) implementation for #697 but is also meant to encourage discussion about this Issue or make private decisions about it public.

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.