### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/hdr/decoder.rs
+++ b/src/hdr/decoder.rs
@@ -884,10 +884,10 @@ fn parse_dimensions_line(line: &str, strict: bool) -> ImageResult<(u32, u32)> {
     const DIMENSIONS_COUNT: usize = 4;
 
     let mut dim_parts = line.split_whitespace();
-    let c1_tag = dim_parts.next().ok_or_else(|| DecoderError::DimensionsLineTooShort(0, DIMENSIONS_COUNT))?;
-    let c1_str = dim_parts.next().ok_or_else(|| DecoderError::DimensionsLineTooShort(1, DIMENSIONS_COUNT))?;
-    let c2_tag = dim_parts.next().ok_or_else(|| DecoderError::DimensionsLineTooShort(2, DIMENSIONS_COUNT))?;
-    let c2_str = dim_parts.next().ok_or_else(|| DecoderError::DimensionsLineTooShort(3, DIMENSIONS_COUNT))?;
+    let c1_tag = dim_parts.next().ok_or(DecoderError::DimensionsLineTooShort(0, DIMENSIONS_COUNT))?;
+    let c1_str = dim_parts.next().ok_or(DecoderError::DimensionsLineTooShort(1, DIMENSIONS_COUNT))?;
+    let c2_tag = dim_parts.next().ok_or(DecoderError::DimensionsLineTooShort(2, DIMENSIONS_COUNT))?;
+    let c2_str = dim_parts.next().ok_or(DecoderError::DimensionsLineTooShort(3, DIMENSIONS_COUNT))?;
     if strict && dim_parts.next().is_some() {
         // extra data in dimensions line
         return Err(DecoderError::DimensionsLineTooLong(DIMENSIONS_COUNT).into());

--- a/src/ico/decoder.rs
+++ b/src/ico/decoder.rs
@@ -178,7 +178,7 @@ fn read_entry<R: Read>(r: &mut R) -> ImageResult<DirEntry> {
 
 /// Find the entry with the highest (color depth, size).
 fn best_entry(mut entries: Vec<DirEntry>) -> ImageResult<DirEntry> {
-    let mut best = entries.pop().ok_or_else(|| DecoderError::NoEntries)?;
+    let mut best = entries.pop().ok_or(DecoderError::NoEntries)?;
 
     let mut best_score = (
         best.bits_per_pixel,

--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -400,7 +400,7 @@ impl<'a, W: Write> JpegEncoder<'a, W> {
             200 - scale * 2
         };
 
-        let mut tables = vec![STD_LUMA_QTABLE.clone(), STD_CHROMA_QTABLE.clone()];
+        let mut tables = vec![STD_LUMA_QTABLE, STD_CHROMA_QTABLE];
         tables.iter_mut().for_each(|t|
             t.iter_mut().for_each(|v| {
                 *v = clamp(

--- a/src/jpeg/encoder.rs
+++ b/src/jpeg/encoder.rs
@@ -688,7 +688,7 @@ impl<'a, W: Write> ImageEncoder for JpegEncoder<'a, W> {
 
 fn build_jfif_header(m: &mut Vec<u8>, density: PixelDensity) {
     m.clear();
-    m.extend_from_slice("JFIF".as_bytes());
+    m.extend_from_slice(b"JFIF");
     m.extend_from_slice(&[0, 0x01, 0x02,
         match density.unit {
         PixelDensityUnit::PixelAspectRatio => 0x00,

--- a/src/webp/vp8.rs
+++ b/src/webp/vp8.rs
@@ -1292,7 +1292,7 @@ impl<R: Read> Vp8Decoder<R> {
             let luma = self.b
                 .read_with_tree(&KEYFRAME_YMODE_TREE, &KEYFRAME_YMODE_PROBS, 0);
             mb.luma_mode = LumaMode::from_i8(luma)
-                .ok_or_else(|| DecoderError::LumaPredictionModeInvalid(luma))?;
+                .ok_or(DecoderError::LumaPredictionModeInvalid(luma))?;
 
             match mb.luma_mode.into_intra() {
                 // `LumaMode::B` - This is predicted individually
@@ -1307,7 +1307,7 @@ impl<R: Read> Vp8Decoder<R> {
                                 0,
                             );
                             let bmode = IntraMode::from_i8(intra)
-                                .ok_or_else(|| DecoderError::IntraPredictionModeInvalid(intra))?;
+                                .ok_or(DecoderError::IntraPredictionModeInvalid(intra))?;
                             mb.bpred[x + y * 4] = bmode;
 
                             self.top[mbx].bpred[12 + x] = bmode;
@@ -1326,7 +1326,7 @@ impl<R: Read> Vp8Decoder<R> {
             let chroma = self.b
                 .read_with_tree(&KEYFRAME_UV_MODE_TREE, &KEYFRAME_UV_MODE_PROBS, 0);
             mb.chroma_mode = ChromaMode::from_i8(chroma)
-                .ok_or_else(|| DecoderError::ChromaPredictionModeInvalid(chroma))?;
+                .ok_or(DecoderError::ChromaPredictionModeInvalid(chroma))?;
         }
 
         self.top[mbx].chroma_mode = mb.chroma_mode;


### PR DESCRIPTION
Fixing these clippy warnings makes the code cleaner and more readable, and in some cases improves performance (particularly, fixing unnecessary lazy evaluation by changing `ok_or_else` to `ok_or` (well, maybe not, because the compiler may be smart enough to optimise them out)).

