### PR TITLE
Update to ravif 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ jpeg = { package = "jpeg-decoder", version = "0.1.22", default-features = false,
 png = { version = "0.16.5", optional = true }
 scoped_threadpool = { version = "0.1", optional = true }
 tiff = { version = "0.6.0", optional = true }
-ravif = { version = "0.6.6", optional = true }
+ravif = { version = "0.7.0", optional = true }
 rgb = { version = "0.8.25", optional = true }
 mp4parse = { version = "0.11.5", optional = true }
 dav1d = { version = "0.6.0", optional = true }


### PR DESCRIPTION
The version which introduced the breaking change fixed in #1456 has been yanked and republished as 0.7