### PR TITLE
[Codecs] BC4 support

### DIFF
--- a/src/codecs/dds.rs
+++ b/src/codecs/dds.rs
@@ -172,6 +172,7 @@ impl<R: Read> DdsDecoder<R> {
                 b"DXT1" => DXTVariant::DXT1,
                 b"DXT3" => DXTVariant::DXT3,
                 b"DXT5" => DXTVariant::DXT5,
+                b"ATI1" => DXTVariant::BC4, // Note: there might be more FourCC referring to BC4?
                 fourcc => {
                     return Err(ImageError::Unsupported(
                         UnsupportedError::from_format_and_kind(

--- a/src/codecs/dds.rs
+++ b/src/codecs/dds.rs
@@ -172,7 +172,7 @@ impl<R: Read> DdsDecoder<R> {
                 b"DXT1" => DXTVariant::DXT1,
                 b"DXT3" => DXTVariant::DXT3,
                 b"DXT5" => DXTVariant::DXT5,
-                b"ATI1" => DXTVariant::BC4, // Note: there might be more FourCC referring to BC4?
+                b"ATI1" => DXTVariant::BC4,
                 fourcc => {
                     return Err(ImageError::Unsupported(
                         UnsupportedError::from_format_and_kind(


### PR DESCRIPTION
This pull request adds support for the BC4 (ATI1) block compression encoding and decoding to the `dxt` module. Since the BC4 is similar to the BC3 (DXT5), the existing encoding and decoding of BC3 implementation is reused. More information about BC3 and BC4 can be found in [Texture Compression Techniques (T. Paltashev and I. Perminov; 2014)](https://sv-journal.org/2014-1/06.php?lang=en) and [Texture Block Compression in Direct3D 11 (Microsoft)](https://docs.microsoft.com/en-us/windows/win32/direct3d11/texture-block-compression-in-direct3d-11).

The output format is a single channel and therefore the color type `L8` was chosen. Additionaly, the FourCC code `ATI1` that corresponds to this compression in the DDS format is included.

As this is my first pull request for this project, feel free to start a discussion. Some thoughts I had during development:
* There are no tests in the `dxt` module. I added mine in `dxt`, but is there a better spot for this?
* There is now more code duplication (e.g. `decode_dxt1_row`, `decode_dxt3_row`, `decode_dxt5_row` and `decode_bc4_row`). Should I refactor parts of the module to reduce such code duplication?
* I think the BC1 (DXT1), BC2 (DXT3) and BC3 (DXT5) implementations have no tests. Should these be added before any refactoring?
* The `DXTVariant` enum is not non-exhaustive. I added BC4 here for now, but there is propably a better solution?
* I would like to submit BC5 support in the near future as well. Is there anything I should keep in mind?

---

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.
