### PR TITLE
Added auto-vectorization optimizations to `ImageBuffer` methods.

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -3,7 +3,7 @@ use num_traits::Zero;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut, Index, IndexMut, Range};
 use std::path::Path;
-use std::slice::{Chunks, ChunksMut, ChunksExact, ChunksExactMut};
+use std::slice::{ChunksExact, ChunksExactMut};
 
 use crate::color::{FromColor, Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
 use crate::flat::{FlatSamples, SampleLayout};
@@ -105,7 +105,7 @@ pub struct Rows<'a, P: Pixel + 'a>
 where
     <P as Pixel>::Subpixel: 'a,
 {
-    pixels: Chunks<'a, P::Subpixel>,
+    pixels: ChunksExact<'a, P::Subpixel>,
 }
 
 impl<'a, P: Pixel + 'a> Rows<'a, P> {
@@ -115,7 +115,7 @@ impl<'a, P: Pixel + 'a> Rows<'a, P> {
         let row_len = (width as usize) * usize::from(<P as Pixel>::CHANNEL_COUNT);
         if row_len == 0 {
             Rows {
-                pixels: [].chunks(1),
+                pixels: [].chunks_exact(1),
             }
         } else {
             let pixels = pixels.get(..row_len*height as usize)
@@ -123,7 +123,7 @@ impl<'a, P: Pixel + 'a> Rows<'a, P> {
             // Rows are physically present. In particular, height is smaller than `usize::MAX` as
             // all subpixels can be indexed.
             Rows {
-                pixels: pixels.chunks(row_len),
+                pixels: pixels.chunks_exact(row_len),
             }
         }
     }
@@ -177,7 +177,7 @@ pub struct RowsMut<'a, P: Pixel + 'a>
 where
     <P as Pixel>::Subpixel: 'a,
 {
-    pixels: ChunksMut<'a, P::Subpixel>,
+    pixels: ChunksExactMut<'a, P::Subpixel>,
 }
 
 impl<'a, P: Pixel + 'a> RowsMut<'a, P> {
@@ -187,7 +187,7 @@ impl<'a, P: Pixel + 'a> RowsMut<'a, P> {
         let row_len = (width as usize) * usize::from(<P as Pixel>::CHANNEL_COUNT);
         if row_len == 0 {
             RowsMut {
-                pixels: [].chunks_mut(1),
+                pixels: [].chunks_exact_mut(1),
             }
         } else {
             let pixels = pixels.get_mut(..row_len*height as usize)
@@ -195,7 +195,7 @@ impl<'a, P: Pixel + 'a> RowsMut<'a, P> {
             // Rows are physically present. In particular, height is smaller than `usize::MAX` as
             // all subpixels can be indexed.
             RowsMut {
-                pixels: pixels.chunks_mut(row_len),
+                pixels: pixels.chunks_exact_mut(row_len),
             }
         }
     }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -3,7 +3,7 @@ use num_traits::Zero;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut, Index, IndexMut, Range};
 use std::path::Path;
-use std::slice::{Chunks, ChunksMut};
+use std::slice::{Chunks, ChunksMut, ChunksExact, ChunksExactMut};
 
 use crate::color::{FromColor, Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
 use crate::flat::{FlatSamples, SampleLayout};
@@ -20,7 +20,7 @@ pub struct Pixels<'a, P: Pixel + 'a>
 where
     P::Subpixel: 'a,
 {
-    chunks: Chunks<'a, P::Subpixel>,
+    chunks: ChunksExact<'a, P::Subpixel>,
 }
 
 impl<'a, P: Pixel + 'a> Iterator for Pixels<'a, P>
@@ -59,7 +59,7 @@ pub struct PixelsMut<'a, P: Pixel + 'a>
 where
     P::Subpixel: 'a,
 {
-    chunks: ChunksMut<'a, P::Subpixel>,
+    chunks: ChunksExactMut<'a, P::Subpixel>,
 }
 
 impl<'a, P: Pixel + 'a> Iterator for PixelsMut<'a, P>
@@ -140,7 +140,7 @@ where
         let row = self.pixels.next()?;
         Some(Pixels {
             // Note: this is not reached when CHANNEL_COUNT is 0.
-            chunks: row.chunks(<P as Pixel>::CHANNEL_COUNT as usize),
+            chunks: row.chunks_exact(<P as Pixel>::CHANNEL_COUNT as usize),
         })
     }
 }
@@ -163,7 +163,7 @@ where
         let row = self.pixels.next_back()?;
         Some(Pixels {
             // Note: this is not reached when CHANNEL_COUNT is 0.
-            chunks: row.chunks(<P as Pixel>::CHANNEL_COUNT as usize),
+            chunks: row.chunks_exact(<P as Pixel>::CHANNEL_COUNT as usize),
         })
     }
 }
@@ -212,7 +212,7 @@ where
         let row = self.pixels.next()?;
         Some(PixelsMut {
             // Note: this is not reached when CHANNEL_COUNT is 0.
-            chunks: row.chunks_mut(<P as Pixel>::CHANNEL_COUNT as usize),
+            chunks: row.chunks_exact_mut(<P as Pixel>::CHANNEL_COUNT as usize),
         })
     }
 }
@@ -235,7 +235,7 @@ where
         let row = self.pixels.next_back()?;
         Some(PixelsMut {
             // Note: this is not reached when CHANNEL_COUNT is 0.
-            chunks: row.chunks_mut(<P as Pixel>::CHANNEL_COUNT as usize),
+            chunks: row.chunks_exact_mut(<P as Pixel>::CHANNEL_COUNT as usize),
         })
     }
 }
@@ -538,7 +538,7 @@ where
     /// The iteration order is x = 0 to width then y = 0 to height
     pub fn pixels(&self) -> Pixels<P> {
         Pixels {
-            chunks: self.inner_pixels().chunks(<P as Pixel>::CHANNEL_COUNT as usize),
+            chunks: self.inner_pixels().chunks_exact(<P as Pixel>::CHANNEL_COUNT as usize),
         }
     }
 
@@ -688,7 +688,7 @@ where
     /// Returns an iterator over the mutable pixels of this image.
     pub fn pixels_mut(&mut self) -> PixelsMut<P> {
         PixelsMut {
-            chunks: self.inner_pixels_mut().chunks_mut(<P as Pixel>::CHANNEL_COUNT as usize),
+            chunks: self.inner_pixels_mut().chunks_exact_mut(<P as Pixel>::CHANNEL_COUNT as usize),
         }
     }
 


### PR DESCRIPTION
fixes #1298 , fixes #1299 

In order to allow for auto-vectorization optimizations the uses of `Chunk`/`ChunkMut` have been replaced with `ChunkExact`/`ChunkExactMut`. 

The best guess for why `Chunk` and `ChunkMut` don't result in auto-vectorization is that as far as the compiler is concerned they iterate over dynamically sized slices (and therefor the compiler might not know where the end is which would result in no auto-vectorization). While it could be inferred that each chunk is less than or equal to known const size, I don't know rust well enough to know if that is done.

Regardless this is the resulting disassembly for the following rust code (both with `opt-level = 3`):
```rust
fn test_func() -> RgbaImage
{
    ImageBuffer::from_pixel(7500, 7500, Rgba([0,0,0,255]))
}
```
asm before this PR (full: https://gist.github.com/ZackJorquera/60eaded17e04c3dc63d60ebd00fc11d0):
```asm
.LBB7_2:
    cmp rbx, 4
    mov eax, 4
    cmovb   rax, rbx
    mov qword ptr [rsp + 8], rax
    cmp rbx, 3
    jbe .LBB7_3
    sub rbx, rax
    add rax, rcx
    mov dword ptr [rcx], -16777216
    mov rcx, rax
    test    rbx, rbx
    jne .LBB7_2
    mov rax, r15
    add rsp, 112
    .cfi_def_cfa_offset 32
    pop rbx
    .cfi_def_cfa_offset 24
    pop r14
    .cfi_def_cfa_offset 16
    pop r15
    .cfi_def_cfa_offset 8
    ret
```
asm this PR (full: https://gist.github.com/ZackJorquera/1c395d05f44345bcae69c950d7f4573b):
```asm
.LBB5_2:
    movups  xmmword ptr [rax + 4*rcx - 176], xmm0
    movups  xmmword ptr [rax + 4*rcx - 160], xmm0
    movups  xmmword ptr [rax + 4*rcx - 144], xmm0
    movups  xmmword ptr [rax + 4*rcx - 128], xmm0
    movups  xmmword ptr [rax + 4*rcx - 112], xmm0
    movups  xmmword ptr [rax + 4*rcx - 96], xmm0
    movups  xmmword ptr [rax + 4*rcx - 80], xmm0
    movups  xmmword ptr [rax + 4*rcx - 64], xmm0
    movups  xmmword ptr [rax + 4*rcx - 48], xmm0
    movups  xmmword ptr [rax + 4*rcx - 32], xmm0
    movups  xmmword ptr [rax + 4*rcx - 16], xmm0
    movups  xmmword ptr [rax + 4*rcx], xmm0
    add rcx, 48
    cmp rcx, 56250044
    jne .LBB5_2
    mov rax, rbx
    pop rbx
    .cfi_def_cfa_offset 8
    ret
```

This is also a good change because if the `Chunk`/`ChunkMut` iters were to ever return a remainder chuck (theoretically as in practice this will never happen as stated in #1299) then the program would crash at [this assert](https://github.com/image-rs/image/blob/master/src/color.rs#L255). 
