### PR TITLE
Make FromColor public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ extern crate quickcheck;
 
 use std::io::Write;
 
-pub use crate::color::{ColorType, ExtendedColorType};
+pub use crate::color::{ColorType, ExtendedColorType, FromColor};
 
 pub use crate::color::{Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
 


### PR DESCRIPTION
It is useful to have this trait public to convert an image buffer into an existing buffer rather than creating a new one.

For example (taken from ImageBuffer::convert):
```rust
let mut my_existing_buffer: GrayImage;
let my_rgba_buffer: RgbaImage;
from (to, from) in my_existing_buffer.pixels_mut().zip(src.pixels()) {
  to.from_color(from);
}
```

An alternative solution to my current problem would be to introduce a method on `ImageBuffer` that allows you to convert into an existing `ImageBuffer` however that seemed less flexible.