### PR TITLE
Require Seekable Writer

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -1,5 +1,5 @@
 use std::io;
-use std::io::Write;
+use std::io::{Write, Seek};
 use std::path::Path;
 use std::u32;
 
@@ -895,8 +895,11 @@ impl DynamicImage {
         dynamic_map!(*self, ref p => imageops::rotate270(p))
     }
 
-    /// Encode this image and write it to ```w```
-    pub fn write_to<W: Write, F: Into<ImageOutputFormat>>(
+    /// Encode this image and write it to ```w```.
+    /// If your ```w``` is not seekable,
+    /// you can write to a `Cursor::new(Vec::<u8>::new())` first,
+    /// which can then be written to a file.
+    pub fn write_to<W: Write + Seek, F: Into<ImageOutputFormat>>(
         &self,
         w: &mut W,
         format: F,

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -146,7 +146,6 @@ pub(crate) fn save_buffer_impl(
     height: u32,
     color: color::ColorType,
 ) -> ImageResult<()> {
-    let fout = &mut BufWriter::new(File::create(path)?);
     let format =  ImageFormat::from_path(path)?;
     save_buffer_with_format_impl(path, buf, width, height, color, format)
 }
@@ -161,7 +160,7 @@ pub(crate) fn save_buffer_with_format_impl(
     color: color::ColorType,
     format: ImageFormat,
 ) -> ImageResult<()> {
-    let fout = &mut BufWriter::new(File::create(path)?);
+    let fout = &mut BufWriter::new(File::create(path)?); // always seekable
 
     match format {
         #[cfg(feature = "gif")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,13 +16,12 @@
 //! Load images using [`io::Reader`]:
 //!
 //! ```rust,no_run
-//! # use std::io::Cursor;
 //! use image::io::Reader as ImageReader;
 //! # fn main() -> Result<(), image::ImageError> {
 //! # let bytes = vec![0u8];
 //!
 //! let img = ImageReader::open("myimage.png")?.decode()?;
-//! let img2 = ImageReader::new(Cursor::new(bytes)).decode()?;
+//! let img2 = ImageReader::new(std::io::Cursor::new(bytes)).decode()?;
 //! # Ok(())
 //! # }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! And save them using [`save`] or [`write_to`] methods:
 //!
 //! ```rust,no_run
-//! # use std::io::Write;
+//! # use std::io::{Write, Cursor};
 //! # use image::ImageOutputFormat;
 //! # use image::DynamicImage;
 //! # #[cfg(feature = "png")]
@@ -40,7 +40,7 @@
 //! img.save("empty.jpg")?;
 //!
 //! let mut bytes: Vec<u8> = Vec::new();
-//! img2.write_to(&mut bytes, image::ImageOutputFormat::Png)?;
+//! img2.write_to(&mut Cursor::new(&mut bytes), image::ImageOutputFormat::Png)?;
 //! # Ok(())
 //! # }
 //! # #[cfg(not(feature = "png"))] fn main() {}

--- a/tests/save_jpeg.rs
+++ b/tests/save_jpeg.rs
@@ -3,24 +3,25 @@
 extern crate image;
 
 use image::{ImageOutputFormat, ImageFormat};
+use std::io::Cursor;
 
 #[test]
 fn jqeg_qualitys() {
     let img = image::open("tests/images/tiff/testsuite/mandrill.tiff").unwrap();
 
     let mut default = vec![];
-    img.write_to(&mut default, ImageFormat::Jpeg).unwrap();
+    img.write_to(&mut Cursor::new(&mut default), ImageFormat::Jpeg).unwrap();
     assert_eq!(&[255, 216], &default[..2]);
 
     let mut small = vec![];
-    img.write_to(&mut small, ImageOutputFormat::Jpeg(10))
+    img.write_to(&mut Cursor::new(&mut small), ImageOutputFormat::Jpeg(10))
         .unwrap();
     assert_eq!(&[255, 216], &small[..2]);
 
     assert!(small.len() < default.len());
 
     let mut large = vec![];
-    img.write_to(&mut large, ImageOutputFormat::Jpeg(99))
+    img.write_to(&mut Cursor::new(&mut large), ImageOutputFormat::Jpeg(99))
         .unwrap();
     assert_eq!(&[255, 216], &large[..2]);
 


### PR DESCRIPTION
This PR changes the API, now requiring all writers to be seekable. 

Non-Seekable writers are pretty rare, and can still be used by allocating a temporary seekable byte vector. This allows us to allocate less in the common case, which is writing to an already seekable destination. At this moment, no encoder utilizes this advantage yet (TiffEncoder only writes to files?). The individual encoders could be revisited to see whether they can already profit from this new requirement.

@fintelia @HeroicKatora  I looked at the avif encoder. The `fallback` buffer is required for reasons other than seeking. It is necessary because of the design of the avif library, which allocates a vector in any case. I was not yet able to remove that temporary buffer even when requiring `Seek` from the writer.


