### PR TITLE
Add const implementation for build_huff_lut

### DIFF
--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -11,7 +11,7 @@ use crate::error::{ImageError, ImageResult, ParameterError, ParameterErrorKind, 
 use crate::image::{ImageEncoder, ImageFormat};
 use crate::math::utils::clamp;
 
-use super::entropy::build_huff_lut;
+use super::entropy::build_huff_lut_const;
 use super::transform;
 
 // Markers
@@ -67,6 +67,9 @@ static STD_LUMA_DC_VALUES: [u8; 12] = [
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B,
 ];
 
+static STD_LUMA_DC_HUFF_LUT: [(u8, u16); 256] = build_huff_lut_const(&STD_LUMA_DC_CODE_LENGTHS,
+                                                                      &STD_LUMA_DC_VALUES);
+
 // Code lengths and values for table K.4
 static STD_CHROMA_DC_CODE_LENGTHS: [u8; 16] = [
     0x00, 0x03, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -75,6 +78,9 @@ static STD_CHROMA_DC_CODE_LENGTHS: [u8; 16] = [
 static STD_CHROMA_DC_VALUES: [u8; 12] = [
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B,
 ];
+
+static STD_CHROMA_DC_HUFF_LUT: [(u8, u16); 256] = build_huff_lut_const(&STD_CHROMA_DC_CODE_LENGTHS,
+                                                                      &STD_CHROMA_DC_VALUES);
 
 // Code lengths and values for table k.5
 static STD_LUMA_AC_CODE_LENGTHS: [u8; 16] = [
@@ -95,6 +101,9 @@ static STD_LUMA_AC_VALUES: [u8; 162] = [
     0xF9, 0xFA,
 ];
 
+static STD_LUMA_AC_HUFF_LUT: [(u8, u16); 256] = build_huff_lut_const(&STD_LUMA_AC_CODE_LENGTHS,
+                                                                      &STD_LUMA_AC_VALUES);
+
 // Code lengths and values for table k.6
 static STD_CHROMA_AC_CODE_LENGTHS: [u8; 16] = [
     0x00, 0x02, 0x01, 0x02, 0x04, 0x04, 0x03, 0x04, 0x07, 0x05, 0x04, 0x04, 0x00, 0x01, 0x02, 0x77,
@@ -112,6 +121,9 @@ static STD_CHROMA_AC_VALUES: [u8; 162] = [
     0xE2, 0xE3, 0xE4, 0xE5, 0xE6, 0xE7, 0xE8, 0xE9, 0xEA, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8,
     0xF9, 0xFA,
 ];
+
+static STD_CHROMA_AC_HUFF_LUT: [(u8, u16); 256] = build_huff_lut_const(&STD_CHROMA_AC_CODE_LENGTHS,
+                                                                      &STD_CHROMA_AC_VALUES);
 
 static DCCLASS: u8 = 0;
 static ACCLASS: u8 = 1;
@@ -260,7 +272,7 @@ impl<'a, W: Write + 'a> BitWriter<'a, W> {
 
         Ok(dcval)
     }
-    
+
     fn write_segment(&mut self, marker: u8, data: Option<&[u8]>) -> io::Result<()> {
         self.w.write_all(&[0xFF, marker])?;
 
@@ -361,12 +373,6 @@ impl<'a, W: Write> JpegEncoder<'a, W> {
     /// the quality parameter ```quality``` with a value in the range 1-100
     /// where 1 is the worst and 100 is the best.
     pub fn new_with_quality(w: &mut W, quality: u8) -> JpegEncoder<W> {
-        let ld = build_huff_lut(&STD_LUMA_DC_CODE_LENGTHS, &STD_LUMA_DC_VALUES);
-        let la = build_huff_lut(&STD_LUMA_AC_CODE_LENGTHS, &STD_LUMA_AC_VALUES);
-
-        let cd = build_huff_lut(&STD_CHROMA_DC_CODE_LENGTHS, &STD_CHROMA_DC_VALUES);
-        let ca = build_huff_lut(&STD_CHROMA_AC_CODE_LENGTHS, &STD_CHROMA_AC_VALUES);
-
         let components = vec![
             Component {
                 id: LUMAID,
@@ -420,10 +426,10 @@ impl<'a, W: Write> JpegEncoder<'a, W> {
             components,
             tables,
 
-            luma_dctable: ld,
-            luma_actable: la,
-            chroma_dctable: cd,
-            chroma_actable: ca,
+            luma_dctable: STD_LUMA_DC_HUFF_LUT.to_vec(),
+            luma_actable: STD_LUMA_AC_HUFF_LUT.to_vec(),
+            chroma_dctable: STD_CHROMA_DC_HUFF_LUT.to_vec(),
+            chroma_actable: STD_CHROMA_AC_HUFF_LUT.to_vec(),
 
             pixel_density: PixelDensity::default(),
         }
@@ -894,6 +900,12 @@ mod tests {
     use super::{build_jfif_header, JpegEncoder, PixelDensity};
     use super::super::JpegDecoder;
 
+    #[cfg(feature = "benchmarks")]
+    extern crate test;
+    #[cfg(feature = "benchmarks")]
+    use test::{Bencher};
+
+
     fn decode(encoded: &[u8]) -> Vec<u8> {
         let decoder = JpegDecoder::new(Cursor::new(encoded))
             .expect("Could not decode image");
@@ -1007,4 +1019,14 @@ mod tests {
         assert!(100 < decoded[1] && decoded[1] < 150, "bad green channel in {:?}", &decoded);
         assert!(decoded[2] < 50, "bad blue channel in {:?}", &decoded);
     }
+
+    #[cfg(feature = "benchmarks")]
+    #[bench]
+    fn bench_jpeg_encoder_new(b: &mut Bencher) {
+        b.iter(|| {
+            let mut y = vec![];
+            let x = JpegEncoder::new(&mut y);
+        })
+    }
+
 }

--- a/src/jpeg/entropy.rs
+++ b/src/jpeg/entropy.rs
@@ -1,3 +1,69 @@
+#![feature(const_fn)]
+
+/// Given an array containing the number of codes of each code length,
+/// this function generates the huffman codes lengths and their respective
+/// code lengths as specified by the JPEG spec.
+const fn derive_codes_and_sizes_const(bits: &[u8]) -> ([u8; 256], [u16; 256]) {
+    let mut huffsize = [0u8; 256];
+    let mut huffcode = [0u16; 256];
+
+    let mut k = 0;
+
+    // Annex C.2
+    // Figure C.1
+    // Generate table of individual code lengths
+    let mut i = 0;
+    while i < 16 {
+        let mut j = 0;
+        while j < bits[i as usize] {
+            huffsize[k] = i + 1;
+            k += 1;
+            j += 1;
+        }
+        i += 1;
+    }
+
+    huffsize[k] = 0;
+
+    // Annex C.2
+    // Figure C.2
+    // Generate table of huffman codes
+    k = 0;
+    let mut code = 0u16;
+    let mut size = huffsize[0];
+
+    while huffsize[k] != 0 {
+        huffcode[k] = code;
+        code += 1;
+        k += 1;
+
+        if huffsize[k] == size {
+            continue;
+        }
+
+        // FIXME there is something wrong with this code
+        let diff = huffsize[k].wrapping_sub(size);
+        code = if diff < 16 { code << diff as usize } else { 0 };
+
+        size = size.wrapping_add(diff);
+    }
+
+    (huffsize, huffcode)
+}
+
+pub(crate) const fn build_huff_lut_const(bits: &[u8], huffval: &[u8]) -> [(u8, u16); 256] {
+    let mut lut = [(17u8, 0u16); 256];
+    let (huffsize, huffcode) = derive_codes_and_sizes_const(bits);
+
+    let mut i = 0;
+    while i < huffval.len() {
+        lut[huffval[i] as usize] = (huffsize[i], huffcode[i]);
+        i += 1;
+    }
+
+    lut
+}
+
 /// Given an array containing the number of codes of each code length,
 /// this function generates the huffman codes lengths and their respective
 /// code lengths as specified by the JPEG spec.
@@ -58,4 +124,25 @@ pub(crate) fn build_huff_lut(bits: &[u8], huffval: &[u8]) -> Vec<(u8, u16)> {
     }
 
     lut
+}
+
+#[cfg(test)]
+mod test {
+    // Code lengths and values for table K.4
+    static STD_CHROMA_DC_CODE_LENGTHS: [u8; 16] = [
+        0x00, 0x03, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ];
+
+    static STD_CHROMA_DC_VALUES: [u8; 12] = [
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B,
+    ];
+
+    use super::{build_huff_lut, build_huff_lut_const};
+
+    #[test]
+    fn test_build_huff_lut() {
+        let cd = build_huff_lut(&STD_CHROMA_DC_CODE_LENGTHS, &STD_CHROMA_DC_VALUES);
+        let cd_const = build_huff_lut_const(&STD_CHROMA_DC_CODE_LENGTHS, &STD_CHROMA_DC_VALUES).to_vec();
+        assert_eq!(cd_const, cd);
+    }
 }

--- a/src/jpeg/entropy.rs
+++ b/src/jpeg/entropy.rs
@@ -3,7 +3,7 @@
 /// Given an array containing the number of codes of each code length,
 /// this function generates the huffman codes lengths and their respective
 /// code lengths as specified by the JPEG spec.
-const fn derive_codes_and_sizes_const(bits: &[u8]) -> ([u8; 256], [u16; 256]) {
+const fn derive_codes_and_sizes(bits: &[u8]) -> ([u8; 256], [u16; 256]) {
     let mut huffsize = [0u8; 256];
     let mut huffcode = [0u16; 256];
 
@@ -53,7 +53,7 @@ const fn derive_codes_and_sizes_const(bits: &[u8]) -> ([u8; 256], [u16; 256]) {
 
 pub(crate) const fn build_huff_lut_const(bits: &[u8], huffval: &[u8]) -> [(u8, u16); 256] {
     let mut lut = [(17u8, 0u16); 256];
-    let (huffsize, huffcode) = derive_codes_and_sizes_const(bits);
+    let (huffsize, huffcode) = derive_codes_and_sizes(bits);
 
     let mut i = 0;
     while i < huffval.len() {
@@ -62,57 +62,6 @@ pub(crate) const fn build_huff_lut_const(bits: &[u8], huffval: &[u8]) -> [(u8, u
     }
 
     lut
-}
-
-/// Given an array containing the number of codes of each code length,
-/// this function generates the huffman codes lengths and their respective
-/// code lengths as specified by the JPEG spec.
-fn derive_codes_and_sizes(bits: &[u8]) -> (Vec<u8>, Vec<u16>) {
-    let mut huffsize = vec![0u8; 256];
-    let mut huffcode = vec![0u16; 256];
-
-    let mut k = 0;
-    let mut j;
-
-    // Annex C.2
-    // Figure C.1
-    // Generate table of individual code lengths
-    for i in 0u8..16 {
-        j = 0;
-
-        while j < bits[usize::from(i)] {
-            huffsize[k] = i + 1;
-            k += 1;
-            j += 1;
-        }
-    }
-
-    huffsize[k] = 0;
-
-    // Annex C.2
-    // Figure C.2
-    // Generate table of huffman codes
-    k = 0;
-    let mut code = 0u16;
-    let mut size = huffsize[0];
-
-    while huffsize[k] != 0 {
-        huffcode[k] = code;
-        code += 1;
-        k += 1;
-
-        if huffsize[k] == size {
-            continue;
-        }
-
-        // FIXME there is something wrong with this code
-        let diff = huffsize[k].wrapping_sub(size);
-        code = if diff < 16 { code << diff as usize } else { 0 };
-
-        size = size.wrapping_add(diff);
-    }
-
-    (huffsize, huffcode)
 }
 
 pub(crate) fn build_huff_lut(bits: &[u8], huffval: &[u8]) -> Vec<(u8, u16)> {


### PR DESCRIPTION
This PR adds a const implementation of derive_codes_and_sizes and build_huff_lut - as these functions are typically used on const data - this speeds up JpegEncoder::new / JpegEncoder::new_with_quality by 4x (2250ns -> 500ns), but this is only really significant if you're making many, many small images and creating new encoders for each.

This isn't currently compatible without using nightly on 1.34, but it does compile without nightly on 1.46, so merging this PR would require a bump in the minimum version required. 
