### PR TITLE
Fix clippy warnings (requires higher rustc version)

### DIFF
--- a/src/pnm/decoder.rs
+++ b/src/pnm/decoder.rs
@@ -616,10 +616,7 @@ impl<R: Read> PnmDecoder<R> {
 fn read_separated_ascii<T: FromStr<Err = ParseIntError>>(reader: &mut dyn Read) -> ImageResult<T>
     where T::Err: Display
 {
-    let is_separator = |v: &u8| match *v {
-        b'\t' | b'\n' | b'\x0b' | b'\x0c' | b'\r' | b' ' => true,
-        _ => false,
-    };
+    let is_separator = |v: &u8| matches! { *v, b'\t' | b'\n' | b'\x0b' | b'\x0c' | b'\r' | b' ' };
 
     let token = reader
         .bytes()

--- a/src/tga/header.rs
+++ b/src/tga/header.rs
@@ -41,29 +41,22 @@ impl ImageType {
 
     /// Check if the image format uses colors as opposed to gray scale.
     pub(crate) fn is_color(&self) -> bool {
-        match *self {
+        matches! { *self,
             ImageType::RawColorMap
             | ImageType::RawTrueColor
             | ImageType::RunTrueColor
-            | ImageType::RunColorMap => true,
-            _ => false,
+            | ImageType::RunColorMap
         }
     }
 
     /// Does the image use a color map.
     pub(crate) fn is_color_mapped(&self) -> bool {
-        match *self {
-            ImageType::RawColorMap | ImageType::RunColorMap => true,
-            _ => false,
-        }
+        matches! { *self, ImageType::RawColorMap | ImageType::RunColorMap }
     }
 
     /// Is the image run length encoded.
     pub(crate) fn is_encoded(&self) -> bool {
-        match *self {
-            ImageType::RunColorMap | ImageType::RunTrueColor | ImageType::RunGrayScale => true,
-            _ => false,
-        }
+        matches! {*self, ImageType::RunColorMap | ImageType::RunTrueColor | ImageType::RunGrayScale }
     }
 }
 


### PR DESCRIPTION
Fix clippy warnings, but these changes are not compatible with the current minimal rust version. See: https://github.com/image-rs/image/pull/1331#issuecomment-706098502
