### PR TITLE
Add write_image_with_speed_quality function.

### DIFF
--- a/src/codecs/avif/mod.rs
+++ b/src/codecs/avif/mod.rs
@@ -49,7 +49,7 @@ impl<W: Write> AvifEncoder<W> {
     pub fn write_image_with_speed_quality(mut self, data: &[u8], width: u32, height: u32, color: ColorType, quality: u8, speed: u8) -> ImageResult<()> {
         // Clamp quality and speed to range
         let quality = max(0, min(quality, 100));
-        let speed = max(1, min(speed, 10));
+        let speed = max(0, min(speed, 10));
 
         let config = self.config(color, quality, speed);
         // `ravif` needs strongly typed data so let's convert. We can either use a temporarily

--- a/src/codecs/avif/mod.rs
+++ b/src/codecs/avif/mod.rs
@@ -48,7 +48,7 @@ impl<W: Write> AvifEncoder<W> {
     /// conversion may be more efficient.
     pub fn write_image_with_speed_quality(mut self, data: &[u8], width: u32, height: u32, color: ColorType, quality: u8, speed: u8) -> ImageResult<()> {
         // Clamp quality and speed to range
-        let quality = max(1, min(quality, 100));
+        let quality = max(0, min(quality, 100));
         let speed = max(1, min(speed, 10));
 
         let config = self.config(color, quality, speed);

--- a/src/codecs/avif/mod.rs
+++ b/src/codecs/avif/mod.rs
@@ -33,8 +33,9 @@ impl<W: Write> AvifEncoder<W> {
         AvifEncoder::new_with_speed_quality(w, 1, 100)
     }
 
-    /// Create a new encoder with specified speed and quality,
-    /// that writes its output to `w`.
+    /// Create a new encoder with specified speed and quality, that writes its output to `w`.
+    /// `speed` accepts a value in the range 0-10, where 0 is the slowest and 10 is the fastest.
+    /// `quality` accepts a value in the range 0-100, where 0 is the worst and 100 is the best.
     pub fn new_with_speed_quality(w: W, speed: u8, quality: u8) -> Self {
         // Clamp quality and speed to range
         let quality = min(quality, 100);


### PR DESCRIPTION
A draft change to add an additional method to avif to allow writing an image while specifying the quality and speed. It's a bit messy with the number of arguments, but shouldn't break any existing apis.

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

