### PR TITLE
Fix compiling with avif-encoder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ jpeg = { package = "jpeg-decoder", version = "0.1.22", default-features = false,
 png = { version = "0.16.5", optional = true }
 scoped_threadpool = { version = "0.1", optional = true }
 tiff = { version = "0.6.0", optional = true }
-ravif = { version = "0.6.0", optional = true }
+ravif = { version = "0.6.6", optional = true }
 rgb = { version = "0.8.25", optional = true }
 mp4parse = { version = "0.11.5", optional = true }
 dav1d = { version = "0.6.0", optional = true }

--- a/src/codecs/avif/encoder.rs
+++ b/src/codecs/avif/encoder.rs
@@ -72,6 +72,8 @@ impl<W: Write> AvifEncoder<W> {
                 speed,
                 premultiplied_alpha: false,
                 color_space: ravif::ColorSpace::RGB,
+                // match core count
+                threads: 0,
             } 
         }
     }


### PR DESCRIPTION
Works around a breaking change done by the latest version of `ravif`, which added a new field to `Config`.