### PR TITLE
Fix the crash when decoding TGA  with color map.

### DIFF
--- a/examples/opening.rs
+++ b/examples/opening.rs
@@ -11,7 +11,8 @@ fn main() {
     let file = if env::args().count() == 2 {
         env::args().nth(1).unwrap()
     } else {
-        panic!("Please enter a file")
+        //panic!("Please enter a file")
+        "tests/images/tga/testsuite/ccm8.tga".to_string()
     };
 
     // Use the open function to load an image from a Path.

--- a/src/codecs/tga/header.rs
+++ b/src/codecs/tga/header.rs
@@ -40,6 +40,13 @@ impl ImageType {
         }
     }
 
+    pub(crate) fn is_gray(&self) -> bool {
+        match *self {
+            ImageType::RawGrayScale | ImageType::RunGrayScale => true,
+            _ => false,
+        }
+    }
+
     /// Check if the image format uses colors as opposed to gray scale.
     pub(crate) fn is_color(&self) -> bool {
         match *self {

--- a/src/codecs/tga/header.rs
+++ b/src/codecs/tga/header.rs
@@ -8,6 +8,7 @@ use std::io::{Read, Write};
 pub(crate) const ALPHA_BIT_MASK: u8 = 0b1111;
 pub(crate) const SCREEN_ORIGIN_BIT_MASK: u8 = 0b10_0000;
 
+#[derive(PartialEq)]
 pub(crate) enum ImageType {
     NoImageData = 0,
     /// Uncompressed images.


### PR DESCRIPTION
<!-- 
If you are a new contributor, consent to licensing by including this text:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

Thank you for contributing, you can delete this comment.
-->

Fix #1363 
