### PR TITLE
frame: Add buffer_mut function

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -83,6 +83,11 @@ impl Frame {
         &self.buffer
     }
 
+    /// Returns a mutable image buffer
+    pub fn buffer_mut(&mut self) -> &mut RgbaImage {
+        &mut self.buffer
+    }
+
     /// Returns the image buffer
     pub fn into_buffer(self) -> RgbaImage {
         self.buffer


### PR DESCRIPTION
This allows getting a mutable `RgbaImage` from a mutable `Frame` to easily edit a frame sequence (e.g. a GIF image).

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.
