### PR TITLE
add public resize_to_fit and resize_to_fill utility functions

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -35,7 +35,7 @@ use crate::image::{GenericImage, GenericImageView, ImageDecoder, ImageFormat, Im
 use crate::image::ImageEncoder;
 use crate::io::free_functions;
 use crate::imageops;
-use crate::math::resize_dimensions;
+use crate::math;
 use crate::traits::Pixel;
 
 /// A Dynamic Image
@@ -756,7 +756,7 @@ impl DynamicImage {
     /// within the bounds specified by ```nwidth``` and ```nheight```.
     pub fn resize(&self, nwidth: u32, nheight: u32, filter: imageops::FilterType) -> DynamicImage {
         let (width2, height2) =
-            resize_dimensions(self.width(), self.height(), nwidth, nheight, false);
+            math::resize_to_fit((self.width(), self.height()), (nwidth, nheight));
 
         self.resize_exact(width2, height2, filter)
     }
@@ -783,7 +783,7 @@ impl DynamicImage {
     /// May give aliasing artifacts if new size is close to old size.
     pub fn thumbnail(&self, nwidth: u32, nheight: u32) -> DynamicImage {
         let (width2, height2) =
-            resize_dimensions(self.width(), self.height(), nwidth, nheight, false);
+            math::resize_to_fit((self.width(), self.height()), (nwidth, nheight));
         self.thumbnail_exact(width2, height2)
     }
 
@@ -810,7 +810,7 @@ impl DynamicImage {
         filter: imageops::FilterType,
     ) -> DynamicImage {
         let (width2, height2) =
-            resize_dimensions(self.width(), self.height(), nwidth, nheight, true);
+            math::resize_to_fill((self.width(), self.height()), (nwidth, nheight));
 
         let mut intermediate = self.resize_exact(width2, height2, filter);
         let (iwidth, iheight) = intermediate.dimensions();

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -4,4 +4,5 @@ pub mod utils;
 
 mod rect;
 pub use self::rect::Rect;
-pub(crate) use self::utils::resize_dimensions;
+
+pub use self::utils::{resize_to_fit, resize_to_fill};

--- a/src/math/utils.rs
+++ b/src/math/utils.rs
@@ -24,6 +24,18 @@ where
     a
 }
 
+/// Resizes the given size to fit into a new size while preserving the aspect ratio.
+/// The returned size can be smaller than the requested size in one or the other dimension.
+pub fn resize_to_fit(size: (u32, u32), new_size: (u32, u32)) -> (u32, u32) {
+    resize_dimensions(size.0, size.1, new_size.0, new_size.1, false)
+}
+
+/// Resizes the given size to fill a new size while preserving the aspect ratio.
+/// The returned size can be larger than the requested size in one or the other dimension.
+pub fn resize_to_fill(size: (u32, u32), new_size: (u32, u32)) -> (u32, u32) {
+    resize_dimensions(size.0, size.1, new_size.0, new_size.1, true)
+}
+
 /// Calculates the width and height an image should be resized to.
 /// This preserves aspect ratio, and based on the `fill` parameter
 /// will either fill the dimensions to fit inside the smaller constraint
@@ -31,7 +43,7 @@ where
 /// aspect ratio), or will shrink so that both dimensions are
 /// completely contained with in the given `width` and `height`,
 /// with empty space on one axis.
-pub(crate) fn resize_dimensions(width: u32, height: u32, nwidth: u32, nheight: u32, fill: bool) -> (u32, u32) {
+fn resize_dimensions(width: u32, height: u32, nwidth: u32, nheight: u32, fill: bool) -> (u32, u32) {
     let ratio = u64::from(width) * u64::from(nheight);
     let nratio = u64::from(nwidth) * u64::from(height);
 


### PR DESCRIPTION
Proposed API would look like this:
```
/// Resizes the given size to fit into a new size while preserving the aspect ratio.
/// The returned size can be smaller than the requested size in one or the other dimension.
pub fn resize_to_fit(size: (u32, u32), new_size: (u32, u32)) -> (u32, u32) {
    resize_dimensions(size.0, size.1, new_size.0, new_size.1, false)
}

/// Resizes the given size to fill a new size while preserving the aspect ratio.
/// The returned size can be larger than the requested size in one or the other dimension.
pub fn resize_to_fill(size: (u32, u32), new_size: (u32, u32)) -> (u32, u32) {
    resize_dimensions(size.0, size.1, new_size.0, new_size.1, true)
}
```
Feel free to comment/suggest alternatives.

If this API is validated, I'll rewrite the functions to get rid of the old `resize_dimensions` function.