### PR TITLE
Add size hint for build_huff_lut

### DIFF
--- a/src/codecs/jpeg/entropy.rs
+++ b/src/codecs/jpeg/entropy.rs
@@ -1,9 +1,9 @@
 /// Given an array containing the number of codes of each code length,
 /// this function generates the huffman codes lengths and their respective
 /// code lengths as specified by the JPEG spec.
-fn derive_codes_and_sizes(bits: &[u8]) -> (Vec<u8>, Vec<u16>) {
-    let mut huffsize = vec![0u8; 256];
-    let mut huffcode = vec![0u16; 256];
+fn derive_codes_and_sizes(bits: &[u8]) -> ([u8; 256], [u16; 256]) {
+    let mut huffsize = [0u8; 256];
+    let mut huffcode = [0u16; 256];
 
     let mut k = 0;
 
@@ -48,8 +48,8 @@ fn derive_codes_and_sizes(bits: &[u8]) -> (Vec<u8>, Vec<u16>) {
     (huffsize, huffcode)
 }
 
-pub(crate) fn build_huff_lut(bits: &[u8], huffval: &[u8]) -> Vec<(u8, u16)> {
-    let mut lut = vec![(17u8, 0u16); 256];
+pub(crate) fn build_huff_lut(bits: &[u8], huffval: &[u8]) -> [(u8, u16); 256] {
+    let mut lut = [(17u8, 0u16); 256];
     let (huffsize, huffcode) = derive_codes_and_sizes(bits);
 
     for (i, &v) in huffval.iter().enumerate() {

--- a/src/codecs/jpeg/entropy.rs
+++ b/src/codecs/jpeg/entropy.rs
@@ -1,7 +1,7 @@
 /// Given an array containing the number of codes of each code length,
 /// this function generates the huffman codes lengths and their respective
 /// code lengths as specified by the JPEG spec.
-fn derive_codes_and_sizes(bits: &[u8]) -> ([u8; 256], [u16; 256]) {
+fn derive_codes_and_sizes(bits: &[u8; 16]) -> ([u8; 256], [u16; 256]) {
     let mut huffsize = [0u8; 256];
     let mut huffcode = [0u16; 256];
 
@@ -48,7 +48,7 @@ fn derive_codes_and_sizes(bits: &[u8]) -> ([u8; 256], [u16; 256]) {
     (huffsize, huffcode)
 }
 
-pub(crate) fn build_huff_lut(bits: &[u8], huffval: &[u8]) -> [(u8, u16); 256] {
+pub(crate) fn build_huff_lut(bits: &[u8; 16], huffval: &[u8]) -> [(u8, u16); 256] {
     let mut lut = [(17u8, 0u16); 256];
     let (huffsize, huffcode) = derive_codes_and_sizes(bits);
 


### PR DESCRIPTION
Since huff_lut always has to be 256 items long, we can get rid of bounds checks by returning [(u8, 16); 256] from build_huff_lut, and storing Box<[(u8, 16); 256]> instead of Vec, which does not have a length known at compile-time.

Improvements as below, after 3 runs of `cargo +nightly bench --features "benchmarks"` to ensure steady state times for both.
```
    L8-rawvec/64: -0.035us = -0.106%
    L8-bufvec/64: -0.666us = -1.817%
      L8-file/64: -3.075us = -7.898%
   L8-rawvec/128: 0.340us = 0.277%
   L8-bufvec/128: -3.600us = -2.581%
     L8-file/128: -6.200us = -4.572%
   L8-rawvec/256: 1.110us = 0.229%
   L8-bufvec/256: -5.100us = -0.941%
     L8-file/256: 5.070us = 1.017%
  Rgb8-rawvec/64: -2.159us = -2.176%
  Rgb8-bufvec/64: -1.590us = -1.466%
    Rgb8-file/64: 0.070us = 0.069%
 Rgb8-rawvec/128: -6.770us = -1.739%
 Rgb8-bufvec/128: -7.850us = -1.860%
   Rgb8-file/128: -0.270us = -0.069%
 Rgb8-rawvec/256: -0.018ms = -1.140%
 Rgb8-bufvec/256: -0.041ms = -2.452%
   Rgb8-file/256: 0.008ms = 0.550%
 Rgba8-rawvec/64: -2.479us = -2.505%
 Rgba8-bufvec/64: -4.440us = -4.128%
   Rgba8-file/64: -4.654us = -4.454%
Rgba8-rawvec/128: -4.750us = -1.232%
Rgba8-bufvec/128: -16.870us = -4.008%
  Rgba8-file/128: -18.930us = -4.698%
Rgba8-rawvec/256: -0.026ms = -1.684%
Rgba8-bufvec/256: -0.070ms = -4.182%
  Rgba8-file/256: -0.061ms = -3.869%
                             -2.127%
```

Also provides a ~20% improvement for initializing JpegEncoder, which is nice (looks like the new version of Rust already gives us a 10% improvement from last time):
```
test codecs::jpeg::encoder::tests::bench_jpeg_encoder_new ... bench:       1,745 ns/iter (+/- 99)
test codecs::jpeg::encoder::tests::bench_jpeg_encoder_old ... bench:       2,132 ns/iter (+/- 99)
```

As a side note, I think the reason why the CI might not be running is that TravisCI seems to be limiting free projects to 10000 credits (1000 minutes of build time for Linux, less if using Windows / Macs) per month. A single push to this repo probably uses around 25% of these, so I'm guessing it runs out pretty quickly - link here: https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing.