### PR TITLE
Move the dynimage::resize_dimensions function to math::utils

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -35,6 +35,7 @@ use crate::image::{GenericImage, GenericImageView, ImageDecoder, ImageFormat, Im
 use crate::image::ImageEncoder;
 use crate::io::free_functions;
 use crate::imageops;
+use crate::math::resize_dimensions;
 use crate::traits::Pixel;
 
 /// A Dynamic Image
@@ -1322,46 +1323,6 @@ pub fn load_from_memory_with_format(buf: &[u8], format: ImageFormat) -> ImageRes
     free_functions::load(b, format)
 }
 
-/// Calculates the width and height an image should be resized to.
-/// This preserves aspect ratio, and based on the `fill` parameter
-/// will either fill the dimensions to fit inside the smaller constraint
-/// (will overflow the specified bounds on one axis to preserve
-/// aspect ratio), or will shrink so that both dimensions are
-/// completely contained with in the given `width` and `height`,
-/// with empty space on one axis.
-fn resize_dimensions(width: u32, height: u32, nwidth: u32, nheight: u32, fill: bool) -> (u32, u32) {
-    let ratio = u64::from(width) * u64::from(nheight);
-    let nratio = u64::from(nwidth) * u64::from(height);
-
-    let use_width = if fill {
-        nratio > ratio
-    } else {
-        nratio <= ratio
-    };
-    let intermediate = if use_width {
-        u64::from(height) * u64::from(nwidth) / u64::from(width)
-    } else {
-        u64::from(width) * u64::from(nheight) / u64::from(height)
-    };
-    if use_width {
-        if intermediate <= u64::from(::std::u32::MAX) {
-            (nwidth, intermediate as u32)
-        } else {
-            (
-                (u64::from(nwidth) * u64::from(::std::u32::MAX) / intermediate) as u32,
-                ::std::u32::MAX,
-            )
-        }
-    } else if intermediate <= u64::from(::std::u32::MAX) {
-        (intermediate as u32, nheight)
-    } else {
-        (
-            ::std::u32::MAX,
-            (u64::from(nheight) * u64::from(::std::u32::MAX) / intermediate) as u32,
-        )
-    }
-}
-
 #[cfg(test)]
 mod bench {
     #[cfg(feature = "benchmarks")]
@@ -1381,44 +1342,6 @@ mod test {
     #[test]
     fn test_empty_file() {
         assert!(super::load_from_memory(b"").is_err());
-    }
-
-    quickcheck! {
-        fn resize_bounds_correctly_width(old_w: u32, new_w: u32) -> bool {
-            if old_w == 0 || new_w == 0 { return true; }
-            let result = super::resize_dimensions(old_w, 400, new_w, ::std::u32::MAX, false);
-            result.0 == new_w && result.1 == (400 as f64 * new_w as f64 / old_w as f64) as u32
-        }
-    }
-
-    quickcheck! {
-        fn resize_bounds_correctly_height(old_h: u32, new_h: u32) -> bool {
-            if old_h == 0 || new_h == 0 { return true; }
-            let result = super::resize_dimensions(400, old_h, ::std::u32::MAX, new_h, false);
-            result.1 == new_h && result.0 == (400 as f64 * new_h as f64 / old_h as f64) as u32
-        }
-    }
-
-    #[test]
-    fn resize_handles_fill() {
-        let result = super::resize_dimensions(100, 200, 200, 500, true);
-        assert!(result.0 == 250);
-        assert!(result.1 == 500);
-
-        let result = super::resize_dimensions(200, 100, 500, 200, true);
-        assert!(result.0 == 500);
-        assert!(result.1 == 250);
-    }
-
-    #[test]
-    fn resize_handles_overflow() {
-        let result = super::resize_dimensions(100, ::std::u32::MAX, 200, ::std::u32::MAX, true);
-        assert!(result.0 == 100);
-        assert!(result.1 == ::std::u32::MAX);
-
-        let result = super::resize_dimensions(::std::u32::MAX, 100, ::std::u32::MAX, 200, true);
-        assert!(result.0 == ::std::u32::MAX);
-        assert!(result.1 == 100);
     }
 
     #[cfg(feature = "jpeg")]

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -4,3 +4,4 @@ pub mod utils;
 
 mod rect;
 pub use self::rect::Rect;
+pub(crate) use self::utils::resize_dimensions;

--- a/src/math/utils.rs
+++ b/src/math/utils.rs
@@ -23,3 +23,84 @@ where
     }
     a
 }
+
+/// Calculates the width and height an image should be resized to.
+/// This preserves aspect ratio, and based on the `fill` parameter
+/// will either fill the dimensions to fit inside the smaller constraint
+/// (will overflow the specified bounds on one axis to preserve
+/// aspect ratio), or will shrink so that both dimensions are
+/// completely contained with in the given `width` and `height`,
+/// with empty space on one axis.
+pub(crate) fn resize_dimensions(width: u32, height: u32, nwidth: u32, nheight: u32, fill: bool) -> (u32, u32) {
+    let ratio = u64::from(width) * u64::from(nheight);
+    let nratio = u64::from(nwidth) * u64::from(height);
+
+    let use_width = if fill {
+        nratio > ratio
+    } else {
+        nratio <= ratio
+    };
+    let intermediate = if use_width {
+        u64::from(height) * u64::from(nwidth) / u64::from(width)
+    } else {
+        u64::from(width) * u64::from(nheight) / u64::from(height)
+    };
+    if use_width {
+        if intermediate <= u64::from(::std::u32::MAX) {
+            (nwidth, intermediate as u32)
+        } else {
+            (
+                (u64::from(nwidth) * u64::from(::std::u32::MAX) / intermediate) as u32,
+                ::std::u32::MAX,
+            )
+        }
+    } else if intermediate <= u64::from(::std::u32::MAX) {
+        (intermediate as u32, nheight)
+    } else {
+        (
+            ::std::u32::MAX,
+            (u64::from(nheight) * u64::from(::std::u32::MAX) / intermediate) as u32,
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    quickcheck! {
+        fn resize_bounds_correctly_width(old_w: u32, new_w: u32) -> bool {
+            if old_w == 0 || new_w == 0 { return true; }
+            let result = super::resize_dimensions(old_w, 400, new_w, ::std::u32::MAX, false);
+            result.0 == new_w && result.1 == (400 as f64 * new_w as f64 / old_w as f64) as u32
+        }
+    }
+
+    quickcheck! {
+        fn resize_bounds_correctly_height(old_h: u32, new_h: u32) -> bool {
+            if old_h == 0 || new_h == 0 { return true; }
+            let result = super::resize_dimensions(400, old_h, ::std::u32::MAX, new_h, false);
+            result.1 == new_h && result.0 == (400 as f64 * new_h as f64 / old_h as f64) as u32
+        }
+    }
+
+    #[test]
+    fn resize_handles_fill() {
+        let result = super::resize_dimensions(100, 200, 200, 500, true);
+        assert!(result.0 == 250);
+        assert!(result.1 == 500);
+
+        let result = super::resize_dimensions(200, 100, 500, 200, true);
+        assert!(result.0 == 500);
+        assert!(result.1 == 250);
+    }
+
+    #[test]
+    fn resize_handles_overflow() {
+        let result = super::resize_dimensions(100, ::std::u32::MAX, 200, ::std::u32::MAX, true);
+        assert!(result.0 == 100);
+        assert!(result.1 == ::std::u32::MAX);
+
+        let result = super::resize_dimensions(::std::u32::MAX, 100, ::std::u32::MAX, 200, true);
+        assert!(result.0 == ::std::u32::MAX);
+        assert!(result.1 == 100);
+    }
+}


### PR DESCRIPTION
Note that math::utils::resize_dimensions() is crate public.
We don't want to expose it outside of this crate in its current form.

Relates to https://github.com/image-rs/image/issues/1354



I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.