### PR TITLE
Ensure that pixels iterator stays in-bounds

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -505,10 +505,16 @@ where
         self.height
     }
 
+    // TODO: choose name under which to expose.
+    fn inner_pixels(&self) -> &[P::Subpixel] {
+        let len = Self::image_buffer_len(self.width, self.height).unwrap();
+        &self.data[..len]
+    }
+
     /// Returns an iterator over the pixels of this image.
     pub fn pixels(&self) -> Pixels<P> {
         Pixels {
-            chunks: self.data.chunks(<P as Pixel>::CHANNEL_COUNT as usize),
+            chunks: self.inner_pixels().chunks(<P as Pixel>::CHANNEL_COUNT as usize),
         }
     }
 
@@ -634,10 +640,16 @@ where
     P::Subpixel: 'static,
     Container: Deref<Target = [P::Subpixel]> + DerefMut,
 {
+    // TODO: choose name under which to expose.
+    fn inner_pixels_mut(&mut self) -> &mut [P::Subpixel] {
+        let len = Self::image_buffer_len(self.width, self.height).unwrap();
+        &mut self.data[..len]
+    }
+
     /// Returns an iterator over the mutable pixels of this image.
     pub fn pixels_mut(&mut self) -> PixelsMut<P> {
         PixelsMut {
-            chunks: self.data.chunks_mut(<P as Pixel>::CHANNEL_COUNT as usize),
+            chunks: self.inner_pixels_mut().chunks_mut(<P as Pixel>::CHANNEL_COUNT as usize),
         }
     }
 
@@ -1153,6 +1165,19 @@ mod test {
         assert_eq!(image.pixels_mut().count(), 0);
         assert_eq!(image.rows().count(), 0);
         assert_eq!(image.pixels().count(), 0);
+    }
+
+    #[test]
+    fn pixels_on_large_buffer() {
+        let mut image = RgbImage::from_raw(1, 1, vec![0; 6]).unwrap();
+
+        assert_eq!(image.pixels().count(), 1);
+        assert_eq!(image.enumerate_pixels().count(), 1);
+        assert_eq!(image.pixels_mut().count(), 1);
+        assert_eq!(image.enumerate_pixels_mut().count(), 1);
+
+        assert_eq!(image.rows().count(), 1);
+        assert_eq!(image.rows_mut().count(), 1);
     }
 }
 


### PR DESCRIPTION
The motivation for this change is to make iteration with a larger buffer easy. Consider construction an image from the prefix of a buffer. `ImageBuffer::from_raw(_, _, buf)` does not complain if the buffer is in fact larger than required. In such a case one still expects pixels, especially the ones yielded by the `enumerate_*` iterators, to be in-bounds. In particular, these two loops should be more or less equivalent:

```rust
for x in 0..image.width() {
    for y in 0..image.height() {
         let p = image.get_pixel(x, y);
    }
}
```

```rust
for (x, y, p) in image.enumerate_pixels() {
}
```

But previously the second loop would yield _more_ pixels including ones that are out of bounds beyond the height of the image.