### PR TITLE
Add Default to the Primitive trait

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -27,7 +27,7 @@ impl EncodableLayout for [u16] {
 }
 
 /// Primitive trait from old stdlib
-pub trait Primitive: Copy + NumCast + Num + PartialOrd<Self> + Clone + Bounded {}
+pub trait Primitive: Copy + NumCast + Num + PartialOrd<Self> + Clone + Bounded + Default {}
 
 impl Primitive for usize {}
 impl Primitive for u8 {}


### PR DESCRIPTION
I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

This is strictly speaking a breaking change, but since `Primitive` already requires `NumCast`, you can always implement `Default` by doing the equivalent of `<MyPrimitive as NumCast>::from(0)`.