### PR TITLE
Direct user to DynamicImage for converting

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -416,6 +416,8 @@ where
 /// [`RgbImage`]: type.RgbImage.html
 /// [`GrayImage`]: type.GrayImage.html
 ///
+/// To convert between images of different Pixel types use [`DynamicImage`]: enum.DynamicImage.html
+///
 /// ## Examples
 ///
 /// Create a simple canvas and paint a small cross.
@@ -448,6 +450,15 @@ where
 /// });
 ///
 /// image::imageops::overlay(&mut img, &on_top, 128, 128);
+/// ```
+///
+/// Convert an RgbaImage to a GrayImage.
+///
+/// ```no_run
+/// use image::{open, DynamicImage};
+///
+/// let rgba = open("path/to/some.png").unwrap().into_rgba();
+/// let gray = DynamicImage::ImageRgba8(rgba).into_luma();
 /// ```
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub struct ImageBuffer<P: Pixel, Container> {


### PR DESCRIPTION
Attempts to address the documentation suggestion in #1252

A lot of the methods for modifying an image are found in the `ImageBuffer` so that is where I was looking when trying to convert an image to a different Pixel type.

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.
