### PR TITLE
Allow setting the AvifEncoder ColorSpace

### DIFF
--- a/src/codecs/avif/mod.rs
+++ b/src/codecs/avif/mod.rs
@@ -3,9 +3,8 @@
 /// The [AVIF] specification defines an image derivative of the AV1 bitstream, an open video codec.
 ///
 /// [AVIF]: https://aomediacodec.github.io/av1-avif/
-
 pub use self::decoder::AvifDecoder;
-pub use self::encoder::AvifEncoder;
+pub use self::encoder::{AvifEncoder, ColorSpace};
 
 mod decoder;
 mod encoder;


### PR DESCRIPTION
I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

This change makes it possible to use the ravif YCbCr encoding option, which converts RGB to YCbCr, getting higher compression ratios in AVIF.