### PR TITLE
imageops: Add `?Sized` bound to generic type `Map`.

### DIFF
--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -318,7 +318,7 @@ macro_rules! do_dithering(
 /// Floyd-Steinberg dithering to improve the visual conception
 pub fn dither<Pix, Map>(image: &mut ImageBuffer<Pix, Vec<u8>>, color_map: &Map)
 where
-    Map: ColorMap<Color = Pix>,
+    Map: ColorMap<Color = Pix> + ?Sized,
     Pix: Pixel<Subpixel = u8> + 'static,
 {
     let (width, height) = image.dimensions();
@@ -359,7 +359,7 @@ pub fn index_colors<Pix, Map>(
     color_map: &Map,
 ) -> ImageBuffer<Luma<u8>, Vec<u8>>
 where
-    Map: ColorMap<Color = Pix>,
+    Map: ColorMap<Color = Pix> + ?Sized,
     Pix: Pixel<Subpixel = u8> + 'static,
 {
     let mut indices = ImageBuffer::new(image.width(), image.height());


### PR DESCRIPTION
This allows unsized types like those returned by `Box<dyn ColorMap<_>>>.as_ref()` to be passed into these functions.

<!-- 
If you are a new contributor, consent to licensing by including this text:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

Thank you for contributing, you can delete this comment.
-->

