### PR TITLE
Add ImageOutputFormat support for AVIF

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -19,6 +19,8 @@ use crate::pnm;
 use crate::farbfeld;
 #[cfg(feature = "tga")]
 use crate::tga;
+#[cfg(feature = "avif")]
+use crate::avif;
 
 use crate::buffer_::{
     BgrImage, BgraImage, ConvertBuffer, GrayAlphaImage, GrayAlpha16Image,
@@ -774,6 +776,11 @@ impl DynamicImage {
             #[cfg(feature = "tga")]
             image::ImageOutputFormat::Tga => {
                 tga::TgaEncoder::new(w).write_image(&bytes, width, height, color)
+            }
+
+            #[cfg(feature = "avif")]
+            image::ImageOutputFormat::Avif => {
+                avif::AvifEncoder::new(w).write_image(&bytes, width, height, color)
             }
 
             image::ImageOutputFormat::Unsupported(msg) => {

--- a/src/image.rs
+++ b/src/image.rs
@@ -137,6 +137,10 @@ pub enum ImageOutputFormat {
     /// An Image in TGA Format
     Tga,
 
+    #[cfg(feature = "avif")]
+    /// An image in AVIF Format
+    Avif,
+
     /// A value for signalling an error: An unsupported format was requested
     // Note: When TryFrom is stabilized, this value should not be needed, and
     // a TryInto<ImageOutputFormat> should be used instead of an Into<ImageOutputFormat>.
@@ -165,6 +169,8 @@ impl From<ImageFormat> for ImageOutputFormat {
             ImageFormat::Farbfeld => ImageOutputFormat::Farbfeld,
             #[cfg(feature = "tga")]
             ImageFormat::Tga => ImageOutputFormat::Tga,
+            #[cfg(feature = "avif")]
+            ImageFormat::Avif => ImageOutputFormat::Avif,
 
             f => ImageOutputFormat::Unsupported(format!("{:?}", f)),
         }


### PR DESCRIPTION
PR #1314 added encoding support for the AVIF image format. The PR however did not yet include `ImageOutputFormat` support. An `ImageOutputFormat` entry is required when encoding and writing images through `DynamicImage::write_to`. This commit adds an `Avif` entry to the `ImageOutputFormat` enum, and also includes a conversion from an `ImageFormat` to an `ImageOutputFormat`.

---
I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.
