### PR TITLE
Update num-rational/num-complex dependency to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "./src/lib.rs"
 bytemuck = "1"
 byteorder = "1.3.2"
 num-iter = "0.1.32"
-num-rational = { version = "0.2.1", default-features = false }
+num-rational = { version = "0.3", default-features = false }
 num-traits = "0.2.0"
 gif = { version = "0.10.0", optional = true }
 jpeg = { package = "jpeg-decoder", version = "0.1.17", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ tiff = { version = "0.5.0", optional = true }
 
 [dev-dependencies]
 crc32fast = "1.2.0"
-num-complex = "0.2.0"
+num-complex = "0.3"
 glob = "0.3"
 quickcheck = "0.9"
 criterion = "0.3"


### PR DESCRIPTION
I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.