### PR TITLE
Typo in reader.rs

### DIFF
--- a/src/io/reader.rs
+++ b/src/io/reader.rs
@@ -138,7 +138,7 @@ impl<R: BufRead + Seek> Reader<R> {
     /// Make a format guess based on the content, replacing it on success.
     ///
     /// Returns `Ok` with the guess if no io error occurs. Additionally, replaces the current
-    /// format if the guess was successful. If the guess was not unable to determine a format then
+    /// format if the guess was successful. If the guess was unable to determine a format then
     /// the current format of the reader is unchanged.
     ///
     /// Returns an error if the underlying reader fails. The format is unchanged. The error is a


### PR DESCRIPTION
`not unable` should be just `unable`.

The sentence otherwise reads as if the current format remains unchanged when a format is guessed.
The inverse is then also true when no format is guessed the current format is updated, but no value to update it to is guessed.

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.
