### PR TITLE
Deprecate compound input fn in favor of Reader

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -988,12 +988,13 @@ fn image_to_bytes(image: &DynamicImage) -> Vec<u8> {
 /// content before its path.
 ///
 /// [`io::Reader`]: io/struct.Reader.html
+#[deprecated = "Use `io::Reader`, it combines input functions in more flexible and consistent interface."]
 pub fn open<P>(path: P) -> ImageResult<DynamicImage>
 where
     P: AsRef<Path>,
 {
-    // thin wrapper function to strip generics before calling open_impl
-    free_functions::open_impl(path.as_ref())
+    crate::io::Reader::open(path)?
+        .decode()
 }
 
 /// Read the dimensions of the image located at the specified path.
@@ -1003,12 +1004,13 @@ where
 /// content before its path or manually supplying the format.
 ///
 /// [`io::Reader`]: io/struct.Reader.html
+#[deprecated = "Use `io::Reader`, it combines input functions in more flexible and consistent interface."]
 pub fn image_dimensions<P>(path: P) -> ImageResult<(u32, u32)>
 where
     P: AsRef<Path>,
 {
-    // thin wrapper function to strip generics before calling open_impl
-    free_functions::image_dimensions_impl(path.as_ref())
+    crate::io::Reader::open(path)?
+        .into_dimensions()
 }
 
 /// Saves the supplied buffer to a file at the path specified.
@@ -1063,9 +1065,12 @@ where
 /// Try [`io::Reader`] for more advanced uses.
 ///
 /// [`io::Reader`]: io/struct.Reader.html
+#[deprecated = "Use `io::Reader`, it combines input functions in more flexible and consistent interface."]
 pub fn load_from_memory(buffer: &[u8]) -> ImageResult<DynamicImage> {
-    let format = free_functions::guess_format(buffer)?;
-    load_from_memory_with_format(buffer, format)
+    let b = io::Cursor::new(buffer);
+    crate::io::Reader::new(b)
+        .with_guessed_format()?
+        .decode()
 }
 
 /// Create a new image from a byte slice
@@ -1078,9 +1083,10 @@ pub fn load_from_memory(buffer: &[u8]) -> ImageResult<DynamicImage> {
 /// [`load`]: fn.load.html
 /// [`io::Reader`]: io/struct.Reader.html
 #[inline(always)]
-pub fn load_from_memory_with_format(buf: &[u8], format: ImageFormat) -> ImageResult<DynamicImage> {
-    let b = io::Cursor::new(buf);
-    free_functions::load(b, format)
+#[deprecated = "Use `io::Reader`, it combines input functions in more flexible and consistent interface."]
+pub fn load_from_memory_with_format(buffer: &[u8], format: ImageFormat) -> ImageResult<DynamicImage> {
+    let b = io::Cursor::new(buffer);
+    crate::io::Reader::with_format(b, format).decode()
 }
 
 /// Calculates the width and height an image should be resized to.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,7 @@
 #![cfg_attr(all(test, feature = "benchmarks"), feature(test))]
 // it's a bit of a pain otherwise
 #![allow(clippy::many_single_char_names)]
+#![cfg_attr(test, allow(deprecated))]
 
 #[cfg(all(test, feature = "benchmarks"))]
 extern crate test;
@@ -170,6 +171,7 @@ pub use crate::traits::{EncodableLayout, Primitive, Pixel};
 
 // Opening and loading images
 pub use crate::io::free_functions::{guess_format, load};
+#[allow(deprecated)]
 pub use crate::dynimage::{load_from_memory, load_from_memory_with_format, open,
                    save_buffer, save_buffer_with_format, image_dimensions};
 


### PR DESCRIPTION
Any comments on the questions below are welcome.

In light of #1318 and previously #1291 , #1232 , #1231 , #1072 , #792 (possibly more), I conclude that opening files with the functions in the main module is at least misunderstood but quite possibly a bad interface in itself. It's often not clear how to do combine aspects of these methods by performing parts of them manually—such as how to open a file with a known image type. In that sense these functions are too numerable and too specific at the same time.

`io::Reader` intends to fix this by encapsulating the known inputs as an object and then presenting builder-style methods for adjusting the details, independent of whether one opens a file or reads a slice of data from memory.

This PR intends to deprecate the utility wrappers in `dynimage`, not the primitive methods in `io/free_functions.rs`—`guess_format` and `load`. This was always planned.

The main concern is to find the sweet spot for the scope of the deprecation.
* Are we okay with the set of methods being deprecated?
* Are the replacements actually easy enough to be discovered? Should we add some more documentation concerning this? One particular sore spot might be loading from memory since __no__ method in `Reader` takes a byte slice as input. For new Rusteceans the generics might be unecessarily confusing.
* Should we delay this until a writer has been added?