### PR TITLE
Add copyless DynamicImage to byte slice/vec conversion

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -699,7 +699,9 @@ impl DynamicImage {
         image_as_bytes(self)
     }
 
-    /// Return this image's pixels as a byte vector.
+    /// Return this image's pixels as a byte vector. If the `ImageBuffer`
+    /// container is `Vec<u8>`, this operation is free. Otherwise, a copy
+    /// is returned.
     pub fn into_bytes(self) -> Vec<u8> {
         image_into_bytes(self)
     }
@@ -1188,15 +1190,6 @@ fn image_to_bytes(image: &DynamicImage) -> Vec<u8> {
 }
 
 fn image_into_bytes(image: DynamicImage) -> Vec<u8> {
-    fn cast_vec(mut src: Vec<u16>) -> Vec<u8> {
-        unsafe {
-            let len = 2 * src.len();
-            let cap = 2 * src.capacity();
-            let ptr = src.as_mut_ptr();
-            std::mem::forget(src);
-            Vec::from_raw_parts(ptr as *mut u8, len, cap)
-        }
-    }
     match image {
         DynamicImage::ImageLuma8(a) => a.into_raw(),
         DynamicImage::ImageLumaA8(a) => a.into_raw(),
@@ -1204,10 +1197,10 @@ fn image_into_bytes(image: DynamicImage) -> Vec<u8> {
         DynamicImage::ImageRgba8(a) => a.into_raw(),
         DynamicImage::ImageBgr8(a) => a.into_raw(),
         DynamicImage::ImageBgra8(a) => a.into_raw(),
-        DynamicImage::ImageLuma16(a) => cast_vec(a.into_raw()),
-        DynamicImage::ImageLumaA16(a) => cast_vec(a.into_raw()),
-        DynamicImage::ImageRgb16(a) => cast_vec(a.into_raw()),
-        DynamicImage::ImageRgba16(a) => cast_vec(a.into_raw()),
+        DynamicImage::ImageLuma16(_) => image.to_bytes(),
+        DynamicImage::ImageLumaA16(_) => image.to_bytes(),
+        DynamicImage::ImageRgb16(_) => image.to_bytes(),
+        DynamicImage::ImageRgba16(_) => image.to_bytes(),
     }
 }
 

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -1214,16 +1214,16 @@ fn image_into_bytes(image: DynamicImage) -> Vec<u8> {
 fn image_as_bytes(image: &DynamicImage) -> &[u8] {
     use bytemuck::cast_slice;
     match image {
-        DynamicImage::ImageLuma8(a) => &a.as_flat_samples().samples,
-        DynamicImage::ImageLumaA8(a) => &a.as_flat_samples().samples,
-        DynamicImage::ImageRgb8(a) => &a.as_flat_samples().samples,
-        DynamicImage::ImageRgba8(a) => &a.as_flat_samples().samples,
-        DynamicImage::ImageBgr8(a) => &a.as_flat_samples().samples,
-        DynamicImage::ImageBgra8(a) => &a.as_flat_samples().samples,
-        DynamicImage::ImageLuma16(a) => cast_slice(&a.as_flat_samples().samples),
-        DynamicImage::ImageLumaA16(a) => cast_slice(&a.as_flat_samples().samples),
-        DynamicImage::ImageRgb16(a) => cast_slice(&a.as_flat_samples().samples),
-        DynamicImage::ImageRgba16(a) => cast_slice(&a.as_flat_samples().samples),
+        DynamicImage::ImageLuma8(a) => &*a,
+        DynamicImage::ImageLumaA8(a) => &*a,
+        DynamicImage::ImageRgb8(a) => &*a,
+        DynamicImage::ImageRgba8(a) => &*a,
+        DynamicImage::ImageBgr8(a) => &*a,
+        DynamicImage::ImageBgra8(a) => &*a,
+        DynamicImage::ImageLuma16(a) => cast_slice(&*a),
+        DynamicImage::ImageLumaA16(a) => cast_slice(&*a),
+        DynamicImage::ImageRgb16(a) => cast_slice(&*a),
+        DynamicImage::ImageRgba16(a) => cast_slice(&*a),
     }
 }
 

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -694,7 +694,7 @@ impl DynamicImage {
         }
     }
 
-    /// Return this image's pixels as a byte slice.
+    /// Return this image's pixels as a native endian byte slice.
     pub fn as_bytes(&self) -> &[u8] {
         image_as_bytes(self)
     }

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -1212,13 +1212,7 @@ fn image_into_bytes(image: DynamicImage) -> Vec<u8> {
 }
 
 fn image_as_bytes(image: &DynamicImage) -> &[u8] {
-    fn cast_slice(src: &[u16]) -> &[u8] {
-        unsafe {
-            let len = 2 * src.len();
-            let ptr = src.as_ptr();
-            std::slice::from_raw_parts(ptr as *const u8, len)
-        }
-    }
+    use bytemuck::cast_slice;
     match image {
         DynamicImage::ImageLuma8(a) => &a.as_flat_samples().samples,
         DynamicImage::ImageLumaA8(a) => &a.as_flat_samples().samples,


### PR DESCRIPTION
Adds `DynamicImage::into_bytes(self)` and `DynamicImage::as_bytes(&self)`. 

The primary motivation for this was needing the underlying storage buffer as a `byte` vector without having to create a copy using `to_bytes`. I added `as_bytes` as an extra convenience. 