### PR TITLE
Derive Debug, Hash, PartialEq, Eq for DynamicImage

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -39,7 +39,7 @@ use crate::math::resize_dimensions;
 use crate::traits::Pixel;
 
 /// A Dynamic Image
-#[derive(Clone)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum DynamicImage {
     /// Each pixel in this image is 8-bit Luma
     ImageLuma8(GrayImage),


### PR DESCRIPTION
All variants of `DynamicImage` (which are all `ImageBuffer` types) derive `Debug, Hash, PartialEq, Eq`.

`DynamicImage` not implementing them seems like an undesirable restriction, this makes it usable where those traits are required.