### PR TITLE
Export the EncodableLayout trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,7 @@ pub use crate::buffer_::{
 pub use crate::flat::FlatSamples;
 
 // Traits
-pub use crate::traits::{Primitive, Pixel};
+pub use crate::traits::{EncodableLayout, Primitive, Pixel};
 
 // Opening and loading images
 pub use crate::io::free_functions::{guess_format, load};


### PR DESCRIPTION
This trait is used to bound the `save` method on ImageBuffer and
DynamicImage which avoids leaking the implementation detail of using
bytemuck for casting particular channel slices to bytes. This trait is
sealed so there are little breakage risks, this allows downstream crates
to name it as a bound.