### PR TITLE
Decoding limits try 2

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -754,7 +754,7 @@ impl DynamicImage {
     /// Resize this image using the specified filter algorithm.
     /// Returns a new image. The image's aspect ratio is preserved.
     /// The image is scaled to the maximum possible size that fits
-    /// within the bounds specified by ```nwidth``` and ```nheight```.
+    /// within the bounds specified by `nwidth` and `nheight`.
     pub fn resize(&self, nwidth: u32, nheight: u32, filter: imageops::FilterType) -> DynamicImage {
         let (width2, height2) =
             resize_dimensions(self.width(), self.height(), nwidth, nheight, false);
@@ -764,7 +764,7 @@ impl DynamicImage {
 
     /// Resize this image using the specified filter algorithm.
     /// Returns a new image. Does not preserve aspect ratio.
-    /// ```nwidth``` and ```nheight``` are the new image's dimensions
+    /// `nwidth` and `nheight` are the new image's dimensions
     pub fn resize_exact(
         &self,
         nwidth: u32,
@@ -777,7 +777,7 @@ impl DynamicImage {
     /// Scale this image down to fit within a specific size.
     /// Returns a new image. The image's aspect ratio is preserved.
     /// The image is scaled to the maximum possible size that fits
-    /// within the bounds specified by ```nwidth``` and ```nheight```.
+    /// within the bounds specified by `nwidth` and `nheight`.
     ///
     /// This method uses a fast integer algorithm where each source
     /// pixel contributes to exactly one target pixel.
@@ -789,8 +789,8 @@ impl DynamicImage {
     }
 
     /// Scale this image down to a specific size.
-    /// Returns a new image. Does not preserve aspect ratio.
-    /// ```nwidth``` and ```nheight``` are the new image's dimensions.
+    /// Returns a new image. Does not peserve aspect ratio.
+    /// `nwidth` and `nheight` are the new image's dimensions.
     /// This method uses a fast integer algorithm where each source
     /// pixel contributes to exactly one target pixel.
     /// May give aliasing artifacts if new size is close to old size.
@@ -802,7 +802,7 @@ impl DynamicImage {
     /// Returns a new image. The image's aspect ratio is preserved.
     /// The image is scaled to the maximum possible size that fits
     /// within the larger (relative to aspect ratio) of the bounds
-    /// specified by ```nwidth``` and ```nheight```, then cropped to
+    /// specified by `nwidth` and `nheight`, then cropped to
     /// fit within the other bound.
     pub fn resize_to_fill(
         &self,
@@ -826,14 +826,14 @@ impl DynamicImage {
     }
 
     /// Performs a Gaussian blur on this image.
-    /// ```sigma``` is a measure of how much to blur by.
+    /// `sigma` is a measure of how much to blur by.
     pub fn blur(&self, sigma: f32) -> DynamicImage {
         dynamic_map!(*self, ref p => imageops::blur(p, sigma))
     }
 
     /// Performs an unsharpen mask on this image.
-    /// ```sigma``` is the amount to blur the image by.
-    /// ```threshold``` is a control of how much to sharpen.
+    /// `sigma` is the amount to blur the image by.
+    /// `threshold` is a control of how much to sharpen.
     ///
     /// See <https://en.wikipedia.org/wiki/Unsharp_masking#Digital_unsharp_masking>
     pub fn unsharpen(&self, sigma: f32, threshold: i32) -> DynamicImage {
@@ -850,14 +850,14 @@ impl DynamicImage {
     }
 
     /// Adjust the contrast of this image.
-    /// ```contrast``` is the amount to adjust the contrast by.
+    /// `contrast` is the amount to adjust the contrast by.
     /// Negative values decrease the contrast and positive values increase the contrast.
     pub fn adjust_contrast(&self, c: f32) -> DynamicImage {
         dynamic_map!(*self, ref p => imageops::contrast(p, c))
     }
 
     /// Brighten the pixels of this image.
-    /// ```value``` is the amount to brighten each pixel by.
+    /// `value` is the amount to brighten each pixel by.
     /// Negative values decrease the brightness and positive values increase it.
     pub fn brighten(&self, value: i32) -> DynamicImage {
         dynamic_map!(*self, ref p => imageops::brighten(p, value))

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -789,7 +789,7 @@ impl DynamicImage {
     }
 
     /// Scale this image down to a specific size.
-    /// Returns a new image. Does not peserve aspect ratio.
+    /// Returns a new image. Does not preserve aspect ratio.
     /// `nwidth` and `nheight` are the new image's dimensions.
     /// This method uses a fast integer algorithm where each source
     /// pixel contributes to exactly one target pixel.

--- a/src/error.rs
+++ b/src/error.rs
@@ -167,6 +167,13 @@ pub enum LimitErrorKind {
     DimensionError,
     /// The operation would have performed an allocation larger than allowed.
     InsufficientMemory,
+    /// The specified strict limits are not supported for this operation
+    Unsupported {
+        /// The given limits 
+        limits: crate::io::Limits,
+        /// The supported strict limits
+        supported: crate::io::LimitSupport,
+    },
     #[doc(hidden)]
     /// Do not use this, not part of stability guarantees.
     __NonExhaustive(NonExhaustiveMarker),
@@ -497,6 +504,17 @@ impl fmt::Display for LimitError {
         match self.kind {
             LimitErrorKind::InsufficientMemory => write!(fmt, "Insufficient memory"),
             LimitErrorKind::DimensionError => write!(fmt, "Image is too large"),
+            LimitErrorKind::Unsupported {
+                limits,
+                supported,
+            } => {
+                write!(fmt, "The following strict limits are specified but not supported by the opertation: ")?;
+                if limits.max_alloc.is_some() && limits.max_alloc_strict && !supported.max_alloc_strict {
+                    write!(fmt, "maximum number of bytes allocated must be less than {}",
+                        limits.max_alloc.unwrap())?;
+                }
+                Ok(())
+            },
             LimitErrorKind::__NonExhaustive(marker) => match marker._private {},
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -505,14 +505,9 @@ impl fmt::Display for LimitError {
             LimitErrorKind::InsufficientMemory => write!(fmt, "Insufficient memory"),
             LimitErrorKind::DimensionError => write!(fmt, "Image is too large"),
             LimitErrorKind::Unsupported {
-                limits,
-                supported,
+                ..
             } => {
                 write!(fmt, "The following strict limits are specified but not supported by the opertation: ")?;
-                if limits.max_alloc.is_some() && limits.max_alloc_strict && !supported.max_alloc_strict {
-                    write!(fmt, "maximum number of bytes allocated must be less than {}",
-                        limits.max_alloc.unwrap())?;
-                }
                 Ok(())
             },
             LimitErrorKind::__NonExhaustive(marker) => match marker._private {},

--- a/src/image.rs
+++ b/src/image.rs
@@ -643,6 +643,7 @@ pub trait ImageDecoder<'a>: Sized {
     ///     decoder.read_image(buf.as_bytes());
     ///     buf
     /// }
+    /// ```
     fn read_image(self, buf: &mut [u8]) -> ImageResult<()> {
         self.read_image_with_progress(buf, |_| {})
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -686,14 +686,18 @@ pub trait ImageDecoder<'a>: Sized {
     /// limits that is possible to set.
     ///
     /// Note to implementors: make sure you call [`Limits::check_support`] so that 
-    /// decoding fails if any unsupported strict limits are set.
-    /// [`Limits::check_support`] will also check the `max_image_width` and
+    /// decoding fails if any unsupported strict limits are set. Also make sure
+    /// you call [`Limits::check_dimensions`] to check the `max_image_width` and
     /// `max_image_height` limits.
     ///
     /// [`Limits`]: ./io/struct.Limits.html
     /// [`Limits::check_support`]: ./io/struct.Limits.html#method.check_support
+    /// [`Limits::check_dimensions`]: ./io/struct.Limits.html#method.check_dimensions
     fn set_limits(&mut self, limits: crate::io::Limits) -> ImageResult<()> {
-        limits.check_support(self, crate::io::LimitSupport::default())?;
+        limits.check_support(&crate::io::LimitSupport::default())?;
+
+        let (width, height) = self.dimensions();
+        limits.check_dimensions(width, height)?;
 
         Ok(())
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -681,6 +681,22 @@ pub trait ImageDecoder<'a>: Sized {
 
         Ok(())
     }
+
+    /// Set decoding limits for this decoder. See [`Limits`] for the different kinds of 
+    /// limits that is possible to set.
+    ///
+    /// Note to implementors: make sure you call [`Limits::check_support`] so that 
+    /// decoding fails if any unsupported strict limits are set.
+    /// [`Limits::check_support`] will also check the `max_image_width` and
+    /// `max_image_height` limits.
+    ///
+    /// [`Limits`]: ./io/struct.Limits.html
+    /// [`Limits::check_support`]: ./io/struct.Limits.html#method.check_support
+    fn set_limits(&mut self, limits: crate::io::Limits) -> ImageResult<()> {
+        limits.check_support(self, crate::io::LimitSupport::default())?;
+
+        Ok(())
+    }
 }
 
 /// Specialized image decoding not be supported by all formats

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -34,39 +34,76 @@ pub(crate) fn open_impl(path: &Path) -> ImageResult<DynamicImage> {
 #[allow(unused_variables)]
 // r is unused if no features are supported.
 pub fn load<R: BufRead + Seek>(r: R, format: ImageFormat) -> ImageResult<DynamicImage> {
+    load_inner(r, super::Limits::default(), format)
+}
+
+pub(crate) trait DecoderVisitor {
+    type Result;
+    fn visit_decoder<'a, D: ImageDecoder<'a>>(self, decoder: D) -> ImageResult<Self::Result>;
+}
+
+pub(crate) fn load_decoder<R: BufRead + Seek, V: DecoderVisitor>(r: R, format: ImageFormat, visitor: V) -> ImageResult<V::Result> {
     #[allow(unreachable_patterns)]
     // Default is unreachable if all features are supported.
     match format {
         #[cfg(feature = "avif-decoder")]
-        image::ImageFormat::Avif => DynamicImage::from_decoder(avif::AvifDecoder::new(r)?),
+        image::ImageFormat::Avif => visitor.visit_decoder(avif::AvifDecoder::new(r)?),
         #[cfg(feature = "png")]
-        image::ImageFormat::Png => DynamicImage::from_decoder(png::PngDecoder::new(r)?),
+        image::ImageFormat::Png => visitor.visit_decoder(png::PngDecoder::new(r)?),
         #[cfg(feature = "gif")]
-        image::ImageFormat::Gif => DynamicImage::from_decoder(gif::GifDecoder::new(r)?),
+        image::ImageFormat::Gif => visitor.visit_decoder(gif::GifDecoder::new(r)?),
         #[cfg(feature = "jpeg")]
-        image::ImageFormat::Jpeg => DynamicImage::from_decoder(jpeg::JpegDecoder::new(r)?),
+        image::ImageFormat::Jpeg => visitor.visit_decoder(jpeg::JpegDecoder::new(r)?),
         #[cfg(feature = "webp")]
-        image::ImageFormat::WebP => DynamicImage::from_decoder(webp::WebPDecoder::new(r)?),
+        image::ImageFormat::WebP => visitor.visit_decoder(webp::WebPDecoder::new(r)?),
         #[cfg(feature = "tiff")]
-        image::ImageFormat::Tiff => DynamicImage::from_decoder(tiff::TiffDecoder::new(r)?),
+        image::ImageFormat::Tiff => visitor.visit_decoder(tiff::TiffDecoder::new(r)?),
         #[cfg(feature = "tga")]
-        image::ImageFormat::Tga => DynamicImage::from_decoder(tga::TgaDecoder::new(r)?),
+        image::ImageFormat::Tga => visitor.visit_decoder(tga::TgaDecoder::new(r)?),
         #[cfg(feature = "dds")]
-        image::ImageFormat::Dds => DynamicImage::from_decoder(dds::DdsDecoder::new(r)?),
+        image::ImageFormat::Dds => visitor.visit_decoder(dds::DdsDecoder::new(r)?),
         #[cfg(feature = "bmp")]
-        image::ImageFormat::Bmp => DynamicImage::from_decoder(bmp::BmpDecoder::new(r)?),
+        image::ImageFormat::Bmp => visitor.visit_decoder(bmp::BmpDecoder::new(r)?),
         #[cfg(feature = "ico")]
-        image::ImageFormat::Ico => DynamicImage::from_decoder(ico::IcoDecoder::new(r)?),
+        image::ImageFormat::Ico => visitor.visit_decoder(ico::IcoDecoder::new(r)?),
         #[cfg(feature = "hdr")]
-        image::ImageFormat::Hdr => DynamicImage::from_decoder(hdr::HdrAdapter::new(BufReader::new(r))?),
+        image::ImageFormat::Hdr => visitor.visit_decoder(hdr::HdrAdapter::new(BufReader::new(r))?),
         #[cfg(feature = "openexr")]
-        image::ImageFormat::OpenExr => DynamicImage::from_decoder(openexr::OpenExrDecoder::new(r)?),
+        image::ImageFormat::OpenExr => visitor.visit_decoder(openexr::OpenExrDecoder::new(r)?),
         #[cfg(feature = "pnm")]
-        image::ImageFormat::Pnm => DynamicImage::from_decoder(pnm::PnmDecoder::new(BufReader::new(r))?),
+        image::ImageFormat::Pnm => visitor.visit_decoder(pnm::PnmDecoder::new(r)?),
         #[cfg(feature = "farbfeld")]
-        image::ImageFormat::Farbfeld => DynamicImage::from_decoder(farbfeld::FarbfeldDecoder::new(r)?),
+        image::ImageFormat::Farbfeld => visitor.visit_decoder(farbfeld::FarbfeldDecoder::new(r)?),
         _ => Err(ImageError::Unsupported(ImageFormatHint::Exact(format).into())),
     }
+}
+
+pub(crate) fn load_inner<R: BufRead + Seek>(r: R, limits: super::Limits, format: ImageFormat) -> ImageResult<DynamicImage> {
+    struct LoadVisitor(super::Limits);
+
+    impl DecoderVisitor for LoadVisitor {
+        type Result = DynamicImage;
+
+        fn visit_decoder<'a, D: ImageDecoder<'a>>(self, mut decoder: D) -> ImageResult<Self::Result> {
+            let mut limits = self.0;
+            let total_bytes = decoder.total_bytes();
+            // Check that we do not allocate a bigger buffer than we are allowed to
+            // FIXME: should this rather go in `DynamicImage::from_decoder` somehow?
+            if let Some(max_alloc) = limits.max_alloc.as_mut() {
+                if *max_alloc < total_bytes {
+                    return Err(ImageError::Limits(crate::error::LimitError::from_kind(
+                        crate::error::LimitErrorKind::InsufficientMemory)))
+                }
+                // We are allocating a buffer of size `total_bytes` outside of
+                // the decoder. Therefore the decoder gets a smaller limit.
+                *max_alloc -= total_bytes;
+            }
+            decoder.set_limits(self.0)?;
+            DynamicImage::from_decoder(decoder)
+        }
+    }
+
+    load_decoder(r, format, LoadVisitor(limits))
 }
 
 pub(crate) fn image_dimensions_impl(path: &Path) -> ImageResult<(u32, u32)> {
@@ -83,40 +120,16 @@ pub(crate) fn image_dimensions_impl(path: &Path) -> ImageResult<(u32, u32)> {
 pub(crate) fn image_dimensions_with_format_impl<R: BufRead + Seek>(fin: R, format: ImageFormat)
     -> ImageResult<(u32, u32)>
 {
-    #[allow(unreachable_patterns,unreachable_code)]
-    // Default is unreachable if all features are supported.
-    // Code after the match is unreachable if none are.
-    Ok(match format {
-        #[cfg(feature = "avif-decoder")]
-        image::ImageFormat::Avif => avif::AvifDecoder::new(fin)?.dimensions(),
-        #[cfg(feature = "jpeg")]
-        image::ImageFormat::Jpeg => jpeg::JpegDecoder::new(fin)?.dimensions(),
-        #[cfg(feature = "png")]
-        image::ImageFormat::Png => png::PngDecoder::new(fin)?.dimensions(),
-        #[cfg(feature = "gif")]
-        image::ImageFormat::Gif => gif::GifDecoder::new(fin)?.dimensions(),
-        #[cfg(feature = "webp")]
-        image::ImageFormat::WebP => webp::WebPDecoder::new(fin)?.dimensions(),
-        #[cfg(feature = "tiff")]
-        image::ImageFormat::Tiff => tiff::TiffDecoder::new(fin)?.dimensions(),
-        #[cfg(feature = "tga")]
-        image::ImageFormat::Tga => tga::TgaDecoder::new(fin)?.dimensions(),
-        #[cfg(feature = "dds")]
-        image::ImageFormat::Dds => dds::DdsDecoder::new(fin)?.dimensions(),
-        #[cfg(feature = "bmp")]
-        image::ImageFormat::Bmp => bmp::BmpDecoder::new(fin)?.dimensions(),
-        #[cfg(feature = "ico")]
-        image::ImageFormat::Ico => ico::IcoDecoder::new(fin)?.dimensions(),
-        #[cfg(feature = "hdr")]
-        image::ImageFormat::Hdr => hdr::HdrAdapter::new(fin)?.dimensions(),
-        #[cfg(feature = "openexr")]
-        image::ImageFormat::OpenExr => openexr::OpenExrDecoder::new(fin)?.dimensions(),
-        #[cfg(feature = "pnm")]
-        image::ImageFormat::Pnm => {
-            pnm::PnmDecoder::new(fin)?.dimensions()
+        struct DimVisitor;
+
+        impl DecoderVisitor for DimVisitor {
+            type Result = (u32, u32);
+            fn visit_decoder<'a, D: ImageDecoder<'a>>(self, decoder: D) -> ImageResult<Self::Result> {
+                Ok(decoder.dimensions())
+            }
         }
-        format => return Err(ImageError::Unsupported(ImageFormatHint::Exact(format).into())),
-    })
+
+        load_decoder(fin, format, DimVisitor)
 }
 
 #[allow(unused_variables)]

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -33,12 +33,13 @@ impl Default for LimitSupport {
 /// a critical bug. If a decoder cannot guarantee that it will uphold a strict limit it 
 /// *must* fail with `image::error::LimitErrorKind::Unsupported`.
 ///
-/// Currently there are no strict limits supported, however they will be added in the
-/// future. [`LimitSupport`] will default to support being false and decoders should
-/// enable support for the limits they support in [`ImageDecoder::set_limits`].
+/// Currently the only strict limits supported are the `max_image_width` and `max_image_height`
+/// limits, however more will be added in the future. [`LimitSupport`] will default to support
+/// being false and decoders should enable support for the limits they support in
+/// [`ImageDecoder::set_limits`].
 ///
-/// The limit check should only ever fail if a limit will be exceeded or an unsupported
-/// strict limit is used.
+/// The limit check should only ever fail if a limit will be exceeded or an unsupported strict
+/// limit is used.
 ///
 /// [`LimitSupport`]: ./struct.LimitSupport.html
 /// [`ImageDecoder::set_limits`]: ../trait.ImageDecoder.html#method.set_limits
@@ -49,9 +50,9 @@ pub struct Limits {
     pub max_image_width: Option<u32>,
     /// The maximum allowed image height. This limit is strict. The default is no limit.
     pub max_image_height: Option<u32>,
-    /// The maximum allowed sum of allocations allocated by the decoder at any one 
-    /// time exluding allocator overhead. This limit is non-strict by default and
-    /// some decoders may ignore it. The default is 512MiB.
+    /// The maximum allowed sum of allocations allocated by the decoder at any one time exluding
+    /// allocator overhead. This limit is non-strict by default and some decoders may ignore it.
+    /// The default is 512MiB.
     pub max_alloc: Option<u64>,
     _non_exhaustive: (),
 }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,5 +1,113 @@
 //! Input and output of images.
+
+use crate::{error, ImageError, ImageResult};
+
 mod reader;
 pub(crate) mod free_functions;
 
 pub use self::reader::Reader;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+/// Set of supported strict limits for a decoder
+pub struct LimitSupport {
+    /// This field indicates whether the strict limit on the number of bytes is
+    /// supported.
+    pub max_alloc_strict: bool,
+    _non_exhaustive: (),
+}
+
+impl Default for LimitSupport {
+    fn default() -> LimitSupport {
+        LimitSupport {
+            max_alloc_strict: false,
+            _non_exhaustive: (),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+/// Resource limits for decoding.
+///
+/// Limits can be either *strict* or *non-strict*. Non-strict limits are best-effort
+/// limits where the library does not guarantee that limit wont be exceeded. Do note 
+/// that it is still considered a bug if a non-strict limit is exceeded, however as 
+/// some of the underlying decoders do . For strict
+/// limits the library makes a stronger guarantee that the limit will not be exceeded.
+/// Exceeding a strict limit is considered a critical bug. If a decoder cannot 
+/// guaranree that it will uphold a strict limit it *must* fail with 
+/// `image::error::LimitErrorKind::Unsupported`.
+///
+/// The limit check should only ever fail if a limit will be exceeded or an unsupported strict
+/// limit is used.
+pub struct Limits {
+    /// The maximum allowed image width. This limit is strict. The default is no limit.
+    pub max_image_width: Option<u32>,
+    /// The maximum allowed image height. This limit is strict. The default is no limit.
+    pub max_image_height: Option<u32>,
+    /// The maximum allowed amount of memory to be allocated by the 
+    /// decoder at any one time. This limit is non-strict by default,
+    /// set `max_alloc_strict` to make this limit strict. The default 
+    /// is 512MiB. Note that limits below 1MiB are not supported, this 
+    /// is also the case if this limit is strict.
+    pub max_alloc: Option<u64>,
+    /// If `max_alloc` should be a strict limit.
+    pub max_alloc_strict: bool,
+    _non_exhaustive: (),
+}
+
+impl Default for Limits {
+    fn default() -> Limits {
+        Limits {
+            max_image_width: None,
+            max_image_height: None,
+            max_alloc: Some(512*1024*1024),
+            max_alloc_strict: false,
+            _non_exhaustive: (),
+        }
+    }
+}
+
+impl Limits {
+    /// Disable all limits
+    pub fn no_limits() -> Limits {
+        Limits {
+            max_image_width: None,
+            max_image_height: None,
+            max_alloc: None,
+            max_alloc_strict: false,
+            _non_exhaustive: (),
+        }
+    }
+
+    /// Check if the current limits given a decoder and a set of supported strict limits.
+    ///
+    /// This function checks that all currently set strict limits are supported. It also
+    /// checks the `max_image_width` and `max_image_height` limits using the dimensions
+    /// from the decoder.
+    pub fn check_support<'a, D: crate::ImageDecoder<'a>>(&self, decoder: &mut D, supported: LimitSupport) -> ImageResult<()> {
+        if self.max_alloc.is_some() && self.max_alloc_strict && !supported.max_alloc_strict {
+            return Err(ImageError::Limits(error::LimitError::from_kind(
+                error::LimitErrorKind::Unsupported {
+                    limits: *self,
+                    supported: supported,
+                })))
+        }
+
+        let (width, height) = decoder.dimensions();
+        if let Some(max_width) = self.max_image_width {
+            if width > max_width {
+                return Err(ImageError::Limits(crate::error::LimitError::from_kind(
+                    crate::error::LimitErrorKind::DimensionError)))
+            }
+        }
+
+        if let Some(max_height) = self.max_image_height {
+            if height > max_height {
+                return Err(ImageError::Limits(crate::error::LimitError::from_kind(
+                    crate::error::LimitErrorKind::DimensionError)))
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -7,7 +7,7 @@ pub(crate) mod free_functions;
 
 pub use self::reader::Reader;
 
-/// Set of supported strict limits for a decoder
+/// Set of supported strict limits for a decoder.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[allow(missing_copy_implementations)]
 pub struct LimitSupport {
@@ -25,16 +25,23 @@ impl Default for LimitSupport {
 /// Resource limits for decoding.
 ///
 /// Limits can be either *strict* or *non-strict*. Non-strict limits are best-effort
-/// limits where the library does not guarantee that limit wont be exceeded. Do note 
+/// limits where the library does not guarantee that limit will not be exceeded. Do note 
 /// that it is still considered a bug if a non-strict limit is exceeded, however as 
 /// some of the underlying decoders do not support not support such limits one cannot 
 /// rely on these limits being supported. For stric limits the library makes a stronger 
 /// guarantee that the limit will not be exceeded. Exceeding a strict limit is considered 
-/// a critical bug. If a decoder cannot guaranree that it will uphold a strict limit it 
+/// a critical bug. If a decoder cannot guarantee that it will uphold a strict limit it 
 /// *must* fail with `image::error::LimitErrorKind::Unsupported`.
+///
+/// Currently there are no strict limits supported, however they will be added in the
+/// future. [`LimitSupport`] will default to support being false and decoders should
+/// enable support for the limits they support in [`ImageDecoder::set_limits`].
 ///
 /// The limit check should only ever fail if a limit will be exceeded or an unsupported
 /// strict limit is used.
+///
+/// [`LimitSupport`]: ./struct.LimitSupport.html
+/// [`ImageDecoder::set_limits`]: ../trait.ImageDecoder.html#method.set_limits
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[allow(missing_copy_implementations)]
 pub struct Limits {
@@ -42,9 +49,9 @@ pub struct Limits {
     pub max_image_width: Option<u32>,
     /// The maximum allowed image height. This limit is strict. The default is no limit.
     pub max_image_height: Option<u32>,
-    /// The maximum allowed amount of memory to be allocated by the 
-    /// decoder at any one time. This limit is non-strict and some 
-    /// decoders may ignore it. The default is 512MiB.
+    /// The maximum allowed sum of allocations allocated by the decoder at any one 
+    /// time exluding allocator overhead. This limit is non-strict by default and
+    /// some decoders may ignore it. The default is 512MiB.
     pub max_alloc: Option<u64>,
     _non_exhaustive: (),
 }
@@ -61,7 +68,7 @@ impl Default for Limits {
 }
 
 impl Limits {
-    /// Disable all limits
+    /// Disable all limits.
     pub fn no_limits() -> Limits {
         Limits {
             max_image_width: None,

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -117,7 +117,7 @@ impl Limits {
     /// [`reserve`]: #method.reserve
     pub fn free(&mut self, amount: u64) {
         if let Some(max_alloc) = self.max_alloc.as_mut() {
-            *max_alloc -= std::cmp::min(*max_alloc, amount);
+            *max_alloc = max_alloc.saturating_add(amount);
         }
     }
 }

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -7,51 +7,45 @@ pub(crate) mod free_functions;
 
 pub use self::reader::Reader;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 /// Set of supported strict limits for a decoder
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[allow(missing_copy_implementations)]
 pub struct LimitSupport {
-    /// This field indicates whether the strict limit on the number of bytes is
-    /// supported.
-    pub max_alloc_strict: bool,
     _non_exhaustive: (),
 }
 
 impl Default for LimitSupport {
     fn default() -> LimitSupport {
         LimitSupport {
-            max_alloc_strict: false,
             _non_exhaustive: (),
         }
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 /// Resource limits for decoding.
 ///
 /// Limits can be either *strict* or *non-strict*. Non-strict limits are best-effort
 /// limits where the library does not guarantee that limit wont be exceeded. Do note 
 /// that it is still considered a bug if a non-strict limit is exceeded, however as 
-/// some of the underlying decoders do . For strict
-/// limits the library makes a stronger guarantee that the limit will not be exceeded.
-/// Exceeding a strict limit is considered a critical bug. If a decoder cannot 
-/// guaranree that it will uphold a strict limit it *must* fail with 
-/// `image::error::LimitErrorKind::Unsupported`.
+/// some of the underlying decoders do not support not support such limits one cannot 
+/// rely on these limits being supported. For stric limits the library makes a stronger 
+/// guarantee that the limit will not be exceeded. Exceeding a strict limit is considered 
+/// a critical bug. If a decoder cannot guaranree that it will uphold a strict limit it 
+/// *must* fail with `image::error::LimitErrorKind::Unsupported`.
 ///
-/// The limit check should only ever fail if a limit will be exceeded or an unsupported strict
-/// limit is used.
+/// The limit check should only ever fail if a limit will be exceeded or an unsupported
+/// strict limit is used.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[allow(missing_copy_implementations)]
 pub struct Limits {
     /// The maximum allowed image width. This limit is strict. The default is no limit.
     pub max_image_width: Option<u32>,
     /// The maximum allowed image height. This limit is strict. The default is no limit.
     pub max_image_height: Option<u32>,
     /// The maximum allowed amount of memory to be allocated by the 
-    /// decoder at any one time. This limit is non-strict by default,
-    /// set `max_alloc_strict` to make this limit strict. The default 
-    /// is 512MiB. Note that limits below 1MiB are not supported, this 
-    /// is also the case if this limit is strict.
+    /// decoder at any one time. This limit is non-strict and some 
+    /// decoders may ignore it. The default is 512MiB.
     pub max_alloc: Option<u64>,
-    /// If `max_alloc` should be a strict limit.
-    pub max_alloc_strict: bool,
     _non_exhaustive: (),
 }
 
@@ -61,7 +55,6 @@ impl Default for Limits {
             max_image_width: None,
             max_image_height: None,
             max_alloc: Some(512*1024*1024),
-            max_alloc_strict: false,
             _non_exhaustive: (),
         }
     }
@@ -74,40 +67,57 @@ impl Limits {
             max_image_width: None,
             max_image_height: None,
             max_alloc: None,
-            max_alloc_strict: false,
             _non_exhaustive: (),
         }
     }
 
-    /// Check if the current limits given a decoder and a set of supported strict limits.
-    ///
-    /// This function checks that all currently set strict limits are supported. It also
-    /// checks the `max_image_width` and `max_image_height` limits using the dimensions
-    /// from the decoder.
-    pub fn check_support<'a, D: crate::ImageDecoder<'a>>(&self, decoder: &mut D, supported: LimitSupport) -> ImageResult<()> {
-        if self.max_alloc.is_some() && self.max_alloc_strict && !supported.max_alloc_strict {
-            return Err(ImageError::Limits(error::LimitError::from_kind(
-                error::LimitErrorKind::Unsupported {
-                    limits: *self,
-                    supported: supported,
-                })))
-        }
+    /// This function checks that all currently set strict limits are supported.
+    pub fn check_support(&self, _supported: &LimitSupport) -> ImageResult<()> {
+        Ok(())
+    }
 
-        let (width, height) = decoder.dimensions();
+    /// This function checks the `max_image_width` and `max_image_height` limits given
+    /// the image width and height.
+    pub fn check_dimensions(&self, width: u32, height: u32) -> ImageResult<()> {
         if let Some(max_width) = self.max_image_width {
             if width > max_width {
-                return Err(ImageError::Limits(crate::error::LimitError::from_kind(
-                    crate::error::LimitErrorKind::DimensionError)))
+                return Err(ImageError::Limits(error::LimitError::from_kind(
+                    error::LimitErrorKind::DimensionError)))
             }
         }
 
         if let Some(max_height) = self.max_image_height {
             if height > max_height {
-                return Err(ImageError::Limits(crate::error::LimitError::from_kind(
-                    crate::error::LimitErrorKind::DimensionError)))
+                return Err(ImageError::Limits(error::LimitError::from_kind(
+                    error::LimitErrorKind::DimensionError)))
             }
         }
 
         Ok(())
+    }
+
+    /// This function checks that the current limit allows for reserving the set amount
+    /// of bytes, it then reduces the limit accordingly.
+    pub fn reserve(&mut self, amount: u64) -> ImageResult<()> {
+        if let Some(max_alloc) = self.max_alloc.as_mut() {
+            if *max_alloc < amount {
+                return Err(ImageError::Limits(error::LimitError::from_kind(
+                    error::LimitErrorKind::InsufficientMemory)))
+            }
+
+            *max_alloc -= amount;
+        }
+
+        Ok(())
+    }
+
+    /// This function increases the `max_alloc` limit with amount. Should only be used
+    /// togheter with [`reserve`].
+    ///
+    /// [`reserve`]: #method.reserve
+    pub fn free(&mut self, amount: u64) {
+        if let Some(max_alloc) = self.max_alloc.as_mut() {
+            *max_alloc -= std::cmp::min(*max_alloc, amount);
+        }
     }
 }

--- a/src/io/reader.rs
+++ b/src/io/reader.rs
@@ -116,12 +116,12 @@ impl<R: Read> Reader<R> {
         self.format = None;
     }
 
-    /// Disable all decoding limits
+    /// Disable all decoding limits.
     pub fn no_limits(&mut self) {
         self.limits = super::Limits::no_limits();
     }
 
-    /// Set a custom set of decoding limits
+    /// Set a custom set of decoding limits.
     pub fn limits(&mut self, limits: super::Limits) {
         self.limits = limits;
     }

--- a/src/io/reader.rs
+++ b/src/io/reader.rs
@@ -32,8 +32,7 @@ use super::free_functions;
 /// source is some blob in memory and you have constructed the reader in another way. Here is an
 /// example with a `pnm` black-and-white subformat that encodes its pixel matrix with ascii values.
 ///
-#[cfg_attr(feature = "pnm", doc = "```")]
-#[cfg_attr(not(feature = "pnm"), doc = "```no_run")]
+/// ```
 /// # use image::ImageError;
 /// # use image::io::Reader;
 /// # fn main() -> Result<(), ImageError> {
@@ -49,6 +48,7 @@ use super::free_functions;
 ///     .expect("Cursor io never fails");
 /// assert_eq!(reader.format(), Some(ImageFormat::Pnm));
 ///
+/// # #[cfg(feature = "pnm")]
 /// let image = reader.decode()?;
 /// # Ok(()) }
 /// ```

--- a/src/io/reader.rs
+++ b/src/io/reader.rs
@@ -63,6 +63,8 @@ pub struct Reader<R: Read> {
     inner: R,
     /// The format, if one has been set or deduced.
     format: Option<ImageFormat>,
+    /// Decoding limits
+    limits: super::Limits,
 }
 
 impl<R: Read> Reader<R> {
@@ -80,6 +82,7 @@ impl<R: Read> Reader<R> {
         Reader {
             inner: buffered_reader,
             format: None,
+            limits: super::Limits::default(),
         }
     }
 
@@ -91,6 +94,7 @@ impl<R: Read> Reader<R> {
         Reader {
             inner: buffered_reader,
             format: Some(format),
+            limits: super::Limits::default(),
         }
     }
 
@@ -110,6 +114,16 @@ impl<R: Read> Reader<R> {
     /// `ImageError::Unsupported` when the image format has not been set.
     pub fn clear_format(&mut self) {
         self.format = None;
+    }
+
+    /// Disable all decoding limits
+    pub fn no_limits(&mut self) {
+        self.limits = super::Limits::no_limits();
+    }
+
+    /// Set a custom set of decoding limits
+    pub fn limits(&mut self, limits: super::Limits) {
+        self.limits = limits;
     }
 
     /// Unwrap the reader.
@@ -136,6 +150,7 @@ impl Reader<BufReader<File>> {
         Ok(Reader {
             inner: BufReader::new(file),
             format: ImageFormat::from_path(path).ok(),
+            limits: super::Limits::default(),
         })
     }
 }
@@ -207,7 +222,7 @@ impl<R: BufRead + Seek> Reader<R> {
     /// If no format was determined, returns an `ImageError::Unsupported`.
     pub fn decode(mut self) -> ImageResult<DynamicImage> {
         let format = self.require_format()?;
-        free_functions::load(self.inner, format)
+        free_functions::load_inner(self.inner, self.limits, format)
     }
 
     fn require_format(&mut self) -> ImageResult<ImageFormat> {


### PR DESCRIPTION
I have given decoding limits another try based on the latest discussion from #938. 

The current design uses a non-exhaustive `Limits` struct with public fields to provide an interface for setting decoding limits. It also defines a `LimitSupport` that decoders can use together with `Limits::check_support` in order to check if they support all of the limits that are set in a backwards-compatible way.

In the documentation of `Limits` I have written a little bit about the difference between *strict* and *non-strict* limits. The idea being that with non-strict limits decoders that support them should set them but without excluding decoders that do not support limits. For strict limits only decoders that can uphold the limits should be used.

This PR does intentionally not provide any `ImageDecoder::set_limit` implementations. This is to reduce its scope so we can keep the discussion centered around the `Limits` API as well as what kinds of guarantees should be provided by the `Limits` API. These implementations should be easy to add in follow-up PRs.

I also added a little commit to change the formatting of a couple of comments that my editors syntax-highlighting engine didn't like.

Some design questions:
- Should `Limits` and `LimitSupport` use methods instead of public fields to set decoding limits?
- Do the `max_image_width` and `max_image_height` limits make any sense?
- Does the current distinction between strict and non-strict limits make any sense, should there be a different set of guarantees?