### PR TITLE
Refactor: remove unnecessary qualification 

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1368,7 +1368,7 @@ mod test {
         let mut a: RgbImage = ImageBuffer::new(10, 10);
         {
             let val = a.pixels_mut().next().unwrap();
-            *val = color::Rgb([42, 0, 0]);
+            *val = Rgb([42, 0, 0]);
         }
         assert_eq!(a.data[0], 42)
     }

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -1334,7 +1334,7 @@ pub fn write_buffer_with_format<W, F>(
     format: F,
 ) -> ImageResult<()>
 where
-    W: std::io::Write,
+    W: Write,
     F: Into<ImageOutputFormat>,
 {
     // thin wrapper function to strip generics


### PR DESCRIPTION
This pull request removes unnecessary qualification in dynimage.rs and buffer.rs files

For dynimage.rs file, there is a redefinition of  `use std::io::Write;` in the `write_buffer_with_format` function.
For buffer.rs file, there is redefinition of `use crate::{ImageOutputFormat, color::{FromColor, Luma, LumaA, Rgb, Rgba, Bgr, Bgra}};` in `mut_iter` test

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

