### PR TITLE
codecs/gif: Add speed argument

### DIFF
--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -293,6 +293,7 @@ impl<'a, R: Read + 'a> AnimationDecoder<'a> for GifDecoder<R> {
 pub struct GifEncoder<W: Write> {
     w: Option<W>,
     gif_encoder: Option<gif::Encoder<W>>,
+    speed: i32,
 }
 
 /// GIF encoder
@@ -309,9 +310,18 @@ pub type Encoder<W> = GifEncoder<W>;
 impl<W: Write> GifEncoder<W> {
     /// Creates a new GIF encoder.
     pub fn new(w: W) -> GifEncoder<W> {
+        Self::new_with_speed(w, 1)
+    }
+
+    /// Create a new GIF encoder, and has the speed parameter `speed`. See
+    /// [`Frame::from_rgba_speed`](/gif/struct.Frame.html#method.from_rgb_speed)
+    /// for more information.
+    pub fn new_with_speed(w: W, speed: i32) -> GifEncoder<W> {
+        assert!(speed >= 1 && speed <= 30, "speed needs to be in the range [1, 30]");
         GifEncoder {
             w: Some(w),
             gif_encoder: None,
+            speed,
         }
     }
 
@@ -379,7 +389,7 @@ impl<W: Write> GifEncoder<W> {
             rbga_frame.height())?;
 
         // Create the gif::Frame from the animation::Frame
-        let mut frame = Frame::from_rgba(width, height, &mut *rbga_frame);
+        let mut frame = Frame::from_rgba_speed(width, height, &mut *rbga_frame, self.speed);
         // Saturate the conversion to u16::MAX instead of returning an error as that
         // would require a new special cased variant in ParameterErrorKind which most
         // likely couldn't be reused for other cases. This isn't a bad trade-off given


### PR DESCRIPTION
This is straight up forwarded to the underlying gif library, and allows setting the encoding quality to be able to get faster encodes.

This is especially useful for debug builds, where the absence of optimization from the compiler makes this awfully slow. For a simple test gif (260x160, 36 frames), it took more than 1 minute to encode it on a core i7 laptop. On release builds, the difference is much less perceptible, but this still gives the option to the user.

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.
