### PR TITLE
Add size information to function signatures, optimize BitWriter in jpeg

### DIFF
--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -215,7 +215,7 @@ impl<'a, W: Write + 'a> BitWriter<'a, W> {
 
     fn write_block(
         &mut self,
-        block: &[i32],
+        block: &[i32; 64],
         prevdc: i32,
         dctable: &[(u8, u16)],
         actable: &[(u8, u16)],

--- a/src/jpeg/transform.rs
+++ b/src/jpeg/transform.rs
@@ -67,7 +67,7 @@ static FIX_2_053119869: i32 = 16_819;
 static FIX_2_562915447: i32 = 20_995;
 static FIX_3_072711026: i32 = 25_172;
 
-pub(crate) fn fdct(samples: &[u8], coeffs: &mut [i32]) {
+pub(crate) fn fdct(samples: &[u8; 64], coeffs: &mut [i32; 64]) {
     // Pass 1: process rows.
     // Results are scaled by sqrt(8) compared to a true DCT
     // furthermore we scale the results by 2**PASS1_BITS


### PR DESCRIPTION
*EDIT: I've expanded the scope of this PR to introduce other optimizations which are related

This PR adds size information to jpeg::fdct, and JpegEncoder::write_block, which always take arrays of size 64, but don't specify this in the function signature.  Specifying that the size of the input slices is 64 allows for aggresive SIMD generation and removal of all bounds checking in these functions - this actually allows the fdct to heavily take advantage of SIMD -though the generated assembly goes from 205 lines to 447, which might be problematic - you can see this for yourself at https://godbolt.org/z/PWG7b9.

Additionally, this BitWriter method, `write_segment(&mut self, marker: u8, data: Option<&[u8]>)` is very odd, and should really be two seperate functions `write_marker(&mut self, marker: u8)` and `write_segment(&mut self, marker: u8, data: &[u8])`. This change makes the code both cleaner, and a lot more compact, since handling None / Some introduces a lot of overhead which introduces a lot of bloat into the resulting assembly.

The performance improvement is noticeable, at a 4.83% decrease in overall benchmark times from the current master, with no observed regressions.

Benchmark time differences:
```
    L8-rawvec/64: -1.026us = -2.931%
    L8-bufvec/64: -1.129us = -3.178%
      L8-file/64: -2.624us = -6.721%
   L8-rawvec/128: -4.410us = -3.342%
   L8-bufvec/128: -4.460us = -3.351%
     L8-file/128: -10.310us = -7.345%
   L8-rawvec/256: -16.160us = -3.121%
   L8-bufvec/256: -16.360us = -3.130%
     L8-file/256: -41.280us = -7.568%
  Rgb8-rawvec/64: -6.212us = -5.966%
  Rgb8-bufvec/64: -4.250us = -4.009%
    Rgb8-file/64: -7.710us = -6.842%
 Rgb8-rawvec/128: -23.740us = -5.835%
 Rgb8-bufvec/128: -19.730us = -4.762%
   Rgb8-file/128: -33.370us = -7.642%
 Rgb8-rawvec/256: -0.094ms = -5.813%
 Rgb8-bufvec/256: -0.074ms = -4.465%
   Rgb8-file/256: -0.134ms = -7.787%
 Rgba8-rawvec/64: -4.869us = -4.779%
 Rgba8-bufvec/64: -2.556us = -2.500%
   Rgba8-file/64: -4.430us = -4.169%
Rgba8-rawvec/128: -5.740us = -1.430%
Rgba8-bufvec/128: -11.660us = -2.893%
  Rgba8-file/128: -21.810us = -5.312%
Rgba8-rawvec/256: -0.102ms = -6.337%
Rgba8-bufvec/256: -0.048ms = -3.007%
  Rgba8-file/256: -0.100ms = -6.077%
                             -4.826%
```

This also removes the use of `byteorder` in jpeg::encoder.rs entirely by removing the last write_u16 and using write_all with .to_be_bytes() instead.