### PR TITLE
describe the pixel enumeration order in the doc comment to avoid confusion

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -535,6 +535,7 @@ where
     }
 
     /// Returns an iterator over the pixels of this image.
+    /// The iteration order is x = 0 to width then y = 0 to height
     pub fn pixels(&self) -> Pixels<P> {
         Pixels {
             chunks: self.inner_pixels().chunks(<P as Pixel>::CHANNEL_COUNT as usize),
@@ -553,6 +554,7 @@ where
     /// Enumerates over the pixels of the image.
     /// The iterator yields the coordinates of each pixel
     /// along with a reference to them.
+    /// The iteration order is x = 0 to width then y = 0 to height
     pub fn enumerate_pixels(&self) -> EnumeratePixels<P> {
         EnumeratePixels {
             pixels: self.pixels(),


### PR DESCRIPTION

- main change is the doc string for the enumerator, because I always get confused about the iteration order is it first rows then columns or the other way around. Maybe that helps other for confused people like me.
- the other stuff is just apply cargo fmt

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

