### PR TITLE
Some helper and interop for FlatSamples

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -416,7 +416,15 @@ where
 /// [`RgbImage`]: type.RgbImage.html
 /// [`GrayImage`]: type.GrayImage.html
 ///
-/// To convert between images of different Pixel types use [`DynamicImage`]: enum.DynamicImage.html
+/// To convert between images of different Pixel types use [`DynamicImage`].
+///
+/// You can retrieve a complete description of the buffer's layout and contents through
+/// [`as_flat_samples`] and [`as_flat_samples_mut`]. This can be handy to also use the contents in
+/// a foreign language, map it as a GPU host buffer or other similar tasks.
+///
+/// [`DynamicImage`]: enum.DynamicImage.html
+/// [`as_flat_samples`]: #method.as_flat_samples
+/// [`as_flat_samples_mut`]: #method.as_flat_samples_mut
 ///
 /// ## Examples
 ///
@@ -639,6 +647,20 @@ where
         let layout = self.sample_layout();
         FlatSamples {
             samples: self.data.as_ref(),
+            layout,
+            color_hint: Some(P::COLOR_TYPE),
+        }
+    }
+
+    /// Return a mutable view on the raw sample buffer.
+    ///
+    /// See [`into_flat_samples`](#method.into_flat_samples) for more details.
+    pub fn as_flat_samples_mut(&mut self) -> FlatSamples<&mut [P::Subpixel]>
+        where Container: AsMut<[P::Subpixel]>
+    {
+        let layout = self.sample_layout();
+        FlatSamples {
+            samples: self.data.as_mut(),
             layout,
             color_hint: Some(P::COLOR_TYPE),
         }

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -61,7 +61,7 @@ use crate::traits::{Pixel, Primitive};
 /// but not every possible configuration can be interpreted as a [`GenericImageView`] or
 /// [`GenericImage`]. The methods [`as_view`] and [`as_view_mut`] construct the actual implementors
 /// of these traits and perform necessary checks. To manually perform this and other layout checks
-/// use [`check_index_validities`].
+/// use [`is_normal`] or [`has_aliased_samples`].
 ///
 /// Instances can be constructed not only by hand. The buffer instances returned by library
 /// functions such as [`ImageBuffer::as_flat_samples`] guarantee that the conversion to a generic
@@ -71,6 +71,9 @@ use crate::traits::{Pixel, Primitive};
 ///
 /// [`GenericImage`]: ../trait.GenericImage.html
 /// [`GenericImageView`]: ../trait.GenericImageView.html
+/// [`ImageBuffer::as_flat_samples`]: ../struct.ImageBuffer.html#method.as_flat_samples
+/// [`is_normal`]: #method.is_normal
+/// [`has_aliased_samples`]: #method.has_aliased_samples
 /// [`as_view`]: #method.as_view
 /// [`as_view_mut`]: #method.as_view_mut
 /// [`with_monocolor`]: #method.with_monocolor

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -56,13 +56,24 @@ use crate::traits::{Pixel, Primitive};
 /// A flat buffer over a (multi channel) image.
 ///
 /// In contrast to `ImageBuffer`, this representation of a sample collection is much more lenient
-/// in the layout thereof. In particular, it also allows grouping by color planes instead of by
-/// pixel, at least for the purpose of a `GenericImageView`.
+/// in the layout thereof. It also allows grouping by color planes instead of by pixel as long as
+/// the strides of each extent are constant. This struct itself has no invariants on the strides
+/// but not every possible configuration can be interpreted as a [`GenericImageView`] or
+/// [`GenericImage`]. The methods [`as_view`] and [`as_view_mut`] construct the actual implementors
+/// of these traits and perform necessary checks. To manually perform this and other layout checks
+/// use [`check_index_validities`].
 ///
-/// Note that the strides need not conform to the assumption that constructed indices actually
-/// refer inside the underlying buffer but return values of library functions will always guarantee
-/// this. To manually make this check use `check_index_validities` and maybe put that inside an
-/// assert.
+/// Instances can be constructed not only by hand. The buffer instances returned by library
+/// functions such as [`ImageBuffer::as_flat_samples`] guarantee that the conversion to a generic
+/// image or generic view succeeds. A very different constructor is [`with_monocolor`]. It uses a
+/// single pixel as the backing storage for an arbitrarily sized read-only raster by mapping each
+/// pixel to the same samples by setting some strides to `0`.
+///
+/// [`GenericImage`]: ../trait.GenericImage.html
+/// [`GenericImageView`]: ../trait.GenericImageView.html
+/// [`as_view`]: #method.as_view
+/// [`as_view_mut`]: #method.as_view_mut
+/// [`with_monocolor`]: #method.with_monocolor
 #[derive(Clone, Debug)]
 pub struct FlatSamples<Buffer> {
     /// Underlying linear container holding sample values.

--- a/src/image.rs
+++ b/src/image.rs
@@ -682,8 +682,14 @@ pub trait GenericImage: GenericImageView {
     ///
     /// In order to copy only a piece of the other image, use [`GenericImageView::view`].
     ///
+    /// You can use [`FlatSamples`] to source pixels from an arbitrary regular raster of channel
+    /// values, for example from a foreign interface or a fixed image.
+    ///
     /// # Returns
     /// Returns an error if the image is too large to be copied at the given position
+    ///
+    /// [`GenericImageView::view`]: trait.GenericImageView.html#method.view
+    /// [`FlatSamples`]: flat/struct.FlatSamples.html
     fn copy_from<O>(&mut self, other: &O, x: u32, y: u32) -> ImageResult<()>
     where
         O: GenericImageView<Pixel = Self::Pixel>,


### PR DESCRIPTION
Closes: #616 (with a true helper)

- [x] Rewrite some documentation to refer to the helper methods in a discoverable way