### PR TITLE
Implement std::error::Error for flat::Error

### DIFF
--- a/src/flat.rs
+++ b/src/flat.rs
@@ -1451,6 +1451,32 @@ impl From<Error> for ImageError {
     }
 }
 
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::TooLarge => write!(f, "The layout is too large"),
+            Error::NormalFormRequired(form) => write!(
+                f,
+                "The layout needs to {}",
+                match form {
+                    NormalForm::ColumnMajorPacked => "be packed and in column major form",
+                    NormalForm::ImagePacked => "be fully packed",
+                    NormalForm::PixelPacked => "have packed pixels",
+                    NormalForm::RowMajorPacked => "be packed and in row major form",
+                    NormalForm::Unaliased => "not have any aliasing channels",
+                }
+            ),
+            Error::WrongColor(color) => write!(
+                f,
+                "The chosen color type does not match the hint {:?}",
+                color
+            ),
+        }
+    }
+}
+
+impl error::Error for Error {}
+
 impl PartialOrd for NormalForm {
     /// Compares the logical preconditions.
     ///


### PR DESCRIPTION
Closes: #1285 