### PR TITLE
Add width()/height() to DynamicImage

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -715,6 +715,20 @@ impl DynamicImage {
         }
     }
 
+    /// Returns the width of the underlying image
+    pub fn width(&self) -> u32 {
+        dynamic_map!(*self, ref p -> {
+            p.width()
+        })
+    }
+
+    /// Returns the height of the underlying image
+    pub fn height(&self) -> u32 {
+        dynamic_map!(*self, ref p -> {
+            p.height()
+        })
+    }
+
     /// Return a grayscale version of this image.
     pub fn grayscale(&self) -> DynamicImage {
         match *self {


### PR DESCRIPTION
All variants implement width()/height() naturally and there are situations where you want to know the size of the image without first
converting it and without having to manually handle all variants.

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.