### PR TITLE
Improved documentation of pixel enumeration and coordinate access.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ For convenience `DynamicImage` reimplements all image processing functions.
 
 #### [`SubImage`](https://docs.rs/image/*/image/struct.SubImage.html)
 A view into another image, delimited by the coordinates of a rectangle.
+The coordinates given set the position of the top left corner of the rectangle.
 This is used to perform image processing functions on a subregion of an image.
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The most important methods for decoders are...
 All pixels are parameterised by their component type.
 
 ## Images
+Individual pixels within images are indexed with (0,0) at the top left corner. 
 ### The [`GenericImageView`](https://docs.rs/image/*/image/trait.GenericImageView.html) and [`GenericImage`](https://docs.rs/image/*/image/trait.GenericImage.html) Traits
 
 Traits that provide methods for inspecting (`GenericImageView`) and manipulating (`GenericImage`) images, parameterised over the image's pixel type.

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -693,6 +693,7 @@ where
     /// The iterator yields the coordinates of each pixel
     /// along with a reference to them.
     /// The iteration order is x = 0 to width then y = 0 to height
+    /// Starting from the top left.
     pub fn enumerate_pixels(&self) -> EnumeratePixels<P> {
         EnumeratePixels {
             pixels: self.pixels(),

--- a/src/image.rs
+++ b/src/image.rs
@@ -772,6 +772,7 @@ pub trait GenericImageView {
 
     /// Returns an subimage that is an immutable view into this image.
     /// You can use [`GenericImage::sub_image`] if you need a mutable view instead.
+    /// The coordinates set the position of the top left corner of the view.
     fn view(&self, x: u32, y: u32, width: u32, height: u32) -> SubImage<&Self::InnerImageView> {
         SubImage::new(self.inner(), x, y, width, height)
     }
@@ -898,6 +899,7 @@ pub trait GenericImage: GenericImageView {
 
     /// Returns a mutable subimage that is a view into this image.
     /// If you want an immutable subimage instead, use [`GenericImageView::view`]
+    /// The coordinates set the position of the top left corner of the SubImage.
     fn sub_image(
         &mut self,
         x: u32,
@@ -931,6 +933,7 @@ type DerefSubpixel<I> = <DerefPixel<I> as Pixel>::Subpixel;
 
 impl<I> SubImage<I> {
     /// Construct a new subimage
+    /// The coordinates set the position of the top left corner of the SubImage.
     pub fn new(image: I, x: u32, y: u32, width: u32, height: u32) -> SubImage<I> {
         SubImage {
             image,

--- a/src/image.rs
+++ b/src/image.rs
@@ -731,7 +731,7 @@ pub trait GenericImageView {
         x >= ix && x < ix + iw && y >= iy && y < iy + ih
     }
 
-    /// Returns the pixel located at (x, y)
+    /// Returns the pixel located at (x, y). Indexed from top left.
     ///
     /// # Panics
     ///
@@ -740,7 +740,7 @@ pub trait GenericImageView {
     /// TODO: change this signature to &P
     fn get_pixel(&self, x: u32, y: u32) -> Self::Pixel;
 
-    /// Returns the pixel located at (x, y)
+    /// Returns the pixel located at (x, y). Indexed from top left.
     ///
     /// This function can be implemented in a way that ignores bounds checking.
     /// # Safety
@@ -784,21 +784,21 @@ pub trait GenericImage: GenericImageView {
     /// indirections and it eases the use of nested SubImages.
     type InnerImage: GenericImage<Pixel = Self::Pixel>;
 
-    /// Gets a reference to the mutable pixel at location `(x, y)`
+    /// Gets a reference to the mutable pixel at location `(x, y)`. Indexed from top left.
     ///
     /// # Panics
     ///
     /// Panics if `(x, y)` is out of bounds.
     fn get_pixel_mut(&mut self, x: u32, y: u32) -> &mut Self::Pixel;
 
-    /// Put a pixel at location (x, y)
+    /// Put a pixel at location (x, y). Indexed from top left.
     ///
     /// # Panics
     ///
     /// Panics if `(x, y)` is out of bounds.
     fn put_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel);
 
-    /// Puts a pixel at location (x, y)
+    /// Puts a pixel at location (x, y). Indexed from top left.
     ///
     /// This function can be implemented in a way that ignores bounds checking.
     /// # Safety

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -30,6 +30,7 @@ pub mod colorops;
 mod sample;
 
 /// Return a mutable view into an image
+/// The coordinates set the position of the top left corner of the crop.
 pub fn crop<I: GenericImageView>(
     image: &mut I,
     x: u32,
@@ -42,6 +43,7 @@ pub fn crop<I: GenericImageView>(
 }
 
 /// Return an immutable view into an image
+/// The coordinates set the position of the top left corner of the crop.
 pub fn crop_imm<I: GenericImageView>(
     image: &I,
     x: u32,


### PR DESCRIPTION
It was unclear where the coordinate space in an image started from. I have added notes about it in a few key places.


I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.
