### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/bmp/encoder.rs
+++ b/src/bmp/encoder.rs
@@ -77,7 +77,7 @@ impl<'a, W: Write + 'a> BMPEncoder<'a, W> {
             // Assume BGRA32
             self.writer.write_u32::<LittleEndian>(0xff << 16)?; // red mask
             self.writer.write_u32::<LittleEndian>(0xff << 8)?; // green mask
-            self.writer.write_u32::<LittleEndian>(0xff << 0)?; // blue mask
+            self.writer.write_u32::<LittleEndian>(0xff)?; // blue mask
             self.writer.write_u32::<LittleEndian>(0xff << 24)?; // alpha mask
             self.writer.write_u32::<LittleEndian>(0x73524742)?; // colorspace - sRGB
 

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -901,9 +901,9 @@ impl<'buf, Subpixel> FlatSamples<&'buf [Subpixel]> {
             layout: SampleLayout {
                 channels: P::CHANNEL_COUNT,
                 channel_stride: 1,
-                width: width,
+                width,
                 width_stride: 0,
-                height: height,
+                height,
                 height_stride: 0,
             },
             color_hint: Some(P::COLOR_TYPE),

--- a/src/gif.rs
+++ b/src/gif.rs
@@ -137,7 +137,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for GifDecoder<R> {
                     }
                 })
             };
-            buf.copy_from_slice(&mut image_buffer.into_raw());
+            buf.copy_from_slice(&image_buffer.into_raw());
         }
         Ok(())
     }
@@ -386,7 +386,7 @@ impl<W: Write> Encoder<W> {
         }
 
         // TODO: this is not very idiomatic yet. Should return an EncodingError.
-        inner_dimensions(width, height).ok_or(ImageError::Parameter(ParameterError::from_kind(
+        inner_dimensions(width, height).ok_or_else(|| ImageError::Parameter(ParameterError::from_kind(
             ParameterErrorKind::DimensionMismatch
         )))
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -619,7 +619,11 @@ pub trait GenericImageView {
     /// Returns the pixel located at (x, y)
     ///
     /// This function can be implemented in a way that ignores bounds checking.
-    #[allow(clippy::missing_safety_doc)]
+    /// # Safety
+    ///
+    /// The coordinates must be [`in_bounds`] of the image.
+    ///
+    /// [`in_bounds`]: #method.in_bounds
     unsafe fn unsafe_get_pixel(&self, x: u32, y: u32) -> Self::Pixel {
         self.get_pixel(x, y)
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -619,6 +619,7 @@ pub trait GenericImageView {
     /// Returns the pixel located at (x, y)
     ///
     /// This function can be implemented in a way that ignores bounds checking.
+    #[allow(clippy::missing_safety_doc)]
     unsafe fn unsafe_get_pixel(&self, x: u32, y: u32) -> Self::Pixel {
         self.get_pixel(x, y)
     }
@@ -672,6 +673,7 @@ pub trait GenericImage: GenericImageView {
     /// Puts a pixel at location (x, y)
     ///
     /// This function can be implemented in a way that ignores bounds checking.
+    #[allow(clippy::missing_safety_doc)]
     unsafe fn unsafe_put_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel) {
         self.put_pixel(x, y, pixel);
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -677,7 +677,11 @@ pub trait GenericImage: GenericImageView {
     /// Puts a pixel at location (x, y)
     ///
     /// This function can be implemented in a way that ignores bounds checking.
-    #[allow(clippy::missing_safety_doc)]
+    /// # Safety
+    ///
+    /// The coordinates must be [`in_bounds`] of the image.
+    ///
+    /// [`in_bounds`]: traits.GenericImageView.html#method.in_bounds
     unsafe fn unsafe_put_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel) {
         self.put_pixel(x, y, pixel);
     }

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -216,7 +216,7 @@ pub(crate) fn save_buffer_with_format_impl(
             .write_image(buf, width, height, color),
         #[cfg(feature = "tga")]
         image::ImageFormat::Tga => tga::TgaEncoder::new(fout).write_image(buf, width, height, color),
-        format => return Err(ImageError::Unsupported(ImageFormatHint::Exact(format).into())),
+        format => Err(ImageError::Unsupported(ImageFormatHint::Exact(format).into())),
     }
 }
 
@@ -231,8 +231,7 @@ pub(crate) fn guess_format_from_path_impl(path: &Path) -> Result<ImageFormat, Pa
         .and_then(|s| s.to_str())
         .map(str::to_ascii_lowercase);
 
-    let ext = ext.as_ref()
-        .map(String::as_str);
+    let ext = ext.as_deref();
 
     Ok(match ext {
         Some("jpg") | Some("jpeg") => image::ImageFormat::Jpeg,
@@ -255,7 +254,7 @@ pub(crate) fn guess_format_from_path_impl(path: &Path) -> Result<ImageFormat, Pa
     })
 }
 
-static MAGIC_BYTES: [(&'static [u8], ImageFormat); 19] = [
+static MAGIC_BYTES: [(&[u8], ImageFormat); 19] = [
     (b"\x89PNG\r\n\x1a\n", ImageFormat::Png),
     (&[0xff, 0xd8, 0xff], ImageFormat::Jpeg),
     (b"GIF89a", ImageFormat::Gif),

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -231,7 +231,8 @@ pub(crate) fn guess_format_from_path_impl(path: &Path) -> Result<ImageFormat, Pa
         .and_then(|s| s.to_str())
         .map(str::to_ascii_lowercase);
 
-    let ext = ext.as_deref();
+    let ext = ext.as_ref()
+        .map(String::as_str);
 
     Ok(match ext {
         Some("jpg") | Some("jpeg") => image::ImageFormat::Jpeg,

--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -463,7 +463,7 @@ impl<'a, W: Write> JPEGEncoder<'a, W> {
                 self.encode_image(&image)
             },
             _ => {
-                return Err(ImageError::Unsupported(
+                Err(ImageError::Unsupported(
                     UnsupportedError::from_format_and_kind(
                         ImageFormat::Jpeg.into(),
                         UnsupportedErrorKind::Color(color_type.into()),

--- a/src/math/nq.rs
+++ b/src/math/nq.rs
@@ -160,24 +160,20 @@ impl NeuQuant {
     #[inline(always)]
     pub fn map_pixel(&self, pixel: &mut [u8]) {
         assert_eq!(pixel.len(), 4);
-        match (pixel[0], pixel[1], pixel[2], pixel[3]) {
-            (r, g, b, a) => {
-                let i = self.search_netindex(b, g, r, a);
-                pixel[0] = self.colormap[i].r as u8;
-                pixel[1] = self.colormap[i].g as u8;
-                pixel[2] = self.colormap[i].b as u8;
-                pixel[3] = self.colormap[i].a as u8;
-            }
-        }
+        let (r, g, b, a) = (pixel[0], pixel[1], pixel[2], pixel[3]);
+        let i = self.search_netindex(b, g, r, a);
+        pixel[0] = self.colormap[i].r as u8;
+        pixel[1] = self.colormap[i].g as u8;
+        pixel[2] = self.colormap[i].b as u8;
+        pixel[3] = self.colormap[i].a as u8;
     }
 
     /// Finds the best-matching index in the color map for `pixel`
     #[inline(always)]
     pub fn index_of(&self, pixel: &[u8]) -> usize {
         assert_eq!(pixel.len(), 4);
-        match (pixel[0], pixel[1], pixel[2], pixel[3]) {
-            (r, g, b, a) => self.search_netindex(b, g, r, a),
-        }
+        let (r, g, b, a) = (pixel[0], pixel[1], pixel[2], pixel[3]);
+        self.search_netindex(b, g, r, a)
     }
 
     /// Lookup pixel values for color at `idx` in the colormap.

--- a/src/png.rs
+++ b/src/png.rs
@@ -386,7 +386,7 @@ impl<R: Read> ApngDecoder<R> {
             ColorType::L8 | ColorType::Rgb8 | ColorType::La8 | ColorType::Rgba8 => Ok(()),
             // TODO: do not handle multi-byte colors. Remember to implement it in `mix_next_frame`.
             ColorType::L16 | ColorType::Rgb16 | ColorType::La16 | ColorType::Rgba16  => {
-                return Err(unsupported_color(self.inner.color_type.into()))
+                Err(unsupported_color(self.inner.color_type.into()))
             },
             _ => unreachable!("{:?} not a valid png color", self.inner.color_type),
         }

--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -237,7 +237,7 @@ impl<R: Read> PnmDecoder<R> {
             [b'P', b'5'] => PNMSubtype::Graymap(SampleEncoding::Binary),
             [b'P', b'6'] => PNMSubtype::Pixmap(SampleEncoding::Binary),
             [b'P', b'7'] => PNMSubtype::ArbitraryMap,
-            _ => Err(DecoderError::PnmMagicInvalid(magic))?,
+            _ => return Err(DecoderError::PnmMagicInvalid(magic).into()),
         };
 
         match subtype {
@@ -345,7 +345,7 @@ trait HeaderReader: BufRead {
                         break; // We're done as we already have some content
                     }
                 }
-                Ok(byte) if !byte.is_ascii() => Err(DecoderError::NonAsciiByteInHeader(byte))?,
+                Ok(byte) if !byte.is_ascii() => return Err(DecoderError::NonAsciiByteInHeader(byte).into()),
                 Ok(byte) => {
                     bytes.push(byte);
                 },
@@ -423,7 +423,7 @@ trait HeaderReader: BufRead {
     fn read_arbitrary_header(&mut self) -> ImageResult<ArbitraryHeader> {
         fn parse_single_value_line(line_val: &mut Option<u32>, rest: &str, line: PnmHeaderLine) -> ImageResult<()> {
             if line_val.is_some() {
-                return Err(DecoderError::HeaderLineDuplicated(line).into());
+                Err(DecoderError::HeaderLineDuplicated(line).into())
             } else {
                 let v = rest.trim().parse().map_err(|err| DecoderError::UnparsableValue(ErrorDataSource::Line(line), rest.to_owned(), err))?;
                 *line_val = Some(v);

--- a/src/pnm/header.rs
+++ b/src/pnm/header.rs
@@ -297,7 +297,7 @@ impl PNMHeader {
                 impl<'a> fmt::Display for TupltypeWriter<'a> {
                     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                         match self.0 {
-                            Some(tt) => write!(f, "TUPLTYPE {}\n", tt.name()),
+                            Some(tt) => writeln!(f, "TUPLTYPE {}", tt.name()),
                             None => Ok(()),
                         }
                     }


### PR DESCRIPTION
Good day!

I've fixed some clippy warnings. There are still three warnings like the following.

clippy 0.0.21

```sh
warning: All variants have the same postfix: `Invalid`
  --> src/dds.rs:22:1
   |
22 | / enum DecoderError {
23 | |     /// Wrong DDS channel width
24 | |     PixelFormatSizeInvalid(u32),
25 | |     /// Wrong DDS header size
...  |
31 | |     DdsSignatureInvalid,
32 | | }
   | |_^
   |
   = note: `#[warn(clippy::enum_variant_names)]` on by default
   = help: remove the postfixes and use full paths to the variants instead of glob imports
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#enum_variant_names

warning: needless `fn main` in doctest
   --> src/imageops/mod.rs:171:4
    |
171 | /// use image::{RgbaImage};
    |    ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(clippy::needless_doctest_main)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_doctest_main

warning: called `.as_ref().map(String::as_str)` on an Option value. This can be done more directly by calling `ext.as_deref()` instead
   --> src/io/free_functions.rs:234:15
    |
234 |       let ext = ext.as_ref()
    |  _______________^
235 | |         .map(String::as_str);
    | |____________________________^ help: try using as_deref instead: `ext.as_deref()`
    |
    = note: `#[warn(clippy::option_as_ref_deref)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#option_as_ref_deref

warning: 3 warnings emitted
```