### PR TITLE
Update meta data for 0.23.14

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,18 @@ Rust image aims to be a pure-Rust implementation of various popular image format
 
 ## Changes
 
+### Version 0.23.14
+
+- Unified gif blending in different decode methods, fixing out-of-bounds checks
+  in a number of weirdly positioned frames.
+- Hardened TGA decoder against a number of malicious inputs.
+- Fix forward incompatible usage of the panic macro.
+- Fix load_rect for gif reaching `unreachable!()` code.
+
+- Added `ExtendedColorType::A8`.
+- Allow TGA to load alpha-only images.
+- Optimized load_rect to avoid unnecessary seeks.
+
 ### Version 0.23.13
 
 - Fix an inconsistency in supported formats of different methods for encoding

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "image"
-version = "0.23.13"
+version = "0.23.14"
 edition = "2018"
 license = "MIT"
 description = "Imaging library written in Rust. Provides basic filters and decoders for the most common image formats."
@@ -27,7 +27,7 @@ num-iter = "0.1.32"
 num-rational = { version = "0.3", default-features = false }
 num-traits = "0.2.0"
 gif = { version = "0.11.1", optional = true }
-jpeg = { package = "jpeg-decoder", version = "0.1.17", default-features = false, optional = true }
+jpeg = { package = "jpeg-decoder", version = "0.1.22", default-features = false, optional = true }
 png = { version = "0.16.5", optional = true }
 scoped_threadpool = { version = "0.1", optional = true }
 tiff = { version = "0.6.0", optional = true }


### PR DESCRIPTION
The TGA fixes are pretty useful on their own, this also bumps the minimum required version of `jpeg` in preparation for what will be required anyways once we start looking at ICC&EXIF—which is necessary to fix issues such as #1440 in the long run.