### PR TITLE
imageops: introduce tile function

### DIFF
--- a/examples/tile/main.rs
+++ b/examples/tile/main.rs
@@ -1,0 +1,9 @@
+use image::RgbaImage;
+
+fn main() {
+    let mut img = RgbaImage::new(1920, 1080);
+    let tile = image::open("examples/scaleup/tinycross.png").unwrap();
+
+    image::imageops::tile(&mut img, &tile);
+    img.save("tiled_wallpaper.png").unwrap();
+}

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -164,6 +164,32 @@ where
     }
 }
 
+/// Tile an image by repeating it multiple times
+///
+/// # Examples
+/// ```no_run
+/// use image::{RgbaImage};
+///
+/// fn main() {
+///      let mut img = RgbaImage::new(1920, 1080);
+///      let tile = image::open("tile.png").unwrap();
+///
+///      image::imageops::tile(&mut img, &tile);
+///      img.save("tiled_wallpaper.png").unwrap();
+/// }
+/// ```
+pub fn tile<I, J>(bottom: &mut I, top: &J)
+where
+    I: GenericImage,
+    J: GenericImageView<Pixel = I::Pixel>,
+{
+    for x in (0..bottom.width()).step_by(top.width() as usize) {
+        for y in (0..bottom.height()).step_by(top.height() as usize) {
+            overlay(bottom, top, x, y);
+        }
+    }
+}
+
 /// Replace the contents of an image at a given coordinate (x, y)
 pub fn replace<I, J>(bottom: &mut I, top: &J, x: u32, y: u32)
 where


### PR DESCRIPTION
I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

Example usage:

```rust
pub fn example_tile() {
    let mut img = RgbaImage::new(300, 170);
    let background_color = Rgba::from_slice(&[20, 20, 20, 255]);
    for p in img.pixels_mut() {
        *p = *background_color;
    }

    let tile = image::open("spinner.png").unwrap();

    image::imageops::tile(&mut img, &tile);
    img.save("test.png").unwrap();
}
```

Example output image:

![test](https://user-images.githubusercontent.com/989521/87873676-c8a0ab80-c9c3-11ea-9d0d-e15105da5a4a.png)
