### PR TITLE
`to_image` now only requires `I::Target: GenericImageView`

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -987,7 +987,7 @@ impl<I> SubImage<I> {
     pub fn to_image(&self) -> ImageBuffer<DerefPixel<I>, Vec<DerefSubpixel<I>>>
     where
         I: Deref,
-        I::Target: GenericImage + 'static,
+        I::Target: GenericImageView + 'static,
     {
         let mut out = ImageBuffer::new(self.xstride, self.ystride);
         let borrowed = self.image.deref();


### PR DESCRIPTION
This change downgrades the trait bound on `to_image` from `GenericImage` to `GenericImageView`, because it only requires immutable access to the inner image. `GenericImage: GenericImageView`, so this change should be fully backwards compatible.

Fixes https://github.com/image-rs/image/issues/1469

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.