### PR TITLE
Add non-consumable equivalent of into_raw to ImageBuffer

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -646,6 +646,11 @@ where
         self.data
     }
 
+    /// Returns the underlying raw buffer
+    pub fn as_raw(&self) -> &Container {
+        &self.data
+    }
+
     /// The width and height of this image.
     pub fn dimensions(&self) -> (u32, u32) {
         (self.width, self.height)


### PR DESCRIPTION
I license past and future contributions under the dual MIT/Apache-2.0 license.

I needed a way in my game engine to share raw image data across multiple iterations of infinite loop (because obviously I don't want to load it every time or copy it) so I added one.