### PR TITLE
Derive Debug for gif Repeat

### DIFF
--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -318,7 +318,7 @@ impl FrameInfo {
 }
 
 /// Number of repetitions for a GIF animation
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum Repeat {
     /// Finite number of repetitions
     Finite(u16),


### PR DESCRIPTION
I've been working with the animated image encoders and decoders in `image`, and discovered that the `Repeat` enum used by the gif encoder, does not implement the `Debug` trait. This PR adds a derive for Debug, so it can be used directly by anything that requires the Debug trait to be implemented.