### PR TITLE
Deprecate clamp function

### DIFF
--- a/src/codecs/jpeg/encoder.rs
+++ b/src/codecs/jpeg/encoder.rs
@@ -8,7 +8,7 @@ use num_iter::range_step;
 use crate::{Bgr, Bgra, ColorType, GenericImageView, ImageBuffer, Luma, LumaA, Pixel, Rgb, Rgba};
 use crate::error::{ImageError, ImageResult, ParameterError, ParameterErrorKind, UnsupportedError, UnsupportedErrorKind};
 use crate::image::{ImageEncoder, ImageFormat};
-use crate::math::utils::clamp;
+use crate::utils::clamp;
 
 use super::entropy::build_huff_lut;
 use super::transform;

--- a/src/codecs/webp/vp8.rs
+++ b/src/codecs/webp/vp8.rs
@@ -23,7 +23,7 @@ use crate::error::{
 };
 use crate::image::ImageFormat;
 
-use crate::math::utils::clamp;
+use crate::utils::clamp;
 
 const MAX_SEGMENTS: usize = 4;
 const NUM_DCT_TOKENS: usize = 12;

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -7,7 +7,7 @@ use crate::color::{Luma, Rgba};
 use crate::image::{GenericImage, GenericImageView};
 #[allow(deprecated)]
 use crate::math::nq;
-use crate::math::utils::clamp;
+use crate::utils::clamp;
 use crate::traits::{Pixel, Primitive};
 use crate::ImageBuffer;
 

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -9,7 +9,7 @@ use num_traits::{NumCast, ToPrimitive, Zero};
 
 use crate::ImageBuffer;
 use crate::image::GenericImageView;
-use crate::math::utils::clamp;
+use crate::utils::clamp;
 use crate::traits::{Enlargeable, Pixel, Primitive};
 
 /// Available Sampling Filters.

--- a/src/math/utils.rs
+++ b/src/math/utils.rs
@@ -10,6 +10,7 @@
 /// assert_eq!(utils::clamp(15, 0, 10), 10);
 /// ```
 #[inline]
+#[deprecated]
 pub fn clamp<N>(a: N, min: N, max: N) -> N
 where
     N: PartialOrd,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -113,6 +113,20 @@ pub struct NonExhaustiveMarker {
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum Empty { }
 
+#[inline]
+pub(crate) fn clamp<N>(a: N, min: N, max: N) -> N
+where
+    N: PartialOrd,
+{
+    if a < min {
+        min
+    } else if a > max {
+        max
+    } else {
+        a
+    }
+}
+
 #[cfg(test)]
 mod test {
     #[test]


### PR DESCRIPTION
The _clamp_ function can easily be implemented with an `if` statement. There is no need for it to be part of image's public API. Since the function is internally used by the crate, I added an implementation to our internal utils module and converted all instances to use that instead.