### PR TITLE
creates a method to encode ImageBuffers to a specified writer

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -1292,6 +1292,29 @@ where
     free_functions::save_buffer_with_format_impl(path.as_ref(), buf, width, height, color, format)
 }
 
+/// Writes the supplied buffer to a writer in the specified format.
+///
+/// The buffer is assumed to have the correct format according
+/// to the specified color type.
+/// This will lead to corrupted writers if the buffer contains
+/// malformed data. Currently only jpeg, png, ico, bmp, 
+/// pnm, gif, tga, farbfeld and avif formats are supported.
+pub fn write_buffer_with_format<W, F>(
+    writer: &mut W,
+    buf: &[u8],
+    width: u32,
+    height: u32,
+    color: color::ColorType,
+    format: F,
+) -> ImageResult<()>
+where
+    W: std::io::Write,
+    F: Into<ImageOutputFormat>,
+{
+    // thin wrapper function to strip generics
+    free_functions::write_buffer_impl(writer, buf, width, height, color, format.into())
+}
+
 /// Create a new image from a byte slice
 ///
 /// Makes an educated guess about the image format.

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -19,7 +19,7 @@ use crate::codecs::pnm;
 use crate::codecs::farbfeld;
 #[cfg(feature = "tga")]
 use crate::codecs::tga;
-#[cfg(feature = "avif")]
+#[cfg(feature = "avif-encoder")]
 use crate::codecs::avif;
 
 use crate::buffer_::{
@@ -994,7 +994,7 @@ impl DynamicImage {
                 tga::TgaEncoder::new(w).write_image(bytes, width, height, color)
             }
 
-            #[cfg(feature = "avif")]
+            #[cfg(feature = "avif-encoder")]
             image::ImageOutputFormat::Avif => {
                 avif::AvifEncoder::new(w).write_image(bytes, width, height, color)
             }

--- a/src/image.rs
+++ b/src/image.rs
@@ -243,7 +243,7 @@ pub enum ImageOutputFormat {
     /// An Image in TGA Format
     Tga,
 
-    #[cfg(feature = "avif")]
+    #[cfg(feature = "avif-encoder")]
     /// An image in AVIF Format
     Avif,
 
@@ -275,7 +275,7 @@ impl From<ImageFormat> for ImageOutputFormat {
             ImageFormat::Farbfeld => ImageOutputFormat::Farbfeld,
             #[cfg(feature = "tga")]
             ImageFormat::Tga => ImageOutputFormat::Tga,
-            #[cfg(feature = "avif")]
+            #[cfg(feature = "avif-encoder")]
             ImageFormat::Avif => ImageOutputFormat::Avif,
 
             f => ImageOutputFormat::Unsupported(format!("{:?}", f)),

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -163,49 +163,29 @@ pub(crate) fn save_buffer_with_format_impl(
 ) -> ImageResult<()> {
     let fout = &mut BufWriter::new(File::create(path)?);
 
-    match format {
-        #[cfg(feature = "gif")]
-        image::ImageFormat::Gif => gif::GifEncoder::new(fout).encode(buf, width, height, color),
-        #[cfg(feature = "ico")]
-        image::ImageFormat::Ico => ico::IcoEncoder::new(fout).write_image(buf, width, height, color),
-        #[cfg(feature = "jpeg")]
-        image::ImageFormat::Jpeg => jpeg::JpegEncoder::new(fout).write_image(buf, width, height, color),
-        #[cfg(feature = "png")]
-        image::ImageFormat::Png => png::PngEncoder::new(fout).write_image(buf, width, height, color),
+    let format = match format {
         #[cfg(feature = "pnm")]
         image::ImageFormat::Pnm => {
             let ext = path.extension()
             .and_then(|s| s.to_str())
             .map_or("".to_string(), |s| s.to_ascii_lowercase());
-            match &*ext {
-                "pbm" => pnm::PnmEncoder::new(fout)
-                    .with_subtype(pnm::PNMSubtype::Bitmap(pnm::SampleEncoding::Binary))
-                    .write_image(buf, width, height, color),
-                "pgm" => pnm::PnmEncoder::new(fout)
-                    .with_subtype(pnm::PNMSubtype::Graymap(pnm::SampleEncoding::Binary))
-                    .write_image(buf, width, height, color),
-                "ppm" => pnm::PnmEncoder::new(fout)
-                    .with_subtype(pnm::PNMSubtype::Pixmap(pnm::SampleEncoding::Binary))
-                    .write_image(buf, width, height, color),
-                "pam" => pnm::PnmEncoder::new(fout).write_image(buf, width, height, color),
-                _ => Err(ImageError::Unsupported(ImageFormatHint::Exact(format).into())), // Unsupported Pnm subtype.
-            }
+            ImageOutputFormat::Pnm(match &*ext {
+                "pbm" => pnm::PNMSubtype::Bitmap(pnm::SampleEncoding::Binary),
+                "pgm" => pnm::PNMSubtype::Graymap(pnm::SampleEncoding::Binary),
+                "ppm" => pnm::PNMSubtype::Pixmap(pnm::SampleEncoding::Binary),
+                _ => { return Err(ImageError::Unsupported(ImageFormatHint::Exact(format).into())) }, // Unsupported Pnm subtype.
+            })
         },
-        #[cfg(feature = "farbfeld")]
-        image::ImageFormat::Farbfeld => farbfeld::FarbfeldEncoder::new(fout).write_image(buf, width, height, color),
-        #[cfg(feature = "avif-encoder")]
-        image::ImageFormat::Avif => avif::AvifEncoder::new(fout).write_image(buf, width, height, color),
         // #[cfg(feature = "hdr")]
         // image::ImageFormat::Hdr => hdr::HdrEncoder::new(fout).encode(&[Rgb<f32>], width, height), // usize
-        #[cfg(feature = "bmp")]
-        image::ImageFormat::Bmp => bmp::BmpEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "tiff")]
-        image::ImageFormat::Tiff => tiff::TiffEncoder::new(fout)
-            .write_image(buf, width, height, color),
-        #[cfg(feature = "tga")]
-        image::ImageFormat::Tga => tga::TgaEncoder::new(fout).write_image(buf, width, height, color),
-        format => Err(ImageError::Unsupported(ImageFormatHint::Exact(format).into())),
-    }
+        image::ImageFormat::Tiff => {
+            return tiff::TiffEncoder::new(fout).write_image(buf, width, height, color);
+        },
+        format => format.into(),
+    };
+
+    write_buffer_impl(fout, buf, width, height, color, format)
 }
 
 #[allow(unused_variables)]
@@ -238,7 +218,7 @@ pub(crate) fn write_buffer_impl<W: std::io::Write>(
         ImageOutputFormat::Farbfeld => farbfeld::FarbfeldEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "tga")]
         ImageOutputFormat::Tga => tga::TgaEncoder::new(fout).write_image(buf, width, height, color),
-        #[cfg(feature = "avif")]
+        #[cfg(feature = "avif-encoder")]
         ImageOutputFormat::Avif => avif::AvifEncoder::new(fout).write_image(buf, width, height, color),
         ImageOutputFormat::Unsupported(format) => Err(ImageError::Unsupported(ImageFormatHint::Name(format).into())),
         format => Err(ImageError::Unsupported(ImageFormatHint::Name(format!("{:?}", format)).into()))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,7 @@ pub use crate::traits::{EncodableLayout, Primitive, Pixel};
 // Opening and loading images
 pub use crate::io::free_functions::{guess_format, load};
 pub use crate::dynimage::{load_from_memory, load_from_memory_with_format, open,
-                   save_buffer, save_buffer_with_format, image_dimensions};
+                   save_buffer, save_buffer_with_format, write_buffer_with_format, image_dimensions};
 
 pub use crate::dynimage::DynamicImage;
 


### PR DESCRIPTION
Addresses #834 by implementing a method called `write_to` in ImageBuffer.

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

