### PR TITLE
File path is now checked before creating file on save

### DIFF
--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -128,8 +128,8 @@ pub(crate) fn save_buffer_impl(
     height: u32,
     color: color::ColorType,
 ) -> ImageResult<()> {
-    let fout = &mut BufWriter::new(File::create(path)?);
     let format =  ImageFormat::from_path(path)?;
+    let fout = &mut BufWriter::new(File::create(path)?);
     save_buffer_with_format_impl(path, buf, width, height, color, format)
 }
 


### PR DESCRIPTION
Switched order of lines so that file path is checked before file is created during `save()`.

Closes #1513 .

This change passes all tests in `cargo test`.

I'm a new contributor:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

