### PR TITLE
fix unused import warning in farbfeld.rs

### DIFF
--- a/src/farbfeld.rs
+++ b/src/farbfeld.rs
@@ -23,7 +23,7 @@ use std::io::{self, Seek, SeekFrom, Read, Write, BufReader, BufWriter};
 use byteorder::{BigEndian, ByteOrder, NativeEndian};
 
 use crate::color::ColorType;
-use crate::error::{EncodingError, DecodingError, ImageError, ImageResult, UnsupportedError, UnsupportedErrorKind};
+use crate::error::{DecodingError, ImageError, ImageResult, UnsupportedError, UnsupportedErrorKind};
 use crate::image::{self, ImageDecoder, ImageDecoderExt, ImageEncoder, ImageFormat, Progress};
 
 /// farbfeld Reader


### PR DESCRIPTION
Fixes the following warning:

warning: unused import: `EncodingError`
  --> src/farbfeld.rs:26:20
   |
26 | use crate::error::{EncodingError, DecodingError, ImageError, ImageResult, UnsupportedError, UnsupportedErrorKind};
   |                    ^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

