### PR TITLE
Add ARGB ColorType

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1299,6 +1299,8 @@ pub type GrayAlphaImage = ImageBuffer<LumaA<u8>, Vec<u8>>;
 pub(crate) type BgrImage = ImageBuffer<Bgr<u8>, Vec<u8>>;
 /// Sendable Bgr + alpha channel image buffer
 pub(crate) type BgraImage = ImageBuffer<Bgra<u8>, Vec<u8>>;
+/// Sendable Argb image buffer
+pub(crate) type ArgbImage = ImageBuffer<Argb<u8>, Vec<u8>>;
 /// Sendable 16-bit Rgb image buffer
 pub(crate) type Rgb16Image = ImageBuffer<Rgb<u16>, Vec<u16>>;
 /// Sendable 16-bit Rgb + alpha channel image buffer
@@ -1307,6 +1309,8 @@ pub(crate) type Rgba16Image = ImageBuffer<Rgba<u16>, Vec<u16>>;
 pub(crate) type Gray16Image = ImageBuffer<Luma<u16>, Vec<u16>>;
 /// Sendable 16-bit grayscale + alpha channel image buffer
 pub(crate) type GrayAlpha16Image = ImageBuffer<LumaA<u16>, Vec<u16>>;
+/// Sendable 16-bit ARGB buffer
+pub(crate) type Argb16Image = ImageBuffer<Argb<u16>, Vec<u16>>;
 
 #[cfg(test)]
 mod test {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -6,7 +6,7 @@ use std::ops::{Deref, DerefMut, Index, IndexMut, Range};
 use std::path::Path;
 use std::slice::{ChunksExact, ChunksExactMut};
 
-use crate::color::{FromColor, Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
+use crate::color::{FromColor, Luma, LumaA, Rgb, Rgba, Bgr, Bgra, Argb};
 use crate::flat::{FlatSamples, SampleLayout};
 use crate::dynimage::{save_buffer, save_buffer_with_format};
 use crate::error::ImageResult;

--- a/src/color.rs
+++ b/src/color.rs
@@ -1007,6 +1007,19 @@ impl FromColor<Argb<u16>> for Argb<u8> {
     }
 }
 
+impl FromColor<Argb<u8>> for Argb<u16> {
+    fn from_color(&mut self, other: &Argb<u8>) {
+        let argb = self.channels_mut();
+        let argb8 = other.channels();
+        argb[0] = upcast_channel(argb8[0]);
+        argb[1] = upcast_channel(argb8[1]);
+        argb[2] = upcast_channel(argb8[2]);
+        argb[3] = upcast_channel(argb8[3]);
+
+    }
+}
+
+
 impl FromColor<Rgba<u8>> for Argb<u16> {
     fn from_color(&mut self, other: &Rgba<u8>) {
         let argb = self.channels_mut();
@@ -1020,17 +1033,6 @@ impl FromColor<Rgba<u8>> for Argb<u16> {
 }
 
 
-impl FromColor<Argb<u8>> for Argb<u16> {
-    fn from_color(&mut self, other: &Argb<u8>) {
-        let argb = self.channels_mut();
-        let argb8 = other.channels();
-        argb[0] = upcast_channel(argb8[0]);
-        argb[1] = upcast_channel(argb8[1]);
-        argb[2] = upcast_channel(argb8[2]);
-        argb[3] = upcast_channel(argb8[3]);
-
-    }
-}
 
 impl FromColor<LumaA<u8>> for Argb<u16> {
     fn from_color(&mut self, other: &LumaA<u8>) {
@@ -1386,10 +1388,12 @@ macro_rules! downcast_bit_depth_early {
 downcast_bit_depth_early!(Luma, Luma, LumaA);
 downcast_bit_depth_early!(Rgb, Rgb, LumaA);
 downcast_bit_depth_early!(Rgba, Rgba, LumaA);
+downcast_bit_depth_early!(Argb, Argb, LumaA);
 // Rgb
 downcast_bit_depth_early!(Luma, Luma, Rgb);
 downcast_bit_depth_early!(LumaA, LumaA, Rgb);
 downcast_bit_depth_early!(Rgba, Rgba, Rgb);
+downcast_bit_depth_early!(Argb, Argb, Rgb);
 // Rgba
 downcast_bit_depth_early!(Luma, Luma, Rgba);
 downcast_bit_depth_early!(LumaA, LumaA, Rgba);
@@ -1399,11 +1403,13 @@ downcast_bit_depth_early!(Luma, Luma, Bgr);
 downcast_bit_depth_early!(LumaA, LumaA, Bgr);
 downcast_bit_depth_early!(Rgb, Rgb, Bgr);
 downcast_bit_depth_early!(Rgba, Rgba, Bgr);
+downcast_bit_depth_early!(Argb, Argb, Bgr);
 // Bgra
 downcast_bit_depth_early!(Luma, Luma, Bgra);
 downcast_bit_depth_early!(LumaA, LumaA, Bgra);
 downcast_bit_depth_early!(Rgb, Rgb, Bgra);
 downcast_bit_depth_early!(Rgba, Rgba, Bgra);
+downcast_bit_depth_early!(Argb, Argb, Bgra);
 // Argb
 downcast_bit_depth_early!(Luma, Luma, Argb);
 downcast_bit_depth_early!(LumaA, LumaA, Argb);

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -25,7 +25,7 @@ use crate::codecs::avif;
 use crate::buffer_::{
     BgrImage, BgraImage, ConvertBuffer, GrayAlphaImage, GrayAlpha16Image,
     GrayImage, Gray16Image, ImageBuffer, RgbImage, Rgb16Image, RgbaImage,
-    Rgba16Image,
+    Rgba16Image, ArgbImage, Argb16Image
 };
 use crate::color::{self, IntoColor};
 use crate::error::{ImageError, ImageFormatHint, ImageResult, ParameterError, ParameterErrorKind, UnsupportedError, UnsupportedErrorKind};
@@ -59,6 +59,9 @@ pub enum DynamicImage {
     /// Each pixel in this image is 8-bit Bgr with alpha
     ImageBgra8(BgraImage),
 
+    /// Each pixel in this image is 8-bit Argb
+    ImageArgb8(ArgbImage),
+
     /// Each pixel in this image is 16-bit Luma
     ImageLuma16(Gray16Image),
 
@@ -70,6 +73,11 @@ pub enum DynamicImage {
 
     /// Each pixel in this image is 16-bit Rgb with alpha
     ImageRgba16(Rgba16Image),
+
+    /// Each pixel in this image is 16-bit Argb
+    ImageArgb16(Argb16Image),
+
+
 }
 
 macro_rules! dynamic_map(
@@ -81,10 +89,12 @@ macro_rules! dynamic_map(
                         DynamicImage::ImageRgba8(ref $image) => DynamicImage::ImageRgba8($action),
                         DynamicImage::ImageBgr8(ref $image) => DynamicImage::ImageBgr8($action),
                         DynamicImage::ImageBgra8(ref $image) => DynamicImage::ImageBgra8($action),
+                        DynamicImage::ImageArgb8(ref $image) => DynamicImage::ImageArgb8($action),
                         DynamicImage::ImageLuma16(ref $image) => DynamicImage::ImageLuma16($action),
                         DynamicImage::ImageLumaA16(ref $image) => DynamicImage::ImageLumaA16($action),
                         DynamicImage::ImageRgb16(ref $image) => DynamicImage::ImageRgb16($action),
                         DynamicImage::ImageRgba16(ref $image) => DynamicImage::ImageRgba16($action),
+                        DynamicImage::ImageArgb16(ref $image) => DynamicImage::ImageArgb16($action)
                 }
         );
 
@@ -96,10 +106,12 @@ macro_rules! dynamic_map(
                         DynamicImage::ImageRgba8(ref mut $image) => DynamicImage::ImageRgba8($action),
                         DynamicImage::ImageBgr8(ref mut $image) => DynamicImage::ImageBgr8($action),
                         DynamicImage::ImageBgra8(ref mut $image) => DynamicImage::ImageBgra8($action),
+                        DynamicImage::ImageArgb8(ref mut $image) => DynamicImage::ImageArgb8($action),
                         DynamicImage::ImageLuma16(ref mut $image) => DynamicImage::ImageLuma16($action),
                         DynamicImage::ImageLumaA16(ref mut $image) => DynamicImage::ImageLumaA16($action),
                         DynamicImage::ImageRgb16(ref mut $image) => DynamicImage::ImageRgb16($action),
                         DynamicImage::ImageRgba16(ref mut $image) => DynamicImage::ImageRgba16($action),
+                        DynamicImage::ImageArgb16(ref mut $image) => DynamicImage::ImageArgb16($action)
                 }
         );
 
@@ -111,10 +123,12 @@ macro_rules! dynamic_map(
                         DynamicImage::ImageRgba8(ref $image) => $action,
                         DynamicImage::ImageBgr8(ref $image) => $action,
                         DynamicImage::ImageBgra8(ref $image) => $action,
+                        DynamicImage::ImageArgb8(ref $image) => $action,
                         DynamicImage::ImageLuma16(ref $image) => $action,
                         DynamicImage::ImageLumaA16(ref $image) => $action,
                         DynamicImage::ImageRgb16(ref $image) => $action,
                         DynamicImage::ImageRgba16(ref $image) => $action,
+                        DynamicImage::ImageArgb16(ref $image) => $action
                 }
         );
 
@@ -126,10 +140,12 @@ macro_rules! dynamic_map(
                         DynamicImage::ImageRgba8(ref mut $image) => $action,
                         DynamicImage::ImageBgr8(ref mut $image) => $action,
                         DynamicImage::ImageBgra8(ref mut $image) => $action,
+                        DynamicImage::ImageArgb8(ref mut $image) => $action,
                         DynamicImage::ImageLuma16(ref mut $image) => $action,
                         DynamicImage::ImageLumaA16(ref mut $image) => $action,
                         DynamicImage::ImageRgb16(ref mut $image) => $action,
                         DynamicImage::ImageRgba16(ref mut $image) => $action,
+                        DynamicImage::ImageArgb16(ref mut $image) => $action
                 }
         );
 );
@@ -166,6 +182,10 @@ impl DynamicImage {
         DynamicImage::ImageBgr8(ImageBuffer::new(w, h))
     }
 
+    /// Creates a dynamic image backed by a buffer of ARGB pixels.
+    pub fn new_argb8(w: u32, h: u32) -> DynamicImage{
+        DynamicImage::ImageArgb8(ImageBuffer::new(w, h))
+    }
     /// Creates a dynamic image backed by a buffer of grey pixels.
     pub fn new_luma16(w: u32, h: u32) -> DynamicImage {
         DynamicImage::ImageLuma16(ImageBuffer::new(w, h))
@@ -185,6 +205,10 @@ impl DynamicImage {
     /// Creates a dynamic image backed by a buffer of RGBA pixels.
     pub fn new_rgba16(w: u32, h: u32) -> DynamicImage {
         DynamicImage::ImageRgba16(ImageBuffer::new(w, h))
+    }
+    /// Creates a dynamic image backed by a buffer of ARGB pixels.
+    pub fn new_argb16(w: u32, h: u32) -> DynamicImage{
+        DynamicImage::ImageArgb16(ImageBuffer::new(w, h))
     }
 
     /// Decodes an encoded image into a dynamic image.
@@ -312,6 +336,20 @@ impl DynamicImage {
         })
     }
 
+    /// Returns a copy of this image as an ARGB image{
+    pub fn to_argb8(&self) -> ArgbImage{
+        dynamic_map!(*self, ref p -> {
+            p.convert()
+        })
+    }
+
+    /// Returns a copy of this image as an ARGB image{
+    pub fn to_argb16(&self) -> Argb16Image{
+        dynamic_map!(*self, ref p -> {
+            p.convert()
+        })
+    }
+
     /// Consume the image and returns a RGB image.
     ///
     /// If the image was already the correct format, it is returned as is.
@@ -377,6 +415,40 @@ impl DynamicImage {
         match self {
             DynamicImage::ImageRgba16(x) => x,
             x => x.to_rgba16(),
+        }
+    }
+
+    /// Consume the image and returns a ARGB image.
+    ///
+    /// If the image was already the correct format, it is returned as is.
+    /// Otherwise, a copy is created.
+    #[deprecated = "replaced by `into_argb8`"]
+    pub fn into_argb(self) -> ArgbImage {
+        match self {
+            DynamicImage::ImageArgb8(x) => x,
+            x => x.to_argb8(),
+        }
+    }
+
+    /// Consume the image and returns a ARGB image.
+    ///
+    /// If the image was already the correct format, it is returned as is.
+    /// Otherwise, a copy is created.
+    pub fn into_argb8(self) -> ArgbImage {
+        match self {
+            DynamicImage::ImageArgb8(x) => x,
+            x => x.to_argb8(),
+        }
+    }
+
+    /// Consume the image and returns a ARGB image.
+    ///
+    /// If the image was already the correct format, it is returned as is.
+    /// Otherwise, a copy is created.
+    pub fn into_argb16(self) -> Argb16Image {
+        match self {
+            DynamicImage::ImageArgb16(x) => x,
+            x => x.to_argb16(),
         }
     }
 
@@ -559,6 +631,22 @@ impl DynamicImage {
         }
     }
 
+    /// Return a reference to an 8bit ARGB image
+    pub fn as_argb8(&self) -> Option<&ArgbImage> {
+        match *self {
+            DynamicImage::ImageArgb8(ref p) => Some(p),
+            _ => None,
+        }
+    }
+
+    /// Return a mutable reference to an 8bit ARGB image
+    pub fn as_mut_argb8(&mut self) -> Option<&mut ArgbImage> {
+        match *self {
+            DynamicImage::ImageArgb8(ref mut p) => Some(p),
+            _ => None,
+        }
+    }
+
     /// Return a reference to an 8bit BGRA image
     pub fn as_bgra8(&self) -> Option<&BgraImage> {
         match *self {
@@ -639,6 +727,22 @@ impl DynamicImage {
         }
     }
 
+    /// Return a reference to an 16bit ARGB image
+    pub fn as_argb16(&self) -> Option<&Argb16Image> {
+        match *self {
+            DynamicImage::ImageArgb16(ref p) => Some(p),
+            _ => None,
+        }
+    }
+
+    /// Return a mutable reference to an 16bit ARGB image
+    pub fn as_mut_argb16(&mut self) -> Option<&mut Argb16Image> {
+        match *self {
+            DynamicImage::ImageArgb16(ref mut p) => Some(p),
+            _ => None,
+        }
+    }
+
     /// Return a reference to an 16bit Grayscale image
     pub fn as_luma16(&self) -> Option<&Gray16Image> {
         match *self {
@@ -678,6 +782,7 @@ impl DynamicImage {
             DynamicImage::ImageLumaA8(ref p) => Some(p.as_flat_samples()),
             DynamicImage::ImageRgb8(ref p) => Some(p.as_flat_samples()),
             DynamicImage::ImageRgba8(ref p) => Some(p.as_flat_samples()),
+            DynamicImage::ImageArgb8(ref p) => Some(p.as_flat_samples()),
             DynamicImage::ImageBgr8(ref p) => Some(p.as_flat_samples()),
             DynamicImage::ImageBgra8(ref p) => Some(p.as_flat_samples()),
             _ => None,
@@ -691,6 +796,7 @@ impl DynamicImage {
             DynamicImage::ImageLumaA16(ref p) => Some(p.as_flat_samples()),
             DynamicImage::ImageRgb16(ref p) => Some(p.as_flat_samples()),
             DynamicImage::ImageRgba16(ref p) => Some(p.as_flat_samples()),
+            DynamicImage::ImageArgb16(ref p) => Some(p.as_flat_samples()),
             _ => None,
         }
     }
@@ -721,10 +827,12 @@ impl DynamicImage {
             DynamicImage::ImageRgba8(_) => color::ColorType::Rgba8,
             DynamicImage::ImageBgra8(_) => color::ColorType::Bgra8,
             DynamicImage::ImageBgr8(_) => color::ColorType::Bgr8,
+            DynamicImage::ImageArgb8(_) => color::ColorType::Argb8,
             DynamicImage::ImageLuma16(_) => color::ColorType::L16,
             DynamicImage::ImageLumaA16(_) => color::ColorType::La16,
             DynamicImage::ImageRgb16(_) => color::ColorType::Rgb16,
             DynamicImage::ImageRgba16(_) => color::ColorType::Rgba16,
+            DynamicImage::ImageArgb16(_) => color::ColorType::Argb16
         }
     }
 
@@ -737,10 +845,12 @@ impl DynamicImage {
             DynamicImage::ImageRgba8(ref p) => DynamicImage::ImageLuma8(imageops::grayscale(p)),
             DynamicImage::ImageBgr8(ref p) => DynamicImage::ImageLuma8(imageops::grayscale(p)),
             DynamicImage::ImageBgra8(ref p) => DynamicImage::ImageLuma8(imageops::grayscale(p)),
+            DynamicImage::ImageArgb8(ref p) => DynamicImage::ImageLuma8(imageops::grayscale(p)),
             DynamicImage::ImageLuma16(ref p) => DynamicImage::ImageLuma16(p.clone()),
             DynamicImage::ImageLumaA16(ref p) => DynamicImage::ImageLuma16(imageops::grayscale(p)),
             DynamicImage::ImageRgb16(ref p) => DynamicImage::ImageLuma16(imageops::grayscale(p)),
             DynamicImage::ImageRgba16(ref p) => DynamicImage::ImageLuma16(imageops::grayscale(p)),
+            DynamicImage::ImageArgb16(ref p) => DynamicImage::ImageLuma16(imageops::grayscale(p))
         }
     }
 
@@ -1070,10 +1180,12 @@ impl GenericImage for DynamicImage {
             DynamicImage::ImageRgba8(ref mut p) => p.put_pixel(x, y, pixel),
             DynamicImage::ImageBgr8(ref mut p) => p.put_pixel(x, y, pixel.to_bgr()),
             DynamicImage::ImageBgra8(ref mut p) => p.put_pixel(x, y, pixel.to_bgra()),
+            DynamicImage::ImageArgb8(ref mut p) => p.put_pixel(x,y,pixel.to_argb()),
             DynamicImage::ImageLuma16(ref mut p) => p.put_pixel(x, y, pixel.to_luma().into_color()),
             DynamicImage::ImageLumaA16(ref mut p) => p.put_pixel(x, y, pixel.to_luma_alpha().into_color()),
             DynamicImage::ImageRgb16(ref mut p) => p.put_pixel(x, y, pixel.to_rgb().into_color()),
             DynamicImage::ImageRgba16(ref mut p) => p.put_pixel(x, y, pixel.into_color()),
+            DynamicImage::ImageArgb16(ref mut p) => p.put_pixel(x,y,pixel.to_argb().into_color())
         }
     }
     /// DEPRECATED: Use iterator `pixels_mut` to blend the pixels directly.
@@ -1085,10 +1197,12 @@ impl GenericImage for DynamicImage {
             DynamicImage::ImageRgba8(ref mut p) => p.blend_pixel(x, y, pixel),
             DynamicImage::ImageBgr8(ref mut p) => p.blend_pixel(x, y, pixel.to_bgr()),
             DynamicImage::ImageBgra8(ref mut p) => p.blend_pixel(x, y, pixel.to_bgra()),
+            DynamicImage::ImageArgb8(ref mut p) => p.blend_pixel(x,y,pixel.to_argb()),
             DynamicImage::ImageLuma16(ref mut p) => p.blend_pixel(x, y, pixel.to_luma().into_color()),
             DynamicImage::ImageLumaA16(ref mut p) => p.blend_pixel(x, y, pixel.to_luma_alpha().into_color()),
             DynamicImage::ImageRgb16(ref mut p) => p.blend_pixel(x, y, pixel.to_rgb().into_color()),
             DynamicImage::ImageRgba16(ref mut p) => p.blend_pixel(x, y, pixel.into_color()),
+            DynamicImage::ImageArgb16(ref mut p) => p.blend_pixel(x,y,pixel.to_argb().into_color())
         }
     }
 
@@ -1138,6 +1252,11 @@ fn decoder_to_image<'a, I: ImageDecoder<'a>>(decoder: I) -> ImageResult<DynamicI
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLumaA8)
         }
 
+        color::ColorType::Argb8 =>{
+            let buf = image::decoder_to_vec(decoder)?;
+            ImageBuffer::from_raw(w,h,buf).map(DynamicImage::ImageArgb8)
+        }
+
         color::ColorType::Rgb16 => {
             let buf = image::decoder_to_vec(decoder)?;
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageRgb16)
@@ -1155,6 +1274,11 @@ fn decoder_to_image<'a, I: ImageDecoder<'a>>(decoder: I) -> ImageResult<DynamicI
         color::ColorType::La16 => {
             let buf = image::decoder_to_vec(decoder)?;
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLumaA16)
+        }
+
+        color::ColorType::Argb16 =>{
+            let buf = image::decoder_to_vec(decoder)?;
+            ImageBuffer::from_raw(w,h,buf).map(DynamicImage::ImageArgb16)
         }
         _ => return Err(ImageError::Unsupported(UnsupportedError::from_format_and_kind(
             ImageFormatHint::Unknown,
@@ -1180,10 +1304,12 @@ fn image_to_bytes(image: &DynamicImage) -> Vec<u8> {
         DynamicImage::ImageRgba8(ref a) => a.as_raw().clone(),
         DynamicImage::ImageBgr8(ref a) => a.as_raw().clone(),
         DynamicImage::ImageBgra8(ref a) => a.as_raw().clone(),
+        DynamicImage::ImageArgb8(ref a) => a.as_raw().clone(),
         DynamicImage::ImageLuma16(ref a) => a.as_bytes().to_vec(),
         DynamicImage::ImageLumaA16(ref a) => a.as_bytes().to_vec(),
         DynamicImage::ImageRgb16(ref a) => a.as_bytes().to_vec(),
         DynamicImage::ImageRgba16(ref a) => a.as_bytes().to_vec(),
+        DynamicImage::ImageArgb16(ref a) => a.as_bytes().to_vec()
     }
 }
 
@@ -1195,10 +1321,12 @@ fn image_into_bytes(image: DynamicImage) -> Vec<u8> {
         DynamicImage::ImageRgba8(a) => a.into_raw(),
         DynamicImage::ImageBgr8(a) => a.into_raw(),
         DynamicImage::ImageBgra8(a) => a.into_raw(),
+        DynamicImage::ImageArgb8(a) => a.into_raw(),
         DynamicImage::ImageLuma16(_) => image.to_bytes(),
         DynamicImage::ImageLumaA16(_) => image.to_bytes(),
         DynamicImage::ImageRgb16(_) => image.to_bytes(),
         DynamicImage::ImageRgba16(_) => image.to_bytes(),
+        DynamicImage::ImageArgb16(_) => image.to_bytes(),
     }
 }
 
@@ -1211,10 +1339,12 @@ fn image_as_bytes(image: &DynamicImage) -> &[u8] {
         DynamicImage::ImageRgba8(a) => &*a,
         DynamicImage::ImageBgr8(a) => &*a,
         DynamicImage::ImageBgra8(a) => &*a,
+        DynamicImage::ImageArgb8(a) => &*a,
         DynamicImage::ImageLuma16(a) => cast_slice(&*a),
         DynamicImage::ImageLumaA16(a) => cast_slice(&*a),
         DynamicImage::ImageRgb16(a) => cast_slice(&*a),
         DynamicImage::ImageRgba16(a) => cast_slice(&*a),
+        DynamicImage::ImageArgb16(a) => cast_slice(&*a)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ use std::io::Write;
 
 pub use crate::color::{ColorType, ExtendedColorType};
 
-pub use crate::color::{Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
+pub use crate::color::{Luma, LumaA, Rgb, Rgba, Bgr, Bgra, Argb};
 
 pub use crate::error::{ImageError, ImageResult};
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -5,7 +5,7 @@
 use num_traits::{Bounded, Num, NumCast};
 use std::ops::{AddAssign};
 
-use crate::color::{ColorType, Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
+use crate::color::{ColorType, Luma, LumaA, Rgb, Rgba, Bgr, Bgra, Argb};
 
 /// Types which are safe to treat as an immutable byte slice in a pixel layout
 /// for image encoding.
@@ -191,6 +191,9 @@ pub trait Pixel: Copy + Clone {
 
     /// Convert this pixel to BGR with an alpha channel
     fn to_bgra(&self) -> Bgra<Self::Subpixel>;
+
+    /// Convert this pixel to ARGB
+    fn to_argb(&self) -> Argb<Self::Subpixel>;
 
     /// Apply the function ```f``` to each channel of this pixel.
     fn map<F>(&self, f: F) -> Self


### PR DESCRIPTION
I needed an ARGB buffer for one of my projects and I decided to implement it in the image crate instead of doing it myself. I'm not sure if something like this is needed in the official crate (the only reference I could find to ARGB is #820), but I decided to open a PR anyway. The biggest change is to the `define_colors` macro, since it did not support alpha channels in any other position than the last position. 

I wasn't sure where I needed to add the new ColorType (i.e. encoding/decoding parts), so I kept it as basic as possible.

If you are a new contributor, consent to licensing by including this text:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.