### PR TITLE
introduce gradients in imageops

### DIFF
--- a/examples/gradient/main.rs
+++ b/examples/gradient/main.rs
@@ -1,0 +1,16 @@
+use image::{Rgba, RgbaImage, Pixel};
+
+fn main() {
+    let mut img = RgbaImage::new(100, 100);
+
+    let start = Rgba::from_slice(&[0, 128, 0, 0]);
+    let end = Rgba::from_slice(&[255, 255, 255, 255]);
+
+    image::imageops::vertical_gradient(&mut img, start, end);
+    img.save("vertical_gradient.png").unwrap();
+    image::imageops::vertical_gradient(&mut img, end, start);
+    img.save("vertical_gradient_reverse.png").unwrap();
+
+    image::imageops::horizontal_gradient(&mut img, start, end);
+    img.save("horizontal_gradient.png").unwrap();
+}

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -216,9 +216,9 @@ where
 {
     for y in 0..img.height() {
         let pixel = start.map2(stop, |a, b| {
-            let y = <S::SignedLarger as NumCast>::from(y).unwrap();
-            let height = <S::SignedLarger as NumCast>::from(img.height()).unwrap();
-            S::lerp(a, b, y, height)
+            let y = <S::Ratio as NumCast>::from(y).unwrap();
+            let height = <S::Ratio as NumCast>::from(img.height() - 1).unwrap();
+            S::lerp(a, b, y / height)
         });
         
         for x in 0..img.width() {
@@ -251,9 +251,9 @@ where
 {
     for x in 0..img.width() {
         let pixel = start.map2(stop, |a, b| {
-            let x = <S::SignedLarger as NumCast>::from(x).unwrap();
-            let width = <S::SignedLarger as NumCast>::from(img.width()).unwrap();
-            S::lerp(a, b, x, width)
+            let x = <S::Ratio as NumCast>::from(x).unwrap();
+            let width = <S::Ratio as NumCast>::from(img.width() - 1).unwrap();
+            S::lerp(a, b, x / width)
         });
         
         for y in 0..img.height() {
@@ -335,5 +335,35 @@ mod tests {
         assert!(*target.get_pixel(0, 0) == Rgb([0, 0, 0]));
         assert!(*target.get_pixel(1, 1) == Rgb([0, 0, 0]));
         assert!(*target.get_pixel(15, 15) == Rgb([0, 0, 0]));
+    }
+
+    use super::{horizontal_gradient, vertical_gradient};
+
+    #[test]
+    /// Test that horizontal gradients are correctly generated
+    fn test_image_horizontal_gradient_limits() {
+        let mut img = ImageBuffer::new(100, 1);
+
+        let start = Rgb([0u8, 128, 0]);
+        let end = Rgb([255u8, 255, 255]);
+
+        horizontal_gradient(&mut img, &start, &end);
+
+        assert_eq!(img.get_pixel(0, 0), &start);
+        assert_eq!(img.get_pixel(img.width() - 1, 0), &end);
+    }
+
+    #[test]
+    /// Test that vertical gradients are correctly generated
+    fn test_image_vertical_gradient_limits() {
+        let mut img = ImageBuffer::new(1, 100);
+
+        let start = Rgb([0u8, 128, 0]);
+        let end = Rgb([255u8, 255, 255]);
+
+        vertical_gradient(&mut img, &start, &end);
+
+        assert_eq!(img.get_pixel(0, 0), &start);
+        assert_eq!(img.get_pixel(0, img.height() - 1), &end);
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -3,7 +3,7 @@
 // Note copied from the stdlib under MIT license
 
 use num_traits::{Bounded, Num, NumCast};
-use std::ops::{AddAssign, Neg};
+use std::ops::{AddAssign};
 
 use crate::color::{ColorType, Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
 
@@ -68,16 +68,14 @@ impl Enlargeable for u32 {
 }
 
 /// Linear interpolation without involving floating numbers.
-pub trait Lerp: Sized + Bounded + NumCast {
-    type SignedLarger: Primitive + AddAssign + Neg + 'static;
+pub trait Lerp: Bounded + NumCast {
+    type Ratio: Primitive;
 
-    fn lerp(a: Self, b: Self, i: Self::SignedLarger, n: Self::SignedLarger) -> Self {
-        let a = <Self::SignedLarger as NumCast>::from(a).unwrap();
-        let b = <Self::SignedLarger as NumCast>::from(b).unwrap();
-        let i = <Self::SignedLarger as NumCast>::from(i).unwrap();
-        let n = <Self::SignedLarger as NumCast>::from(n).unwrap();
+    fn lerp(a: Self, b: Self, ratio: Self::Ratio) -> Self {
+        let a = <Self::Ratio as NumCast>::from(a).unwrap();
+        let b = <Self::Ratio as NumCast>::from(b).unwrap();
 
-        let res = a + (i * (b - a) / n);
+        let res = a + (b - a) * ratio;
 
         if res > NumCast::from(Self::max_value()).unwrap() {
             Self::max_value()
@@ -90,15 +88,15 @@ pub trait Lerp: Sized + Bounded + NumCast {
 }
 
 impl Lerp for u8 {
-    type SignedLarger = i32;
+    type Ratio = f32;
 }
 
 impl Lerp for u16 {
-    type SignedLarger = i32;
+    type Ratio = f32;
 }
 
 impl Lerp for u32 {
-    type SignedLarger = i64;
+    type Ratio = f64;
 }
 
 /// A generalized pixel.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -3,7 +3,7 @@
 // Note copied from the stdlib under MIT license
 
 use num_traits::{Bounded, Num, NumCast};
-use std::ops::AddAssign;
+use std::ops::{AddAssign, Neg};
 
 use crate::color::{ColorType, Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
 
@@ -65,6 +65,40 @@ impl Enlargeable for u16 {
 }
 impl Enlargeable for u32 {
     type Larger = u64;
+}
+
+/// Linear interpolation without involving floating numbers.
+pub trait Lerp: Sized + Bounded + NumCast {
+    type SignedLarger: Primitive + AddAssign + Neg + 'static;
+
+    fn lerp(a: Self, b: Self, i: Self::SignedLarger, n: Self::SignedLarger) -> Self {
+        let a = <Self::SignedLarger as NumCast>::from(a).unwrap();
+        let b = <Self::SignedLarger as NumCast>::from(b).unwrap();
+        let i = <Self::SignedLarger as NumCast>::from(i).unwrap();
+        let n = <Self::SignedLarger as NumCast>::from(n).unwrap();
+
+        let res = a + (i * (b - a) / n);
+
+        if res > NumCast::from(Self::max_value()).unwrap() {
+            Self::max_value()
+        } else if res < NumCast::from(0).unwrap() {
+            NumCast::from(0).unwrap()
+        } else {
+            NumCast::from(res).unwrap()
+        }
+    }
+}
+
+impl Lerp for u8 {
+    type SignedLarger = i32;
+}
+
+impl Lerp for u16 {
+    type SignedLarger = i32;
+}
+
+impl Lerp for u32 {
+    type SignedLarger = i64;
 }
 
 /// A generalized pixel.


### PR DESCRIPTION
This is a very basic linear gradient implementation for both vertical and horizontal directions. The implementation does not support the concept of multiple gradient stops, but it could be implemented quite easily using this contribution as a starting point.

Included examples that can be run to check correct behavior of a RGBA gradient on PNG image output.

Example usage:

```rust
use image::{Rgba, RgbaImage, Pixel};

fn main() {
    let mut img = RgbaImage::new(100, 100);

    let start = Rgba::from_slice(&[0, 128, 0, 0]);
    let end = Rgba::from_slice(&[255, 255, 255, 255]);

    image::imageops::vertical_gradient(&mut img, start, end);
    img.save("vertical_gradient.png").unwrap();

    image::imageops::horizontal_gradient(&mut img, start, end);
    img.save("horizontal_gradient.png").unwrap();
}
```

Result of the examples:

![horizontal_gradient](https://user-images.githubusercontent.com/989521/88478405-4a568300-cf48-11ea-9c5e-92331eb16852.png)
![vertical_gradient](https://user-images.githubusercontent.com/989521/88478406-4c204680-cf48-11ea-918a-2c0ff8013f99.png)

(They render weird on a white background, because there is an alpha gradient as well)
