### PR TITLE
Optimize default implementation of copy_from

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,3 +74,7 @@ harness = false
 path = "benches/encode.rs"
 name = "encode"
 harness = false
+
+[[bench]]
+name = "copy_from"
+harness = false

--- a/benches/copy_from.rs
+++ b/benches/copy_from.rs
@@ -1,0 +1,14 @@
+use image::{GenericImage, ImageBuffer, Rgba};
+use criterion::{black_box, Criterion, criterion_group, criterion_main};
+
+pub fn bench_copy_from(c: &mut Criterion) {
+    let src = ImageBuffer::from_pixel(2048, 2048, Rgba([255u8, 0, 0, 255]));
+    let mut dst = ImageBuffer::from_pixel(2048, 2048, Rgba([0u8, 0, 0, 255]));
+
+    c.bench_function("copy_from", |b| {
+        b.iter(|| dst.copy_from(black_box(&src), 0, 0))
+    });
+}
+
+criterion_group!(benches, bench_copy_from);
+criterion_main!(benches);

--- a/src/image.rs
+++ b/src/image.rs
@@ -841,8 +841,8 @@ pub trait GenericImage: GenericImageView {
             )));
         }
 
-        for i in 0..other.width() {
-            for k in 0..other.height() {
+        for k in 0..other.height() {
+            for i in 0..other.width() {
                 let p = other.get_pixel(i, k);
                 self.put_pixel(i + x, k + y, p);
             }


### PR DESCRIPTION
Copying by row instead of by column makes this function 5x to 10x faster for typical image types (like `ImageBuffer`) that store pixels by row.

