### PR TITLE
Iterator impls

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -15,7 +15,6 @@ use crate::traits::{EncodableLayout, Pixel};
 use crate::utils::expand_packed;
 
 /// Iterate over pixel refs.
-#[derive(Clone)]
 pub struct Pixels<'a, P: Pixel + 'a>
 where
     P::Subpixel: 'a,
@@ -51,6 +50,12 @@ where
     #[inline(always)]
     fn next_back(&mut self) -> Option<&'a P> {
         self.chunks.next_back().map(|v| <P as Pixel>::from_slice(v))
+    }
+}
+
+impl<P: Pixel> Clone for Pixels<'_, P> {
+    fn clone(&self) -> Self {
+        Pixels { chunks: self.chunks.clone() }
     }
 }
 
@@ -100,7 +105,6 @@ where
 /// This iterator is created with [`ImageBuffer::rows`]. See its document for details.
 ///
 /// [`ImageBuffer::rows`]: ../struct.ImageBuffer.html#method.rows
-#[derive(Clone)]
 pub struct Rows<'a, P: Pixel + 'a>
 where
     <P as Pixel>::Subpixel: 'a,
@@ -165,6 +169,12 @@ where
             // Note: this is not reached when CHANNEL_COUNT is 0.
             chunks: row.chunks(<P as Pixel>::CHANNEL_COUNT as usize),
         })
+    }
+}
+
+impl<P: Pixel> Clone for Rows<'_, P> {
+    fn clone(&self) -> Self {
+        Rows { pixels: self.pixels.clone() }
     }
 }
 
@@ -241,7 +251,6 @@ where
 }
 
 /// Enumerate the pixels of an image.
-#[derive(Clone)]
 pub struct EnumeratePixels<'a, P: Pixel + 'a>
 where
     <P as Pixel>::Subpixel: 'a,
@@ -279,8 +288,16 @@ where
     }
 }
 
+impl<P: Pixel> Clone for EnumeratePixels<'_, P> {
+    fn clone(&self) -> Self {
+        EnumeratePixels {
+            pixels: self.pixels.clone(),
+            ..*self
+        }
+    }
+}
+
 /// Enumerate the rows of an image.
-#[derive(Clone)]
 pub struct EnumerateRows<'a, P: Pixel + 'a>
 where
     <P as Pixel>::Subpixel: 'a,
@@ -320,6 +337,15 @@ where
 {
     fn len(&self) -> usize {
         self.rows.len()
+    }
+}
+
+impl<P: Pixel> Clone for EnumerateRows<'_, P> {
+    fn clone(&self) -> Self {
+        EnumerateRows {
+            rows: self.rows.clone(),
+            ..*self
+        }
     }
 }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,5 +1,6 @@
 //! Contains the generic `ImageBuffer` struct.
 use num_traits::Zero;
+use std::fmt;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut, Index, IndexMut, Range};
 use std::path::Path;
@@ -59,6 +60,18 @@ impl<P: Pixel> Clone for Pixels<'_, P> {
     }
 }
 
+impl<P: Pixel> fmt::Debug for Pixels<'_, P>
+where
+    P::Subpixel: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f
+            .debug_struct("Pixels")
+            .field("chunks", &self.chunks)
+            .finish()
+    }
+}
+
 /// Iterate over mutable pixel refs.
 pub struct PixelsMut<'a, P: Pixel + 'a>
 where
@@ -97,6 +110,18 @@ where
         self.chunks
             .next_back()
             .map(|v| <P as Pixel>::from_slice_mut(v))
+    }
+}
+
+impl<P: Pixel> fmt::Debug for PixelsMut<'_, P>
+where
+    P::Subpixel: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f
+            .debug_struct("PixelsMut")
+            .field("chunks", &self.chunks)
+            .finish()
     }
 }
 
@@ -178,6 +203,18 @@ impl<P: Pixel> Clone for Rows<'_, P> {
     }
 }
 
+impl<P: Pixel> fmt::Debug for Rows<'_, P>
+where
+    P::Subpixel: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f
+            .debug_struct("Rows")
+            .field("pixels", &self.pixels)
+            .finish()
+    }
+}
+
 /// Iterate over mutable rows of an image
 ///
 /// This iterator is created with [`ImageBuffer::rows_mut`]. See its document for details.
@@ -250,6 +287,18 @@ where
     }
 }
 
+impl<P: Pixel> fmt::Debug for RowsMut<'_, P>
+where
+    P::Subpixel: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f
+            .debug_struct("RowsMut")
+            .field("pixels", &self.pixels)
+            .finish()
+    }
+}
+
 /// Enumerate the pixels of an image.
 pub struct EnumeratePixels<'a, P: Pixel + 'a>
 where
@@ -294,6 +343,21 @@ impl<P: Pixel> Clone for EnumeratePixels<'_, P> {
             pixels: self.pixels.clone(),
             ..*self
         }
+    }
+}
+
+impl<P: Pixel> fmt::Debug for EnumeratePixels<'_, P>
+where
+    P::Subpixel: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f
+          .debug_struct("EnumeratePixels")
+          .field("pixels", &self.pixels)
+          .field("x", &self.x)
+          .field("y", &self.y)
+          .field("width", &self.width)
+          .finish()
     }
 }
 
@@ -349,6 +413,20 @@ impl<P: Pixel> Clone for EnumerateRows<'_, P> {
     }
 }
 
+impl<P: Pixel> fmt::Debug for EnumerateRows<'_, P>
+where
+    P::Subpixel: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f
+          .debug_struct("EnumerateRows")
+          .field("rows", &self.rows)
+          .field("y", &self.y)
+          .field("width", &self.width)
+          .finish()
+    }
+}
+
 /// Enumerate the pixels of an image.
 pub struct EnumeratePixelsMut<'a, P: Pixel + 'a>
 where
@@ -384,6 +462,21 @@ where
 {
     fn len(&self) -> usize {
         self.pixels.len()
+    }
+}
+
+impl<P: Pixel> fmt::Debug for EnumeratePixelsMut<'_, P>
+where
+    P::Subpixel: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f
+          .debug_struct("EnumeratePixelsMut")
+          .field("pixels", &self.pixels)
+          .field("x", &self.x)
+          .field("y", &self.y)
+          .field("width", &self.width)
+          .finish()
     }
 }
 
@@ -427,6 +520,20 @@ where
 {
     fn len(&self) -> usize {
         self.rows.len()
+    }
+}
+
+impl<P: Pixel> fmt::Debug for EnumerateRowsMut<'_, P>
+where
+    P::Subpixel: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f
+          .debug_struct("EnumerateRowsMut")
+          .field("rows", &self.rows)
+          .field("y", &self.y)
+          .field("width", &self.width)
+          .finish()
     }
 }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -543,6 +543,7 @@ pub trait ImageEncoder {
 }
 
 /// Immutable pixel iterator
+#[derive(Debug)]
 pub struct Pixels<'a, I: ?Sized + 'a> {
     image: &'a I,
     x: u32,

--- a/src/image.rs
+++ b/src/image.rs
@@ -573,6 +573,12 @@ impl<'a, I: GenericImageView> Iterator for Pixels<'a, I> {
     }
 }
 
+impl<I: ?Sized> Clone for Pixels<'_, I> {
+    fn clone(&self) -> Self {
+        Pixels { ..*self }
+    }
+}
+
 /// Trait to inspect an image.
 pub trait GenericImageView {
     /// The type of pixel.


### PR DESCRIPTION
Relaxes or adds impls for `Debug` and `Clone` to applicable iterators. Note that deriving the impls on the `ImageBuffer` iterators does not lead to the wanted outcome as it would introduce a bound of `Debug` on the pixel type and not on the channel type. This is more restrictive and not representative of the underlying representation.

Closes: #1266 