### PR TITLE
Metadata

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -3,6 +3,7 @@ use std::ops::{Index, IndexMut};
 use num_traits::{NumCast, ToPrimitive, Zero};
 
 use crate::traits::{Pixel, Primitive};
+use crate::utils::NonExhaustiveMarker;
 
 /// An enumeration over supported color types and bit depths
 #[derive(Copy, PartialEq, Eq, Debug, Clone, Hash)]
@@ -31,12 +32,11 @@ pub enum ColorType {
     Bgra8,
 
     #[doc(hidden)]
-    __NonExhaustive(crate::utils::NonExhaustiveMarker),
+    __NonExhaustive(NonExhaustiveMarker),
 }
 
 /// Color information of an image's texels.
 #[derive(Clone, Debug, PartialEq)]
-#[non_exhaustive]
 pub enum Color {
     /// The color space is given by an encoded ICC profile.
     ///
@@ -65,6 +65,9 @@ pub enum Color {
         /// The absolute luminance of the values in the color space.
         luminance: Luminance,
     },
+
+    #[doc(hidden)]
+    __NonExhaustive(NonExhaustiveMarker),
 }
 
 /// Transfer functions from encoded chromatic samples to physical quantity.
@@ -74,7 +77,6 @@ pub enum Color {
 /// describes how scene lighting is encoded as an electric signal. These are applied to each
 /// stimulus value.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum Transfer {
     /// Specified in ITU Rec.709.
     Bt709,
@@ -96,22 +98,26 @@ pub enum Transfer {
     Bt2100Pq,
     /// ITU Rec.2100 Hybrid Log-Gamma.
     Bt2100Hlg,
+
+    #[doc(hidden)]
+    __NonExhaustive(NonExhaustiveMarker),
 }
 
 /// The reference brightness of the color specification.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum Luminance {
     /// 100cd/m².
     Sdr,
     /// 10_000cd/m².
     /// Known as high-dynamic range.
     Hdr,
+
+    #[doc(hidden)]
+    __NonExhaustive(NonExhaustiveMarker),
 }
 
 /// The relative stimuli of the three corners of a triangular gamut.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum Primaries {
     Bt601_525,
     Bt601_625,
@@ -119,13 +125,18 @@ pub enum Primaries {
     Smpte240,
     Bt2020,
     Bt2100,
+
+    #[doc(hidden)]
+    __NonExhaustive(NonExhaustiveMarker),
 }
 
 /// The whitepoint/standard illuminant.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum Whitepoint {
     D65,
+
+    #[doc(hidden)]
+    __NonExhaustive(NonExhaustiveMarker),
 }
 
 impl ColorType {
@@ -247,7 +258,7 @@ pub enum ExtendedColorType {
     Unknown(u8),
 
     #[doc(hidden)]
-    __NonExhaustive(crate::utils::NonExhaustiveMarker),
+    __NonExhaustive(NonExhaustiveMarker),
 }
 
 impl ExtendedColorType {

--- a/src/image.rs
+++ b/src/image.rs
@@ -569,7 +569,6 @@ pub trait ImageDecoder<'a>: Sized {
     fn metagram(&mut self, recorder: &mut Recorder) {
         let (width, height) = self.dimensions();
         recorder.dimensions(width, height);
-        recorder.color(self.original_color_type());
     }
 
     /// Returns all the bytes in the image.

--- a/src/image.rs
+++ b/src/image.rs
@@ -10,6 +10,7 @@ use std::usize;
 use crate::ImageBuffer;
 use crate::color::{ColorType, ExtendedColorType};
 use crate::error::{ImageError, ImageFormatHint, ImageResult, LimitError, LimitErrorKind, ParameterError, ParameterErrorKind};
+use crate::io::Recorder;
 use crate::math::Rect;
 use crate::traits::Pixel;
 
@@ -558,6 +559,17 @@ pub trait ImageDecoder<'a>: Sized {
     /// be as few as 1 or as many as `total_bytes()`.
     fn scanline_bytes(&self) -> u64 {
         self.total_bytes()
+    }
+
+    /// Record auxiliary information.
+    /// For decoders that may encounter additional extra data, i.e. EXIF data that might be
+    /// discovered while reading the image, a `SharedRecorder` should be retrieved and data
+    /// recorded with it instead. All relevant information should be added before returning from
+    /// the `read_image` call.
+    fn metagram(&mut self, recorder: &mut Recorder) {
+        let (width, height) = self.dimensions();
+        recorder.dimensions(width, height);
+        recorder.color(self.original_color_type());
     }
 
     /// Returns all the bytes in the image.

--- a/src/io/metadata.rs
+++ b/src/io/metadata.rs
@@ -3,8 +3,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::color::Color;
 
-// oder (Engram), Metagram, 
-/// Collects some arbitrary meta data of an image.
+/// Collects some arbitrary metadata of an image.
 ///
 /// Note that information collected here will, per default, appear opaque to the `image` library
 /// itself. For example, the width and height of an image might be recorded as one set of values
@@ -13,7 +12,7 @@ use crate::color::Color;
 /// recheck with the specific decoder if you require color accuracy beyond presuming sRGB. (This
 /// may be improved upon in the future, if you have a concrete draft please open an issue).
 #[derive(Clone, Default)]
-pub struct Metagram {
+pub struct MetadataContainer {
     /// The original width in pixels.
     pub width: u32,
     /// The original height in pixels.
@@ -26,10 +25,37 @@ pub struct Metagram {
     _non_exhaustive: (),
 }
 
-/// A buffer for the extra meta data produced by an image decoder.
+/// Hints whether one specific metadatum is requested.
+#[derive(Clone, Copy)]
+pub enum DatumRequested {
+    /// The decoder should skip the datum when encountered.
+    Ignore,
+    /// The decoder should decode, validate, and add the datum.
+    Record,
+}
+
+/// Configure the caller needs of metadata.
+///
+/// Not every piece of metadata can be added for free. For example, reading EXIF profiles is
+/// commonly associated with decoding of additional chunks, validation, and additional resource
+/// usage. All of these can be opt-out by allowing such a customization. Note that, nevertheless,
+/// the absence of metadata is not definitive proof of its absence in the original file. It might
+/// be more recent than the decoder and not yet have support.
+#[derive(Clone, Default)]
+// We may want to add a non-copy field?
+#[allow(missing_copy_implementations)]
+pub struct RecorderConfig {
+    /// Whether the decoder should try to provide color profile data.
+    pub color_profile: DatumRequested,
+    /// Whether the decoder should try to provide EXIF data.
+    pub exif: DatumRequested,
+    _non_exhaustive: (),
+}
+
+/// A buffer for the extra metadata produced by an image decoder.
 ///
 /// There are two main ways of creation: Any consumer of the `ImageDecoder` interface can create
-/// their own recorder to retrieve meta data from the decoder. A decoder wrapping another format
+/// their own recorder to retrieve metadata from the decoder. A decoder wrapping another format
 /// (i.e. jpeg-within-tiff) might create a recorder from a `SharedRecorder` to add additional data
 /// to the outer recorder instead.
 ///
@@ -44,7 +70,7 @@ pub struct Metagram {
 /// #   fn color_type(&self) -> image::ColorType { todo!() }
 /// #   fn into_reader(self) -> image::ImageResult<std::io::Empty> { Ok(std::io::empty()) }
 /// # }
-/// use image::io::{Metagram, Recorder};
+/// use image::io::{MetadataContainer, Recorder};
 ///
 /// let mut some_decoder = // ..
 /// # FakeDecoder;
@@ -58,33 +84,50 @@ pub struct Metagram {
 ///     some_decoder.read_image(&mut _buffer);
 /// }
 ///
-/// let meta: Metagram = recorder.to_result();
+/// let meta: MetadataContainer = recorder.to_result();
 /// ```
 pub struct Recorder {
     inner: RecorderInner,
+    config: RecorderConfig,
 }
 
 enum RecorderInner {
-    Owned(Box<RefCell<Metagram>>),
-    Shared(Arc<Mutex<Metagram>>),
+    Owned(Box<RefCell<MetadataContainer>>),
+    Shared(Arc<Mutex<MetadataContainer>>),
 }
 
-/// An owned handle to a `Metagram`, that allows concurrent modification.
+/// An owned handle to a `MetadataContainer`, that allows concurrent modification.
 #[allow(missing_copy_implementations)]
 pub struct SharedRecorder {
-    inner: Arc<Mutex<Metagram>>,
+    inner: Arc<Mutex<MetadataContainer>>,
+    config: RecorderConfig,
 }
 
 impl Recorder {
-    /// Create a recorder recording into a new, empty meta data.
+    /// Create a recorder recording into a new, empty metadata.
     pub fn new() -> Self {
         Recorder::default()
     }
 
+    /// Get the current configuration.
+    pub fn config(&self) -> &RecorderConfig {
+        &self.config
+    }
+
+    /// Get a mutable reference to the current configuration.
+    ///
+    /// Note that the configuration is cloned when converting between `Recorder` and
+    /// `SharedRecorder` but it is not _shared_ between instances. That is, changes only apply to
+    /// this instance and not to clones.
+    pub fn config_mut(&mut self) -> &mut RecorderConfig {
+        &mut self.config
+    }
+
     /// Create a record that already contains some data.
-    pub fn with(meta: Metagram) -> Self {
+    pub fn with(meta: MetadataContainer) -> Self {
         Recorder {
             inner: RecorderInner::Owned(Box::new(RefCell::new(meta))),
+            config: RecorderConfig::default(),
         }
     }
 
@@ -113,28 +156,29 @@ impl Recorder {
 
         SharedRecorder {
             inner,
+            config: self.config.clone(),
         }
     }
 
-    /// Get a clone of the configured meta data.
-    pub fn to_result(&self) -> Metagram {
+    /// Get a clone of the configured metadata.
+    pub fn to_result(&self) -> MetadataContainer {
         self.inner.to_result()
     }
 }
 
 impl RecorderInner {
-    fn with_mut(&self, function: impl FnOnce(&mut Metagram)) {
+    fn with_mut(&self, function: impl FnOnce(&mut MetadataContainer)) {
         match self {
             RecorderInner::Owned(boxed) => {
                 function(&mut boxed.borrow_mut())
             }
             RecorderInner::Shared(arc) => {
-                function(&mut arc.lock().unwrap())
+                function(&mut arc.lock().unwrap_or_else(|err| err.into_inner()))
             }
         }
     }
 
-    fn to_result(&self) -> Metagram {
+    fn to_result(&self) -> MetadataContainer {
         match self {
             RecorderInner::Owned(boxed) => boxed.borrow().clone(),
             RecorderInner::Shared(arc) => arc.lock().unwrap().clone(),
@@ -142,7 +186,8 @@ impl RecorderInner {
     }
 }
 
-/// Setters for recording meta data.
+/// Setters for recording metadata.
+///
 /// Any change here should also be made for `SharedRecorder` unless it is specifically not possible
 /// to perform on a shared, and locked struct.
 impl Recorder {
@@ -160,9 +205,32 @@ impl Recorder {
     pub fn exif(&self, data: Vec<u8>) {
         self.inner.with_mut(|meta| meta.set_exif(data))
     }
+
+    /// Mutate the metadata container.
+    ///
+    /// This will make the changes visible to all other recorders sharing the container target. It
+    /// is not specified what happens when `function` panics but there will be no undefined
+    /// behavior.
+    pub fn with_mut(&self, function: impl FnOnce(&mut MetadataContainer)) {
+        self.inner.with_mut(function)
+    }
 }
 
 impl SharedRecorder {
+    /// Get the current configuration.
+    pub fn config(&self) -> &RecorderConfig {
+        &self.config
+    }
+
+    /// Get a mutable reference to the current configuration.
+    ///
+    /// Note that the configuration is cloned when converting between `Recorder` and
+    /// `SharedRecorder` but it is not _shared_ between instances. That is, changes only apply to
+    /// this instance and not to clones.
+    pub fn config_mut(&mut self) -> &mut RecorderConfig {
+        &mut self.config
+    }
+
     /// Add original dimensions.
     pub fn dimensions(&self, width: u32, height: u32) {
         self.with_mut(|meta| meta.set_dimensions((width, height)));
@@ -178,7 +246,12 @@ impl SharedRecorder {
         self.with_mut(|meta| meta.set_exif(data))
     }
 
-    fn with_mut(&self, function: impl FnOnce(&mut Metagram)) {
+    /// Mutate the shared metadata container.
+    ///
+    /// This will make the changes visible to all other recorders sharing the container target. It
+    /// is not specified what happens when `function` panics but there will be no undefined
+    /// behavior.
+    pub fn with_mut(&self, function: impl FnOnce(&mut MetadataContainer)) {
         // Regarding lock recovery: None of the inner methods should usually panic. The only
         // exception would be from allocation error while inserting a new exif tag or something.
         function(&mut self.inner.lock().unwrap_or_else(|err| err.into_inner()))
@@ -187,7 +260,7 @@ impl SharedRecorder {
 
 /// Private implementation of metagram, existing for the purpose of make assignment available as
 /// methods.
-impl Metagram {
+impl MetadataContainer {
     fn set_dimensions(&mut self, (width, height): (u32, u32)) {
         self.width = width;
         self.height = height;
@@ -206,15 +279,25 @@ impl Default for Recorder {
     fn default() -> Self {
         Recorder {
             inner: RecorderInner::Owned(Default::default()),
+            config: RecorderConfig::default(),
         }
     }
 }
 
 /// Convert a shared recorder into a non-thread safe variant.
-/// The two will _still_ record to the same meta data collection but this new instances could be
+/// The two will _still_ record to the same metadata collection but this new instances could be
 /// used as a method argument to another `ImageDecoder` impl.
 impl From<SharedRecorder> for Recorder {
     fn from(shared: SharedRecorder) -> Recorder {
-        Recorder { inner: RecorderInner::Shared(shared.inner) }
+        Recorder {
+            inner: RecorderInner::Shared(shared.inner),
+            config: shared.config,
+        }
+    }
+}
+
+impl Default for DatumRequested {
+    fn default() -> Self {
+        DatumRequested::Record
     }
 }

--- a/src/io/metagram.rs
+++ b/src/io/metagram.rs
@@ -152,7 +152,7 @@ impl Recorder {
     }
 
     /// Add a color profile.
-    pub fn color(&self, color: Vec<u8>) {
+    pub fn color(&self, color: Color) {
         self.inner.with_mut(|meta| meta.set_color(color))
     }
 
@@ -169,7 +169,7 @@ impl SharedRecorder {
     }
 
     /// Add a color profile.
-    pub fn color(&self, color: Vec<u8>) {
+    pub fn color(&self, color: Color) {
         self.with_mut(|meta| meta.set_color(color))
     }
 
@@ -193,7 +193,7 @@ impl Metagram {
         self.height = height;
     }
 
-    fn set_color(&mut self, color: Vec<u8>) {
+    fn set_color(&mut self, color: Color) {
         self.color_profile = Some(color);
     }
 

--- a/src/io/metagram.rs
+++ b/src/io/metagram.rs
@@ -1,0 +1,156 @@
+use std::cell::RefCell;
+use std::sync::{Arc, Mutex};
+use std::collections::HashMap;
+
+use crate::color;
+
+// oder (Engram), Metagram, 
+/// Collects some arbitrary meta data of an image.
+#[derive(Clone, Default)]
+pub struct Metagram {
+    width: u32,
+    height: u32,
+    color: Option<color::ExtendedColorType>,
+    color_profile_iccp: Vec<u8>,
+    exif: Vec<u8>,
+    comments: Vec<String>,
+}
+
+/// A buffer for the extra meta data produced by an image decoder.
+pub struct Recorder {
+    inner: RecorderInner,
+}
+
+enum RecorderInner {
+    Owned(Box<RefCell<Metagram>>),
+    Shared(Arc<Mutex<Metagram>>),
+}
+
+/// An owned handle to a `Metagram`, that allows concurrent modification.
+#[allow(missing_copy_implementations)]
+pub struct SharedRecorder {
+    inner: Arc<Mutex<Metagram>>,
+}
+
+impl Metagram {
+    pub fn dimensions(&mut self, width: u32, height: u32) {
+        self.width = width;
+        self.height = height;
+    }
+
+    pub fn color(&mut self, color: color::ExtendedColorType) {
+        self.color = Some(color);
+    }
+
+    pub fn add_comment(&mut self, comment: String) {
+        self.comments.push(comment)
+    }
+
+    pub fn set_exif(&mut self, data: Vec<u8>) {
+        self.exif = data;
+    }
+}
+
+impl Recorder {
+    pub fn new() -> Self {
+        Recorder::default()
+    }
+
+    pub fn with(meta: Metagram) -> Self {
+        Recorder {
+            inner: RecorderInner::Owned(Box::new(RefCell::new(meta))),
+        }
+    }
+
+    pub fn dimensions(&self, width: u32, height: u32) {
+        self.inner.with_mut(|meta| meta.dimensions(width, height))
+    }
+
+    pub fn color(&self, color: color::ExtendedColorType) {
+        self.inner.with_mut(|meta| meta.color(color))
+    }
+
+    /// Add an additional comment.
+    pub fn add_comment(&self, comment: String) {
+        self.inner.with_mut(|meta| meta.add_comment(comment))
+    }
+
+    /// Overwrite all EXIF data.
+    pub fn exif(&self, data: Vec<u8>) {
+        self.inner.with_mut(|meta| meta.set_exif(data))
+    }
+
+    /// Split the recorder such that it can be sent to a different thread.
+    pub fn share(&mut self) -> SharedRecorder {
+        let inner;
+        match &self.inner {
+            RecorderInner::Shared(arc) => {
+                inner = Arc::clone(&arc);
+            },
+            RecorderInner::Owned(boxed) => {
+                let meta = boxed.borrow().clone();
+                let arc = Arc::new(Mutex::new(meta));
+                inner = Arc::clone(&arc);
+                self.inner = RecorderInner::Shared(arc);
+            }
+        };
+
+        SharedRecorder {
+            inner,
+        }
+    }
+
+    /// Get a clone of the configured meta data.
+    pub fn to_result(&self) -> Metagram {
+        self.inner.to_result()
+    }
+}
+
+impl RecorderInner {
+    fn with_mut(&self, function: impl FnOnce(&mut Metagram)) {
+        match self {
+            RecorderInner::Owned(boxed) => {
+                function(&mut boxed.borrow_mut())
+            }
+            RecorderInner::Shared(arc) => {
+                function(&mut arc.lock().unwrap())
+            }
+        }
+    }
+
+    fn to_result(&self) -> Metagram {
+        match self {
+            RecorderInner::Owned(boxed) => boxed.borrow().clone(),
+            RecorderInner::Shared(arc) => arc.lock().unwrap().clone(),
+        }
+    }
+}
+
+impl SharedRecorder {
+    pub fn set_exif(&mut self, data: Vec<u8>) {
+        self.with_mut(|meta| meta.set_exif(data))
+    }
+
+    fn with_mut(&self, function: impl FnOnce(&mut Metagram)) {
+        // Regarding lock recovery: None of the inner methods should usually panic. The only
+        // exception would be from allocation error while inserting a new exif tag or something.
+        function(&mut self.inner.lock().unwrap_or_else(|err| err.into_inner()))
+    }
+}
+
+impl Default for Recorder {
+    fn default() -> Self {
+        Recorder {
+            inner: RecorderInner::Owned(Default::default()),
+        }
+    }
+}
+
+/// Convert a shared recorder into a non-thread safe variant.
+/// The two will _still_ record to the same meta data collection but this new instances could be
+/// used as a method argument to another `ImageDecoder` impl.
+impl From<SharedRecorder> for Recorder {
+    fn from(shared: SharedRecorder) -> Recorder {
+        Recorder { inner: RecorderInner::Shared(shared.inner) }
+    }
+}

--- a/src/io/metagram.rs
+++ b/src/io/metagram.rs
@@ -1,6 +1,8 @@
 use std::cell::RefCell;
 use std::sync::{Arc, Mutex};
 
+use crate::color::Color;
+
 // oder (Engram), Metagram, 
 /// Collects some arbitrary meta data of an image.
 ///
@@ -16,8 +18,9 @@ pub struct Metagram {
     pub width: u32,
     /// The original height in pixels.
     pub height: u32,
-    /// An ICC profile characterizing color interpretation of the image input.
-    pub color_profile: Option<Vec<u8>>,
+    /// The available color information.
+    /// For example, an ICC profile characterizing color interpretation of the image input.
+    pub color_profile: Option<Color>,
     /// Encoded EXIF data associated with the image.
     pub exif: Option<Vec<u8>>,
     _non_exhaustive: (),

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,7 +1,7 @@
 //! Input and output of images.
-mod metagram;
+mod metadata;
 mod reader;
 pub(crate) mod free_functions;
 
 pub use self::reader::Reader;
-pub use self::metagram::{Metagram, Recorder, SharedRecorder};
+pub use self::metadata::{DatumRequested, MetadataContainer, Recorder, RecorderConfig, SharedRecorder};

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,5 +1,7 @@
 //! Input and output of images.
+mod metagram;
 mod reader;
 pub(crate) mod free_functions;
 
 pub use self::reader::Reader;
+pub use self::metagram::{Metagram, Recorder, SharedRecorder};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,9 +101,9 @@ extern crate quickcheck;
 
 use std::io::Write;
 
-pub use crate::color::{ColorType, ExtendedColorType};
+pub use crate::color_::{ColorType, ExtendedColorType};
 
-pub use crate::color::{Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
+pub use crate::color_::{Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
 
 pub use crate::error::{ImageError, ImageResult};
 
@@ -354,11 +354,16 @@ pub mod webp {
     pub use crate::codecs::webp::{vp8, WebPDecoder};
 }
 
+pub mod color {
+    pub(crate) use crate::color_::*;
+    pub use crate::color_::{Color, Luminance, Transfer, Primaries, Whitepoint};
+}
 
 mod animation;
 #[path = "buffer.rs"]
 mod buffer_;
-mod color;
+#[path = "color.rs"]
+mod color_;
 mod dynimage;
 mod image;
 mod traits;


### PR DESCRIPTION
Adds a common interface for decoding meta data.

The `Metagram` struct, storing all meta data, is partly public and has a `Default` implementation that should be interpreted as having no meta data. The goal is that the metadata can later again be used by encoders, and in any case there are no invariants between the fields. Also note that EXIF and ICC are treated as opaque blobs for now. We do _not yet_ interpret the color conversion and source information given in them to inform the conversion to the `rgb`ish types of `DynamicImage`¹.

This considers two decoder implementations: Either the data is immediately available or it will be supplied during the decoding process. In the first case the decoders has already decoded all data from a header and stores it directly into a `Recoder` borrowed from the caller while in the second case they want to keep an instance for the following decoding call, realized with a `SharedRecorder` that provides thread-safe shared access to a single target. 

The design also considers recursive use in that a `Recorder` can share the target of a `SharedRecorder`. This allows any decoder, holding on to a `SharedRecorder`, to create a new argument that can be passed to another decoder's `ImageDecoder::metagram` method.

The combined encoding-decoding/decoding-encoding process may be lossy in all instances, for the moment it is a best-effort. There is no attempt at adding any impls in this PR.

------

¹Reasoning: We don't have library integration for this yet. Furthermore, it would affect downstream users to change the output color types too suddenly. Instead, my traint of thought is to establish that in the future both original and output color spaces will be defined in `Metagram` and make those fields as accurate as possible. That preparse decoders for the flexibility necessary to transparently handle a change in the decoding interpretation, but the discussion on this is not part of the PR.