### PR TITLE
Update to num-rational 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "./src/lib.rs"
 bytemuck = "1"
 byteorder = "1.3.2"
 num-iter = "0.1.32"
-num-rational = { version = "0.3", default-features = false }
+num-rational = { version = "0.4", default-features = false }
 num-traits = "0.2.0"
 gif = { version = "0.11.1", optional = true }
 jpeg = { package = "jpeg-decoder", version = "0.1.22", default-features = false, optional = true }


### PR DESCRIPTION
I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

----

This might need special care if num-rational is used in any public API.

