### PR TITLE
Rough draft including ravif for AVIF encoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ env:
     - FEATURES='webp'
     - FEATURES='hdr'
     - FEATURES='farbfeld'
-    - FEATURES='ravif'
 matrix:
   allow_failures:
     - name: "Clippy"
@@ -39,6 +38,9 @@ matrix:
     - name: "Fuzz corpus"
     - rust: nightly
   include:
+    - os: linux
+      rust: stable
+      env: FEATURES='ravif'
     - os: osx
       rust: 1.34.2
     - os: windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
     - FEATURES='webp'
     - FEATURES='hdr'
     - FEATURES='farbfeld'
+    - FEATURES='ravif'
 matrix:
   allow_failures:
     - name: "Clippy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ jpeg = { package = "jpeg-decoder", version = "0.1.17", default-features = false,
 png = { version = "0.16.5", optional = true }
 scoped_threadpool = { version = "0.1", optional = true }
 tiff = { version = "0.5.0", optional = true }
+ravif = { version = "0.6.0", optional = true }
+rgb = { version = "0.8.25", optional = true }
 
 [dev-dependencies]
 crc32fast = "1.2.0"
@@ -51,7 +53,10 @@ hdr = ["scoped_threadpool"]
 dxt = []
 dds = ["dxt"]
 farbfeld = []
+
 jpeg_rayon = ["jpeg/rayon"]
+
+avif = ["ravif", "rgb"]
 
 benchmarks = []
 

--- a/Cargo.toml.public-private-dependencies
+++ b/Cargo.toml.public-private-dependencies
@@ -35,6 +35,7 @@ jpeg = { package = "jpeg-decoder", version = "0.1.17", default-features = false,
 png = { version = "0.16.0", optional = true }
 scoped_threadpool = { version = "0.1", optional = true }
 tiff = { version = "0.5.0", optional = true }
+ravif = { version = "0.6.0", optional = true }
 
 [dev-dependencies]
 crc32fast = "1.2.0"

--- a/examples/convert.rs
+++ b/examples/convert.rs
@@ -1,0 +1,20 @@
+//! An example of opening an image.
+extern crate image;
+
+use std::env;
+use std::path::Path;
+
+fn main() {
+    let (from, into) = if env::args_os().count() == 3 {
+        (env::args_os().nth(1).unwrap(), env::args_os().nth(2).unwrap())
+    } else {
+        println!("Please enter a from and into path.");
+        std::process::exit(1);
+    };
+
+    // Use the open function to load an image from a Path.
+    // ```open``` returns a dynamic image.
+    let im = image::open(&Path::new(&from)).unwrap();
+    // Write the contents of this image using extension guessing.
+    im.save(&Path::new(&into)).unwrap();
+}

--- a/src/avif/mod.rs
+++ b/src/avif/mod.rs
@@ -1,0 +1,83 @@
+use std::io::Write;
+
+use crate::{flat, ColorType, DynamicImage, ImageBuffer, ImageFormat, Rgba, Pixel};
+use crate::{ImageError, ImageResult};
+use crate::error::{EncodingError, ParameterError, ParameterErrorKind, UnsupportedError, UnsupportedErrorKind};
+
+use ravif::{Img, ColorSpace, Config, RGBA8, encode_rgba};
+use rgb::AsPixels;
+
+pub struct AvifEncoder<W> {
+    inner: W,
+    fallback: Vec<RGBA8>,
+}
+
+impl<W: Write> AvifEncoder<W> {
+    /// Create a new encoder that writes its output to `w`.
+    pub fn new(w: W) -> Self {
+        AvifEncoder { inner: w, fallback: vec![] }
+    }
+
+    pub fn encode(mut self, data: &[u8], width: u32, height: u32, color: ColorType) -> ImageResult<()> {
+        let config = self.config(color);
+        // `ravif` needs strongly typed data so let's convert. We can either use a temporarily
+        // owned version in our own buffer or zero-copy if possible by using the input buffer.
+        // This requires going through `rgb`.
+        let buffer = self.encode_as_img(data, width, height, color)?;
+        let (data, _color_size, _alpha_size) = encode_rgba(buffer, &config)
+            .map_err(|err| ImageError::Encoding(
+                EncodingError::new(ImageFormat::Avif.into(), err)
+            ))?;
+        self.inner.write_all(&data)?;
+        Ok(())
+    }
+
+    fn config(&self, _color: ColorType) -> Config {
+        Config {
+            quality: 100,
+            alpha_quality: 100,
+            speed: 1,
+            premultiplied_alpha: false,
+            color_space: ColorSpace::RGB,
+        }
+    }
+
+    fn encode_as_img<'buf>(&'buf mut self, data: &'buf [u8], width: u32, height: u32, color: ColorType)
+        -> ImageResult<Img<&'buf [RGBA8]>>
+    {
+        fn try_from_raw<P: Pixel + 'static>(data: &[P::Subpixel], width: u32, height: u32)
+            -> ImageResult<ImageBuffer<P, &[P::Subpixel]>>
+        {
+            ImageBuffer::from_raw(width, height, data).ok_or_else(|| {
+                ImageError::Parameter(ParameterError::from_kind(ParameterErrorKind::DimensionMismatch))
+            })
+        };
+
+        match color {
+            ColorType::Rgba8 => {
+                // ravif doesn't do any checks but has some asserts, so we do the checks.
+                let img = try_from_raw::<Rgba<u8>>(data, width, height)?;
+                // Now, internally ravif uses u32 but it takes usize. We could do some checked
+                // conversion but instead we use that a non-empty image must be addressable.
+                if img.pixels().len() == 0 {
+                    return Err(ImageError::Parameter(ParameterError::from_kind(ParameterErrorKind::DimensionMismatch)));
+                }
+
+                Ok(Img::new(rgb::AsPixels::as_pixels(data), width as usize, height as usize))
+            },
+            // we need a separate buffer..
+            ColorType::L8 | ColorType::La8 | ColorType::Rgb8 | ColorType::Bgr8 | ColorType::Bgra8 => {
+                todo!()
+            }
+            // we need to really convert data..
+            ColorType::L16 | ColorType::La16 | ColorType::Rgb16 | ColorType::Rgba16 => {
+                todo!()
+            }
+            // for cases we do not support at all?
+            _ => Err(ImageError::Unsupported(UnsupportedError::from_format_and_kind(
+                    ImageFormat::Avif.into(),
+                    UnsupportedErrorKind::Color(color.into()),
+                )))
+        }
+    }
+}

--- a/src/avif/mod.rs
+++ b/src/avif/mod.rs
@@ -36,7 +36,7 @@ impl<W: Write> AvifEncoder<W> {
     /// The encoder currently requires all data to be RGBA8, it will be converted internally if
     /// necessary. When data is suitably aligned, i.e. u16 channels to two bytes, then the
     /// conversion may be more efficient.
-    pub fn encode(mut self, data: &[u8], width: u32, height: u32, color: ColorType) -> ImageResult<()> {
+    pub fn write_image(mut self, data: &[u8], width: u32, height: u32, color: ColorType) -> ImageResult<()> {
         let config = self.config(color);
         // `ravif` needs strongly typed data so let's convert. We can either use a temporarily
         // owned version in our own buffer or zero-copy if possible by using the input buffer.

--- a/src/avif/mod.rs
+++ b/src/avif/mod.rs
@@ -1,3 +1,8 @@
+//! Encoding of AVIF images.
+///
+/// The [AVIF] specification defines an image derivative of the AV1 bitstream, an open video codec.
+///
+/// [AVIF]: https://aomediacodec.github.io/av1-avif/
 use std::borrow::Cow;
 use std::io::Write;
 
@@ -12,6 +17,9 @@ use num_traits::Zero;
 use ravif::{Img, ColorSpace, Config, RGBA8, encode_rgba};
 use rgb::AsPixels;
 
+/// AVIF Encoder.
+///
+/// Writes one image into the chosen output.
 pub struct AvifEncoder<W> {
     inner: W,
     fallback: Vec<u8>,
@@ -23,6 +31,11 @@ impl<W: Write> AvifEncoder<W> {
         AvifEncoder { inner: w, fallback: vec![] }
     }
 
+    /// Encode image data with the indicated color type.
+    ///
+    /// The encoder currently requires all data to be RGBA8, it will be converted internally if
+    /// necessary. When data is suitably aligned, i.e. u16 channels to two bytes, then the
+    /// conversion may be more efficient.
     pub fn encode(mut self, data: &[u8], width: u32, height: u32, color: ColorType) -> ImageResult<()> {
         let config = self.config(color);
         // `ravif` needs strongly typed data so let's convert. We can either use a temporarily

--- a/src/image.rs
+++ b/src/image.rs
@@ -57,6 +57,9 @@ pub enum ImageFormat {
     /// An Image in farbfeld Format
     Farbfeld,
 
+    /// An Image in AVIF format.
+    Avif,
+
     #[doc(hidden)]
     __NonExhaustive(crate::utils::NonExhaustiveMarker),
 }
@@ -92,6 +95,8 @@ impl ImageFormat {
             ImageFormat::Ico => &["ico"],
             ImageFormat::Hdr => &["hdr"],
             ImageFormat::Farbfeld => &["ff"],
+            // According to: https://aomediacodec.github.io/av1-avif/#mime-registration
+            ImageFormat::Avif => &["avif", "heif", "heifs", "hif"],
             ImageFormat::__NonExhaustive(marker) => match marker._private {},
         }
     }

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -28,6 +28,8 @@ use crate::tiff;
 use crate::webp;
 #[cfg(feature = "farbfeld")]
 use crate::farbfeld;
+#[cfg(feature = "avif")]
+use crate::avif;
 
 use crate::color;
 use crate::image;
@@ -184,6 +186,8 @@ pub(crate) fn save_buffer_impl(
             .write_image(buf, width, height, color),
         #[cfg(feature = "tga")]
         "tga" => tga::TgaEncoder::new(fout).write_image(buf, width, height, color),
+        #[cfg(feature = "avif")]
+        "avif" => avif::AvifEncoder::new(fout).write_image(buf, width, height, color),
         _ => Err(ImageError::Unsupported(ImageFormatHint::from(path).into())),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,6 +235,8 @@ pub mod tiff;
 pub mod webp;
 #[cfg(feature = "farbfeld")]
 pub mod farbfeld;
+#[cfg(feature = "avif")]
+pub mod avif;
 
 mod animation;
 #[path = "buffer.rs"]


### PR DESCRIPTION
Converts the data to the `Img` buffer and encodes it into an intermediate vector, then writes this into the output writer. It tries to avoid actually allocating for that conversion. It considers that `RGBA8` can be converted from any byte slice and uses the applicable conversion. Any non-rgba8 image is converted using an intermediate buffer. (cc: @fintelia) Some of this code may be used for the conversion feature as well.
However it does not support limits.

Closes: #1152 
