### PR TITLE
Use the new ravif::encode_rgb function for encoding Rgb8 images

### DIFF
--- a/src/codecs/avif/encoder.rs
+++ b/src/codecs/avif/encoder.rs
@@ -15,7 +15,7 @@ use crate::error::{EncodingError, ParameterError, ParameterErrorKind, Unsupporte
 
 use bytemuck::{Pod, PodCastError, try_cast_slice, try_cast_slice_mut};
 use num_traits::Zero;
-use ravif::{Img, Config, RGBA8, encode_rgba};
+use ravif::{encode_rgba, encode_rgb, Config, Img, RGB8, RGBA8};
 use rgb::AsPixels;
 
 /// AVIF Encoder.
@@ -47,6 +47,11 @@ impl ColorSpace {
             Self::__NonExhaustive(marker) => match marker._private {},
         }
     }
+}
+
+enum RgbColor<'buf> {
+    Rgb8(Img<&'buf [RGB8]>),
+    Rgba8(Img<&'buf [RGBA8]>),
 }
 
 impl<W: Write> AvifEncoder<W> {
@@ -89,17 +94,27 @@ impl<W: Write> AvifEncoder<W> {
     /// The encoder currently requires all data to be RGBA8, it will be converted internally if
     /// necessary. When data is suitably aligned, i.e. u16 channels to two bytes, then the
     /// conversion may be more efficient.
-    pub fn write_image(mut self, data: &[u8], width: u32, height: u32, color: ColorType) -> ImageResult<()> {
+    pub fn write_image(
+        mut self,
+        data: &[u8],
+        width: u32,
+        height: u32,
+        color: ColorType,
+    ) -> ImageResult<()> {
         self.set_color(color);
         let config = self.config;
         // `ravif` needs strongly typed data so let's convert. We can either use a temporarily
         // owned version in our own buffer or zero-copy if possible by using the input buffer.
         // This requires going through `rgb`.
-        let buffer = self.encode_as_img(data, width, height, color)?;
-        let (data, _color_size, _alpha_size) = encode_rgba(buffer, &config)
-            .map_err(|err| ImageError::Encoding(
-                EncodingError::new(ImageFormat::Avif.into(), err)
-            ))?;
+        let result = match self.encode_as_img(data, width, height, color)? {
+            RgbColor::Rgb8(buffer) => encode_rgb(buffer, &config).map(|(data, _color_size)| data),
+            RgbColor::Rgba8(buffer) => {
+                encode_rgba(buffer, &config).map(|(data, _color_size, _alpha_size)| data)
+            }
+        };
+        let data = result.map_err(|err| {
+            ImageError::Encoding(EncodingError::new(ImageFormat::Avif.into(), err))
+        })?;
         self.inner.write_all(&data)?;
         Ok(())
     }
@@ -109,9 +124,13 @@ impl<W: Write> AvifEncoder<W> {
         // self.config.color_space = ColorSpace::RGB;
     }
 
-    fn encode_as_img<'buf>(&'buf mut self, data: &'buf [u8], width: u32, height: u32, color: ColorType)
-        -> ImageResult<Img<&'buf [RGBA8]>>
-    {
+    fn encode_as_img<'buf>(
+        &'buf mut self,
+        data: &'buf [u8],
+        width: u32,
+        height: u32,
+        color: ColorType,
+    ) -> ImageResult<RgbColor<'buf>> {
         // Error wrapping utility for color dependent buffer dimensions.
         fn try_from_raw<P: Pixel + 'static>(data: &[P::Subpixel], width: u32, height: u32)
             -> ImageResult<ImageBuffer<P, &[P::Subpixel]>>
@@ -122,8 +141,10 @@ impl<W: Write> AvifEncoder<W> {
         };
 
         // Convert to target color type using few buffer allocations.
-        fn convert_into<'buf, P>(buf: &'buf mut Vec<u8>, image: ImageBuffer<P, &[P::Subpixel]>)
-            -> Img<&'buf [RGBA8]>
+        fn convert_into<'buf, P>(
+            buf: &'buf mut Vec<u8>,
+            image: ImageBuffer<P, &[P::Subpixel]>,
+        ) -> Img<&'buf [RGBA8]>
         where
             P: Pixel + 'static,
             Rgba<u8>: FromColor<P>,
@@ -168,58 +189,77 @@ impl<W: Write> AvifEncoder<W> {
         }
 
         match color {
+            ColorType::Rgb8 => {
+                // ravif doesn't do any checks but has some asserts, so we do the checks.
+                let img = try_from_raw::<Rgb<u8>>(data, width, height)?;
+                // Now, internally ravif uses u32 but it takes usize. We could do some checked
+                // conversion but instead we use that a non-empty image must be addressable.
+                if img.pixels().len() == 0 {
+                    return Err(ImageError::Parameter(ParameterError::from_kind(
+                        ParameterErrorKind::DimensionMismatch,
+                    )));
+                }
+
+                Ok(RgbColor::Rgb8(Img::new(
+                    rgb::AsPixels::as_pixels(data),
+                    width as usize,
+                    height as usize,
+                )))
+            }
             ColorType::Rgba8 => {
                 // ravif doesn't do any checks but has some asserts, so we do the checks.
                 let img = try_from_raw::<Rgba<u8>>(data, width, height)?;
                 // Now, internally ravif uses u32 but it takes usize. We could do some checked
                 // conversion but instead we use that a non-empty image must be addressable.
                 if img.pixels().len() == 0 {
-                    return Err(ImageError::Parameter(ParameterError::from_kind(ParameterErrorKind::DimensionMismatch)));
+                    return Err(ImageError::Parameter(ParameterError::from_kind(
+                        ParameterErrorKind::DimensionMismatch,
+                    )));
                 }
 
-                Ok(Img::new(rgb::AsPixels::as_pixels(data), width as usize, height as usize))
-            },
+                Ok(RgbColor::Rgba8(Img::new(
+                    rgb::AsPixels::as_pixels(data),
+                    width as usize,
+                    height as usize,
+                )))
+            }
             // we need a separate buffer..
             ColorType::L8 => {
                 let image = try_from_raw::<Luma<u8>>(data, width, height)?;
-                Ok(convert_into(&mut self.fallback, image))
+                Ok(RgbColor::Rgba8(convert_into(&mut self.fallback, image)))
             }
             ColorType::La8 => {
                 let image = try_from_raw::<LumaA<u8>>(data, width, height)?;
-                Ok(convert_into(&mut self.fallback, image))
-            }
-            ColorType::Rgb8 => {
-                let image = try_from_raw::<Rgb<u8>>(data, width, height)?;
-                Ok(convert_into(&mut self.fallback, image))
+                Ok(RgbColor::Rgba8(convert_into(&mut self.fallback, image)))
             }
             ColorType::Bgr8 => {
                 let image = try_from_raw::<Bgr<u8>>(data, width, height)?;
-                Ok(convert_into(&mut self.fallback, image))
+                Ok(RgbColor::Rgba8(convert_into(&mut self.fallback, image)))
             }
             ColorType::Bgra8 => {
                 let image = try_from_raw::<Bgra<u8>>(data, width, height)?;
-                Ok(convert_into(&mut self.fallback, image))
+                Ok(RgbColor::Rgba8(convert_into(&mut self.fallback, image)))
             }
             // we need to really convert data..
             ColorType::L16 => {
                 let buffer = cast_buffer(data)?;
                 let image = try_from_raw::<Luma<u16>>(&buffer, width, height)?;
-                Ok(convert_into(&mut self.fallback, image))
+                Ok(RgbColor::Rgba8(convert_into(&mut self.fallback, image)))
             }
             ColorType::La16 => {
                 let buffer = cast_buffer(data)?;
                 let image = try_from_raw::<LumaA<u16>>(&buffer, width, height)?;
-                Ok(convert_into(&mut self.fallback, image))
+                Ok(RgbColor::Rgba8(convert_into(&mut self.fallback, image)))
             }
             ColorType::Rgb16 => {
                 let buffer = cast_buffer(data)?;
                 let image = try_from_raw::<Rgb<u16>>(&buffer, width, height)?;
-                Ok(convert_into(&mut self.fallback, image))
+                Ok(RgbColor::Rgba8(convert_into(&mut self.fallback, image)))
             }
             ColorType::Rgba16 => {
                 let buffer = cast_buffer(data)?;
                 let image = try_from_raw::<Rgba<u16>>(&buffer, width, height)?;
-                Ok(convert_into(&mut self.fallback, image))
+                Ok(RgbColor::Rgba8(convert_into(&mut self.fallback, image)))
             }
             // for cases we do not support at all?
             _ => Err(ImageError::Unsupported(UnsupportedError::from_format_and_kind(


### PR DESCRIPTION
Uses the new [`ravif::encode_rgb`](https://docs.rs/ravif/0.7.0/ravif/fn.encode_rgb.html) method for encoding `Rgb8` images, instead of copying them into a `Rgba8` image just to have `ravif` ignore the alpha channel.