### PR TITLE
Avif and default tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,30 @@ jobs:
       if: ${{ matrix.rust != '1.34.2' }}
       env:
         FEATURES: ${{ matrix.features }}
+  test_defaults:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - name: build
+      run: cargo build -v --release
+    - name: test
+      run: cargo test -v --release
+  test_avif:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: install-dependencies
+      run: sudo apt update && sudo apt install nasm libdav1d-dev
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - name: build
+      run: cargo build -v --no-default-features --features="avif"
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: install-dependencies
-      run: sudo apt update && sudo apt install nasm libdav1d-dev
+      run: sudo apt update && sudo apt install nasm
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
@@ -52,6 +52,8 @@ jobs:
         override: true
     - name: build
       run: cargo build -v --no-default-features --features="avif"
+    # We don't test this yet, as it requires libdav1d which isn't in ubuntu 20.04
+    # run: cargo build -v --no-default-features --features="avif-decoding"
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,12 +58,17 @@ hdr = ["scoped_threadpool"]
 dxt = []
 dds = ["dxt"]
 farbfeld = []
+
 # Enables multi-threading.
 # Requires latest stable Rust.
 jpeg_rayon = ["jpeg/rayon"]
-# Non-default, enables avif encoding.
+# Non-default, enables avif support.
 # Requires latest stable Rust.
-avif = ["mp4parse", "dav1d", "dcv-color-primitives", "ravif", "rgb"]
+avif = ["avif-encoder"]
+# Requires latest stable Rust and recent nasm (>= 2.14).
+avif-encoder = ["ravif", "rgb"]
+# Non-default, even in `avif`. Requires stable Rust and native dependency libdav1d.
+avif-decoder = ["mp4parse", "dcv-color-primitives", "dav1d"]
 
 # Build some inline benchmarks. Useful only during development.
 # Requires rustc nightly for feature test.

--- a/src/codecs/avif/mod.rs
+++ b/src/codecs/avif/mod.rs
@@ -3,8 +3,12 @@
 /// The [AVIF] specification defines an image derivative of the AV1 bitstream, an open video codec.
 ///
 /// [AVIF]: https://aomediacodec.github.io/av1-avif/
+#[cfg(feature = "avif-decoder")]
 pub use self::decoder::AvifDecoder;
+#[cfg(feature = "avif-encoder")]
 pub use self::encoder::{AvifEncoder, ColorSpace};
 
+#[cfg(feature = "avif-decoder")]
 mod decoder;
+#[cfg(feature = "avif-encoder")]
 mod encoder;

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -27,7 +27,7 @@ use crate::codecs::tiff;
 use crate::codecs::webp;
 #[cfg(feature = "farbfeld")]
 use crate::codecs::farbfeld;
-#[cfg(feature = "avif")]
+#[cfg(any(feature = "avif-encoder", feature = "avif-decoder"))]
 use crate::codecs::avif;
 
 use crate::color;
@@ -59,7 +59,7 @@ pub fn load<R: BufRead + Seek>(r: R, format: ImageFormat) -> ImageResult<Dynamic
     #[allow(unreachable_patterns)]
     // Default is unreachable if all features are supported.
     match format {
-        #[cfg(feature = "avif")]
+        #[cfg(feature = "avif-decoder")]
         image::ImageFormat::Avif => DynamicImage::from_decoder(avif::AvifDecoder::new(r)?),
         #[cfg(feature = "png")]
         image::ImageFormat::Png => DynamicImage::from_decoder(png::PngDecoder::new(r)?),
@@ -107,7 +107,7 @@ pub(crate) fn image_dimensions_with_format_impl<R: BufRead + Seek>(fin: R, forma
     // Default is unreachable if all features are supported.
     // Code after the match is unreachable if none are.
     Ok(match format {
-        #[cfg(feature = "avif")]
+        #[cfg(feature = "avif-decoder")]
         image::ImageFormat::Avif => avif::AvifDecoder::new(fin)?.dimensions(),
         #[cfg(feature = "jpeg")]
         image::ImageFormat::Jpeg => jpeg::JpegDecoder::new(fin)?.dimensions(),
@@ -193,7 +193,7 @@ pub(crate) fn save_buffer_with_format_impl(
         },
         #[cfg(feature = "farbfeld")]
         image::ImageFormat::Farbfeld => farbfeld::FarbfeldEncoder::new(fout).write_image(buf, width, height, color),
-        #[cfg(feature = "avif")]
+        #[cfg(feature = "avif-encoder")]
         image::ImageFormat::Avif => avif::AvifEncoder::new(fout).write_image(buf, width, height, color),
         // #[cfg(feature = "hdr")]
         // image::ImageFormat::Hdr => hdr::HdrEncoder::new(fout).encode(&[Rgb<f32>], width, height), // usize

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,7 @@ pub mod flat;
 ///
 /// Re-exports of dependencies that reach version `1` will be discussed when it happens.
 pub mod codecs {
-    #[cfg(feature = "avif")]
+    #[cfg(any(feature = "avif-encoder", feature = "avif-decoder"))]
     pub mod avif;
     #[cfg(feature = "bmp")]
     pub mod bmp;
@@ -243,7 +243,7 @@ pub mod codecs {
     pub mod webp;
 }
 
-#[cfg(feature = "avif")]
+#[cfg(feature = "avif-encoder")]
 #[deprecated = "Use codecs::avif instead"]
 pub mod avif {
     //! Encoding of AVIF images.


### PR DESCRIPTION
Note that this splits avif-feature into encoder and decoder.

They require different native dependencies in their build systems, one
of the available on Ubuntu-20.04 (the latest Github build environment)
while the other one is not.

Unblocks: #1418 