### PR TITLE
Fixed Inconsistent capitalization of Encoder/Decoder structs.

### DIFF
--- a/benches/encode.rs
+++ b/benches/encode.rs
@@ -1,7 +1,7 @@
 extern crate criterion;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use image::{ColorType, bmp::BmpEncoder, jpeg::JPEGEncoder};
+use image::{ColorType, bmp::BmpEncoder, jpeg::JpegEncoder};
 
 use std::fs::File;
 use std::io::{BufWriter, Write, Seek, SeekFrom};
@@ -116,7 +116,7 @@ impl EncoderBase for Bmp {
 
 impl EncoderBase for Jpeg {
     fn encode(&self, mut into: impl Write, im: &[u8], size: u32, color: ColorType) {
-        let mut x = JPEGEncoder::new(&mut into);
+        let mut x = JpegEncoder::new(&mut into);
         x.encode(im, size, size, color).unwrap();
     }
 }

--- a/benches/encode.rs
+++ b/benches/encode.rs
@@ -1,7 +1,7 @@
 extern crate criterion;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use image::{ColorType, bmp::BMPEncoder, jpeg::JPEGEncoder};
+use image::{ColorType, bmp::BmpEncoder, jpeg::JPEGEncoder};
 
 use std::fs::File;
 use std::io::{BufWriter, Write, Seek, SeekFrom};
@@ -109,7 +109,7 @@ impl<T: EncoderBase> Encoder for T {
 
 impl EncoderBase for Bmp {
     fn encode(&self, mut into: impl Write, im: &[u8], size: u32, color: ColorType) {
-        let mut x = BMPEncoder::new(&mut into);
+        let mut x = BmpEncoder::new(&mut into);
         x.encode(im, size, size, color).unwrap();
     }
 }

--- a/src/bmp/encoder.rs
+++ b/src/bmp/encoder.rs
@@ -18,6 +18,8 @@ pub struct BmpEncoder<'a, W: 'a> {
 ///
 /// An alias of [`BmpEncoder`].
 ///
+/// TODO: remove
+///
 /// [`BmpEncoder`]: struct.BmpEncoder.html
 #[allow(dead_code)]
 #[deprecated(note = "Use `BmpEncoder` instead")]

--- a/src/bmp/encoder.rs
+++ b/src/bmp/encoder.rs
@@ -14,6 +14,15 @@ pub struct BmpEncoder<'a, W: 'a> {
     writer: &'a mut W,
 }
 
+/// BMP Encoder
+///
+/// An alias of [`BmpEncoder`].
+///
+/// [`BmpEncoder`]: struct.BmpEncoder.html
+#[allow(dead_code)]
+#[deprecated(note = "Use `BmpEncoder` instead")]
+pub type BMPEncoder<'a, W> = BmpEncoder<'a, W>;
+
 impl<'a, W: Write + 'a> BmpEncoder<'a, W> {
     /// Create a new encoder that writes its output to ```w```.
     pub fn new(w: &'a mut W) -> Self {

--- a/src/bmp/encoder.rs
+++ b/src/bmp/encoder.rs
@@ -10,14 +10,14 @@ const BITMAPINFOHEADER_SIZE: u32 = 40;
 const BITMAPV4HEADER_SIZE: u32 = 108;
 
 /// The representation of a BMP encoder.
-pub struct BMPEncoder<'a, W: 'a> {
+pub struct BmpEncoder<'a, W: 'a> {
     writer: &'a mut W,
 }
 
-impl<'a, W: Write + 'a> BMPEncoder<'a, W> {
+impl<'a, W: Write + 'a> BmpEncoder<'a, W> {
     /// Create a new encoder that writes its output to ```w```.
     pub fn new(w: &'a mut W) -> Self {
-        BMPEncoder { writer: w }
+        BmpEncoder { writer: w }
     }
 
     /// Encodes the image ```image```
@@ -211,7 +211,7 @@ impl<'a, W: Write + 'a> BMPEncoder<'a, W> {
     }
 }
 
-impl<'a, W: Write> ImageEncoder for BMPEncoder<'a, W> {
+impl<'a, W: Write> ImageEncoder for BmpEncoder<'a, W> {
     fn write_image(
         mut self,
         buf: &[u8],
@@ -251,7 +251,7 @@ fn get_pixel_info(c: color::ColorType) -> io::Result<(u32, u32, u32)> {
 #[cfg(test)]
 mod tests {
     use super::super::BmpDecoder;
-    use super::BMPEncoder;
+    use super::BmpEncoder;
     use crate::color::ColorType;
     use crate::image::ImageDecoder;
     use std::io::Cursor;
@@ -259,7 +259,7 @@ mod tests {
     fn round_trip_image(image: &[u8], width: u32, height: u32, c: ColorType) -> Vec<u8> {
         let mut encoded_data = Vec::new();
         {
-            let mut encoder = BMPEncoder::new(&mut encoded_data);
+            let mut encoder = BmpEncoder::new(&mut encoded_data);
             encoder
                 .encode(&image, width, height, c)
                 .expect("could not encode image");
@@ -286,7 +286,7 @@ mod tests {
     fn huge_files_return_error() {
         let mut encoded_data = Vec::new();
         let image = vec![0u8; 3 * 40_000 * 40_000]; // 40_000x40_000 pixels, 3 bytes per pixel, allocated on the heap
-        let mut encoder = BMPEncoder::new(&mut encoded_data);
+        let mut encoder = BmpEncoder::new(&mut encoded_data);
         let result = encoder.encode(&image, 40_000, 40_000, ColorType::Rgb8);
         assert!(result.is_err());
     }

--- a/src/bmp/mod.rs
+++ b/src/bmp/mod.rs
@@ -8,16 +8,8 @@
 //!
 
 pub use self::decoder::BmpDecoder;
-pub use self::encoder::BmpEncoder;
-
-/// BMP Encoder
-///
-/// An alias of [`BmpEncoder`].
-///
-/// [`BmpEncoder`]: struct.BmpEncoder.html
-#[allow(dead_code)]
-#[deprecated(note = "Use `BmpEncoder` instead")]
-pub type BMPEncoder<'a, W> = BmpEncoder<'a, W>;
+#[allow(deprecated)]
+pub use self::encoder::{BmpEncoder, BMPEncoder};
 
 mod decoder;
 mod encoder;

--- a/src/bmp/mod.rs
+++ b/src/bmp/mod.rs
@@ -8,7 +8,7 @@
 //!
 
 pub use self::decoder::BmpDecoder;
-#[allow(deprecated)]
+#[allow(deprecated)] // TODO: when `BMPEncoder` is removed, remove this flag
 pub use self::encoder::{BmpEncoder, BMPEncoder};
 
 mod decoder;

--- a/src/bmp/mod.rs
+++ b/src/bmp/mod.rs
@@ -8,7 +8,16 @@
 //!
 
 pub use self::decoder::BmpDecoder;
-pub use self::encoder::BMPEncoder;
+pub use self::encoder::BmpEncoder;
+
+/// BMP Encoder
+///
+/// An alias of [`BmpEncoder`].
+///
+/// [`BmpEncoder`]: struct.BmpEncoder.html
+#[allow(dead_code)]
+#[deprecated(note = "Use `BmpEncoder` instead")]
+pub type BMPEncoder<'a, W> = BmpEncoder<'a, W>;
 
 mod decoder;
 mod encoder;

--- a/src/dds.rs
+++ b/src/dds.rs
@@ -11,7 +11,7 @@ use std::io::Read;
 use byteorder::{LittleEndian, ReadBytesExt};
 
 use crate::color::ColorType;
-use crate::dxt::{DxtDecoder, DXTReader, DXTVariant};
+use crate::dxt::{DxtDecoder, DxtReader, DxtVariant};
 use crate::error::{
     DecodingError, ImageError, ImageFormatHint, ImageResult, UnsupportedError, UnsupportedErrorKind,
 };
@@ -169,9 +169,9 @@ impl<R: Read> DdsDecoder<R> {
 
         if header.pixel_format.flags & 0x4 != 0 {
             let variant = match &header.pixel_format.fourcc {
-                b"DXT1" => DXTVariant::DXT1,
-                b"DXT3" => DXTVariant::DXT3,
-                b"DXT5" => DXTVariant::DXT5,
+                b"DXT1" => DxtVariant::DXT1,
+                b"DXT3" => DxtVariant::DXT3,
+                b"DXT5" => DxtVariant::DXT5,
                 fourcc => {
                     return Err(ImageError::Unsupported(
                         UnsupportedError::from_format_and_kind(
@@ -196,7 +196,7 @@ impl<R: Read> DdsDecoder<R> {
 }
 
 impl<'a, R: 'a + Read> ImageDecoder<'a> for DdsDecoder<R> {
-    type Reader = DXTReader<R>;
+    type Reader = DxtReader<R>;
 
     fn dimensions(&self) -> (u32, u32) {
         self.inner.dimensions()

--- a/src/dds.rs
+++ b/src/dds.rs
@@ -11,7 +11,7 @@ use std::io::Read;
 use byteorder::{LittleEndian, ReadBytesExt};
 
 use crate::color::ColorType;
-use crate::dxt::{DxtDecoder, DxtReader, DxtVariant};
+use crate::dxt::{DxtDecoder, DxtReader, DXTVariant};
 use crate::error::{
     DecodingError, ImageError, ImageFormatHint, ImageResult, UnsupportedError, UnsupportedErrorKind,
 };
@@ -169,9 +169,9 @@ impl<R: Read> DdsDecoder<R> {
 
         if header.pixel_format.flags & 0x4 != 0 {
             let variant = match &header.pixel_format.fourcc {
-                b"DXT1" => DxtVariant::DXT1,
-                b"DXT3" => DxtVariant::DXT3,
-                b"DXT5" => DxtVariant::DXT5,
+                b"DXT1" => DXTVariant::DXT1,
+                b"DXT3" => DXTVariant::DXT3,
+                b"DXT5" => DXTVariant::DXT5,
                 fourcc => {
                     return Err(ImageError::Unsupported(
                         UnsupportedError::from_format_and_kind(

--- a/src/dxt.rs
+++ b/src/dxt.rs
@@ -17,8 +17,14 @@ use crate::image::{self, ImageDecoder, ImageDecoderExt, ImageReadBuffer, Progres
 /// What version of DXT compression are we using?
 /// Note that DXT2 and DXT4 are left away as they're
 /// just DXT3 and DXT5 with premultiplied alpha
+///
+/// DEPRECATED: The name of this enum will be changed to [`DxtVariant`].
+///
+/// TODO: rename to [`DxtVariant`]
+///
+/// [`DxtVariant`]: type.DxtVariant.html
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum DxtVariant {
+pub enum DXTVariant {
     /// The DXT1 format. 48 bytes of RGB data in a 4x4 pixel square is
     /// compressed into an 8 byte block of DXT1 data
     DXT1,
@@ -32,36 +38,37 @@ pub enum DxtVariant {
 
 /// DXT compression version.
 ///
-/// An alias of [`DxtVariant`].
+/// An alias of [`DXTVariant`].
 ///
-/// [`DxtVariant`]: enum.DxtVariant.html
+/// TODO: remove when [`DXTVariant`] is renamed.
+///
+/// [`DXTVariant`]: enum.DXTVariant.html
 #[allow(dead_code)]
-#[deprecated(note = "Use `DxtVariant` instead")]
-pub type DXTVariant = DxtVariant;
+pub type DxtVariant = DXTVariant;
 
-impl DxtVariant {
+impl DXTVariant {
     /// Returns the amount of bytes of raw image data
     /// that is encoded in a single DXTn block
     fn decoded_bytes_per_block(self) -> usize {
         match self {
-            DxtVariant::DXT1 => 48,
-            DxtVariant::DXT3 | DxtVariant::DXT5 => 64,
+            DXTVariant::DXT1 => 48,
+            DXTVariant::DXT3 | DXTVariant::DXT5 => 64,
         }
     }
 
     /// Returns the amount of bytes per block of encoded DXTn data
     fn encoded_bytes_per_block(self) -> usize {
         match self {
-            DxtVariant::DXT1 => 8,
-            DxtVariant::DXT3 | DxtVariant::DXT5 => 16,
+            DXTVariant::DXT1 => 8,
+            DXTVariant::DXT3 | DXTVariant::DXT5 => 16,
         }
     }
 
     /// Returns the color type that is stored in this DXT variant
     pub fn color_type(self) -> ColorType {
         match self {
-            DxtVariant::DXT1 => ColorType::Rgb8,
-            DxtVariant::DXT3 | DxtVariant::DXT5 => ColorType::Rgba8,
+            DXTVariant::DXT1 => ColorType::Rgb8,
+            DXTVariant::DXT3 | DXTVariant::DXT5 => ColorType::Rgba8,
         }
     }
 }
@@ -71,7 +78,7 @@ pub struct DxtDecoder<R: Read> {
     inner: R,
     width_blocks: u32,
     height_blocks: u32,
-    variant: DxtVariant,
+    variant: DXTVariant,
     row: u32,
 }
 
@@ -87,7 +94,7 @@ impl<R: Read> DxtDecoder<R> {
         r: R,
         width: u32,
         height: u32,
-        variant: DxtVariant,
+        variant: DXTVariant,
     ) -> Result<DxtDecoder<R>, ImageError> {
         if width % 4 != 0 || height % 4 != 0 {
             // TODO: this is actually a bit of a weird case. We could return `DecodingError` but
@@ -115,9 +122,9 @@ impl<R: Read> DxtDecoder<R> {
             vec![0u8; self.variant.encoded_bytes_per_block() * self.width_blocks as usize];
         self.inner.read_exact(&mut src)?;
         match self.variant {
-            DxtVariant::DXT1 => decode_dxt1_row(&src, buf),
-            DxtVariant::DXT3 => decode_dxt3_row(&src, buf),
-            DxtVariant::DXT5 => decode_dxt5_row(&src, buf),
+            DXTVariant::DXT1 => decode_dxt1_row(&src, buf),
+            DXTVariant::DXT3 => decode_dxt3_row(&src, buf),
+            DXTVariant::DXT5 => decode_dxt5_row(&src, buf),
         }
         self.row += 1;
         Ok(buf.len())
@@ -193,6 +200,8 @@ pub struct DxtReader<R: Read> {
 ///
 /// An alias of [`DxtReader`].
 ///
+/// TODO: remove
+///
 /// [`DxtReader`]: struct.DxtReader.html
 #[allow(dead_code)]
 #[deprecated(note = "Use `DxtReader` instead")]
@@ -214,6 +223,8 @@ pub struct DxtEncoder<W: Write> {
 ///
 /// An alias of [`DxtEncoder`].
 ///
+/// TODO: remove
+///
 /// [`DxtEncoder`]: struct.DxtEncoder.html
 #[allow(dead_code)]
 #[deprecated(note = "Use `DxtEncoder` instead")]
@@ -234,7 +245,7 @@ impl<W: Write> DxtEncoder<W> {
         data: &[u8],
         width: u32,
         height: u32,
-        variant: DxtVariant,
+        variant: DXTVariant,
     ) -> ImageResult<()> {
         if width % 4 != 0 || height % 4 != 0 {
             // TODO: this is not very idiomatic yet. Should return an EncodingError.
@@ -251,9 +262,9 @@ impl<W: Write> DxtEncoder<W> {
 
         for chunk in data.chunks(width_blocks as usize * stride) {
             let data = match variant {
-                DxtVariant::DXT1 => encode_dxt1_row(chunk),
-                DxtVariant::DXT3 => encode_dxt3_row(chunk),
-                DxtVariant::DXT5 => encode_dxt5_row(chunk),
+                DXTVariant::DXT1 => encode_dxt1_row(chunk),
+                DXTVariant::DXT3 => encode_dxt3_row(chunk),
+                DXTVariant::DXT5 => encode_dxt5_row(chunk),
             };
             self.w.write_all(&data)?;
         }

--- a/src/dxt.rs
+++ b/src/dxt.rs
@@ -18,7 +18,7 @@ use crate::image::{self, ImageDecoder, ImageDecoderExt, ImageReadBuffer, Progres
 /// Note that DXT2 and DXT4 are left away as they're
 /// just DXT3 and DXT5 with premultiplied alpha
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum DXTVariant {
+pub enum DxtVariant {
     /// The DXT1 format. 48 bytes of RGB data in a 4x4 pixel square is
     /// compressed into an 8 byte block of DXT1 data
     DXT1,
@@ -30,29 +30,38 @@ pub enum DXTVariant {
     DXT5,
 }
 
-impl DXTVariant {
+/// DXT compression version.
+///
+/// An alias of [`DxtVariant`].
+///
+/// [`DxtVariant`]: enum.DxtVariant.html
+#[allow(dead_code)]
+#[deprecated(note = "Use `DxtVariant` instead")]
+pub type DXTVariant = DxtVariant;
+
+impl DxtVariant {
     /// Returns the amount of bytes of raw image data
     /// that is encoded in a single DXTn block
     fn decoded_bytes_per_block(self) -> usize {
         match self {
-            DXTVariant::DXT1 => 48,
-            DXTVariant::DXT3 | DXTVariant::DXT5 => 64,
+            DxtVariant::DXT1 => 48,
+            DxtVariant::DXT3 | DxtVariant::DXT5 => 64,
         }
     }
 
     /// Returns the amount of bytes per block of encoded DXTn data
     fn encoded_bytes_per_block(self) -> usize {
         match self {
-            DXTVariant::DXT1 => 8,
-            DXTVariant::DXT3 | DXTVariant::DXT5 => 16,
+            DxtVariant::DXT1 => 8,
+            DxtVariant::DXT3 | DxtVariant::DXT5 => 16,
         }
     }
 
     /// Returns the color type that is stored in this DXT variant
     pub fn color_type(self) -> ColorType {
         match self {
-            DXTVariant::DXT1 => ColorType::Rgb8,
-            DXTVariant::DXT3 | DXTVariant::DXT5 => ColorType::Rgba8,
+            DxtVariant::DXT1 => ColorType::Rgb8,
+            DxtVariant::DXT3 | DxtVariant::DXT5 => ColorType::Rgba8,
         }
     }
 }
@@ -62,7 +71,7 @@ pub struct DxtDecoder<R: Read> {
     inner: R,
     width_blocks: u32,
     height_blocks: u32,
-    variant: DXTVariant,
+    variant: DxtVariant,
     row: u32,
 }
 
@@ -78,7 +87,7 @@ impl<R: Read> DxtDecoder<R> {
         r: R,
         width: u32,
         height: u32,
-        variant: DXTVariant,
+        variant: DxtVariant,
     ) -> Result<DxtDecoder<R>, ImageError> {
         if width % 4 != 0 || height % 4 != 0 {
             // TODO: this is actually a bit of a weird case. We could return `DecodingError` but
@@ -106,9 +115,9 @@ impl<R: Read> DxtDecoder<R> {
             vec![0u8; self.variant.encoded_bytes_per_block() * self.width_blocks as usize];
         self.inner.read_exact(&mut src)?;
         match self.variant {
-            DXTVariant::DXT1 => decode_dxt1_row(&src, buf),
-            DXTVariant::DXT3 => decode_dxt3_row(&src, buf),
-            DXTVariant::DXT5 => decode_dxt5_row(&src, buf),
+            DxtVariant::DXT1 => decode_dxt1_row(&src, buf),
+            DxtVariant::DXT3 => decode_dxt3_row(&src, buf),
+            DxtVariant::DXT5 => decode_dxt5_row(&src, buf),
         }
         self.row += 1;
         Ok(buf.len())
@@ -118,7 +127,7 @@ impl<R: Read> DxtDecoder<R> {
 // Note that, due to the way that DXT compression works, a scanline is considered to consist out of
 // 4 lines of pixels.
 impl<'a, R: 'a + Read> ImageDecoder<'a> for DxtDecoder<R> {
-    type Reader = DXTReader<R>;
+    type Reader = DxtReader<R>;
 
     fn dimensions(&self) -> (u32, u32) {
         (self.width_blocks * 4, self.height_blocks * 4)
@@ -133,7 +142,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for DxtDecoder<R> {
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
-        Ok(DXTReader {
+        Ok(DxtReader {
             buffer: ImageReadBuffer::new(self.scanline_bytes(), self.total_bytes()),
             decoder: self,
         })
@@ -175,11 +184,21 @@ impl<'a, R: 'a + Read + Seek> ImageDecoderExt<'a> for DxtDecoder<R> {
 }
 
 /// DXT reader
-pub struct DXTReader<R: Read> {
+pub struct DxtReader<R: Read> {
     buffer: ImageReadBuffer,
     decoder: DxtDecoder<R>,
 }
-impl<R: Read> Read for DXTReader<R> {
+
+/// DXT reader
+///
+/// An alias of [`DxtReader`].
+///
+/// [`DxtReader`]: struct.DxtReader.html
+#[allow(dead_code)]
+#[deprecated(note = "Use `DxtReader` instead")]
+pub type DXTReader<R> = DxtReader<R>;
+
+impl<R: Read> Read for DxtReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let decoder = &mut self.decoder;
         self.buffer.read(buf, |buf| decoder.read_scanline(buf))
@@ -187,14 +206,23 @@ impl<R: Read> Read for DXTReader<R> {
 }
 
 /// DXT encoder
-pub struct DXTEncoder<W: Write> {
+pub struct DxtEncoder<W: Write> {
     w: W,
 }
 
-impl<W: Write> DXTEncoder<W> {
+/// DXT encoder
+///
+/// An alias of [`DxtEncoder`].
+///
+/// [`DxtEncoder`]: struct.DxtEncoder.html
+#[allow(dead_code)]
+#[deprecated(note = "Use `DxtEncoder` instead")]
+pub type DXTEncoder<W> = DxtEncoder<W>;
+
+impl<W: Write> DxtEncoder<W> {
     /// Create a new encoder that writes its output to ```w```
-    pub fn new(w: W) -> DXTEncoder<W> {
-        DXTEncoder { w }
+    pub fn new(w: W) -> DxtEncoder<W> {
+        DxtEncoder { w }
     }
 
     /// Encodes the image data ```data```
@@ -206,7 +234,7 @@ impl<W: Write> DXTEncoder<W> {
         data: &[u8],
         width: u32,
         height: u32,
-        variant: DXTVariant,
+        variant: DxtVariant,
     ) -> ImageResult<()> {
         if width % 4 != 0 || height % 4 != 0 {
             // TODO: this is not very idiomatic yet. Should return an EncodingError.
@@ -223,9 +251,9 @@ impl<W: Write> DXTEncoder<W> {
 
         for chunk in data.chunks(width_blocks as usize * stride) {
             let data = match variant {
-                DXTVariant::DXT1 => encode_dxt1_row(chunk),
-                DXTVariant::DXT3 => encode_dxt3_row(chunk),
-                DXTVariant::DXT5 => encode_dxt5_row(chunk),
+                DxtVariant::DXT1 => encode_dxt1_row(chunk),
+                DxtVariant::DXT3 => encode_dxt3_row(chunk),
+                DxtVariant::DXT5 => encode_dxt5_row(chunk),
             };
             self.w.write_all(&data)?;
         }

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -746,14 +746,14 @@ impl DynamicImage {
 
             #[cfg(feature = "gif")]
             image::ImageOutputFormat::Gif => {
-                let mut g = gif::Encoder::new(w);
+                let mut g = gif::GifEncoder::new(w);
                 g.encode_frame(crate::animation::Frame::new(self.to_rgba()))?;
                 Ok(())
             }
 
             #[cfg(feature = "ico")]
             image::ImageOutputFormat::Ico => {
-                let i = ico::ICOEncoder::new(w);
+                let i = ico::IcoEncoder::new(w);
 
                 i.encode(&bytes, width, height, color)?;
                 Ok(())

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -705,7 +705,7 @@ impl DynamicImage {
         match format {
             #[cfg(feature = "png")]
             image::ImageOutputFormat::Png => {
-                let p = png::PNGEncoder::new(w);
+                let p = png::PngEncoder::new(w);
                 match *self {
                     DynamicImage::ImageBgra8(_) => {
                         bytes = self.to_rgba().iter().cloned().collect();
@@ -761,7 +761,7 @@ impl DynamicImage {
 
             #[cfg(feature = "bmp")]
             image::ImageOutputFormat::Bmp => {
-                let mut b = bmp::BMPEncoder::new(w);
+                let mut b = bmp::BmpEncoder::new(w);
                 b.encode(&bytes, width, height, color)?;
                 Ok(())
             }

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -722,7 +722,7 @@ impl DynamicImage {
             }
             #[cfg(feature = "pnm")]
             image::ImageOutputFormat::Pnm(subtype) => {
-                let mut p = pnm::PNMEncoder::new(w).with_subtype(subtype);
+                let mut p = pnm::PnmEncoder::new(w).with_subtype(subtype);
                 match *self {
                     DynamicImage::ImageBgra8(_) => {
                         bytes = self.to_rgba().iter().cloned().collect();
@@ -739,7 +739,7 @@ impl DynamicImage {
             }
             #[cfg(feature = "jpeg")]
             image::ImageOutputFormat::Jpeg(quality) => {
-                let j = jpeg::JPEGEncoder::new_with_quality(w, quality);
+                let j = jpeg::JpegEncoder::new_with_quality(w, quality);
                 j.write_image(&bytes, width, height, color)?;
                 Ok(())
             }

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -299,6 +299,8 @@ pub struct GifEncoder<W: Write> {
 ///
 /// An alias of [`GifEncoder`].
 ///
+/// TODO: remove
+///
 /// [`GifEncoder`]: struct.GifEncoder.html
 #[allow(dead_code)]
 #[deprecated(note = "Use `GifEncoder` instead")]

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -7,7 +7,7 @@
 //!
 //! # Examples
 //! ```rust,no_run
-//! use image::gif::{GifDecoder, Encoder};
+//! use image::gif::{GifDecoder, GifEncoder};
 //! use image::{ImageDecoder, AnimationDecoder};
 //! use std::fs::File;
 //! # fn main() -> std::io::Result<()> {
@@ -19,7 +19,7 @@
 //!
 //! // Encode frames into a gif and save to a file
 //! let mut file_out = File::open("out.gif")?;
-//! let mut encoder = Encoder::new(file_out);
+//! let mut encoder = GifEncoder::new(file_out);
 //! encoder.encode_frames(frames.into_iter());
 //! # Ok(())
 //! # }
@@ -290,15 +290,24 @@ impl<'a, R: Read + 'a> AnimationDecoder<'a> for GifDecoder<R> {
 }
 
 /// GIF encoder.
-pub struct Encoder<W: Write> {
+pub struct GifEncoder<W: Write> {
     w: Option<W>,
     gif_encoder: Option<gif::Encoder<W>>,
 }
 
-impl<W: Write> Encoder<W> {
+/// GIF encoder
+///
+/// An alias of [`GifEncoder`].
+///
+/// [`GifEncoder`]: struct.GifEncoder.html
+#[allow(dead_code)]
+#[deprecated(note = "Use `GifEncoder` instead")]
+pub type Encoder<W> = GifEncoder<W>;
+
+impl<W: Write> GifEncoder<W> {
     /// Creates a new GIF encoder.
-    pub fn new(w: W) -> Encoder<W> {
-        Encoder {
+    pub fn new(w: W) -> GifEncoder<W> {
+        GifEncoder {
             w: Some(w),
             gif_encoder: None,
         }

--- a/src/hdr/decoder.rs
+++ b/src/hdr/decoder.rs
@@ -125,6 +125,8 @@ pub struct HdrAdapter<R: BufRead> {
 ///
 /// An alias of [`HdrAdapter`].
 ///
+/// TODO: remove
+///
 /// [`HdrAdapter`]: struct.HdrAdapter.html
 #[allow(dead_code)]
 #[deprecated(note = "Use `HdrAdapter` instead")]
@@ -247,6 +249,8 @@ pub struct Rgbe8Pixel {
 /// Refer to [wikipedia](https://en.wikipedia.org/wiki/RGBE_image_format)
 ///
 /// An alias of [`Rgbe8Pixel`].
+///
+/// TODO: remove
 ///
 /// [`Rgbe8Pixel`]: struct.Rgbe8Pixel.html
 #[allow(dead_code)]
@@ -508,6 +512,8 @@ pub struct HdrImageDecoderIterator<R: BufRead> {
 ///
 /// An alias of [`HdrImageDecoderIterator`].
 ///
+/// TODO: remove
+///
 /// [`HdrImageDecoderIterator`]: struct.HdrImageDecoderIterator.html
 #[allow(dead_code)]
 #[deprecated(note = "Use `HdrImageDecoderIterator` instead")]
@@ -756,6 +762,8 @@ pub struct HdrMetadata {
 /// HDR MetaData
 ///
 /// An alias of [`HdrMetadata`].
+///
+/// TODO: remove
 ///
 /// [`HdrMetadata`]: struct.HdrMetadata.html
 #[allow(dead_code)]

--- a/src/hdr/decoder.rs
+++ b/src/hdr/decoder.rs
@@ -115,28 +115,37 @@ impl fmt::Display for LineType {
 
 /// Adapter to conform to ```ImageDecoder``` trait
 #[derive(Debug)]
-pub struct HDRAdapter<R: BufRead> {
+pub struct HdrAdapter<R: BufRead> {
     inner: Option<HdrDecoder<R>>,
     // data: Option<Vec<u8>>,
-    meta: HDRMetadata,
+    meta: HdrMetadata,
 }
 
-impl<R: BufRead> HDRAdapter<R> {
+/// HDR Adapter
+///
+/// An alias of [`HdrAdapter`].
+///
+/// [`HdrAdapter`]: struct.HdrAdapter.html
+#[allow(dead_code)]
+#[deprecated(note = "Use `HdrAdapter` instead")]
+pub type HDRAdapter<R> = HdrAdapter<R>;
+
+impl<R: BufRead> HdrAdapter<R> {
     /// Creates adapter
-    pub fn new(r: R) -> ImageResult<HDRAdapter<R>> {
+    pub fn new(r: R) -> ImageResult<HdrAdapter<R>> {
         let decoder = HdrDecoder::new(r)?;
         let meta = decoder.metadata();
-        Ok(HDRAdapter {
+        Ok(HdrAdapter {
             inner: Some(decoder),
             meta,
         })
     }
 
     /// Allows reading old Radiance HDR images
-    pub fn new_nonstrict(r: R) -> ImageResult<HDRAdapter<R>> {
+    pub fn new_nonstrict(r: R) -> ImageResult<HdrAdapter<R>> {
         let decoder = HdrDecoder::with_strictness(r, false)?;
         let meta = decoder.metadata();
-        Ok(HDRAdapter {
+        Ok(HdrAdapter {
             inner: Some(decoder),
             meta,
         })
@@ -177,7 +186,7 @@ impl<R> Read for HdrReader<R> {
     }
 }
 
-impl<'a, R: 'a + BufRead> ImageDecoder<'a> for HDRAdapter<R> {
+impl<'a, R: 'a + BufRead> ImageDecoder<'a> for HdrAdapter<R> {
     type Reader = HdrReader<R>;
 
     fn dimensions(&self) -> (u32, u32) {
@@ -197,7 +206,7 @@ impl<'a, R: 'a + BufRead> ImageDecoder<'a> for HDRAdapter<R> {
     }
 }
 
-impl<'a, R: 'a + BufRead + Seek> ImageDecoderExt<'a> for HDRAdapter<R> {
+impl<'a, R: 'a + BufRead + Seek> ImageDecoderExt<'a> for HdrAdapter<R> {
     fn read_rect_with_progress<F: Fn(Progress)>(
         &mut self,
         x: u32,
@@ -222,25 +231,34 @@ pub struct HdrDecoder<R> {
     r: R,
     width: u32,
     height: u32,
-    meta: HDRMetadata,
+    meta: HdrMetadata,
 }
 
 /// Refer to [wikipedia](https://en.wikipedia.org/wiki/RGBE_image_format)
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct RGBE8Pixel {
+pub struct Rgbe8Pixel {
     /// Color components
     pub c: [u8; 3],
     /// Exponent
     pub e: u8,
 }
 
+/// Refer to [wikipedia](https://en.wikipedia.org/wiki/RGBE_image_format)
+///
+/// An alias of [`Rgbe8Pixel`].
+///
+/// [`Rgbe8Pixel`]: struct.Rgbe8Pixel.html
+#[allow(dead_code)]
+#[deprecated(note = "Use `Rgbe8Pixel` instead")]
+pub type RGBE8Pixel = Rgbe8Pixel;
+
 /// Creates ```RGBE8Pixel``` from components
-pub fn rgbe8(r: u8, g: u8, b: u8, e: u8) -> RGBE8Pixel {
-    RGBE8Pixel { c: [r, g, b], e }
+pub fn rgbe8(r: u8, g: u8, b: u8, e: u8) -> Rgbe8Pixel {
+    Rgbe8Pixel { c: [r, g, b], e }
 }
 
-impl RGBE8Pixel {
+impl Rgbe8Pixel {
     /// Converts ```RGBE8Pixel``` into ```Rgb<f32>``` linearly
     #[inline]
     pub fn to_hdr(self) -> Rgb<f32> {
@@ -321,7 +339,7 @@ impl<R: BufRead> HdrDecoder<R> {
     /// Warning! Reading wrong file in non-strict mode
     ///   could consume file size worth of memory in the process.
     pub fn with_strictness(mut reader: R, strict: bool) -> ImageResult<HdrDecoder<R>> {
-        let mut attributes = HDRMetadata::new();
+        let mut attributes = HdrMetadata::new();
 
         {
             // scope to make borrowck happy
@@ -378,7 +396,7 @@ impl<R: BufRead> HdrDecoder<R> {
 
             width,
             height,
-            meta: HDRMetadata {
+            meta: HdrMetadata {
                 width,
                 height,
                 ..attributes
@@ -387,12 +405,12 @@ impl<R: BufRead> HdrDecoder<R> {
     } // end with_strictness
 
     /// Returns file metadata. Refer to ```HDRMetadata``` for details.
-    pub fn metadata(&self) -> HDRMetadata {
+    pub fn metadata(&self) -> HdrMetadata {
         self.meta.clone()
     }
 
     /// Consumes decoder and returns a vector of RGBE8 pixels
-    pub fn read_image_native(mut self) -> ImageResult<Vec<RGBE8Pixel>> {
+    pub fn read_image_native(mut self) -> ImageResult<Vec<Rgbe8Pixel>> {
         // Don't read anything if image is empty
         if self.width == 0 || self.height == 0 {
             return Ok(vec![]);
@@ -407,7 +425,7 @@ impl<R: BufRead> HdrDecoder<R> {
     }
 
     /// Consumes decoder and returns a vector of transformed pixels
-    pub fn read_image_transform<T: Send, F: Send + Sync + Fn(RGBE8Pixel) -> T>(
+    pub fn read_image_transform<T: Send, F: Send + Sync + Fn(Rgbe8Pixel) -> T>(
         mut self,
         f: F,
         output_slice: &mut [T],
@@ -459,11 +477,11 @@ impl<R: BufRead> HdrDecoder<R> {
 }
 
 impl<R: BufRead> IntoIterator for HdrDecoder<R> {
-    type Item = ImageResult<RGBE8Pixel>;
-    type IntoIter = HDRImageDecoderIterator<R>;
+    type Item = ImageResult<Rgbe8Pixel>;
+    type IntoIter = HdrImageDecoderIterator<R>;
 
     fn into_iter(self) -> Self::IntoIter {
-        HDRImageDecoderIterator {
+        HdrImageDecoderIterator {
             r: self.r,
             scanline_cnt: self.height as usize,
             buf: vec![Default::default(); self.width as usize],
@@ -476,17 +494,26 @@ impl<R: BufRead> IntoIterator for HdrDecoder<R> {
 }
 
 /// Scanline buffered pixel by pixel iterator
-pub struct HDRImageDecoderIterator<R: BufRead> {
+pub struct HdrImageDecoderIterator<R: BufRead> {
     r: R,
     scanline_cnt: usize,
-    buf: Vec<RGBE8Pixel>, // scanline buffer
+    buf: Vec<Rgbe8Pixel>, // scanline buffer
     col: usize,           // current position in scanline
     scanline: usize,      // current scanline
     trouble: bool,        // optimization, true indicates that we need to check something
     error_encountered: bool,
 }
 
-impl<R: BufRead> HDRImageDecoderIterator<R> {
+/// Scanline buffered pixel by pixel iterator
+///
+/// An alias of [`HdrImageDecoderIterator`].
+///
+/// [`HdrImageDecoderIterator`]: struct.HdrImageDecoderIterator.html
+#[allow(dead_code)]
+#[deprecated(note = "Use `HdrImageDecoderIterator` instead")]
+pub type HDRImageDecoderIterator<R> = HdrImageDecoderIterator<R>;
+
+impl<R: BufRead> HdrImageDecoderIterator<R> {
     // Advances counter to the next pixel
     #[inline]
     fn advance(&mut self) {
@@ -499,8 +526,8 @@ impl<R: BufRead> HDRImageDecoderIterator<R> {
     }
 }
 
-impl<R: BufRead> Iterator for HDRImageDecoderIterator<R> {
-    type Item = ImageResult<RGBE8Pixel>;
+impl<R: BufRead> Iterator for HdrImageDecoderIterator<R> {
+    type Item = ImageResult<Rgbe8Pixel>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if !self.trouble {
@@ -550,10 +577,10 @@ impl<R: BufRead> Iterator for HDRImageDecoderIterator<R> {
     }
 }
 
-impl<R: BufRead> ExactSizeIterator for HDRImageDecoderIterator<R> {}
+impl<R: BufRead> ExactSizeIterator for HdrImageDecoderIterator<R> {}
 
 // Precondition: buf.len() > 0
-fn read_scanline<R: BufRead>(r: &mut R, buf: &mut [RGBE8Pixel]) -> ImageResult<()> {
+fn read_scanline<R: BufRead>(r: &mut R, buf: &mut [Rgbe8Pixel]) -> ImageResult<()> {
     assert!(!buf.is_empty());
     let width = buf.len();
     // first 4 bytes in scanline allow to determine compression method
@@ -631,15 +658,15 @@ fn decode_component<R: BufRead, S: FnMut(usize, u8)>(
 // fb - first 4 bytes of scanline
 fn decode_old_rle<R: BufRead>(
     r: &mut R,
-    fb: RGBE8Pixel,
-    buf: &mut [RGBE8Pixel],
+    fb: Rgbe8Pixel,
+    buf: &mut [Rgbe8Pixel],
 ) -> ImageResult<()> {
     assert!(!buf.is_empty());
     let width = buf.len();
     // convenience function.
     // returns run length if pixel is a run length marker
     #[inline]
-    fn rl_marker(pix: RGBE8Pixel) -> Option<usize> {
+    fn rl_marker(pix: Rgbe8Pixel) -> Option<usize> {
         if pix.c == [1, 1, 1] {
             Some(pix.e as usize)
         } else {
@@ -687,10 +714,10 @@ fn decode_old_rle<R: BufRead>(
     Ok(())
 }
 
-fn read_rgbe<R: BufRead>(r: &mut R) -> io::Result<RGBE8Pixel> {
+fn read_rgbe<R: BufRead>(r: &mut R) -> io::Result<Rgbe8Pixel> {
     let mut buf = [0u8; 4];
     r.read_exact(&mut buf[..])?;
-    Ok(RGBE8Pixel {
+    Ok(Rgbe8Pixel {
         c: [buf[0], buf[1], buf[2]],
         e: buf[3],
     })
@@ -698,7 +725,7 @@ fn read_rgbe<R: BufRead>(r: &mut R) -> io::Result<RGBE8Pixel> {
 
 /// Metadata for Radiance HDR image
 #[derive(Debug, Clone)]
-pub struct HDRMetadata {
+pub struct HdrMetadata {
     /// Width of decoded image. It could be either scanline length,
     /// or scanline count, depending on image orientation.
     pub width: u32,
@@ -726,9 +753,18 @@ pub struct HDRMetadata {
     pub custom_attributes: Vec<(String, String)>,
 }
 
-impl HDRMetadata {
-    fn new() -> HDRMetadata {
-        HDRMetadata {
+/// HDR MetaData
+///
+/// An alias of [`HdrMetadata`].
+///
+/// [`HdrMetadata`]: struct.HdrMetadata.html
+#[allow(dead_code)]
+#[deprecated(note = "Use `HdrMetadata` instead")]
+pub type HDRMetadata = HdrMetadata;
+
+impl HdrMetadata {
+    fn new() -> HdrMetadata {
+        HdrMetadata {
             width: 0,
             height: 0,
             orientation: ((1, 0), (0, 1)),

--- a/src/hdr/encoder.rs
+++ b/src/hdr/encoder.rs
@@ -1,18 +1,27 @@
 use crate::color::Rgb;
 use crate::error::ImageResult;
-use crate::hdr::{rgbe8, RGBE8Pixel, SIGNATURE};
+use crate::hdr::{rgbe8, Rgbe8Pixel, SIGNATURE};
 use std::io::{Result, Write};
 use std::cmp::Ordering;
 
 /// Radiance HDR encoder
-pub struct HDREncoder<W: Write> {
+pub struct HdrEncoder<W: Write> {
     w: W,
 }
 
-impl<W: Write> HDREncoder<W> {
+/// HDR Encoder
+///
+/// An alias of [`HdrEncoder`].
+///
+/// [`HdrEncoder`]: struct.HdrEncoder.html
+#[allow(dead_code)]
+#[deprecated(note = "Use `HdrEncoder` instead")]
+pub type HDREncoder<R> = HdrEncoder<R>;
+
+impl<W: Write> HdrEncoder<W> {
     /// Creates encoder
-    pub fn new(w: W) -> HDREncoder<W> {
-        HDREncoder { w }
+    pub fn new(w: W) -> HdrEncoder<W> {
+        HdrEncoder { w }
     }
 
     /// Encodes the image ```data```
@@ -220,16 +229,16 @@ fn rle_compress(data: &[u8], rle: &mut Vec<u8>) {
     }
 }
 
-fn write_rgbe8<W: Write>(w: &mut W, v: RGBE8Pixel) -> Result<()> {
+fn write_rgbe8<W: Write>(w: &mut W, v: Rgbe8Pixel) -> Result<()> {
     w.write_all(&[v.c[0], v.c[1], v.c[2], v.e])
 }
 
 /// Converts ```Rgb<f32>``` into ```RGBE8Pixel```
-pub fn to_rgbe8(pix: Rgb<f32>) -> RGBE8Pixel {
+pub fn to_rgbe8(pix: Rgb<f32>) -> Rgbe8Pixel {
     let pix = pix.0;
     let mx = f32::max(pix[0], f32::max(pix[1], pix[2]));
     if mx <= 0.0 {
-        RGBE8Pixel { c: [0, 0, 0], e: 0 }
+        Rgbe8Pixel { c: [0, 0, 0], e: 0 }
     } else {
         // let (frac, exp) = mx.frexp(); // unstable yet
         let exp = mx.log2().floor() as i32 + 1;
@@ -238,7 +247,7 @@ pub fn to_rgbe8(pix: Rgb<f32>) -> RGBE8Pixel {
         for (cv, &sv) in conv.iter_mut().zip(pix.iter()) {
             *cv = f32::trunc(sv / mul * 256.0) as u8;
         }
-        RGBE8Pixel {
+        Rgbe8Pixel {
             c: conv,
             e: (exp + 128) as u8,
         }

--- a/src/hdr/encoder.rs
+++ b/src/hdr/encoder.rs
@@ -13,6 +13,8 @@ pub struct HdrEncoder<W: Write> {
 ///
 /// An alias of [`HdrEncoder`].
 ///
+/// TODO: remove
+///
 /// [`HdrEncoder`]: struct.HdrEncoder.html
 #[allow(dead_code)]
 #[deprecated(note = "Use `HdrEncoder` instead")]

--- a/src/ico/encoder.rs
+++ b/src/ico/encoder.rs
@@ -23,6 +23,8 @@ pub struct IcoEncoder<W: Write> {
 ///
 /// An alias of [`IcoEncoder`].
 ///
+/// TODO: remove
+///
 /// [`IcoEncoder`]: struct.IcoEncoder.html
 #[allow(dead_code)]
 #[deprecated(note = "Use `IcoEncoder` instead")]

--- a/src/ico/encoder.rs
+++ b/src/ico/encoder.rs
@@ -5,7 +5,7 @@ use crate::color::ColorType;
 use crate::error::ImageResult;
 use crate::image::ImageEncoder;
 
-use crate::png::PNGEncoder;
+use crate::png::PngEncoder;
 
 // Enum value indicating an ICO image (as opposed to a CUR image):
 const ICO_IMAGE_TYPE: u16 = 1;
@@ -36,7 +36,7 @@ impl<W: Write> ICOEncoder<W> {
         color: ColorType,
     ) -> ImageResult<()> {
         let mut image_data: Vec<u8> = Vec::new();
-        PNGEncoder::new(&mut image_data).encode(data, width, height, color)?;
+        PngEncoder::new(&mut image_data).encode(data, width, height, color)?;
 
         write_icondir(&mut self.w, 1)?;
         write_direntry(

--- a/src/ico/encoder.rs
+++ b/src/ico/encoder.rs
@@ -15,14 +15,23 @@ const ICO_ICONDIR_SIZE: u32 = 6;
 const ICO_DIRENTRY_SIZE: u32 = 16;
 
 /// ICO encoder
-pub struct ICOEncoder<W: Write> {
+pub struct IcoEncoder<W: Write> {
     w: W,
 }
 
-impl<W: Write> ICOEncoder<W> {
+/// ICO encoder
+///
+/// An alias of [`IcoEncoder`].
+///
+/// [`IcoEncoder`]: struct.IcoEncoder.html
+#[allow(dead_code)]
+#[deprecated(note = "Use `IcoEncoder` instead")]
+pub type ICOEncoder<W> = IcoEncoder<W>;
+
+impl<W: Write> IcoEncoder<W> {
     /// Create a new encoder that writes its output to ```w```.
-    pub fn new(w: W) -> ICOEncoder<W> {
-        ICOEncoder { w }
+    pub fn new(w: W) -> IcoEncoder<W> {
+        IcoEncoder { w }
     }
 
     /// Encodes the image ```image``` that has dimensions ```width``` and
@@ -52,7 +61,7 @@ impl<W: Write> ICOEncoder<W> {
     }
 }
 
-impl<W: Write> ImageEncoder for ICOEncoder<W> {
+impl<W: Write> ImageEncoder for IcoEncoder<W> {
     fn write_image(
         self,
         buf: &[u8],

--- a/src/ico/mod.rs
+++ b/src/ico/mod.rs
@@ -7,7 +7,8 @@
 //!  * <https://en.wikipedia.org/wiki/ICO_%28file_format%29>
 
 pub use self::decoder::IcoDecoder;
-pub use self::encoder::ICOEncoder;
+#[allow(deprecated)]
+pub use self::encoder::{IcoEncoder, ICOEncoder};
 
 mod decoder;
 mod encoder;

--- a/src/image.rs
+++ b/src/image.rs
@@ -15,7 +15,7 @@ use crate::traits::Pixel;
 use crate::animation::Frames;
 
 #[cfg(feature = "pnm")]
-use crate::pnm::PnmSubtype;
+use crate::pnm::PNMSubtype;
 
 /// An enumeration of supported image formats.
 /// Not all formats support both encoding and decoding.
@@ -110,7 +110,7 @@ pub enum ImageOutputFormat {
 
     #[cfg(feature = "pnm")]
     /// An Image in one of the PNM Formats
-    Pnm(PnmSubtype),
+    Pnm(PNMSubtype),
 
     #[cfg(feature = "gif")]
     /// An Image in GIF Format
@@ -149,7 +149,7 @@ impl From<ImageFormat> for ImageOutputFormat {
             #[cfg(feature = "jpeg")]
             ImageFormat::Jpeg => ImageOutputFormat::Jpeg(75),
             #[cfg(feature = "pnm")]
-            ImageFormat::Pnm => ImageOutputFormat::Pnm(PnmSubtype::ArbitraryMap),
+            ImageFormat::Pnm => ImageOutputFormat::Pnm(PNMSubtype::ArbitraryMap),
             #[cfg(feature = "gif")]
             ImageFormat::Gif => ImageOutputFormat::Gif,
             #[cfg(feature = "ico")]

--- a/src/image.rs
+++ b/src/image.rs
@@ -15,7 +15,7 @@ use crate::traits::Pixel;
 use crate::animation::Frames;
 
 #[cfg(feature = "pnm")]
-use crate::pnm::PNMSubtype;
+use crate::pnm::PnmSubtype;
 
 /// An enumeration of supported image formats.
 /// Not all formats support both encoding and decoding.
@@ -110,7 +110,7 @@ pub enum ImageOutputFormat {
 
     #[cfg(feature = "pnm")]
     /// An Image in one of the PNM Formats
-    Pnm(PNMSubtype),
+    Pnm(PnmSubtype),
 
     #[cfg(feature = "gif")]
     /// An Image in GIF Format
@@ -149,7 +149,7 @@ impl From<ImageFormat> for ImageOutputFormat {
             #[cfg(feature = "jpeg")]
             ImageFormat::Jpeg => ImageOutputFormat::Jpeg(75),
             #[cfg(feature = "pnm")]
-            ImageFormat::Pnm => ImageOutputFormat::Pnm(PNMSubtype::ArbitraryMap),
+            ImageFormat::Pnm => ImageOutputFormat::Pnm(PnmSubtype::ArbitraryMap),
             #[cfg(feature = "gif")]
             ImageFormat::Gif => ImageOutputFormat::Gif,
             #[cfg(feature = "ico")]

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -85,7 +85,7 @@ pub fn load<R: BufRead + Seek>(r: R, format: ImageFormat) -> ImageResult<Dynamic
         #[cfg(feature = "ico")]
         image::ImageFormat::Ico => DynamicImage::from_decoder(ico::IcoDecoder::new(r)?),
         #[cfg(feature = "hdr")]
-        image::ImageFormat::Hdr => DynamicImage::from_decoder(hdr::HDRAdapter::new(BufReader::new(r))?),
+        image::ImageFormat::Hdr => DynamicImage::from_decoder(hdr::HdrAdapter::new(BufReader::new(r))?),
         #[cfg(feature = "pnm")]
         image::ImageFormat::Pnm => DynamicImage::from_decoder(pnm::PnmDecoder::new(BufReader::new(r))?),
         #[cfg(feature = "farbfeld")]
@@ -131,7 +131,7 @@ pub(crate) fn image_dimensions_with_format_impl<R: BufRead + Seek>(fin: R, forma
         #[cfg(feature = "ico")]
         image::ImageFormat::Ico => ico::IcoDecoder::new(fin)?.dimensions(),
         #[cfg(feature = "hdr")]
-        image::ImageFormat::Hdr => hdr::HDRAdapter::new(fin)?.dimensions(),
+        image::ImageFormat::Hdr => hdr::HdrAdapter::new(fin)?.dimensions(),
         #[cfg(feature = "pnm")]
         image::ImageFormat::Pnm => {
             pnm::PnmDecoder::new(fin)?.dimensions()
@@ -160,23 +160,23 @@ pub(crate) fn save_buffer_impl(
         #[cfg(feature = "ico")]
         "ico" => ico::IcoEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "jpeg")]
-        "jpg" | "jpeg" => jpeg::JPEGEncoder::new(fout).write_image(buf, width, height, color),
+        "jpg" | "jpeg" => jpeg::JpegEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "png")]
         "png" => png::PngEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "pnm")]
-        "pbm" => pnm::PNMEncoder::new(fout)
-            .with_subtype(pnm::PNMSubtype::Bitmap(pnm::SampleEncoding::Binary))
+        "pbm" => pnm::PnmEncoder::new(fout)
+            .with_subtype(pnm::PnmSubtype::Bitmap(pnm::SampleEncoding::Binary))
             .write_image(buf, width, height, color),
         #[cfg(feature = "pnm")]
-        "pgm" => pnm::PNMEncoder::new(fout)
-            .with_subtype(pnm::PNMSubtype::Graymap(pnm::SampleEncoding::Binary))
+        "pgm" => pnm::PnmEncoder::new(fout)
+            .with_subtype(pnm::PnmSubtype::Graymap(pnm::SampleEncoding::Binary))
             .write_image(buf, width, height, color),
         #[cfg(feature = "pnm")]
-        "ppm" => pnm::PNMEncoder::new(fout)
-            .with_subtype(pnm::PNMSubtype::Pixmap(pnm::SampleEncoding::Binary))
+        "ppm" => pnm::PnmEncoder::new(fout)
+            .with_subtype(pnm::PnmSubtype::Pixmap(pnm::SampleEncoding::Binary))
             .write_image(buf, width, height, color),
         #[cfg(feature = "pnm")]
-        "pam" => pnm::PNMEncoder::new(fout).write_image(buf, width, height, color),
+        "pam" => pnm::PnmEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "bmp")]
         "bmp" => bmp::BmpEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "tiff")]
@@ -206,7 +206,7 @@ pub(crate) fn save_buffer_with_format_impl(
         #[cfg(feature = "ico")]
         image::ImageFormat::Ico => ico::IcoEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "jpeg")]
-        image::ImageFormat::Jpeg => jpeg::JPEGEncoder::new(fout).write_image(buf, width, height, color),
+        image::ImageFormat::Jpeg => jpeg::JpegEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "png")]
         image::ImageFormat::Png => png::PngEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "bmp")]

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -162,7 +162,7 @@ pub(crate) fn save_buffer_impl(
         #[cfg(feature = "jpeg")]
         "jpg" | "jpeg" => jpeg::JPEGEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "png")]
-        "png" => png::PNGEncoder::new(fout).write_image(buf, width, height, color),
+        "png" => png::PngEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "pnm")]
         "pbm" => pnm::PNMEncoder::new(fout)
             .with_subtype(pnm::PNMSubtype::Bitmap(pnm::SampleEncoding::Binary))
@@ -178,7 +178,7 @@ pub(crate) fn save_buffer_impl(
         #[cfg(feature = "pnm")]
         "pam" => pnm::PNMEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "bmp")]
-        "bmp" => bmp::BMPEncoder::new(fout).write_image(buf, width, height, color),
+        "bmp" => bmp::BmpEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "tiff")]
         "tif" | "tiff" => tiff::TiffEncoder::new(fout)
             .write_image(buf, width, height, color),
@@ -208,9 +208,9 @@ pub(crate) fn save_buffer_with_format_impl(
         #[cfg(feature = "jpeg")]
         image::ImageFormat::Jpeg => jpeg::JPEGEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "png")]
-        image::ImageFormat::Png => png::PNGEncoder::new(fout).write_image(buf, width, height, color),
+        image::ImageFormat::Png => png::PngEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "bmp")]
-        image::ImageFormat::Bmp => bmp::BMPEncoder::new(fout).write_image(buf, width, height, color),
+        image::ImageFormat::Bmp => bmp::BmpEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "tiff")]
         image::ImageFormat::Tiff => tiff::TiffEncoder::new(fout)
             .write_image(buf, width, height, color),

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -165,15 +165,15 @@ pub(crate) fn save_buffer_impl(
         "png" => png::PngEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "pnm")]
         "pbm" => pnm::PnmEncoder::new(fout)
-            .with_subtype(pnm::PnmSubtype::Bitmap(pnm::SampleEncoding::Binary))
+            .with_subtype(pnm::PNMSubtype::Bitmap(pnm::SampleEncoding::Binary))
             .write_image(buf, width, height, color),
         #[cfg(feature = "pnm")]
         "pgm" => pnm::PnmEncoder::new(fout)
-            .with_subtype(pnm::PnmSubtype::Graymap(pnm::SampleEncoding::Binary))
+            .with_subtype(pnm::PNMSubtype::Graymap(pnm::SampleEncoding::Binary))
             .write_image(buf, width, height, color),
         #[cfg(feature = "pnm")]
         "ppm" => pnm::PnmEncoder::new(fout)
-            .with_subtype(pnm::PnmSubtype::Pixmap(pnm::SampleEncoding::Binary))
+            .with_subtype(pnm::PNMSubtype::Pixmap(pnm::SampleEncoding::Binary))
             .write_image(buf, width, height, color),
         #[cfg(feature = "pnm")]
         "pam" => pnm::PnmEncoder::new(fout).write_image(buf, width, height, color),

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -156,9 +156,9 @@ pub(crate) fn save_buffer_impl(
 
     match &*ext {
         #[cfg(feature = "gif")]
-        "gif" => gif::Encoder::new(fout).encode(buf, width, height, color),
+        "gif" => gif::GifEncoder::new(fout).encode(buf, width, height, color),
         #[cfg(feature = "ico")]
-        "ico" => ico::ICOEncoder::new(fout).write_image(buf, width, height, color),
+        "ico" => ico::IcoEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "jpeg")]
         "jpg" | "jpeg" => jpeg::JPEGEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "png")]
@@ -202,9 +202,9 @@ pub(crate) fn save_buffer_with_format_impl(
 
     match format {
         #[cfg(feature = "gif")]
-        image::ImageFormat::Gif => gif::Encoder::new(fout).encode(buf, width, height, color),
+        image::ImageFormat::Gif => gif::GifEncoder::new(fout).encode(buf, width, height, color),
         #[cfg(feature = "ico")]
-        image::ImageFormat::Ico => ico::ICOEncoder::new(fout).write_image(buf, width, height, color),
+        image::ImageFormat::Ico => ico::IcoEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "jpeg")]
         image::ImageFormat::Jpeg => jpeg::JPEGEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "png")]

--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -344,6 +344,8 @@ pub struct JpegEncoder<'a, W: 'a> {
 ///
 /// An alias of [`JpegEncoder`].
 ///
+/// TODO: remove
+///
 /// [`JpegEncoder`]: struct.JpegEncoder.html
 #[allow(dead_code)]
 #[deprecated(note = "Use `JpegEncoder` instead")]

--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -326,7 +326,7 @@ impl Default for PixelDensity {
 }
 
 /// The representation of a JPEG encoder
-pub struct JPEGEncoder<'a, W: 'a> {
+pub struct JpegEncoder<'a, W: 'a> {
     writer: BitWriter<'a, W>,
 
     components: Vec<Component>,
@@ -340,16 +340,25 @@ pub struct JPEGEncoder<'a, W: 'a> {
     pixel_density: PixelDensity,
 }
 
-impl<'a, W: Write> JPEGEncoder<'a, W> {
+/// JPEG Encoder
+///
+/// An alias of [`JpegEncoder`].
+///
+/// [`JpegEncoder`]: struct.JpegEncoder.html
+#[allow(dead_code)]
+#[deprecated(note = "Use `JpegEncoder` instead")]
+pub type JPEGEncoder<'a, W> = JpegEncoder<'a, W>;
+
+impl<'a, W: Write> JpegEncoder<'a, W> {
     /// Create a new encoder that writes its output to ```w```
-    pub fn new(w: &mut W) -> JPEGEncoder<W> {
-        JPEGEncoder::new_with_quality(w, 75)
+    pub fn new(w: &mut W) -> JpegEncoder<W> {
+        JpegEncoder::new_with_quality(w, 75)
     }
 
     /// Create a new encoder that writes its output to ```w```, and has
     /// the quality parameter ```quality``` with a value in the range 1-100
     /// where 1 is the worst and 100 is the best.
-    pub fn new_with_quality(w: &mut W, quality: u8) -> JPEGEncoder<W> {
+    pub fn new_with_quality(w: &mut W, quality: u8) -> JpegEncoder<W> {
         let ld = build_huff_lut(&STD_LUMA_DC_CODE_LENGTHS, &STD_LUMA_DC_VALUES);
         let la = build_huff_lut(&STD_LUMA_AC_CODE_LENGTHS, &STD_LUMA_AC_VALUES);
 
@@ -403,7 +412,7 @@ impl<'a, W: Write> JPEGEncoder<'a, W> {
         tables.extend(STD_LUMA_QTABLE.iter().map(&scale_value));
         tables.extend(STD_CHROMA_QTABLE.iter().map(&scale_value));
 
-        JPEGEncoder {
+        JpegEncoder {
             writer: BitWriter::new(w),
 
             components,
@@ -668,7 +677,7 @@ impl<'a, W: Write> JPEGEncoder<'a, W> {
     }
 }
 
-impl<'a, W: Write> ImageEncoder for JPEGEncoder<'a, W> {
+impl<'a, W: Write> ImageEncoder for JpegEncoder<'a, W> {
     fn write_image(
         mut self,
         buf: &[u8],
@@ -880,7 +889,7 @@ mod tests {
     use crate::error::ParameterErrorKind::DimensionMismatch;
     use crate::image::ImageDecoder;
 
-    use super::{build_jfif_header, JPEGEncoder, PixelDensity};
+    use super::{build_jfif_header, JpegEncoder, PixelDensity};
     use super::super::JpegDecoder;
 
     fn decode(encoded: &[u8]) -> Vec<u8> {
@@ -900,7 +909,7 @@ mod tests {
         // encode it into a memory buffer
         let mut encoded_img = Vec::new();
         {
-            let encoder = JPEGEncoder::new_with_quality(&mut encoded_img, 100);
+            let encoder = JpegEncoder::new_with_quality(&mut encoded_img, 100);
             encoder
                 .write_image(&img, 1, 1, ColorType::Rgb8)
                 .expect("Could not encode image");
@@ -926,7 +935,7 @@ mod tests {
         // encode it into a memory buffer
         let mut encoded_img = Vec::new();
         {
-            let encoder = JPEGEncoder::new_with_quality(&mut encoded_img, 100);
+            let encoder = JpegEncoder::new_with_quality(&mut encoded_img, 100);
             encoder
                 .write_image(&img[..], 2, 2, ColorType::L8)
                 .expect("Could not encode image");
@@ -968,7 +977,7 @@ mod tests {
         let img = [0; 65_536];
         // Try to encode an image that is too large
         let mut encoded = Vec::new();
-        let encoder = JPEGEncoder::new_with_quality(&mut encoded, 100);
+        let encoder = JpegEncoder::new_with_quality(&mut encoded, 100);
         let result = encoder.write_image(&img, 65_536, 1, ColorType::L8);
         match result {
             Err(ImageError::Parameter(err)) => {
@@ -989,7 +998,7 @@ mod tests {
         let max = std::u16::MAX;
         let image: ImageBuffer<Bgra<u16>, _> = ImageBuffer::from_raw(
             1, 1, vec![0, max / 2, max, max]).unwrap();
-        let mut encoder = JPEGEncoder::new_with_quality(&mut encoded, 100);
+        let mut encoder = JpegEncoder::new_with_quality(&mut encoded, 100);
         encoder.encode_image(&image).unwrap();
         let decoded = decode(&encoded);
         assert!(decoded[0] > 200, "bad red channel in {:?}", &decoded);

--- a/src/jpeg/mod.rs
+++ b/src/jpeg/mod.rs
@@ -8,7 +8,7 @@
 //!
 
 pub use self::decoder::JpegDecoder;
-#[allow(deprecated)]
+#[allow(deprecated)] // TODO: when `JPEGEncoder` is removed, remove this tag
 pub use self::encoder::{JpegEncoder, PixelDensity, PixelDensityUnit, JPEGEncoder};
 
 mod decoder;

--- a/src/jpeg/mod.rs
+++ b/src/jpeg/mod.rs
@@ -8,7 +8,8 @@
 //!
 
 pub use self::decoder::JpegDecoder;
-pub use self::encoder::{JPEGEncoder, PixelDensity, PixelDensityUnit};
+#[allow(deprecated)]
+pub use self::encoder::{JpegEncoder, PixelDensity, PixelDensityUnit, JPEGEncoder};
 
 mod decoder;
 mod encoder;

--- a/src/png.rs
+++ b/src/png.rs
@@ -35,6 +35,8 @@ pub struct PngReader<R: Read> {
 ///
 /// An alias of [`PngReader`].
 ///
+/// TODO: remove
+///
 /// [`PngReader`]: struct.PngReader.html
 #[allow(dead_code)]
 #[deprecated(note = "Use `PngReader` instead")]
@@ -444,6 +446,8 @@ pub struct PngEncoder<W: Write> {
 /// PNG Encoder
 ///
 /// An alias of [`PngEncoder`].
+///
+/// TODO: remove
 ///
 /// [`PngEncoder`]: struct.PngEncoder.html
 #[allow(dead_code)]

--- a/src/png.rs
+++ b/src/png.rs
@@ -20,19 +20,28 @@ use crate::error::{
 };
 use crate::image::{AnimationDecoder, ImageDecoder, ImageEncoder, ImageFormat};
 
-/// PNG Reader
+/// Png Reader
 ///
 /// This reader will try to read the png one row at a time,
 /// however for interlaced png files this is not possible and
 /// these are therefore read at once.
-pub struct PNGReader<R: Read> {
+pub struct PngReader<R: Read> {
     reader: png::Reader<R>,
     buffer: Vec<u8>,
     index: usize,
 }
 
-impl<R: Read> PNGReader<R> {
-    fn new(mut reader: png::Reader<R>) -> ImageResult<PNGReader<R>> {
+/// PNG Reader
+///
+/// An alias of [`PngReader`].
+///
+/// [`PngReader`]: struct.PngReader.html
+#[allow(dead_code)]
+#[deprecated(note = "Use `PngReader` instead")]
+pub type PNGReader<R> = PngReader<R>;
+
+impl<R: Read> PngReader<R> {
+    fn new(mut reader: png::Reader<R>) -> ImageResult<PngReader<R>> {
         let len = reader.output_buffer_size();
         // Since interlaced images do not come in
         // scanline order it is almost impossible to
@@ -47,7 +56,7 @@ impl<R: Read> PNGReader<R> {
             Vec::new()
         };
 
-        Ok(PNGReader {
+        Ok(PngReader {
             reader,
             buffer,
             index: 0,
@@ -55,7 +64,7 @@ impl<R: Read> PNGReader<R> {
     }
 }
 
-impl<R: Read> Read for PNGReader<R> {
+impl<R: Read> Read for PngReader<R> {
     fn read(&mut self, mut buf: &mut [u8]) -> io::Result<usize> {
         // io::Write::write for slice cannot fail
         let readed = buf.write(&self.buffer[self.index..]).unwrap();
@@ -191,7 +200,7 @@ fn unsupported_color(ect: ExtendedColorType) -> ImageError {
 }
 
 impl<'a, R: 'a + Read> ImageDecoder<'a> for PngDecoder<R> {
-    type Reader = PNGReader<R>;
+    type Reader = PngReader<R>;
 
     fn dimensions(&self) -> (u32, u32) {
         self.reader.info().size()
@@ -202,7 +211,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for PngDecoder<R> {
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
-        PNGReader::new(self.reader)
+        PngReader::new(self.reader)
     }
 
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
@@ -426,11 +435,20 @@ impl<'a, R: Read + 'a> AnimationDecoder<'a> for ApngDecoder<R> {
 }
 
 /// PNG encoder
-pub struct PNGEncoder<W: Write> {
+pub struct PngEncoder<W: Write> {
     w: W,
     compression: CompressionType,
     filter: FilterType,
 }
+
+/// PNG Encoder
+///
+/// An alias of [`PngEncoder`].
+///
+/// [`PngEncoder`]: struct.PngEncoder.html
+#[allow(dead_code)]
+#[deprecated(note = "Use `PngEncoder` instead")]
+pub type PNGEncoder<W> = PngEncoder<W>;
 
 /// Compression level of a PNG encoder. The default setting is `Fast`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -472,10 +490,10 @@ pub enum FilterType {
     __NonExhaustive(crate::utils::NonExhaustiveMarker),
 }
 
-impl<W: Write> PNGEncoder<W> {
+impl<W: Write> PngEncoder<W> {
     /// Create a new encoder that writes its output to ```w```
-    pub fn new(w: W) -> PNGEncoder<W> {
-        PNGEncoder {
+    pub fn new(w: W) -> PngEncoder<W> {
+        PngEncoder {
             w,
             compression: CompressionType::Fast,
             filter: FilterType::Sub,
@@ -496,8 +514,8 @@ impl<W: Write> PNGEncoder<W> {
     /// even interlaced row). We might make it the new default variant in which case choosing a
     /// particular filter method likely produces larger images. Be sure to check the release notes
     /// once in a while.
-    pub fn new_with_quality(w: W, compression: CompressionType, filter: FilterType) -> PNGEncoder<W> {
-        PNGEncoder {
+    pub fn new_with_quality(w: W, compression: CompressionType, filter: FilterType) -> PngEncoder<W> {
+        PngEncoder {
             w,
             compression,
             filter,
@@ -547,7 +565,7 @@ impl<W: Write> PNGEncoder<W> {
     }
 }
 
-impl<W: Write> ImageEncoder for PNGEncoder<W> {
+impl<W: Write> ImageEncoder for PngEncoder<W> {
     fn write_image(
         self,
         buf: &[u8],

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -8,7 +8,7 @@ use std::mem;
 use std::num::ParseIntError;
 
 use super::{ArbitraryHeader, ArbitraryTuplType, BitmapHeader, GraymapHeader, PixmapHeader};
-use super::{HeaderRecord, PNMHeader, PNMSubtype, SampleEncoding};
+use super::{HeaderRecord, PnmHeader, PnmSubtype, SampleEncoding};
 use crate::color::{ColorType, ExtendedColorType};
 use crate::error::{
     DecodingError, ImageError, ImageResult, UnsupportedError, UnsupportedErrorKind,
@@ -219,7 +219,7 @@ trait DecodableImageHeader {
 /// PNM decoder
 pub struct PnmDecoder<R> {
     reader: BufReader<R>,
-    header: PNMHeader,
+    header: PnmHeader,
     tuple: TupleType,
 }
 
@@ -230,26 +230,26 @@ impl<R: Read> PnmDecoder<R> {
         let magic = buf.read_magic_constant()?;
 
         let subtype = match magic {
-            [b'P', b'1'] => PNMSubtype::Bitmap(SampleEncoding::Ascii),
-            [b'P', b'2'] => PNMSubtype::Graymap(SampleEncoding::Ascii),
-            [b'P', b'3'] => PNMSubtype::Pixmap(SampleEncoding::Ascii),
-            [b'P', b'4'] => PNMSubtype::Bitmap(SampleEncoding::Binary),
-            [b'P', b'5'] => PNMSubtype::Graymap(SampleEncoding::Binary),
-            [b'P', b'6'] => PNMSubtype::Pixmap(SampleEncoding::Binary),
-            [b'P', b'7'] => PNMSubtype::ArbitraryMap,
+            [b'P', b'1'] => PnmSubtype::Bitmap(SampleEncoding::Ascii),
+            [b'P', b'2'] => PnmSubtype::Graymap(SampleEncoding::Ascii),
+            [b'P', b'3'] => PnmSubtype::Pixmap(SampleEncoding::Ascii),
+            [b'P', b'4'] => PnmSubtype::Bitmap(SampleEncoding::Binary),
+            [b'P', b'5'] => PnmSubtype::Graymap(SampleEncoding::Binary),
+            [b'P', b'6'] => PnmSubtype::Pixmap(SampleEncoding::Binary),
+            [b'P', b'7'] => PnmSubtype::ArbitraryMap,
             _ => Err(DecoderError::PnmMagicInvalid(magic))?,
         };
 
         match subtype {
-            PNMSubtype::Bitmap(enc) => PnmDecoder::read_bitmap_header(buf, enc),
-            PNMSubtype::Graymap(enc) => PnmDecoder::read_graymap_header(buf, enc),
-            PNMSubtype::Pixmap(enc) => PnmDecoder::read_pixmap_header(buf, enc),
-            PNMSubtype::ArbitraryMap => PnmDecoder::read_arbitrary_header(buf),
+            PnmSubtype::Bitmap(enc) => PnmDecoder::read_bitmap_header(buf, enc),
+            PnmSubtype::Graymap(enc) => PnmDecoder::read_graymap_header(buf, enc),
+            PnmSubtype::Pixmap(enc) => PnmDecoder::read_pixmap_header(buf, enc),
+            PnmSubtype::ArbitraryMap => PnmDecoder::read_arbitrary_header(buf),
         }
     }
 
     /// Extract the reader and header after an image has been read.
-    pub fn into_inner(self) -> (R, PNMHeader) {
+    pub fn into_inner(self) -> (R, PnmHeader) {
         (self.reader.into_inner(), self.header)
     }
 
@@ -261,7 +261,7 @@ impl<R: Read> PnmDecoder<R> {
         Ok(PnmDecoder {
             reader,
             tuple: TupleType::PbmBit,
-            header: PNMHeader {
+            header: PnmHeader {
                 decoded: HeaderRecord::Bitmap(header),
                 encoded: None,
             },
@@ -277,7 +277,7 @@ impl<R: Read> PnmDecoder<R> {
         Ok(PnmDecoder {
             reader,
             tuple: tuple_type,
-            header: PNMHeader {
+            header: PnmHeader {
                 decoded: HeaderRecord::Graymap(header),
                 encoded: None,
             },
@@ -293,7 +293,7 @@ impl<R: Read> PnmDecoder<R> {
         Ok(PnmDecoder {
             reader,
             tuple: tuple_type,
-            header: PNMHeader {
+            header: PnmHeader {
                 decoded: HeaderRecord::Pixmap(header),
                 encoded: None,
             },
@@ -306,7 +306,7 @@ impl<R: Read> PnmDecoder<R> {
         Ok(PnmDecoder {
             reader,
             tuple: tuple_type,
-            header: PNMHeader {
+            header: PnmHeader {
                 decoded: HeaderRecord::Arbitrary(header),
                 encoded: None,
             },
@@ -608,7 +608,7 @@ impl<R: Read> PnmDecoder<R> {
     }
 
     /// Get the pnm subtype, depending on the magic constant contained in the header
-    pub fn subtype(&self) -> PNMSubtype {
+    pub fn subtype(&self) -> PnmSubtype {
         self.header.subtype()
     }
 }
@@ -913,7 +913,7 @@ ENDHDR
         assert_eq!(decoder.color_type(), ColorType::L8);
         assert_eq!(decoder.original_color_type(), ExtendedColorType::L1);
         assert_eq!(decoder.dimensions(), (4, 4));
-        assert_eq!(decoder.subtype(), PNMSubtype::ArbitraryMap);
+        assert_eq!(decoder.subtype(), PnmSubtype::ArbitraryMap);
 
         let mut image = vec![0; decoder.total_bytes() as usize];
         decoder.read_image(&mut image).unwrap();
@@ -925,7 +925,7 @@ ENDHDR
         match PnmDecoder::new(&pamdata[..]).unwrap().into_inner() {
             (
                 _,
-                PNMHeader {
+                PnmHeader {
                     decoded:
                         HeaderRecord::Arbitrary(ArbitraryHeader {
                             width: 4,
@@ -956,7 +956,7 @@ ENDHDR
         let decoder = PnmDecoder::new(&pamdata[..]).unwrap();
         assert_eq!(decoder.color_type(), ColorType::L8);
         assert_eq!(decoder.dimensions(), (4, 4));
-        assert_eq!(decoder.subtype(), PNMSubtype::ArbitraryMap);
+        assert_eq!(decoder.subtype(), PnmSubtype::ArbitraryMap);
 
         let mut image = vec![0; decoder.total_bytes() as usize];
         decoder.read_image(&mut image).unwrap();
@@ -968,7 +968,7 @@ ENDHDR
         match PnmDecoder::new(&pamdata[..]).unwrap().into_inner() {
             (
                 _,
-                PNMHeader {
+                PnmHeader {
                     decoded:
                         HeaderRecord::Arbitrary(ArbitraryHeader {
                             width: 4,
@@ -999,7 +999,7 @@ ENDHDR
         let decoder = PnmDecoder::new(&pamdata[..]).unwrap();
         assert_eq!(decoder.color_type(), ColorType::Rgb8);
         assert_eq!(decoder.dimensions(), (2, 2));
-        assert_eq!(decoder.subtype(), PNMSubtype::ArbitraryMap);
+        assert_eq!(decoder.subtype(), PnmSubtype::ArbitraryMap);
 
         let mut image = vec![0; decoder.total_bytes() as usize];
         decoder.read_image(&mut image).unwrap();
@@ -1008,7 +1008,7 @@ ENDHDR
         match PnmDecoder::new(&pamdata[..]).unwrap().into_inner() {
             (
                 _,
-                PNMHeader {
+                PnmHeader {
                     decoded:
                         HeaderRecord::Arbitrary(ArbitraryHeader {
                             maxval: 255,
@@ -1035,7 +1035,7 @@ ENDHDR
         assert_eq!(decoder.dimensions(), (6, 2));
         assert_eq!(
             decoder.subtype(),
-            PNMSubtype::Bitmap(SampleEncoding::Binary)
+            PnmSubtype::Bitmap(SampleEncoding::Binary)
         );
         let mut image = vec![0; decoder.total_bytes() as usize];
         decoder.read_image(&mut image).unwrap();
@@ -1043,7 +1043,7 @@ ENDHDR
         match PnmDecoder::new(&pbmbinary[..]).unwrap().into_inner() {
             (
                 _,
-                PNMHeader {
+                PnmHeader {
                     decoded:
                         HeaderRecord::Bitmap(BitmapHeader {
                             encoding: SampleEncoding::Binary,
@@ -1092,7 +1092,7 @@ ENDHDR
         assert_eq!(decoder.color_type(), ColorType::L8);
         assert_eq!(decoder.original_color_type(), ExtendedColorType::L1);
         assert_eq!(decoder.dimensions(), (6, 2));
-        assert_eq!(decoder.subtype(), PNMSubtype::Bitmap(SampleEncoding::Ascii));
+        assert_eq!(decoder.subtype(), PnmSubtype::Bitmap(SampleEncoding::Ascii));
 
         let mut image = vec![0; decoder.total_bytes() as usize];
         decoder.read_image(&mut image).unwrap();
@@ -1100,7 +1100,7 @@ ENDHDR
         match PnmDecoder::new(&pbmbinary[..]).unwrap().into_inner() {
             (
                 _,
-                PNMHeader {
+                PnmHeader {
                     decoded:
                         HeaderRecord::Bitmap(BitmapHeader {
                             encoding: SampleEncoding::Ascii,
@@ -1124,7 +1124,7 @@ ENDHDR
         assert_eq!(decoder.color_type(), ColorType::L8);
         assert_eq!(decoder.original_color_type(), ExtendedColorType::L1);
         assert_eq!(decoder.dimensions(), (6, 2));
-        assert_eq!(decoder.subtype(), PNMSubtype::Bitmap(SampleEncoding::Ascii));
+        assert_eq!(decoder.subtype(), PnmSubtype::Bitmap(SampleEncoding::Ascii));
 
         let mut image = vec![0; decoder.total_bytes() as usize];
         decoder.read_image(&mut image).unwrap();
@@ -1132,7 +1132,7 @@ ENDHDR
         match PnmDecoder::new(&pbmbinary[..]).unwrap().into_inner() {
             (
                 _,
-                PNMHeader {
+                PnmHeader {
                     decoded:
                         HeaderRecord::Bitmap(BitmapHeader {
                             encoding: SampleEncoding::Ascii,
@@ -1157,7 +1157,7 @@ ENDHDR
         assert_eq!(decoder.dimensions(), (4, 4));
         assert_eq!(
             decoder.subtype(),
-            PNMSubtype::Graymap(SampleEncoding::Binary)
+            PnmSubtype::Graymap(SampleEncoding::Binary)
         );
         let mut image = vec![0; decoder.total_bytes() as usize];
         decoder.read_image(&mut image).unwrap();
@@ -1165,7 +1165,7 @@ ENDHDR
         match PnmDecoder::new(&pbmbinary[..]).unwrap().into_inner() {
             (
                 _,
-                PNMHeader {
+                PnmHeader {
                     decoded:
                         HeaderRecord::Graymap(GraymapHeader {
                             encoding: SampleEncoding::Binary,
@@ -1190,7 +1190,7 @@ ENDHDR
         assert_eq!(decoder.dimensions(), (4, 4));
         assert_eq!(
             decoder.subtype(),
-            PNMSubtype::Graymap(SampleEncoding::Ascii)
+            PnmSubtype::Graymap(SampleEncoding::Ascii)
         );
         let mut image = vec![0; decoder.total_bytes() as usize];
         decoder.read_image(&mut image).unwrap();
@@ -1198,7 +1198,7 @@ ENDHDR
         match PnmDecoder::new(&pbmbinary[..]).unwrap().into_inner() {
             (
                 _,
-                PNMHeader {
+                PnmHeader {
                     decoded:
                         HeaderRecord::Graymap(GraymapHeader {
                             encoding: SampleEncoding::Ascii,

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -8,7 +8,7 @@ use std::mem;
 use std::num::ParseIntError;
 
 use super::{ArbitraryHeader, ArbitraryTuplType, BitmapHeader, GraymapHeader, PixmapHeader};
-use super::{HeaderRecord, PnmHeader, PnmSubtype, SampleEncoding};
+use super::{HeaderRecord, PnmHeader, PNMSubtype, SampleEncoding};
 use crate::color::{ColorType, ExtendedColorType};
 use crate::error::{
     DecodingError, ImageError, ImageResult, UnsupportedError, UnsupportedErrorKind,
@@ -230,21 +230,21 @@ impl<R: Read> PnmDecoder<R> {
         let magic = buf.read_magic_constant()?;
 
         let subtype = match magic {
-            [b'P', b'1'] => PnmSubtype::Bitmap(SampleEncoding::Ascii),
-            [b'P', b'2'] => PnmSubtype::Graymap(SampleEncoding::Ascii),
-            [b'P', b'3'] => PnmSubtype::Pixmap(SampleEncoding::Ascii),
-            [b'P', b'4'] => PnmSubtype::Bitmap(SampleEncoding::Binary),
-            [b'P', b'5'] => PnmSubtype::Graymap(SampleEncoding::Binary),
-            [b'P', b'6'] => PnmSubtype::Pixmap(SampleEncoding::Binary),
-            [b'P', b'7'] => PnmSubtype::ArbitraryMap,
+            [b'P', b'1'] => PNMSubtype::Bitmap(SampleEncoding::Ascii),
+            [b'P', b'2'] => PNMSubtype::Graymap(SampleEncoding::Ascii),
+            [b'P', b'3'] => PNMSubtype::Pixmap(SampleEncoding::Ascii),
+            [b'P', b'4'] => PNMSubtype::Bitmap(SampleEncoding::Binary),
+            [b'P', b'5'] => PNMSubtype::Graymap(SampleEncoding::Binary),
+            [b'P', b'6'] => PNMSubtype::Pixmap(SampleEncoding::Binary),
+            [b'P', b'7'] => PNMSubtype::ArbitraryMap,
             _ => Err(DecoderError::PnmMagicInvalid(magic))?,
         };
 
         match subtype {
-            PnmSubtype::Bitmap(enc) => PnmDecoder::read_bitmap_header(buf, enc),
-            PnmSubtype::Graymap(enc) => PnmDecoder::read_graymap_header(buf, enc),
-            PnmSubtype::Pixmap(enc) => PnmDecoder::read_pixmap_header(buf, enc),
-            PnmSubtype::ArbitraryMap => PnmDecoder::read_arbitrary_header(buf),
+            PNMSubtype::Bitmap(enc) => PnmDecoder::read_bitmap_header(buf, enc),
+            PNMSubtype::Graymap(enc) => PnmDecoder::read_graymap_header(buf, enc),
+            PNMSubtype::Pixmap(enc) => PnmDecoder::read_pixmap_header(buf, enc),
+            PNMSubtype::ArbitraryMap => PnmDecoder::read_arbitrary_header(buf),
         }
     }
 
@@ -608,7 +608,7 @@ impl<R: Read> PnmDecoder<R> {
     }
 
     /// Get the pnm subtype, depending on the magic constant contained in the header
-    pub fn subtype(&self) -> PnmSubtype {
+    pub fn subtype(&self) -> PNMSubtype {
         self.header.subtype()
     }
 }
@@ -913,7 +913,7 @@ ENDHDR
         assert_eq!(decoder.color_type(), ColorType::L8);
         assert_eq!(decoder.original_color_type(), ExtendedColorType::L1);
         assert_eq!(decoder.dimensions(), (4, 4));
-        assert_eq!(decoder.subtype(), PnmSubtype::ArbitraryMap);
+        assert_eq!(decoder.subtype(), PNMSubtype::ArbitraryMap);
 
         let mut image = vec![0; decoder.total_bytes() as usize];
         decoder.read_image(&mut image).unwrap();
@@ -956,7 +956,7 @@ ENDHDR
         let decoder = PnmDecoder::new(&pamdata[..]).unwrap();
         assert_eq!(decoder.color_type(), ColorType::L8);
         assert_eq!(decoder.dimensions(), (4, 4));
-        assert_eq!(decoder.subtype(), PnmSubtype::ArbitraryMap);
+        assert_eq!(decoder.subtype(), PNMSubtype::ArbitraryMap);
 
         let mut image = vec![0; decoder.total_bytes() as usize];
         decoder.read_image(&mut image).unwrap();
@@ -999,7 +999,7 @@ ENDHDR
         let decoder = PnmDecoder::new(&pamdata[..]).unwrap();
         assert_eq!(decoder.color_type(), ColorType::Rgb8);
         assert_eq!(decoder.dimensions(), (2, 2));
-        assert_eq!(decoder.subtype(), PnmSubtype::ArbitraryMap);
+        assert_eq!(decoder.subtype(), PNMSubtype::ArbitraryMap);
 
         let mut image = vec![0; decoder.total_bytes() as usize];
         decoder.read_image(&mut image).unwrap();
@@ -1035,7 +1035,7 @@ ENDHDR
         assert_eq!(decoder.dimensions(), (6, 2));
         assert_eq!(
             decoder.subtype(),
-            PnmSubtype::Bitmap(SampleEncoding::Binary)
+            PNMSubtype::Bitmap(SampleEncoding::Binary)
         );
         let mut image = vec![0; decoder.total_bytes() as usize];
         decoder.read_image(&mut image).unwrap();
@@ -1092,7 +1092,7 @@ ENDHDR
         assert_eq!(decoder.color_type(), ColorType::L8);
         assert_eq!(decoder.original_color_type(), ExtendedColorType::L1);
         assert_eq!(decoder.dimensions(), (6, 2));
-        assert_eq!(decoder.subtype(), PnmSubtype::Bitmap(SampleEncoding::Ascii));
+        assert_eq!(decoder.subtype(), PNMSubtype::Bitmap(SampleEncoding::Ascii));
 
         let mut image = vec![0; decoder.total_bytes() as usize];
         decoder.read_image(&mut image).unwrap();
@@ -1124,7 +1124,7 @@ ENDHDR
         assert_eq!(decoder.color_type(), ColorType::L8);
         assert_eq!(decoder.original_color_type(), ExtendedColorType::L1);
         assert_eq!(decoder.dimensions(), (6, 2));
-        assert_eq!(decoder.subtype(), PnmSubtype::Bitmap(SampleEncoding::Ascii));
+        assert_eq!(decoder.subtype(), PNMSubtype::Bitmap(SampleEncoding::Ascii));
 
         let mut image = vec![0; decoder.total_bytes() as usize];
         decoder.read_image(&mut image).unwrap();
@@ -1157,7 +1157,7 @@ ENDHDR
         assert_eq!(decoder.dimensions(), (4, 4));
         assert_eq!(
             decoder.subtype(),
-            PnmSubtype::Graymap(SampleEncoding::Binary)
+            PNMSubtype::Graymap(SampleEncoding::Binary)
         );
         let mut image = vec![0; decoder.total_bytes() as usize];
         decoder.read_image(&mut image).unwrap();
@@ -1190,7 +1190,7 @@ ENDHDR
         assert_eq!(decoder.dimensions(), (4, 4));
         assert_eq!(
             decoder.subtype(),
-            PnmSubtype::Graymap(SampleEncoding::Ascii)
+            PNMSubtype::Graymap(SampleEncoding::Ascii)
         );
         let mut image = vec![0; decoder.total_bytes() as usize];
         decoder.read_image(&mut image).unwrap();

--- a/src/pnm/encoder.rs
+++ b/src/pnm/encoder.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 
 use super::AutoBreak;
 use super::{ArbitraryHeader, ArbitraryTuplType, BitmapHeader, GraymapHeader, PixmapHeader};
-use super::{HeaderRecord, PnmHeader, PnmSubtype, SampleEncoding};
+use super::{HeaderRecord, PnmHeader, PNMSubtype, SampleEncoding};
 use crate::color::{ColorType, ExtendedColorType};
 use crate::error::{
     ImageError, ImageResult, ParameterError, ParameterErrorKind, UnsupportedError,
@@ -18,7 +18,7 @@ use byteorder::{BigEndian, WriteBytesExt};
 
 enum HeaderStrategy {
     Dynamic,
-    Subtype(PnmSubtype),
+    Subtype(PNMSubtype),
     Chosen(PnmHeader),
 }
 
@@ -37,6 +37,8 @@ pub struct PnmEncoder<W: Write> {
 /// PNM Encoder
 ///
 /// An alias of [`PnmEncoder`].
+///
+/// TODO: remove
 ///
 /// [`PnmEncoder`]: struct.PnmEncoder.html
 #[allow(dead_code)]
@@ -107,7 +109,7 @@ impl<W: Write> PnmEncoder<W> {
     /// RGB image as Graymap) will result in an error.
     ///
     /// This will overwrite the effect of earlier calls to `with_header` and `with_dynamic_header`.
-    pub fn with_subtype(self, subtype: PnmSubtype) -> Self {
+    pub fn with_subtype(self, subtype: PNMSubtype) -> Self {
         PnmEncoder {
             writer: self.writer,
             header: HeaderStrategy::Subtype(subtype),
@@ -219,17 +221,17 @@ impl<W: Write> PnmEncoder<W> {
     /// Try to encode the image with the chosen format, give its corresponding pixel encoding type.
     fn write_subtyped_header(
         &mut self,
-        subtype: PnmSubtype,
+        subtype: PNMSubtype,
         image: FlatSamples,
         width: u32,
         height: u32,
         color: ExtendedColorType,
     ) -> ImageResult<()> {
         let header = match (subtype, color) {
-            (PnmSubtype::ArbitraryMap, color) => {
+            (PNMSubtype::ArbitraryMap, color) => {
                 return self.write_dynamic_header(image, width, height, color)
             }
-            (PnmSubtype::Pixmap(encoding), ExtendedColorType::Rgb8) => PnmHeader {
+            (PNMSubtype::Pixmap(encoding), ExtendedColorType::Rgb8) => PnmHeader {
                 decoded: HeaderRecord::Pixmap(PixmapHeader {
                     encoding,
                     width,
@@ -238,7 +240,7 @@ impl<W: Write> PnmEncoder<W> {
                 }),
                 encoded: None,
             },
-            (PnmSubtype::Graymap(encoding), ExtendedColorType::L8) => PnmHeader {
+            (PNMSubtype::Graymap(encoding), ExtendedColorType::L8) => PnmHeader {
                 decoded: HeaderRecord::Graymap(GraymapHeader {
                     encoding,
                     width,
@@ -247,8 +249,8 @@ impl<W: Write> PnmEncoder<W> {
                 }),
                 encoded: None,
             },
-            (PnmSubtype::Bitmap(encoding), ExtendedColorType::L8)
-            | (PnmSubtype::Bitmap(encoding), ExtendedColorType::L1) => PnmHeader {
+            (PNMSubtype::Bitmap(encoding), ExtendedColorType::L8)
+            | (PNMSubtype::Bitmap(encoding), ExtendedColorType::L1) => PnmHeader {
                 decoded: HeaderRecord::Bitmap(BitmapHeader {
                     encoding,
                     width,

--- a/src/pnm/header.rs
+++ b/src/pnm/header.rs
@@ -11,8 +11,14 @@ pub enum SampleEncoding {
 }
 
 /// Denotes the category of the magic number
+///
+/// DEPRECATED: The name of this enum will be changed to [`PnmSubtype`].
+///
+/// TODO: rename to [`PnmSubtype`].
+///
+/// [`PnmSubtype`]: type.PnmSubtype.html
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum PnmSubtype {
+pub enum PNMSubtype {
     /// Magic numbers P1 and P4
     Bitmap(SampleEncoding),
 
@@ -28,12 +34,13 @@ pub enum PnmSubtype {
 
 /// PNM Subtype
 ///
-/// An alias of [`PnmSubtype`].
+/// An alias of [`PNMSubtype`].
 ///
-/// [`PnmSubtype`]: enum.PnmSubtype.html
+/// TODO: remove when [`DXTVariant`] is renamed.
+///
+/// [`PNMSubtype`]: enum.PNMSubtype.html
 #[allow(dead_code)]
-#[deprecated(note = "Use `PnmSubtype` instead")]
-pub type PNMSubtype = PnmSubtype;
+pub type PnmSubtype = PNMSubtype;
 
 /// Stores the complete header data of a file.
 ///
@@ -49,6 +56,8 @@ pub struct PnmHeader {
 /// PNM Header
 ///
 /// An alias of [`PnmHeader`].
+///
+/// TODO: remove
 ///
 /// [`PnmHeader`]: struct.PnmHeader.html
 #[allow(dead_code)]
@@ -165,39 +174,39 @@ impl ArbitraryTuplType {
     }
 }
 
-impl PnmSubtype {
+impl PNMSubtype {
     /// Get the two magic constant bytes corresponding to this format subtype.
     pub fn magic_constant(self) -> &'static [u8; 2] {
         match self {
-            PnmSubtype::Bitmap(SampleEncoding::Ascii) => b"P1",
-            PnmSubtype::Graymap(SampleEncoding::Ascii) => b"P2",
-            PnmSubtype::Pixmap(SampleEncoding::Ascii) => b"P3",
-            PnmSubtype::Bitmap(SampleEncoding::Binary) => b"P4",
-            PnmSubtype::Graymap(SampleEncoding::Binary) => b"P5",
-            PnmSubtype::Pixmap(SampleEncoding::Binary) => b"P6",
-            PnmSubtype::ArbitraryMap => b"P7",
+            PNMSubtype::Bitmap(SampleEncoding::Ascii) => b"P1",
+            PNMSubtype::Graymap(SampleEncoding::Ascii) => b"P2",
+            PNMSubtype::Pixmap(SampleEncoding::Ascii) => b"P3",
+            PNMSubtype::Bitmap(SampleEncoding::Binary) => b"P4",
+            PNMSubtype::Graymap(SampleEncoding::Binary) => b"P5",
+            PNMSubtype::Pixmap(SampleEncoding::Binary) => b"P6",
+            PNMSubtype::ArbitraryMap => b"P7",
         }
     }
 
     /// Whether samples are stored as binary or as decimal ascii
     pub fn sample_encoding(self) -> SampleEncoding {
         match self {
-            PnmSubtype::ArbitraryMap => SampleEncoding::Binary,
-            PnmSubtype::Bitmap(enc) => enc,
-            PnmSubtype::Graymap(enc) => enc,
-            PnmSubtype::Pixmap(enc) => enc,
+            PNMSubtype::ArbitraryMap => SampleEncoding::Binary,
+            PNMSubtype::Bitmap(enc) => enc,
+            PNMSubtype::Graymap(enc) => enc,
+            PNMSubtype::Pixmap(enc) => enc,
         }
     }
 }
 
 impl PnmHeader {
     /// Retrieve the format subtype from which the header was created.
-    pub fn subtype(&self) -> PnmSubtype {
+    pub fn subtype(&self) -> PNMSubtype {
         match self.decoded {
-            HeaderRecord::Bitmap(BitmapHeader { encoding, .. }) => PnmSubtype::Bitmap(encoding),
-            HeaderRecord::Graymap(GraymapHeader { encoding, .. }) => PnmSubtype::Graymap(encoding),
-            HeaderRecord::Pixmap(PixmapHeader { encoding, .. }) => PnmSubtype::Pixmap(encoding),
-            HeaderRecord::Arbitrary(ArbitraryHeader { .. }) => PnmSubtype::ArbitraryMap,
+            HeaderRecord::Bitmap(BitmapHeader { encoding, .. }) => PNMSubtype::Bitmap(encoding),
+            HeaderRecord::Graymap(GraymapHeader { encoding, .. }) => PNMSubtype::Graymap(encoding),
+            HeaderRecord::Pixmap(PixmapHeader { encoding, .. }) => PNMSubtype::Pixmap(encoding),
+            HeaderRecord::Arbitrary(ArbitraryHeader { .. }) => PNMSubtype::ArbitraryMap,
         }
     }
 

--- a/src/pnm/header.rs
+++ b/src/pnm/header.rs
@@ -12,7 +12,7 @@ pub enum SampleEncoding {
 
 /// Denotes the category of the magic number
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum PNMSubtype {
+pub enum PnmSubtype {
     /// Magic numbers P1 and P4
     Bitmap(SampleEncoding),
 
@@ -26,16 +26,34 @@ pub enum PNMSubtype {
     ArbitraryMap,
 }
 
+/// PNM Subtype
+///
+/// An alias of [`PnmSubtype`].
+///
+/// [`PnmSubtype`]: enum.PnmSubtype.html
+#[allow(dead_code)]
+#[deprecated(note = "Use `PnmSubtype` instead")]
+pub type PNMSubtype = PnmSubtype;
+
 /// Stores the complete header data of a file.
 ///
 /// Internally, provides mechanisms for lossless reencoding. After reading a file with the decoder
 /// it is possible to recover the header and construct an encoder. Using the encoder on the just
 /// loaded image should result in a byte copy of the original file (for single image pnms without
 /// additional trailing data).
-pub struct PNMHeader {
+pub struct PnmHeader {
     pub(crate) decoded: HeaderRecord,
     pub(crate) encoded: Option<Vec<u8>>,
 }
+
+/// PNM Header
+///
+/// An alias of [`PnmHeader`].
+///
+/// [`PnmHeader`]: struct.PnmHeader.html
+#[allow(dead_code)]
+#[deprecated(note = "Use `PnmHeader` instead")]
+pub type PNMHeader = PnmHeader;
 
 pub(crate) enum HeaderRecord {
     Bitmap(BitmapHeader),
@@ -147,39 +165,39 @@ impl ArbitraryTuplType {
     }
 }
 
-impl PNMSubtype {
+impl PnmSubtype {
     /// Get the two magic constant bytes corresponding to this format subtype.
     pub fn magic_constant(self) -> &'static [u8; 2] {
         match self {
-            PNMSubtype::Bitmap(SampleEncoding::Ascii) => b"P1",
-            PNMSubtype::Graymap(SampleEncoding::Ascii) => b"P2",
-            PNMSubtype::Pixmap(SampleEncoding::Ascii) => b"P3",
-            PNMSubtype::Bitmap(SampleEncoding::Binary) => b"P4",
-            PNMSubtype::Graymap(SampleEncoding::Binary) => b"P5",
-            PNMSubtype::Pixmap(SampleEncoding::Binary) => b"P6",
-            PNMSubtype::ArbitraryMap => b"P7",
+            PnmSubtype::Bitmap(SampleEncoding::Ascii) => b"P1",
+            PnmSubtype::Graymap(SampleEncoding::Ascii) => b"P2",
+            PnmSubtype::Pixmap(SampleEncoding::Ascii) => b"P3",
+            PnmSubtype::Bitmap(SampleEncoding::Binary) => b"P4",
+            PnmSubtype::Graymap(SampleEncoding::Binary) => b"P5",
+            PnmSubtype::Pixmap(SampleEncoding::Binary) => b"P6",
+            PnmSubtype::ArbitraryMap => b"P7",
         }
     }
 
     /// Whether samples are stored as binary or as decimal ascii
     pub fn sample_encoding(self) -> SampleEncoding {
         match self {
-            PNMSubtype::ArbitraryMap => SampleEncoding::Binary,
-            PNMSubtype::Bitmap(enc) => enc,
-            PNMSubtype::Graymap(enc) => enc,
-            PNMSubtype::Pixmap(enc) => enc,
+            PnmSubtype::ArbitraryMap => SampleEncoding::Binary,
+            PnmSubtype::Bitmap(enc) => enc,
+            PnmSubtype::Graymap(enc) => enc,
+            PnmSubtype::Pixmap(enc) => enc,
         }
     }
 }
 
-impl PNMHeader {
+impl PnmHeader {
     /// Retrieve the format subtype from which the header was created.
-    pub fn subtype(&self) -> PNMSubtype {
+    pub fn subtype(&self) -> PnmSubtype {
         match self.decoded {
-            HeaderRecord::Bitmap(BitmapHeader { encoding, .. }) => PNMSubtype::Bitmap(encoding),
-            HeaderRecord::Graymap(GraymapHeader { encoding, .. }) => PNMSubtype::Graymap(encoding),
-            HeaderRecord::Pixmap(PixmapHeader { encoding, .. }) => PNMSubtype::Pixmap(encoding),
-            HeaderRecord::Arbitrary(ArbitraryHeader { .. }) => PNMSubtype::ArbitraryMap,
+            HeaderRecord::Bitmap(BitmapHeader { encoding, .. }) => PnmSubtype::Bitmap(encoding),
+            HeaderRecord::Graymap(GraymapHeader { encoding, .. }) => PnmSubtype::Graymap(encoding),
+            HeaderRecord::Pixmap(PixmapHeader { encoding, .. }) => PnmSubtype::Pixmap(encoding),
+            HeaderRecord::Arbitrary(ArbitraryHeader { .. }) => PnmSubtype::ArbitraryMap,
         }
     }
 
@@ -249,11 +267,11 @@ impl PNMHeader {
     pub fn write(&self, writer: &mut dyn io::Write) -> io::Result<()> {
         writer.write_all(self.subtype().magic_constant())?;
         match *self {
-            PNMHeader {
+            PnmHeader {
                 encoded: Some(ref content),
                 ..
             } => writer.write_all(content),
-            PNMHeader {
+            PnmHeader {
                 decoded:
                     HeaderRecord::Bitmap(BitmapHeader {
                         encoding: _encoding,
@@ -262,7 +280,7 @@ impl PNMHeader {
                     }),
                 ..
             } => writeln!(writer, "\n{} {}", width, height),
-            PNMHeader {
+            PnmHeader {
                 decoded:
                     HeaderRecord::Graymap(GraymapHeader {
                         encoding: _encoding,
@@ -272,7 +290,7 @@ impl PNMHeader {
                     }),
                 ..
             } => writeln!(writer, "\n{} {} {}", width, height, maxwhite),
-            PNMHeader {
+            PnmHeader {
                 decoded:
                     HeaderRecord::Pixmap(PixmapHeader {
                         encoding: _encoding,
@@ -282,7 +300,7 @@ impl PNMHeader {
                     }),
                 ..
             } => writeln!(writer, "\n{} {} {}", width, height, maxval),
-            PNMHeader {
+            PnmHeader {
                 decoded:
                     HeaderRecord::Arbitrary(ArbitraryHeader {
                         width,
@@ -313,36 +331,36 @@ impl PNMHeader {
     }
 }
 
-impl From<BitmapHeader> for PNMHeader {
+impl From<BitmapHeader> for PnmHeader {
     fn from(header: BitmapHeader) -> Self {
-        PNMHeader {
+        PnmHeader {
             decoded: HeaderRecord::Bitmap(header),
             encoded: None,
         }
     }
 }
 
-impl From<GraymapHeader> for PNMHeader {
+impl From<GraymapHeader> for PnmHeader {
     fn from(header: GraymapHeader) -> Self {
-        PNMHeader {
+        PnmHeader {
             decoded: HeaderRecord::Graymap(header),
             encoded: None,
         }
     }
 }
 
-impl From<PixmapHeader> for PNMHeader {
+impl From<PixmapHeader> for PnmHeader {
     fn from(header: PixmapHeader) -> Self {
-        PNMHeader {
+        PnmHeader {
             decoded: HeaderRecord::Pixmap(header),
             encoded: None,
         }
     }
 }
 
-impl From<ArbitraryHeader> for PNMHeader {
+impl From<ArbitraryHeader> for PnmHeader {
     fn from(header: ArbitraryHeader) -> Self {
-        PNMHeader {
+        PnmHeader {
             decoded: HeaderRecord::Arbitrary(header),
             encoded: None,
         }

--- a/src/pnm/mod.rs
+++ b/src/pnm/mod.rs
@@ -5,11 +5,13 @@
 //! variants for now as alpha color types are unsupported.
 use self::autobreak::AutoBreak;
 pub use self::decoder::PnmDecoder;
-pub use self::encoder::PNMEncoder;
+#[allow(deprecated)]
+pub use self::encoder::{PnmEncoder, PNMEncoder};
 use self::header::HeaderRecord;
 pub use self::header::{ArbitraryHeader, ArbitraryTuplType, BitmapHeader, GraymapHeader,
                        PixmapHeader};
-pub use self::header::{PNMHeader, PNMSubtype, SampleEncoding};
+#[allow(deprecated)]
+pub use self::header::{PnmHeader, PNMHeader, PnmSubtype, PNMSubtype, SampleEncoding};
 
 mod autobreak;
 mod decoder;
@@ -27,7 +29,7 @@ mod tests {
         let mut encoded_buffer = Vec::new();
 
         {
-            let mut encoder = PNMEncoder::new(&mut encoded_buffer);
+            let mut encoder = PnmEncoder::new(&mut encoded_buffer);
             encoder
                 .encode(buffer, width, height, color)
                 .expect("Failed to encode the image buffer");
@@ -53,12 +55,12 @@ mod tests {
         width: u32,
         height: u32,
         color: ColorType,
-        subtype: PNMSubtype,
+        subtype: PnmSubtype,
     ) {
         let mut encoded_buffer = Vec::new();
 
         {
-            let mut encoder = PNMEncoder::new(&mut encoded_buffer).with_subtype(subtype);
+            let mut encoder = PnmEncoder::new(&mut encoded_buffer).with_subtype(subtype);
             encoder
                 .encode(buffer, width, height, color)
                 .expect("Failed to encode the image buffer");
@@ -84,7 +86,7 @@ mod tests {
         let mut encoded_buffer = Vec::new();
 
         {
-            let mut encoder = PNMEncoder::new(&mut encoded_buffer);
+            let mut encoder = PnmEncoder::new(&mut encoded_buffer);
             encoder
                 .encode(buffer, width, height, color)
                 .expect("Failed to encode the image buffer");
@@ -119,9 +121,9 @@ mod tests {
         ];
 
         execute_roundtrip_default(&buf, 4, 4, ColorType::L8);
-        execute_roundtrip_with_subtype(&buf, 4, 4, ColorType::L8, PNMSubtype::ArbitraryMap);
-        execute_roundtrip_with_subtype(&buf, 4, 4, ColorType::L8, PNMSubtype::Graymap(SampleEncoding::Ascii));
-        execute_roundtrip_with_subtype(&buf, 4, 4, ColorType::L8, PNMSubtype::Graymap(SampleEncoding::Binary));
+        execute_roundtrip_with_subtype(&buf, 4, 4, ColorType::L8, PnmSubtype::ArbitraryMap);
+        execute_roundtrip_with_subtype(&buf, 4, 4, ColorType::L8, PnmSubtype::Graymap(SampleEncoding::Ascii));
+        execute_roundtrip_with_subtype(&buf, 4, 4, ColorType::L8, PnmSubtype::Graymap(SampleEncoding::Binary));
     }
 
     #[test]
@@ -139,20 +141,20 @@ mod tests {
             255, 255, 255,
         ];
         execute_roundtrip_default(&buf, 3, 3, ColorType::Rgb8);
-        execute_roundtrip_with_subtype(&buf, 3, 3, ColorType::Rgb8, PNMSubtype::ArbitraryMap);
+        execute_roundtrip_with_subtype(&buf, 3, 3, ColorType::Rgb8, PnmSubtype::ArbitraryMap);
         execute_roundtrip_with_subtype(
             &buf,
             3,
             3,
             ColorType::Rgb8,
-            PNMSubtype::Pixmap(SampleEncoding::Binary),
+            PnmSubtype::Pixmap(SampleEncoding::Binary),
         );
         execute_roundtrip_with_subtype(
             &buf,
             3,
             3,
             ColorType::Rgb8,
-            PNMSubtype::Pixmap(SampleEncoding::Ascii),
+            PnmSubtype::Pixmap(SampleEncoding::Ascii),
         );
     }
 

--- a/src/pnm/mod.rs
+++ b/src/pnm/mod.rs
@@ -5,13 +5,13 @@
 //! variants for now as alpha color types are unsupported.
 use self::autobreak::AutoBreak;
 pub use self::decoder::PnmDecoder;
-#[allow(deprecated)]
+#[allow(deprecated)] // TODO: when `PNMEncoder` is removed, remove this flag
 pub use self::encoder::{PnmEncoder, PNMEncoder};
 use self::header::HeaderRecord;
 pub use self::header::{ArbitraryHeader, ArbitraryTuplType, BitmapHeader, GraymapHeader,
                        PixmapHeader};
-#[allow(deprecated)]
-pub use self::header::{PnmHeader, PNMHeader, PnmSubtype, PNMSubtype, SampleEncoding};
+#[allow(deprecated)] // TODO: when `PnmHeader` and `PNMSubtype` are removed, remove this flag
+pub use self::header::{PnmHeader, PNMHeader, PNMSubtype, PnmSubtype, SampleEncoding};
 
 mod autobreak;
 mod decoder;
@@ -55,7 +55,7 @@ mod tests {
         width: u32,
         height: u32,
         color: ColorType,
-        subtype: PnmSubtype,
+        subtype: PNMSubtype,
     ) {
         let mut encoded_buffer = Vec::new();
 
@@ -121,9 +121,9 @@ mod tests {
         ];
 
         execute_roundtrip_default(&buf, 4, 4, ColorType::L8);
-        execute_roundtrip_with_subtype(&buf, 4, 4, ColorType::L8, PnmSubtype::ArbitraryMap);
-        execute_roundtrip_with_subtype(&buf, 4, 4, ColorType::L8, PnmSubtype::Graymap(SampleEncoding::Ascii));
-        execute_roundtrip_with_subtype(&buf, 4, 4, ColorType::L8, PnmSubtype::Graymap(SampleEncoding::Binary));
+        execute_roundtrip_with_subtype(&buf, 4, 4, ColorType::L8, PNMSubtype::ArbitraryMap);
+        execute_roundtrip_with_subtype(&buf, 4, 4, ColorType::L8, PNMSubtype::Graymap(SampleEncoding::Ascii));
+        execute_roundtrip_with_subtype(&buf, 4, 4, ColorType::L8, PNMSubtype::Graymap(SampleEncoding::Binary));
     }
 
     #[test]
@@ -141,20 +141,20 @@ mod tests {
             255, 255, 255,
         ];
         execute_roundtrip_default(&buf, 3, 3, ColorType::Rgb8);
-        execute_roundtrip_with_subtype(&buf, 3, 3, ColorType::Rgb8, PnmSubtype::ArbitraryMap);
+        execute_roundtrip_with_subtype(&buf, 3, 3, ColorType::Rgb8, PNMSubtype::ArbitraryMap);
         execute_roundtrip_with_subtype(
             &buf,
             3,
             3,
             ColorType::Rgb8,
-            PnmSubtype::Pixmap(SampleEncoding::Binary),
+            PNMSubtype::Pixmap(SampleEncoding::Binary),
         );
         execute_roundtrip_with_subtype(
             &buf,
             3,
             3,
             ColorType::Rgb8,
-            PnmSubtype::Pixmap(SampleEncoding::Ascii),
+            PNMSubtype::Pixmap(SampleEncoding::Ascii),
         );
     }
 


### PR DESCRIPTION
fixes #1258 
<!-- 
If you are a new contributor, consent to licensing by including this text:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

Thank you for contributing, you can delete this comment.
-->

I created a type definition for each previous struct name and marked them as deprecated. In order to export these typedefs, I needed to use `#[allow(deprecated)]` in some of the `mod.rs` files. Instead, typedef definitions could be in the `mod.rs` files to not have to do this. Or they could be not marked as deprecated. Although, I think the `#[allow(deprecated)]` tags are fine given that the typedefs will be removed in the next version (I assume). 

All the names that were changed:
- `PNGReader` -> `PngReader`
- `PNGEncoder` -> `PngEncoder`
- `BMPEncoder` -> `BmpEncoder`
- `DXTReader` -> `PngReader`
- `DXTEncoder` -> `DxtEncoder`
- `DXTVariant` -> `DxtVariant`
- `gif::Encoder` -> `gif::GifEncoder`
- `ICOEncoder` -> `IcoEncoder`
- `HDRAdapter` -> `HdrAdapter`
- `HDREncoder` -> `HdrEncoder`
- `HDRImageDecoderIterator` -> `HdrImageDecoderIterator`
- `HdrMetadata` -> `HdrMetadata`
- `RGBE8Pixel` -> `Rgbe8Pixel`
- `JPEGEncoder` -> `JpegEncoder`
- `PNMEncoder` -> `PnmEncoder`
- `PNMHeader` -> `PnmHeader`
- `PnmSubtype` -> `PnmSubtype`
