### PR TITLE
Fix wrong expectation of image info

### DIFF
--- a/src/codecs/jpeg/decoder.rs
+++ b/src/codecs/jpeg/decoder.rs
@@ -21,7 +21,9 @@ impl<R: Read> JpegDecoder<R> {
         let mut decoder = jpeg::Decoder::new(r);
 
         decoder.read_info().map_err(ImageError::from_jpeg)?;
-        let mut metadata = decoder.info().unwrap();
+        let mut metadata = decoder.info().ok_or_else(|| {
+            ImageError::Decoding(DecodingError::from_format_hint(ImageFormat::Jpeg.into()))
+        })?;
 
         // We convert CMYK data to RGB before returning it to the user.
         if metadata.pixel_format == jpeg::PixelFormat::CMYK32 {


### PR DESCRIPTION
The decoder unwrapped the info struct from the jpeg decoder. This is not
guaranteed to return Some, e.g. when not even the header of the jpeg
was parsed correctly.

