### PR TITLE
Make `upcast_channel` use the whole range of u16 values.

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -457,7 +457,8 @@ fn downcast_channel(c16: u16) -> u8 {
 
 #[inline]
 fn upcast_channel(c8: u8) -> u16 {
-    NumCast::from(c8.to_u64().unwrap() << 8).unwrap()
+    let x = c8.to_u64().unwrap();
+    NumCast::from((x << 8) | x).unwrap()
 }
 
 

--- a/tests/conversions.rs
+++ b/tests/conversions.rs
@@ -1,0 +1,34 @@
+use image::buffer::ConvertBuffer;
+use image::{ImageBuffer, Rgb, Rgba};
+
+#[test]
+fn test_rgbu8_to_rgbu16() {
+    // Create an all white image using Rgb<u16>s for pixel values
+    let image_u16 =
+        ImageBuffer::from_pixel(2, 2, image::Rgb::<u16>([u16::MAX, u16::MAX, u16::MAX]));
+
+    // Create an all white image using Rgb<u8>s for pixel values and convert it
+    // to Rgb<u16>s.
+    let image_u8 = ImageBuffer::from_pixel(2, 2, image::Rgb::<u8>([u8::MAX, u8::MAX, u8::MAX]));
+    let image_converted: ImageBuffer<Rgb<u16>, _> = image_u8.convert();
+
+    assert_eq!(image_u16, image_converted);
+}
+
+#[test]
+fn test_rgbau8_to_rgbau16() {
+    let image_u16 = ImageBuffer::from_pixel(
+        2,
+        2,
+        image::Rgba::<u16>([u16::MAX, u16::MAX, u16::MAX, u16::MAX]),
+    );
+
+    let image_u8 = ImageBuffer::from_pixel(
+        2,
+        2,
+        image::Rgba::<u8>([u8::MAX, u8::MAX, u8::MAX, u8::MAX]),
+    );
+    let image_converted: ImageBuffer<Rgba<u16>, _> = image_u8.convert();
+
+    assert_eq!(image_u16, image_converted);
+}


### PR DESCRIPTION
The previous version of this function simply multiplied u8 values by
256. This is incorrect, because it means that the largest a converted
u8 value can be is 255 * 256 = 65280, instead of the actual largest
u16 value of 65535. This commit fixes this by changing the function to
multiply by 257 instead (`x | (x << 8)`). This allows the largest
converted u8 value to be 255 * 257 = 65535.

Fixes #1505.


I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.
