### PR TITLE
Reduce copying in src/png.rs

### DIFF
--- a/src/png.rs
+++ b/src/png.rs
@@ -93,8 +93,13 @@ impl<R: Read> Read for PngReader<R> {
 
     fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
         let mut bytes = self.buffer.len();
-        buf.extend_from_slice(&self.buffer);
-        self.buffer = Vec::new();
+        if buf.is_empty() {
+            std::mem::swap(&mut self.buffer, buf);
+        } else {
+            buf.extend_from_slice(&self.buffer);
+            self.buffer.clear();
+        }
+
         self.index = 0;
 
         while let Some(row) = self.reader.next_row()? {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -165,13 +165,13 @@ pub trait Pixel: Copy + Clone {
     /// Returns a view into a slice.
     ///
     /// Note: The slice length is not checked on creation. Thus the caller has to ensure
-    /// that the slice is long enough to present panics if the pixel is used later on.
+    /// that the slice is long enough to prevent panics if the pixel is used later on.
     fn from_slice(slice: &[Self::Subpixel]) -> &Self;
 
     /// Returns mutable view into a mutable slice.
     ///
     /// Note: The slice length is not checked on creation. Thus the caller has to ensure
-    /// that the slice is long enough to present panics if the pixel is used later on.
+    /// that the slice is long enough to prevent panics if the pixel is used later on.
     fn from_slice_mut(slice: &mut [Self::Subpixel]) -> &mut Self;
 
     /// Convert this pixel to RGB


### PR DESCRIPTION
Most of the time we read data into an empty vector. So intead of always copying by `extend_from_slice` and emptying `self.buffer`, just `mem::swap()` them when `buf` is empty (which is the common case).