### PR TITLE
Upgrade tiff to 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: rust
+dist: focal
 sudo: false
 notifications:
   webhooks:
@@ -41,6 +42,12 @@ matrix:
     - os: linux
       rust: stable
       env: FEATURES='ravif'
+      before_install:
+        - sudo apt-get update && 
+          sudo apt-get -y install nasm;
+      script:
+        - cargo test -v --no-default-features --features "$FEATURES" &&
+          cargo doc -v --no-default-features --features "$FEATURES";
     - os: osx
       rust: 1.34.2
     - os: windows

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ gif = { version = "0.11.1", optional = true }
 jpeg = { package = "jpeg-decoder", version = "0.1.17", default-features = false, optional = true }
 png = { version = "0.16.5", optional = true }
 scoped_threadpool = { version = "0.1", optional = true }
-tiff = { version = "0.5.0", optional = true }
+tiff = { version = "0.6.0", optional = true }
 ravif = { version = "0.6.0", optional = true }
 rgb = { version = "0.8.25", optional = true }
 color_quant = "1.1"

--- a/src/codecs/tiff.rs
+++ b/src/codecs/tiff.rs
@@ -147,6 +147,8 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for TiffDecoder<R> {
             tiff::decoder::DecodingResult::U16(v) => utils::vec_u16_into_u8(v),
             tiff::decoder::DecodingResult::U32(v) => utils::vec_u32_into_u8(v),
             tiff::decoder::DecodingResult::U64(v) => utils::vec_u64_into_u8(v),
+            tiff::decoder::DecodingResult::F32(v) => bytemuck::cast_slice::<f32, u8>(v.as_slice()).to_owned(),
+            tiff::decoder::DecodingResult::F64(v) => bytemuck::cast_slice::<f64, u8>(v.as_slice()).to_owned(),
         };
 
         Ok(TiffReader(Cursor::new(buf), PhantomData))
@@ -169,6 +171,12 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for TiffDecoder<R> {
                 buf.copy_from_slice(bytemuck::cast_slice(&v));
             }
             tiff::decoder::DecodingResult::U64(v) => {
+                buf.copy_from_slice(bytemuck::cast_slice(&v));
+            }
+            tiff::decoder::DecodingResult::F32(v) => {
+                buf.copy_from_slice(bytemuck::cast_slice(&v));
+            }
+            tiff::decoder::DecodingResult::F64(v) => {
                 buf.copy_from_slice(bytemuck::cast_slice(&v));
             }
         }


### PR DESCRIPTION
I'm not sure if we should forbid the floating point color types `Rgb{,a}{F32,F64}` more explicitly for now but `bytemuck` makes it painless to defined the buffer conversion, even though our own `ColorType` does not support those buffers yet.