### PR TITLE
Fix tga decoder that decodes color map and 16-bit depth format

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -938,6 +938,21 @@ where
     }
 }
 
+impl<P, Container> Default for ImageBuffer<P, Container>
+where
+    P: Pixel,
+    Container: Default,
+{
+    fn default() -> Self {
+        Self {
+            width: Default::default(),
+            height: Default::default(),
+            _phantom: PhantomData,
+            data: Default::default(),
+        }
+    }
+}
+
 impl<P, Container> Deref for ImageBuffer<P, Container>
 where
     P: Pixel + 'static,
@@ -1296,7 +1311,7 @@ pub(crate) type GrayAlpha16Image = ImageBuffer<LumaA<u16>, Vec<u16>>;
 #[cfg(test)]
 mod test {
     use super::{ImageBuffer, RgbImage};
-    use crate::color;
+    use crate::{color, Rgb};
 
     #[test]
     /// Tests if image buffers from slices work
@@ -1368,6 +1383,12 @@ mod test {
 
         assert_eq!(image.rows().count(), 1);
         assert_eq!(image.rows_mut().count(), 1);
+    }
+
+    #[test]
+    fn default() {
+        let image = ImageBuffer::<Rgb<u8>, Vec<u8>>::default();
+        assert_eq!(image.dimensions(), (0, 0));
     }
 }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -945,8 +945,8 @@ where
 {
     fn default() -> Self {
         Self {
-            width: Default::default(),
-            height: Default::default(),
+            width: 0,
+            height: 0,
             _phantom: PhantomData,
             data: Default::default(),
         }

--- a/src/codecs/avif/mod.rs
+++ b/src/codecs/avif/mod.rs
@@ -49,7 +49,7 @@ impl<W: Write> AvifEncoder<W> {
     pub fn write_image_with_speed_quality(mut self, data: &[u8], width: u32, height: u32, color: ColorType, quality: u8, speed: u8) -> ImageResult<()> {
         // Clamp quality and speed to range
         let quality = max(0, min(quality, 100));
-        let speed = max(1, min(speed, 10));
+        let speed = max(0, min(speed, 10));
 
         let config = self.config(color, quality, speed);
         // `ravif` needs strongly typed data so let's convert. We can either use a temporarily

--- a/src/codecs/avif/mod.rs
+++ b/src/codecs/avif/mod.rs
@@ -48,7 +48,7 @@ impl<W: Write> AvifEncoder<W> {
     /// conversion may be more efficient.
     pub fn write_image_with_speed_quality(mut self, data: &[u8], width: u32, height: u32, color: ColorType, quality: u8, speed: u8) -> ImageResult<()> {
         // Clamp quality and speed to range
-        let quality = max(1, min(quality, 100));
+        let quality = max(0, min(quality, 100));
         let speed = max(1, min(speed, 10));
 
         let config = self.config(color, quality, speed);

--- a/src/codecs/avif/mod.rs
+++ b/src/codecs/avif/mod.rs
@@ -33,8 +33,9 @@ impl<W: Write> AvifEncoder<W> {
         AvifEncoder::new_with_speed_quality(w, 1, 100)
     }
 
-    /// Create a new encoder with specified speed and quality,
-    /// that writes its output to `w`.
+    /// Create a new encoder with specified speed and quality, that writes its output to `w`.
+    /// `speed` accepts a value in the range 0-10, where 0 is the slowest and 10 is the fastest.
+    /// `quality` accepts a value in the range 0-100, where 0 is the worst and 100 is the best.
     pub fn new_with_speed_quality(w: W, speed: u8, quality: u8) -> Self {
         // Clamp quality and speed to range
         let quality = min(quality, 100);

--- a/src/codecs/tga/decoder.rs
+++ b/src/codecs/tga/decoder.rs
@@ -1,4 +1,4 @@
-use super::header::{Header, ImageType, ALPHA_BIT_MASK, SCREEN_ORIGIN_BIT_MASK};
+use super::header::{Header, ImageType, SCREEN_ORIGIN_BIT_MASK};
 use crate::{
     color::{ColorType, ExtendedColorType},
     error::{ImageError, ImageResult, UnsupportedError, UnsupportedErrorKind},
@@ -125,45 +125,21 @@ impl<R: Read + Seek> TgaDecoder<R> {
             ));
         }
 
-        let num_alpha_bits = self.header.image_desc & ALPHA_BIT_MASK;
-
-        let other_channel_bits = if self.header.map_type != 0 {
-            self.header.map_entry_size
-        } else {
-            if num_alpha_bits > self.header.pixel_depth {
-                return Err(ImageError::Unsupported(
-                    UnsupportedError::from_format_and_kind(
-                        ImageFormat::Tga.into(),
-                        UnsupportedErrorKind::Color(ExtendedColorType::Unknown(
-                            self.header.pixel_depth,
-                        )),
-                    ),
-                ));
+        if self.image_type.is_gray() {
+            self.color_type = if self.header.pixel_depth == 8 {
+                ColorType::L8
+            } else {
+                ColorType::La8
             }
-
-            self.header.pixel_depth - num_alpha_bits
-        };
-        let color = self.image_type.is_color();
-
-        match (num_alpha_bits, other_channel_bits, color) {
-            // really, the encoding is BGR and BGRA, this is fixed
-            // up with `TgaDecoder::reverse_encoding`.
-            (0, 32, true) => self.color_type = ColorType::Rgba8,
-            (8, 24, true) => self.color_type = ColorType::Rgba8,
-            (0, 24, true) => self.color_type = ColorType::Rgb8,
-            (8, 8, false) => self.color_type = ColorType::La8,
-            (0, 8, false) => self.color_type = ColorType::L8,
-            _ => {
-                return Err(ImageError::Unsupported(
-                    UnsupportedError::from_format_and_kind(
-                        ImageFormat::Tga.into(),
-                        UnsupportedErrorKind::Color(ExtendedColorType::Unknown(
-                            self.header.pixel_depth,
-                        )),
-                    ),
-                ))
+        } else if self.image_type.is_color() {
+            // 8 bits and 16 bits images will be converted to 24 bits
+            self.color_type = if self.header.pixel_depth <= 24 {
+                ColorType::Rgb8
+            } else {
+                ColorType::Rgba8
             }
         }
+
         Ok(())
     }
 
@@ -286,13 +262,14 @@ impl<R: Read + Seek> TgaDecoder<R> {
     /// the blue and red bytes in the `pixels` array.
     fn reverse_encoding(&mut self, pixels: &mut [u8]) {
         // We only need to reverse the encoding of color images
-        match self.color_type {
-            ColorType::Rgb8 | ColorType::Rgba8 => {
-                for chunk in pixels.chunks_mut(self.bytes_per_pixel) {
-                    chunk.swap(0, 2);
-                }
-            }
-            _ => {}
+        let chunk_size = match self.color_type {
+            ColorType::Rgb8 => 3,
+            ColorType::Rgba8 => 4,
+            _ => return,
+        };
+
+        for chunk in pixels.chunks_mut(chunk_size) {
+            chunk.swap(0, 2);
         }
     }
 
@@ -365,6 +342,20 @@ impl<R: Read + Seek> TgaDecoder<R> {
     }
 }
 
+fn bgr555_to_888(raw: &[u8]) -> [u8; 3] {
+    assert_eq!(raw.len(), 2);
+
+    let c = ((raw[1] as u16) << 8) | raw[0] as u16;
+    let p = 0b_1111_1111 as f32 / 0b_1_1111 as f32;
+
+    [
+        // ARGB
+        (((c & 0b_0000_0000_0001_1111) >> 0) as f32 * p) as u8,
+        (((c & 0b_0000_0011_1110_0000) >> 5) as f32 * p) as u8,
+        (((c & 0b_0111_1100_0000_0000) >> 10) as f32 * p) as u8,
+    ]
+}
+
 impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for TgaDecoder<R> {
     type Reader = TGAReader<R>;
 
@@ -393,10 +384,11 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for TgaDecoder<R> {
         assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
 
         // read the pixels from the data region
-        let len = if self.image_type.is_encoded() {
+        let mut len = if self.image_type.is_encoded() {
             let pixel_data = self.read_all_encoded_data()?;
-            buf[0..pixel_data.len()].copy_from_slice(&pixel_data);
-            pixel_data.len()
+            let len = pixel_data.len();
+            buf[0..len].copy_from_slice(&pixel_data);
+            len
         } else {
             let num_raw_bytes = self.width * self.height * self.bytes_per_pixel;
             self.r.by_ref().read_exact(&mut buf[0..num_raw_bytes])?;
@@ -406,6 +398,20 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for TgaDecoder<R> {
         // expand the indices using the color map if necessary
         if self.image_type.is_color_mapped() {
             let pixel_data = self.expand_color_map(&buf[0..len]);
+            len = pixel_data.len();
+            buf[0..len].copy_from_slice(&pixel_data);
+        }
+
+        // convert bgr555 to bgr888 if necessary
+        if self.color_type == ColorType::Rgb8
+            && (self.bytes_per_pixel == 2
+                || (self.image_type.is_color_mapped()
+                    && ((self.header.map_entry_size + 7) / 8) == 2))
+        {
+            let mut pixel_data = Vec::with_capacity(self.total_bytes() as usize);
+            for chunk in buf[0..len].chunks(2) {
+                pixel_data.extend(bgr555_to_888(chunk).iter());
+            }
             buf.copy_from_slice(&pixel_data);
         }
 

--- a/src/codecs/tga/header.rs
+++ b/src/codecs/tga/header.rs
@@ -39,6 +39,13 @@ impl ImageType {
         }
     }
 
+    pub(crate) fn is_gray(&self) -> bool {
+        match *self {
+            ImageType::RawGrayScale | ImageType::RunGrayScale => true,
+            _ => false,
+        }
+    }
+
     /// Check if the image format uses colors as opposed to gray scale.
     pub(crate) fn is_color(&self) -> bool {
         match *self {

--- a/src/math/utils.rs
+++ b/src/math/utils.rs
@@ -45,6 +45,7 @@ pub(crate) fn resize_dimensions(width: u32, height: u32, nwidth: u32, nheight: u
     } else {
         u64::from(width) * u64::from(nheight) / u64::from(height)
     };
+    let intermediate = std::cmp::max(1, intermediate);
     if use_width {
         if intermediate <= u64::from(::std::u32::MAX) {
             (nwidth, intermediate as u32)
@@ -91,6 +92,13 @@ mod test {
         let result = super::resize_dimensions(200, 100, 500, 200, true);
         assert!(result.0 == 500);
         assert!(result.1 == 250);
+    }
+
+    #[test]
+    fn resize_never_rounds_to_zero() {
+        let result = super::resize_dimensions(1, 150, 128, 128, false);
+        assert!(result.0 > 0);
+        assert!(result.1 > 0);
     }
 
     #[test]


### PR DESCRIPTION
<!-- 
If you are a new contributor, consent to licensing by including this text:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

Thank you for contributing, you can delete this comment.
-->

Fix #1363 , and continue pr  #1369 

Fix tga decoder that decodes color map and 16-bit depth format.
Again, it passed the regression test :)

---

Sorry, I am not very skilled in operating the PR.