### PR TITLE
Clarify use of ImageReader in top-level doc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! # let bytes = vec![0u8];
 //!
 //! let img = ImageReader::open("myimage.png")?.decode()?;
-//! let img2 = ImageReader::new(Cursor::new(bytes)).decode()?;
+//! let img2 = ImageReader::new(Cursor::new(bytes)).with_guessed_format().decode()?;
 //! # Ok(())
 //! # }
 //! ```


### PR DESCRIPTION
I found that ImageReader::new(Cursor::new(...)) fails to determine the type of an image unless I also call `with_guessed_format()`.  This is clearer in the ImageReader docs, but not in the top-level examples.

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

