### PR TITLE
Add TIFF variant to ImageOutputFormat

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -948,7 +948,7 @@ where
 {
     /// Writes the buffer to a writer in the specified format.
     ///
-    /// See [`ImageOutputFormat`](./enum.ImageOutputFormat.html) for
+    /// See [`ImageOutputFormat`](../enum.ImageOutputFormat.html) for
     /// supported types.
     ///
     /// **Note**: TIFF encoding uses buffered writing,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -948,9 +948,11 @@ where
 {
     /// Writes the buffer to a writer in the specified format.
     ///
-    /// The image format is derived from the file extension.
-    /// Currently only jpeg, png, ico, bmp, pnm,
-    /// gif, tga, farbfeld and avif formats are supported.
+    /// See [`ImageOutputFormat`](./enum.ImageOutputFormat.html) for
+    /// supported types.
+    ///
+    /// **Note**: TIFF encoding uses buffered writing,
+    /// which can lead to unexpected use of resources
     pub fn write_to<W, F>(&self, writer: &mut W, format: F) -> ImageResult<()>
     where
         W: std::io::Write,

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -883,6 +883,8 @@ impl DynamicImage {
     }
 
     /// Encode this image and write it to ```w```
+    /// **Note**: TIFF encoding uses buffered writing,
+    /// which can lead to unexpected use of resources
     pub fn write_to<W: Write, F: Into<ImageOutputFormat>>(
         &self,
         w: &mut W,
@@ -950,7 +952,7 @@ impl DynamicImage {
                 Ok(())
             }
 
-            format => free_functions::write_buffer_impl(w, bytes, width, height, color, format)
+            format => write_buffer_with_format(w, bytes, width, height, color, format)
         }
     }
 
@@ -1242,8 +1244,13 @@ where
 /// The buffer is assumed to have the correct format according
 /// to the specified color type.
 /// This will lead to corrupted writers if the buffer contains
-/// malformed data. Currently only jpeg, png, ico, bmp, 
-/// pnm, gif, tga, farbfeld and avif formats are supported.
+/// malformed data.
+///
+/// See [`ImageOutputFormat`](../enum.ImageOutputFormat.html) for
+/// supported types.
+///
+/// **Note**: TIFF encoding uses buffered writing,
+/// which can lead to unexpected use of resources
 pub fn write_buffer_with_format<W, F>(
     writer: &mut W,
     buf: &[u8],

--- a/src/image.rs
+++ b/src/image.rs
@@ -243,6 +243,10 @@ pub enum ImageOutputFormat {
     /// An Image in TGA Format
     Tga,
 
+    #[cfg(feature = "tiff")]
+    /// An Image in TIFF Format
+    Tiff,
+
     #[cfg(feature = "avif-encoder")]
     /// An image in AVIF Format
     Avif,
@@ -275,6 +279,9 @@ impl From<ImageFormat> for ImageOutputFormat {
             ImageFormat::Farbfeld => ImageOutputFormat::Farbfeld,
             #[cfg(feature = "tga")]
             ImageFormat::Tga => ImageOutputFormat::Tga,
+            #[cfg(feature = "tiff")]
+            ImageFormat::Tiff => ImageOutputFormat::Tiff,
+
             #[cfg(feature = "avif-encoder")]
             ImageFormat::Avif => ImageOutputFormat::Avif,
 


### PR DESCRIPTION
Resolves #1446 by adding a TIFF variant to the [`ImageOutputFormat`](https://docs.rs/image/*/image/enum.ImageOutputFormat.html). Also merges [`DynamicImage::write_to`](https://docs.rs/image/0.23.14/image/enum.DynamicImage.html#method.write_to) with `free_functions::write_buffer_impl`.