### PR TITLE
Update gif crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ byteorder = "1.3.2"
 num-iter = "0.1.32"
 num-rational = { version = "0.3", default-features = false }
 num-traits = "0.2.0"
-gif = { version = "0.10.0", optional = true }
+gif = { version = "0.11.1", optional = true }
 jpeg = { package = "jpeg-decoder", version = "0.1.17", default-features = false, optional = true }
 png = { version = "0.16.5", optional = true }
 scoped_threadpool = { version = "0.1", optional = true }


### PR DESCRIPTION
Well this is slightly awkward. In an effort to avoid denial-of-service, the `gif` crate now checks each frame descriptor to be inbounds. Apparently this is not quite expected and there's a test [preventing out-of-bound action](https://github.com/image-rs/image/commit/503690269091d47444e9c94ffbd8f394de897b0b) in case one of the descriptors is actually out of bounds. We'll revert this and do another try.