### PR TITLE
Add bit-depth specific `into_` and `to_` DynamicImage conversion methods

### DIFF
--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -358,15 +358,15 @@ impl<R: Read> ApngDecoder<R> {
         let source = match self.inner.color_type {
             ColorType::L8 => {
                 let image = ImageBuffer::<Luma<_>, _>::from_raw(width, height, buffer).unwrap();
-                DynamicImage::ImageLuma8(image).into_rgba()
+                DynamicImage::ImageLuma8(image).into_rgba8()
             }
             ColorType::La8 => {
                 let image = ImageBuffer::<LumaA<_>, _>::from_raw(width, height, buffer).unwrap();
-                DynamicImage::ImageLumaA8(image).into_rgba()
+                DynamicImage::ImageLumaA8(image).into_rgba8()
             }
             ColorType::Rgb8 => {
                 let image = ImageBuffer::<Rgb<_>, _>::from_raw(width, height, buffer).unwrap();
-                DynamicImage::ImageRgb8(image).into_rgba()
+                DynamicImage::ImageRgb8(image).into_rgba8()
             }
             ColorType::Rgba8 => {
                 ImageBuffer::<Rgba<_>, _>::from_raw(width, height, buffer).unwrap()

--- a/src/color.rs
+++ b/src/color.rs
@@ -521,6 +521,46 @@ impl FromColor<LumaA<u16>> for Luma<u8> {
     }
 }
 
+impl FromColor<LumaA<u8>> for Luma<u16> {
+    fn from_color(&mut self, other: &LumaA<u8>) {
+        let la8 = other.channels();
+        let gray = self.channels_mut();
+        gray[0] = upcast_channel(la8[0]);
+    }
+}
+
+impl FromColor<Rgb<u8>> for Luma<u16> {
+    fn from_color(&mut self, other: &Rgb<u8>) {
+        let rgb = other.channels();
+        let gray = self.channels_mut();
+        gray[0] = upcast_channel(rgb_to_luma(rgb));
+    }
+}
+
+impl FromColor<Rgba<u8>> for Luma<u16> {
+    fn from_color(&mut self, other: &Rgba<u8>) {
+        let rgba = other.channels();
+        let gray = self.channels_mut();
+        gray[0] = upcast_channel(rgb_to_luma(rgba));
+    }
+}
+
+impl FromColor<Bgr<u8>> for Luma<u16> {
+    fn from_color(&mut self, other: &Bgr<u8>) {
+        let bgr = other.channels();
+        let gray = self.channels_mut();
+        gray[0] = upcast_channel(bgr_to_luma(bgr));
+    }
+}
+
+impl FromColor<Bgra<u8>> for Luma<u16> {
+    fn from_color(&mut self, other: &Bgra<u8>) {
+        let bgra = other.channels();
+        let gray = self.channels_mut();
+        gray[0] = upcast_channel(bgr_to_luma(bgra));
+    }
+}
+
 
 // `FromColor` for LumaA
 
@@ -585,6 +625,51 @@ impl FromColor<LumaA<u8>> for LumaA<u16> {
         let alpha = other.channels()[1];
         la8[0] = upcast_channel(gray);
         la8[1] = upcast_channel(alpha);
+    }
+}
+
+impl FromColor<Luma<u8>> for LumaA<u16> {
+    fn from_color(&mut self, other: &Luma<u8>) {
+        let l8 = other.channels()[0];
+        let gray_a = self.channels_mut();
+        gray_a[0] = upcast_channel(l8);
+        gray_a[1] = u16::max_value();
+    }
+}
+
+impl FromColor<Rgb<u8>> for LumaA<u16> {
+    fn from_color(&mut self, other: &Rgb<u8>) {
+        let rgb = other.channels();
+        let gray_a = self.channels_mut();
+        gray_a[0] = upcast_channel(rgb_to_luma(rgb));
+        gray_a[1] = u16::max_value();
+    }
+}
+
+impl FromColor<Rgba<u8>> for LumaA<u16> {
+    fn from_color(&mut self, other: &Rgba<u8>) {
+        let rgba = other.channels();
+        let gray_a = self.channels_mut();
+        gray_a[0] = upcast_channel(rgb_to_luma(rgba));
+        gray_a[1] = upcast_channel(rgba[3]);
+    }
+}
+
+impl FromColor<Bgr<u8>> for LumaA<u16> {
+    fn from_color(&mut self, other: &Bgr<u8>) {
+        let bgr = other.channels();
+        let gray_a = self.channels_mut();
+        gray_a[0] = upcast_channel(bgr_to_luma(bgr));
+        gray_a[1] = u16::max_value();
+    }
+}
+
+impl FromColor<Bgra<u8>> for LumaA<u16> {
+    fn from_color(&mut self, other: &Bgra<u8>) {
+        let bgra = other.channels();
+        let gray_a = self.channels_mut();
+        gray_a[0] = upcast_channel(bgr_to_luma(bgra));
+        gray_a[1] = upcast_channel(bgra[3]);
     }
 }
 
@@ -668,6 +753,63 @@ impl FromColor<Rgba<u8>> for Rgba<u16> {
     }
 }
 
+impl FromColor<LumaA<u8>> for Rgba<u16> {
+    fn from_color(&mut self, other: &LumaA<u8>) {
+        let la8 = other.channels();
+        let gray = upcast_channel(la8[0]);
+        let alpha = upcast_channel(la8[1]);
+        let rgba = self.channels_mut();
+        rgba[0] = gray;
+        rgba[1] = gray;
+        rgba[2] = gray;
+        rgba[3] = alpha;
+    }
+}
+
+impl FromColor<Rgb<u8>> for Rgba<u16> {
+    fn from_color(&mut self, other: &Rgb<u8>) {
+        let rgb = other.channels();
+        let rgba = self.channels_mut();
+        rgba[0] = upcast_channel(rgb[0]);
+        rgba[1] = upcast_channel(rgb[1]);
+        rgba[2] = upcast_channel(rgb[2]);
+        rgba[3] = u16::max_value();
+    }
+}
+
+impl FromColor<Luma<u8>> for Rgba<u16> {
+    fn from_color(&mut self, other: &Luma<u8>) {
+        let l8 = other.channels();
+        let rgba = self.channels_mut();
+        let gray = upcast_channel(l8[0]);
+        rgba[0] = gray;
+        rgba[1] = gray;
+        rgba[2] = gray;
+        rgba[3] = u16::max_value();
+    }
+}
+
+impl FromColor<Bgr<u8>> for Rgba<u16> {
+    fn from_color(&mut self, other: &Bgr<u8>) {
+        let bgr = other.channels();
+        let rgba = self.channels_mut();
+        rgba[0] = upcast_channel(bgr[2]);
+        rgba[1] = upcast_channel(bgr[1]);
+        rgba[2] = upcast_channel(bgr[0]);
+        rgba[3] = u16::max_value();
+    }
+}
+
+impl FromColor<Bgra<u8>> for Rgba<u16> {
+    fn from_color(&mut self, other: &Bgra<u8>) {
+        let bgra = other.channels();
+        let rgba = self.channels_mut();
+        rgba[0] = upcast_channel(bgra[2]);
+        rgba[1] = upcast_channel(bgra[1]);
+        rgba[2] = upcast_channel(bgra[0]);
+        rgba[3] = upcast_channel(bgra[3]);
+    }
+}
 
 // `FromColor` for BGRA
 
@@ -792,6 +934,58 @@ impl FromColor<Rgb<u8>> for Rgb<u16> {
         for (c8, &c16) in self.channels_mut().iter_mut().zip(other.channels()) {
             *c8 = upcast_channel(c16);
         }
+    }
+}
+
+impl FromColor<LumaA<u8>> for Rgb<u16> {
+    fn from_color(&mut self, other: &LumaA<u8>) {
+        let la8 = other.channels();
+        let gray = upcast_channel(la8[0]);
+        let rgb = self.channels_mut();
+        rgb[0] = gray;
+        rgb[1] = gray;
+        rgb[2] = gray;
+    }
+}
+
+impl FromColor<Rgba<u8>> for Rgb<u16> {
+    fn from_color(&mut self, other: &Rgba<u8>) {
+        let rgba = other.channels();
+        let rgb = self.channels_mut();
+        rgb[0] = upcast_channel(rgba[0]);
+        rgb[1] = upcast_channel(rgba[1]);
+        rgb[2] = upcast_channel(rgba[2]);
+    }
+}
+
+impl FromColor<Luma<u8>> for Rgb<u16> {
+    fn from_color(&mut self, other: &Luma<u8>) {
+        let l8 = other.channels();
+        let rgb = self.channels_mut();
+        let gray = upcast_channel(l8[0]);
+        rgb[0] = gray;
+        rgb[1] = gray;
+        rgb[2] = gray;
+    }
+}
+
+impl FromColor<Bgr<u8>> for Rgb<u16> {
+    fn from_color(&mut self, other: &Bgr<u8>) {
+        let bgr = other.channels();
+        let rgb = self.channels_mut();
+        rgb[0] = upcast_channel(bgr[2]);
+        rgb[1] = upcast_channel(bgr[1]);
+        rgb[2] = upcast_channel(bgr[0]);
+    }
+}
+
+impl FromColor<Bgra<u8>> for Rgb<u16> {
+    fn from_color(&mut self, other: &Bgra<u8>) {
+        let bgra = other.channels();
+        let rgb = self.channels_mut();
+        rgb[0] = upcast_channel(bgra[2]);
+        rgb[1] = upcast_channel(bgra[1]);
+        rgb[2] = upcast_channel(bgra[0]);
     }
 }
 

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -194,42 +194,118 @@ impl DynamicImage {
     }
 
     /// Returns a copy of this image as an RGB image.
+    #[deprecated = "replaced by `to_rgb8`"]
     pub fn to_rgb(&self) -> RgbImage {
         dynamic_map!(*self, ref p -> {
             p.convert()
         })
     }
 
+    /// Returns a copy of this image as an RGB image.
+    pub fn to_rgb8(&self) -> RgbImage {
+        dynamic_map!(*self, ref p -> {
+            p.convert()
+        })
+    }
+
+    /// Returns a copy of this image as an RGB image.
+    pub fn to_rgb16(&self) -> Rgb16Image {
+        dynamic_map!(*self, ref p -> {
+            p.convert()
+        })
+    }
+
     /// Returns a copy of this image as an RGBA image.
+    #[deprecated = "replaced by `to_rgba8`"]
     pub fn to_rgba(&self) -> RgbaImage {
         dynamic_map!(*self, ref p -> {
             p.convert()
         })
     }
 
+    /// Returns a copy of this image as an RGBA image.
+    pub fn to_rgba8(&self) -> RgbaImage {
+        dynamic_map!(*self, ref p -> {
+            p.convert()
+        })
+    }
+
+    /// Returns a copy of this image as an RGBA image.
+    pub fn to_rgba16(&self) -> Rgba16Image {
+        dynamic_map!(*self, ref p -> {
+            p.convert()
+        })
+    }
+
     /// Returns a copy of this image as an BGR image.
+    #[deprecated = "replaced by `to_bgr8`"]
     pub fn to_bgr(&self) -> BgrImage {
         dynamic_map!(*self, ref p -> {
             p.convert()
         })
     }
 
+    /// Returns a copy of this image as an BGR image.
+    pub fn to_bgr8(&self) -> BgrImage {
+        dynamic_map!(*self, ref p -> {
+            p.convert()
+        })
+    }
+
     /// Returns a copy of this image as an BGRA image.
+    #[deprecated = "replaced by `to_bgra8`"]
     pub fn to_bgra(&self) -> BgraImage {
         dynamic_map!(*self, ref p -> {
             p.convert()
         })
     }
 
+    /// Returns a copy of this image as an BGRA image.
+    pub fn to_bgra8(&self) -> BgraImage {
+        dynamic_map!(*self, ref p -> {
+            p.convert()
+        })
+    }
+
     /// Returns a copy of this image as a Luma image.
+    #[deprecated = "replaced by `to_luma8`"]
     pub fn to_luma(&self) -> GrayImage {
         dynamic_map!(*self, ref p -> {
             p.convert()
         })
     }
 
+    /// Returns a copy of this image as a Luma image.
+    pub fn to_luma8(&self) -> GrayImage {
+        dynamic_map!(*self, ref p -> {
+            p.convert()
+        })
+    }
+
+    /// Returns a copy of this image as a Luma image.
+    pub fn to_luma16(&self) -> Gray16Image {
+        dynamic_map!(*self, ref p -> {
+            p.convert()
+        })
+    }
+
     /// Returns a copy of this image as a LumaA image.
+    #[deprecated = "replaced by `to_luma_alpha8`"]
     pub fn to_luma_alpha(&self) -> GrayAlphaImage {
+        dynamic_map!(*self, ref p -> {
+            p.convert()
+        })
+    }
+
+    /// Returns a copy of this image as a LumaA image.
+    pub fn to_luma_alpha8(&self) -> GrayAlphaImage {
+        dynamic_map!(*self, ref p -> {
+            p.convert()
+        })
+    }
+
+    /// Returns a copy of this image as a LumaA image.
+    pub fn to_luma_alpha16(&self) -> GrayAlpha16Image {
         dynamic_map!(*self, ref p -> {
             p.convert()
         })
@@ -239,10 +315,33 @@ impl DynamicImage {
     ///
     /// If the image was already the correct format, it is returned as is.
     /// Otherwise, a copy is created.
+    #[deprecated = "replaced by `into_rgb8`"]
     pub fn into_rgb(self) -> RgbImage {
         match self {
             DynamicImage::ImageRgb8(x) => x,
-            x => x.to_rgb(),
+            x => x.to_rgb8(),
+        }
+    }
+
+    /// Consume the image and returns a RGB image.
+    ///
+    /// If the image was already the correct format, it is returned as is.
+    /// Otherwise, a copy is created.
+    pub fn into_rgb8(self) -> RgbImage {
+        match self {
+            DynamicImage::ImageRgb8(x) => x,
+            x => x.to_rgb8(),
+        }
+    }
+
+    /// Consume the image and returns a RGB image.
+    ///
+    /// If the image was already the correct format, it is returned as is.
+    /// Otherwise, a copy is created.
+    pub fn into_rgb16(self) -> Rgb16Image {
+        match self {
+            DynamicImage::ImageRgb16(x) => x,
+            x => x.to_rgb16(),
         }
     }
 
@@ -250,10 +349,33 @@ impl DynamicImage {
     ///
     /// If the image was already the correct format, it is returned as is.
     /// Otherwise, a copy is created.
+    #[deprecated = "replaced by `into_rgba8`"]
     pub fn into_rgba(self) -> RgbaImage {
         match self {
             DynamicImage::ImageRgba8(x) => x,
-            x => x.to_rgba(),
+            x => x.to_rgba8(),
+        }
+    }
+
+    /// Consume the image and returns a RGBA image.
+    ///
+    /// If the image was already the correct format, it is returned as is.
+    /// Otherwise, a copy is created.
+    pub fn into_rgba8(self) -> RgbaImage {
+        match self {
+            DynamicImage::ImageRgba8(x) => x,
+            x => x.to_rgba8(),
+        }
+    }
+
+    /// Consume the image and returns a RGBA image.
+    ///
+    /// If the image was already the correct format, it is returned as is.
+    /// Otherwise, a copy is created.
+    pub fn into_rgba16(self) -> Rgba16Image {
+        match self {
+            DynamicImage::ImageRgba16(x) => x,
+            x => x.to_rgba16(),
         }
     }
 
@@ -261,10 +383,36 @@ impl DynamicImage {
     ///
     /// If the image was already the correct format, it is returned as is.
     /// Otherwise, a copy is created.
+    #[deprecated = "replaced by `into_bgra8`"]
     pub fn into_bgr(self) -> BgrImage {
         match self {
             DynamicImage::ImageBgr8(x) => x,
-            x => x.to_bgr(),
+            x => x.to_bgr8(),
+        }
+    }
+
+    /// Consume the image and returns a BGR image.
+    ///
+    /// If the image was already the correct format, it is returned as is.
+    /// Otherwise, a copy is created.
+    pub fn into_bgr8(self) -> BgrImage {
+        match self {
+            DynamicImage::ImageBgr8(x) => x,
+            x => x.to_bgr8(),
+        }
+    }
+
+    // NOTE: DynamicImage::ImageBgr16 variant does not currently exist, so there is no `into_bgr16`
+
+    /// Consume the image and returns a BGRA image.
+    ///
+    /// If the image was already the correct format, it is returned as is.
+    /// Otherwise, a copy is created.
+    #[deprecated = "replaced by `into_bgra8`"]
+    pub fn into_bgra(self) -> BgraImage {
+        match self {
+            DynamicImage::ImageBgra8(x) => x,
+            x => x.to_bgra8(),
         }
     }
 
@@ -272,10 +420,24 @@ impl DynamicImage {
     ///
     /// If the image was already the correct format, it is returned as is.
     /// Otherwise, a copy is created.
-    pub fn into_bgra(self) -> BgraImage {
+    pub fn into_bgra8(self) -> BgraImage {
         match self {
             DynamicImage::ImageBgra8(x) => x,
-            x => x.to_bgra(),
+            x => x.to_bgra8(),
+        }
+    }
+
+    // NOTE: DynamicImage::ImageBgra16 variant does not currently exist, so there is no `into_bgra16`
+
+    /// Consume the image and returns a Luma image.
+    ///
+    /// If the image was already the correct format, it is returned as is.
+    /// Otherwise, a copy is created.
+    #[deprecated = "replaced by `into_luma8`"]
+    pub fn into_luma(self) -> GrayImage {
+        match self {
+            DynamicImage::ImageLuma8(x) => x,
+            x => x.to_luma8(),
         }
     }
 
@@ -283,10 +445,21 @@ impl DynamicImage {
     ///
     /// If the image was already the correct format, it is returned as is.
     /// Otherwise, a copy is created.
-    pub fn into_luma(self) -> GrayImage {
+    pub fn into_luma8(self) -> GrayImage {
         match self {
             DynamicImage::ImageLuma8(x) => x,
-            x => x.to_luma(),
+            x => x.to_luma8(),
+        }
+    }
+
+    /// Consume the image and returns a Luma image.
+    ///
+    /// If the image was already the correct format, it is returned as is.
+    /// Otherwise, a copy is created.
+    pub fn into_luma16(self) -> Gray16Image {
+        match self {
+            DynamicImage::ImageLuma16(x) => x,
+            x => x.to_luma16(),
         }
     }
 
@@ -294,10 +467,33 @@ impl DynamicImage {
     ///
     /// If the image was already the correct format, it is returned as is.
     /// Otherwise, a copy is created.
+    #[deprecated = "replaced by `into_luma_alpha8`"]
     pub fn into_luma_alpha(self) -> GrayAlphaImage {
         match self {
             DynamicImage::ImageLumaA8(x) => x,
-            x => x.to_luma_alpha(),
+            x => x.to_luma_alpha8(),
+        }
+    }
+
+    /// Consume the image and returns a LumaA image.
+    ///
+    /// If the image was already the correct format, it is returned as is.
+    /// Otherwise, a copy is created.
+    pub fn into_luma_alpha8(self) -> GrayAlphaImage {
+        match self {
+            DynamicImage::ImageLumaA8(x) => x,
+            x => x.to_luma_alpha8(),
+        }
+    }
+
+    /// Consume the image and returns a LumaA image.
+    ///
+    /// If the image was already the correct format, it is returned as is.
+    /// Otherwise, a copy is created.
+    pub fn into_luma_alpha16(self) -> GrayAlpha16Image {
+        match self {
+            DynamicImage::ImageLumaA16(x) => x,
+            x => x.to_luma_alpha16(),
         }
     }
 


### PR DESCRIPTION
I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

---

This PR introduces additional color conversion when the source and destination bit-depth differs. The `DynamicImage` `to_` and `into_` methods have been made consistent by specifying the bit-depth in the name and deprecating the originals. Notably, some of the `Bgr[a]16` conversion methods are missing due to `DynamicImage` having no variant for them.

This addresses the primary concern from #1347, but does not address the return type inconsistency. Some of the type aliases used in the method signatures are private, which results in the documentation being inconsistent. I've decided to leave that change for a separate PR. 

