### PR TITLE
Fix warnings in reference_images tests and unignore them

### DIFF
--- a/tests/reference_images.rs
+++ b/tests/reference_images.rs
@@ -46,7 +46,7 @@ fn render_images() {
     process_images(IMAGE_DIR, None, |base, path, decoder| {
         println!("render_images {}", path.display());
         let img = match image::open(&path) {
-            Ok(img) => img.to_rgba(),
+            Ok(img) => img.to_rgba8(),
             // Do not fail on unsupported error
             // This might happen because the testsuite contains unsupported images
             // or because a specific decoder included via a feature.
@@ -156,7 +156,7 @@ fn check_references() {
         println!("check_references {}", path.display());
 
         let ref_img = match image::open(&path) {
-            Ok(img) => img.to_rgba(),
+            Ok(img) => img.to_rgba8(),
             // Do not fail on unsupported error
             // This might happen because the testsuite contains unsupported images
             // or because a specific decoder included via a feature.
@@ -257,7 +257,7 @@ fn check_references() {
             ReferenceTestKind::SingleImage => {
                 // Read the input file as a single image
                 match image::open(&img_path) {
-                    Ok(img) => test_img = Some(img.to_rgba()),
+                    Ok(img) => test_img = Some(img.to_rgba8()),
                     // Do not fail on unsupported error
                     // This might happen because the testsuite contains unsupported images
                     // or because a specific decoder included via a feature.

--- a/tests/truncate_images.rs
+++ b/tests/truncate_images.rs
@@ -48,55 +48,46 @@ fn truncate_images(decoder: &str) {
 }
 
 #[test]
-#[ignore]
 fn truncate_tga() {
     truncate_images("tga")
 }
 
 #[test]
-#[ignore]
 fn truncate_tiff() {
     truncate_images("tiff")
 }
 
 #[test]
-#[ignore]
 fn truncate_png() {
     truncate_images("png")
 }
 
 #[test]
-#[ignore]
 fn truncate_gif() {
     truncate_images("gif")
 }
 
 #[test]
-#[ignore]
 fn truncate_bmp() {
     truncate_images("bmp")
 }
 
 #[test]
-#[ignore]
 fn truncate_ico() {
     truncate_images("ico")
 }
 
 #[test]
-#[ignore]
 fn truncate_jpg() {
     truncate_images("jpg")
 }
 
 #[test]
-#[ignore]
 fn truncate_hdr() {
     truncate_images("hdr");
 }
 
 #[test]
-#[ignore]
 fn truncate_farbfeld() {
     truncate_images("farbfeld");
 }


### PR DESCRIPTION
The second patch might be better served as just unignoring these tests, since I don't really see why they *are* ignored, it's not like they take an exorbitant amount of time to build or run (`time cargo test -- --ignored` says real 0m5.351s, user 0m14.907s, sys 0m1.250s for me on a pre-compiled run), and being missed in an API transition indicates that they will likely be missed again, later, with potentially more consequences.