### PR TITLE
Fix forward compatibility of panicking

### DIFF
--- a/src/codecs/webp/vp8.rs
+++ b/src/codecs/webp/vp8.rs
@@ -1436,7 +1436,7 @@ impl<R: Read> Vp8Decoder<R> {
                     i16::from(DCT_CAT_BASE[(category - DCT_CAT1) as usize]) + extra
                 }
 
-                c => panic!(format!("unknown token: {}", c)),
+                c => panic!("unknown token: {}", c),
             });
 
             skip = false;

--- a/tests/reference_images.rs
+++ b/tests/reference_images.rs
@@ -54,7 +54,7 @@ fn render_images() {
                 println!("UNSUPPORTED {}: {}", path.display(), e);
                 return;
             }
-            Err(err) => panic!(format!("decoding of {:?} failed with: {}", path, err)),
+            Err(err) => panic!("decoding of {:?} failed with: {}", path, err),
         };
         let mut crc = Crc32::new();
         crc.update(&*img);
@@ -161,7 +161,7 @@ fn check_references() {
             // This might happen because the testsuite contains unsupported images
             // or because a specific decoder included via a feature.
             Err(image::ImageError::Unsupported(_)) => return,
-            Err(err) => panic!(format!("{}", err)),
+            Err(err) => panic!("{}", err),
         };
 
         let (filename, testsuite) = {
@@ -199,17 +199,17 @@ fn check_references() {
                         Ok(decoder) => decoder,
                         Err(image::ImageError::Unsupported(_)) => return,
                         Err(err) => {
-                            panic!(format!("decoding of {:?} failed with: {}", img_path, err))
+                            panic!("decoding of {:?} failed with: {}", img_path, err)
                         }
                     };
 
                     let mut frames = match decoder.into_frames().collect_frames() {
                         Ok(frames) => frames,
                         Err(image::ImageError::Unsupported(_)) => return,
-                        Err(err) => panic!(format!(
+                        Err(err) => panic!(
                             "collecting frames of {:?} failed with: {}",
                             img_path, err
-                        )),
+                        ),
                     };
 
                     // Select a single frame
@@ -228,17 +228,17 @@ fn check_references() {
                         Ok(decoder) => decoder.apng(),
                         Err(image::ImageError::Unsupported(_)) => return,
                         Err(err) => {
-                            panic!(format!("decoding of {:?} failed with: {}", img_path, err))
+                            panic!("decoding of {:?} failed with: {}", img_path, err)
                         }
                     };
 
                     let mut frames = match decoder.into_frames().collect_frames() {
                         Ok(frames) => frames,
                         Err(image::ImageError::Unsupported(_)) => return,
-                        Err(err) => panic!(format!(
+                        Err(err) => panic!(
                             "collecting frames of {:?} failed with: {}",
                             img_path, err
-                        )),
+                        ),
                     };
 
                     // Select a single frame
@@ -262,7 +262,7 @@ fn check_references() {
                     // This might happen because the testsuite contains unsupported images
                     // or because a specific decoder included via a feature.
                     Err(image::ImageError::Unsupported(_)) => return,
-                    Err(err) => panic!(format!("decoding of {:?} failed with: {}", img_path, err)),
+                    Err(err) => panic!("decoding of {:?} failed with: {}", img_path, err),
                 };
             }
         }


### PR DESCRIPTION
The panic macro will change in edition2021 such that it is consistent
between core and std. Currently, only one permits a single formattable
value as the only argument. Instead, it will work more like write and
format itself. This also means that format itself is unnecessary.

Fixed like it should be suggested for: https://github.com/rust-lang/rust/issues/82110