### PR TITLE
Add Rgb(a)32F DynamicImage Variant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "image"
 path = "./src/lib.rs"
 
 [dependencies]
-bytemuck = "1"
+bytemuck = { version = "1.7.0", features = ["extern_crate_alloc"] } # includes cast_vec
 byteorder = "1.3.2"
 num-iter = "0.1.32"
 num-rational = { version = "0.3", default-features = false }

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -41,6 +41,7 @@ use crate::traits::Pixel;
 /// A Dynamic Image
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum DynamicImage {
+
     /// Each pixel in this image is 8-bit Luma
     ImageLuma8(GrayImage),
 
@@ -64,63 +65,49 @@ pub enum DynamicImage {
 
     /// Each pixel in this image is 16-bit Rgb with alpha
     ImageRgba16(Rgba16Image),
+
+    /// Each pixel in this image is 32-bit float Rgb
+    ImageRgb32F(Rgb32FImage),
+
+    /// Each pixel in this image is 32-bit float Rgb with alpha
+    ImageRgba32F(Rgba32FImage),
 }
 
 macro_rules! dynamic_map(
-        ($dynimage: expr, ref $image: ident => $action: expr) => (
-                match $dynimage {
-                        DynamicImage::ImageLuma8(ref $image) => DynamicImage::ImageLuma8($action),
-                        DynamicImage::ImageLumaA8(ref $image) => DynamicImage::ImageLumaA8($action),
-                        DynamicImage::ImageRgb8(ref $image) => DynamicImage::ImageRgb8($action),
-                        DynamicImage::ImageRgba8(ref $image) => DynamicImage::ImageRgba8($action),
-                        DynamicImage::ImageLuma16(ref $image) => DynamicImage::ImageLuma16($action),
-                        DynamicImage::ImageLumaA16(ref $image) => DynamicImage::ImageLumaA16($action),
-                        DynamicImage::ImageRgb16(ref $image) => DynamicImage::ImageRgb16($action),
-                        DynamicImage::ImageRgba16(ref $image) => DynamicImage::ImageRgba16($action),
-                }
-        );
+        ($dynimage: expr, $image: pat => $action: expr) => ({
+            use DynamicImage::*;
+            match $dynimage {
+                ImageLuma8($image) => ImageLuma8($action),
+                ImageLumaA8($image) => ImageLumaA8($action),
+                ImageRgb8($image) => ImageRgb8($action),
+                ImageRgba8($image) => ImageRgba8($action),
+                ImageLuma16($image) => ImageLuma16($action),
+                ImageLumaA16($image) => ImageLumaA16($action),
+                ImageRgb16($image) => ImageRgb16($action),
+                ImageRgba16($image) => ImageRgba16($action),
+                ImageRgb32F($image) => ImageRgb32F($action),
+                ImageRgba32F($image) => ImageRgba32F($action),
+            }
+        });
 
-        ($dynimage: expr, ref mut $image: ident => $action: expr) => (
-                match $dynimage {
-                        DynamicImage::ImageLuma8(ref mut $image) => DynamicImage::ImageLuma8($action),
-                        DynamicImage::ImageLumaA8(ref mut $image) => DynamicImage::ImageLumaA8($action),
-                        DynamicImage::ImageRgb8(ref mut $image) => DynamicImage::ImageRgb8($action),
-                        DynamicImage::ImageRgba8(ref mut $image) => DynamicImage::ImageRgba8($action),
-                        DynamicImage::ImageLuma16(ref mut $image) => DynamicImage::ImageLuma16($action),
-                        DynamicImage::ImageLumaA16(ref mut $image) => DynamicImage::ImageLumaA16($action),
-                        DynamicImage::ImageRgb16(ref mut $image) => DynamicImage::ImageRgb16($action),
-                        DynamicImage::ImageRgba16(ref mut $image) => DynamicImage::ImageRgba16($action),
-                }
-        );
-
-        ($dynimage: expr, ref $image: ident -> $action: expr) => (
-                match $dynimage {
-                        DynamicImage::ImageLuma8(ref $image) => $action,
-                        DynamicImage::ImageLumaA8(ref $image) => $action,
-                        DynamicImage::ImageRgb8(ref $image) => $action,
-                        DynamicImage::ImageRgba8(ref $image) => $action,
-                        DynamicImage::ImageLuma16(ref $image) => $action,
-                        DynamicImage::ImageLumaA16(ref $image) => $action,
-                        DynamicImage::ImageRgb16(ref $image) => $action,
-                        DynamicImage::ImageRgba16(ref $image) => $action,
-                }
-        );
-
-        ($dynimage: expr, ref mut $image: ident -> $action: expr) => (
-                match $dynimage {
-                        DynamicImage::ImageLuma8(ref mut $image) => $action,
-                        DynamicImage::ImageLumaA8(ref mut $image) => $action,
-                        DynamicImage::ImageRgb8(ref mut $image) => $action,
-                        DynamicImage::ImageRgba8(ref mut $image) => $action,
-                        DynamicImage::ImageLuma16(ref mut $image) => $action,
-                        DynamicImage::ImageLumaA16(ref mut $image) => $action,
-                        DynamicImage::ImageRgb16(ref mut $image) => $action,
-                        DynamicImage::ImageRgba16(ref mut $image) => $action,
-                }
+        ($dynimage: expr, |$image: pat| $action: expr) => (
+            match $dynimage {
+                DynamicImage::ImageLuma8($image) => $action,
+                DynamicImage::ImageLumaA8($image) => $action,
+                DynamicImage::ImageRgb8($image) => $action,
+                DynamicImage::ImageRgba8($image) => $action,
+                DynamicImage::ImageLuma16($image) => $action,
+                DynamicImage::ImageLumaA16($image) => $action,
+                DynamicImage::ImageRgb16($image) => $action,
+                DynamicImage::ImageRgba16($image) => $action,
+                DynamicImage::ImageRgb32F($image) => $action,
+                DynamicImage::ImageRgba32F($image) => $action,
+            }
         );
 );
 
 impl DynamicImage {
+
     /// Creates a dynamic image backed by a buffer of grey pixels.
     pub fn new_luma8(w: u32, h: u32) -> DynamicImage {
         DynamicImage::ImageLuma8(ImageBuffer::new(w, h))
@@ -163,6 +150,16 @@ impl DynamicImage {
         DynamicImage::ImageRgba16(ImageBuffer::new(w, h))
     }
 
+    /// Creates a dynamic image backed by a buffer of RGB pixels.
+    pub fn new_rgb32f(w: u32, h: u32) -> DynamicImage {
+        DynamicImage::ImageRgb32F(ImageBuffer::new(w, h))
+    }
+
+    /// Creates a dynamic image backed by a buffer of RGBA pixels.
+    pub fn new_rgba32f(w: u32, h: u32) -> DynamicImage {
+        DynamicImage::ImageRgba32F(ImageBuffer::new(w, h))
+    }
+
     /// Decodes an encoded image into a dynamic image.
     pub fn from_decoder<'a>(decoder: impl ImageDecoder<'a>)
         -> ImageResult<Self>
@@ -171,103 +168,53 @@ impl DynamicImage {
     }
 
     /// Returns a copy of this image as an RGB image.
-    #[deprecated = "replaced by `to_rgb8`"]
-    pub fn to_rgb(&self) -> RgbImage {
-        dynamic_map!(*self, ref p -> {
-            p.convert()
-        })
-    }
-
-    /// Returns a copy of this image as an RGB image.
     pub fn to_rgb8(&self) -> RgbImage {
-        dynamic_map!(*self, ref p -> {
-            p.convert()
-        })
+        dynamic_map!(*self, |ref p| p.convert())
     }
 
     /// Returns a copy of this image as an RGB image.
     pub fn to_rgb16(&self) -> Rgb16Image {
-        dynamic_map!(*self, ref p -> {
-            p.convert()
-        })
+        dynamic_map!(*self, |ref p| p.convert())
     }
 
-    /// Returns a copy of this image as an RGBA image.
-    #[deprecated = "replaced by `to_rgba8`"]
-    pub fn to_rgba(&self) -> RgbaImage {
-        dynamic_map!(*self, ref p -> {
-            p.convert()
-        })
+    /// Returns a copy of this image as an RGB image.
+    pub fn to_rgb32f(&self) -> Rgb32FImage {
+        dynamic_map!(*self, |ref p| p.convert())
     }
 
     /// Returns a copy of this image as an RGBA image.
     pub fn to_rgba8(&self) -> RgbaImage {
-        dynamic_map!(*self, ref p -> {
-            p.convert()
-        })
+        dynamic_map!(*self, |ref p| p.convert())
     }
 
     /// Returns a copy of this image as an RGBA image.
     pub fn to_rgba16(&self) -> Rgba16Image {
-        dynamic_map!(*self, ref p -> {
-            p.convert()
-        })
+        dynamic_map!(*self, |ref p| p.convert())
     }
 
-    /// Returns a copy of this image as a Luma image.
-    #[deprecated = "replaced by `to_luma8`"]
-    pub fn to_luma(&self) -> GrayImage {
-        dynamic_map!(*self, ref p -> {
-            p.convert()
-        })
+    /// Returns a copy of this image as an RGBA image.
+    pub fn to_rgba32f(&self) -> Rgba32FImage {
+        dynamic_map!(*self, |ref p| p.convert())
     }
 
     /// Returns a copy of this image as a Luma image.
     pub fn to_luma8(&self) -> GrayImage {
-        dynamic_map!(*self, ref p -> {
-            p.convert()
-        })
+        dynamic_map!(*self, |ref p| p.convert())
     }
 
     /// Returns a copy of this image as a Luma image.
     pub fn to_luma16(&self) -> Gray16Image {
-        dynamic_map!(*self, ref p -> {
-            p.convert()
-        })
-    }
-
-    /// Returns a copy of this image as a LumaA image.
-    #[deprecated = "replaced by `to_luma_alpha8`"]
-    pub fn to_luma_alpha(&self) -> GrayAlphaImage {
-        dynamic_map!(*self, ref p -> {
-            p.convert()
-        })
+        dynamic_map!(*self, |ref p| p.convert())
     }
 
     /// Returns a copy of this image as a LumaA image.
     pub fn to_luma_alpha8(&self) -> GrayAlphaImage {
-        dynamic_map!(*self, ref p -> {
-            p.convert()
-        })
+        dynamic_map!(*self, |ref p| p.convert())
     }
 
     /// Returns a copy of this image as a LumaA image.
     pub fn to_luma_alpha16(&self) -> GrayAlpha16Image {
-        dynamic_map!(*self, ref p -> {
-            p.convert()
-        })
-    }
-
-    /// Consume the image and returns a RGB image.
-    ///
-    /// If the image was already the correct format, it is returned as is.
-    /// Otherwise, a copy is created.
-    #[deprecated = "replaced by `into_rgb8`"]
-    pub fn into_rgb(self) -> RgbImage {
-        match self {
-            DynamicImage::ImageRgb8(x) => x,
-            x => x.to_rgb8(),
-        }
+        dynamic_map!(*self, |ref p| p.convert())
     }
 
     /// Consume the image and returns a RGB image.
@@ -292,15 +239,14 @@ impl DynamicImage {
         }
     }
 
-    /// Consume the image and returns a RGBA image.
+    /// Consume the image and returns a RGB image.
     ///
     /// If the image was already the correct format, it is returned as is.
     /// Otherwise, a copy is created.
-    #[deprecated = "replaced by `into_rgba8`"]
-    pub fn into_rgba(self) -> RgbaImage {
+    pub fn into_rgb32f(self) -> Rgb32FImage {
         match self {
-            DynamicImage::ImageRgba8(x) => x,
-            x => x.to_rgba8(),
+            DynamicImage::ImageRgb32F(x) => x,
+            x => x.to_rgb32f(),
         }
     }
 
@@ -326,15 +272,14 @@ impl DynamicImage {
         }
     }
 
-    /// Consume the image and returns a Luma image.
+    /// Consume the image and returns a RGBA image.
     ///
     /// If the image was already the correct format, it is returned as is.
     /// Otherwise, a copy is created.
-    #[deprecated = "replaced by `into_luma8`"]
-    pub fn into_luma(self) -> GrayImage {
+    pub fn into_rgba32F(self) -> Rgba32FImage {
         match self {
-            DynamicImage::ImageLuma8(x) => x,
-            x => x.to_luma8(),
+            DynamicImage::ImageRgba32F(x) => x,
+            x => x.to_rgba32f(),
         }
     }
 
@@ -357,18 +302,6 @@ impl DynamicImage {
         match self {
             DynamicImage::ImageLuma16(x) => x,
             x => x.to_luma16(),
-        }
-    }
-
-    /// Consume the image and returns a LumaA image.
-    ///
-    /// If the image was already the correct format, it is returned as is.
-    /// Otherwise, a copy is created.
-    #[deprecated = "replaced by `into_luma_alpha8`"]
-    pub fn into_luma_alpha(self) -> GrayAlphaImage {
-        match self {
-            DynamicImage::ImageLumaA8(x) => x,
-            x => x.to_luma_alpha8(),
         }
     }
 
@@ -503,6 +436,38 @@ impl DynamicImage {
         }
     }
 
+    /// Return a reference to an 16bit RGB image
+    pub fn as_rgb32f(&self) -> Option<&Rgb32FImage> {
+        match *self {
+            DynamicImage::ImageRgb32F(ref p) => Some(p),
+            _ => None,
+        }
+    }
+
+    /// Return a mutable reference to an 32bit RGB image
+    pub fn as_mut_rgb32f(&mut self) -> Option<&mut Rgb32FImage> {
+        match *self {
+            DynamicImage::ImageRgb32F(ref mut p) => Some(p),
+            _ => None,
+        }
+    }
+
+    /// Return a reference to an 32bit RGBA image
+    pub fn as_rgba32f(&self) -> Option<&Rgba32FImage> {
+        match *self {
+            DynamicImage::ImageRgba32F(ref p) => Some(p),
+            _ => None,
+        }
+    }
+
+    /// Return a mutable reference to an 16bit RGBA image
+    pub fn as_mut_rgba32f(&mut self) -> Option<&mut Rgba32FImage> {
+        match *self {
+            DynamicImage::ImageRgba32F(ref mut p) => Some(p),
+            _ => None,
+        }
+    }
+
     /// Return a reference to an 16bit Grayscale image
     pub fn as_luma16(&self) -> Option<&Gray16Image> {
         match *self {
@@ -557,21 +522,34 @@ impl DynamicImage {
         }
     }
 
+    /// Return a view on the raw sample buffer for 32bit per channel images.
+    pub fn as_flat_samples_f32(&self) -> Option<FlatSamples<&[f32]>> {
+        match *self {
+            DynamicImage::ImageRgb32F(ref p) => Some(p.as_flat_samples()),
+            DynamicImage::ImageRgba32F(ref p) => Some(p.as_flat_samples()),
+            _ => None,
+        }
+    }
+
     /// Return this image's pixels as a native endian byte slice.
     pub fn as_bytes(&self) -> &[u8] {
-        image_as_bytes(self)
+        // we can do this because every variant contains an `ImageBuffer<_, Vec<_>>`
+        dynamic_map!(*self, |ref image_buffer| bytemuck::cast_slice(image_buffer.as_raw().as_ref()))
     }
 
     /// Return this image's pixels as a byte vector. If the `ImageBuffer`
     /// container is `Vec<u8>`, this operation is free. Otherwise, a copy
     /// is returned.
     pub fn into_bytes(self) -> Vec<u8> {
-        image_into_bytes(self)
+        // we can do this because every variant contains an `ImageBuffer<_, Vec<_>>`
+        dynamic_map!(self, |ref image_buffer| bytemuck::allocation::cast_vec(image_buffer.into_raw()))
     }
 
     /// Return a copy of this image's pixels as a byte vector.
+    // TODO can't users call `as_bytes().to_vec()` themselves?
+    #[deprecated(note = "use `image.as_bytes().to_vec()` instead")]
     pub fn to_bytes(&self) -> Vec<u8> {
-        image_to_bytes(self)
+        self.as_bytes().to_vec()
     }
 
     /// Return this image's color type.
@@ -585,10 +563,13 @@ impl DynamicImage {
             DynamicImage::ImageLumaA16(_) => color::ColorType::La16,
             DynamicImage::ImageRgb16(_) => color::ColorType::Rgb16,
             DynamicImage::ImageRgba16(_) => color::ColorType::Rgba16,
+            DynamicImage::ImageRgb32F(_) => color::ColorType::Rgb32F,
+            DynamicImage::ImageRgba32F(_) => color::ColorType::Rgba32F,
         }
     }
 
     /// Return a grayscale version of this image.
+    /// Note: does not support f32 images.
     pub fn grayscale(&self) -> DynamicImage {
         match *self {
             DynamicImage::ImageLuma8(ref p) => DynamicImage::ImageLuma8(p.clone()),
@@ -599,13 +580,15 @@ impl DynamicImage {
             DynamicImage::ImageLumaA16(ref p) => DynamicImage::ImageLuma16(imageops::grayscale(p)),
             DynamicImage::ImageRgb16(ref p) => DynamicImage::ImageLuma16(imageops::grayscale(p)),
             DynamicImage::ImageRgba16(ref p) => DynamicImage::ImageLuma16(imageops::grayscale(p)),
+            DynamicImage::ImageRgb32F(_) => unimplemented!("F32 images do not support luma-only pixels"),
+            DynamicImage::ImageRgba32F(_) => unimplemented!("F32 images do not support luma-only pixels"),
         }
     }
 
     /// Invert the colors of this image.
     /// This method operates inplace.
     pub fn invert(&mut self) {
-        dynamic_map!(*self, ref mut p -> imageops::invert(p))
+        dynamic_map!(*self, |ref mut p| imageops::invert(p))
     }
 
     /// Resize this image using the specified filter algorithm.
@@ -773,6 +756,8 @@ impl DynamicImage {
         let mut color = self.color();
         let format = format.into();
 
+        // TODO do not repeat this match statement across the crate
+
         #[allow(deprecated)]
         match format {
             #[cfg(feature = "png")]
@@ -799,7 +784,7 @@ impl DynamicImage {
             #[cfg(feature = "gif")]
             image::ImageOutputFormat::Gif => {
                 let mut g = gif::GifEncoder::new(w);
-                g.encode_frame(crate::animation::Frame::new(self.to_rgba()))?;
+                g.encode_frame(crate::animation::Frame::new(self.to_rgba8()))?;
                 Ok(())
             }
 
@@ -849,9 +834,7 @@ impl DynamicImage {
     where
         Q: AsRef<Path>,
     {
-        dynamic_map!(*self, ref p -> {
-            p.save(path)
-        })
+        dynamic_map!(*self, |ref p| p.save(path))
     }
 
     /// Saves the buffer to a file at the specified path in
@@ -863,27 +846,25 @@ impl DynamicImage {
     where
         Q: AsRef<Path>,
     {
-        dynamic_map!(*self, ref p -> {
-            p.save_with_format(path, format)
-        })
+        dynamic_map!(*self, |ref p| p.save_with_format(path, format))
     }
 }
 
 #[allow(deprecated)]
 impl GenericImageView for DynamicImage {
-    type Pixel = color::Rgba<u8>;
+    type Pixel = color::Rgba<u8>; // TODO use f32 as default for best precision and unbounded color?
     type InnerImageView = Self;
 
     fn dimensions(&self) -> (u32, u32) {
-        dynamic_map!(*self, ref p -> p.dimensions())
+        dynamic_map!(*self, |ref p| p.dimensions())
     }
 
     fn bounds(&self) -> (u32, u32, u32, u32) {
-        dynamic_map!(*self, ref p -> p.bounds())
+        dynamic_map!(*self, |ref p| p.bounds())
     }
 
     fn get_pixel(&self, x: u32, y: u32) -> color::Rgba<u8> {
-        dynamic_map!(*self, ref p -> p.get_pixel(x, y).to_rgba().into_color())
+        dynamic_map!(*self, |ref p| p.get_pixel(x, y).to_rgba().into_color())
     }
 
     fn inner(&self) -> &Self::InnerImageView {
@@ -905,9 +886,11 @@ impl GenericImage for DynamicImage {
             DynamicImage::ImageLumaA16(ref mut p) => p.put_pixel(x, y, pixel.to_luma_alpha().into_color()),
             DynamicImage::ImageRgb16(ref mut p) => p.put_pixel(x, y, pixel.to_rgb().into_color()),
             DynamicImage::ImageRgba16(ref mut p) => p.put_pixel(x, y, pixel.into_color()),
+            DynamicImage::ImageRgb32F(ref mut p) => p.put_pixel(x, y, pixel.to_rgb().into_color()),
+            DynamicImage::ImageRgba32F(ref mut p) => p.put_pixel(x, y, pixel.into_color()),
         }
     }
-    /// DEPRECATED: Use iterator `pixels_mut` to blend the pixels directly.
+
     fn blend_pixel(&mut self, x: u32, y: u32, pixel: color::Rgba<u8>) {
         match *self {
             DynamicImage::ImageLuma8(ref mut p) => p.blend_pixel(x, y, pixel.to_luma()),
@@ -918,10 +901,12 @@ impl GenericImage for DynamicImage {
             DynamicImage::ImageLumaA16(ref mut p) => p.blend_pixel(x, y, pixel.to_luma_alpha().into_color()),
             DynamicImage::ImageRgb16(ref mut p) => p.blend_pixel(x, y, pixel.to_rgb().into_color()),
             DynamicImage::ImageRgba16(ref mut p) => p.blend_pixel(x, y, pixel.into_color()),
+            DynamicImage::ImageRgb32F(ref mut p) => p.blend_pixel(x, y, pixel.to_rgb().into_color()),
+            DynamicImage::ImageRgba32F(ref mut p) => p.blend_pixel(x, y, pixel.into_color()),
         }
     }
 
-    /// DEPRECATED: Do not use is function: It is unimplemented!
+    /// Do not use is function: It is unimplemented!
     fn get_pixel_mut(&mut self, _: u32, _: u32) -> &mut color::Rgba<u8> {
         unimplemented!()
     }
@@ -967,19 +952,32 @@ fn decoder_to_image<'a, I: ImageDecoder<'a>>(decoder: I) -> ImageResult<DynamicI
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageRgba16)
         }
 
+        color::ColorType::Rgb32F => {
+            let buf = image::decoder_to_vec(decoder)?;
+            ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageRgb32F)
+        }
+
+        color::ColorType::Rgba32F => {
+            let buf = image::decoder_to_vec(decoder)?;
+            ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageRgba32F)
+        }
+
         color::ColorType::L16 => {
             let buf = image::decoder_to_vec(decoder)?;
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLuma16)
         }
+
         color::ColorType::La16 => {
             let buf = image::decoder_to_vec(decoder)?;
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLumaA16)
         }
+
         _ => return Err(ImageError::Unsupported(UnsupportedError::from_format_and_kind(
             ImageFormatHint::Unknown,
             UnsupportedErrorKind::Color(color_type.into()),
         ))),
     };
+
     match image {
         Some(image) => Ok(image),
         None => Err(ImageError::Parameter(
@@ -988,48 +986,6 @@ fn decoder_to_image<'a, I: ImageDecoder<'a>>(decoder: I) -> ImageResult<DynamicI
     }
 }
 
-fn image_to_bytes(image: &DynamicImage) -> Vec<u8> {
-    use crate::traits::EncodableLayout;
-
-    match *image {
-        // TODO: consider transmuting
-        DynamicImage::ImageLuma8(ref a) => a.as_raw().clone(),
-        DynamicImage::ImageLumaA8(ref a) => a.as_raw().clone(),
-        DynamicImage::ImageRgb8(ref a) => a.as_raw().clone(),
-        DynamicImage::ImageRgba8(ref a) => a.as_raw().clone(),
-        DynamicImage::ImageLuma16(ref a) => a.as_bytes().to_vec(),
-        DynamicImage::ImageLumaA16(ref a) => a.as_bytes().to_vec(),
-        DynamicImage::ImageRgb16(ref a) => a.as_bytes().to_vec(),
-        DynamicImage::ImageRgba16(ref a) => a.as_bytes().to_vec(),
-    }
-}
-
-fn image_into_bytes(image: DynamicImage) -> Vec<u8> {
-    match image {
-        DynamicImage::ImageLuma8(a) => a.into_raw(),
-        DynamicImage::ImageLumaA8(a) => a.into_raw(),
-        DynamicImage::ImageRgb8(a) => a.into_raw(),
-        DynamicImage::ImageRgba8(a) => a.into_raw(),
-        DynamicImage::ImageLuma16(_) => image.to_bytes(),
-        DynamicImage::ImageLumaA16(_) => image.to_bytes(),
-        DynamicImage::ImageRgb16(_) => image.to_bytes(),
-        DynamicImage::ImageRgba16(_) => image.to_bytes(),
-    }
-}
-
-fn image_as_bytes(image: &DynamicImage) -> &[u8] {
-    use bytemuck::cast_slice;
-    match image {
-        DynamicImage::ImageLuma8(a) => &*a,
-        DynamicImage::ImageLumaA8(a) => &*a,
-        DynamicImage::ImageRgb8(a) => &*a,
-        DynamicImage::ImageRgba8(a) => &*a,
-        DynamicImage::ImageLuma16(a) => cast_slice(&*a),
-        DynamicImage::ImageLumaA16(a) => cast_slice(&*a),
-        DynamicImage::ImageRgb16(a) => cast_slice(&*a),
-        DynamicImage::ImageRgba16(a) => cast_slice(&*a),
-    }
-}
 
 /// Open the image located at the path specified.
 /// The image's format is determined from the path's file extension.

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -1415,10 +1415,12 @@ impl<Buffer, P: Pixel> GenericImage for ViewMut<Buffer, P>
         P::from_slice_mut(&mut self.inner.samples.as_mut()[pixel_range])
     }
 
+    #[allow(deprecated)]
     fn put_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel) {
         *self.get_pixel_mut(x, y) = pixel;
     }
 
+    #[allow(deprecated)]
     fn blend_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel) {
         self.get_pixel_mut(x, y).blend(&pixel);
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -814,6 +814,11 @@ pub trait GenericImage: GenericImageView {
     /// # Panics
     ///
     /// Panics if `(x, y)` is out of bounds.
+    ///
+    /// Panics for dynamic images (this method is deprecated and will be removed).
+    #[deprecated(note="Use `get_pixel` and `put_pixel` instead.")]
+    // TODO: Maybe use some kind of entry API? this would allow pixel type conversion on the fly while still doing only one array lookup
+    //  `let px = image.pixel_entry_at(x,y); px.set_from_rgba(rgba)`
     fn get_pixel_mut(&mut self, x: u32, y: u32) -> &mut Self::Pixel;
 
     /// Put a pixel at location (x, y). Indexed from top left.
@@ -836,8 +841,7 @@ pub trait GenericImage: GenericImageView {
     }
 
     /// Put a pixel at location (x, y), taking into account alpha channels
-    ///
-    /// DEPRECATED: This method will be removed. Blend the pixel directly instead.
+    #[deprecated(note="Use iterator `pixels_mut` to blend the pixels directly")]
     fn blend_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel);
 
     /// Copies all of the pixels from another image into this image.

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -35,6 +35,7 @@ where
 /// Invert each pixel within the supplied image.
 /// This function operates in place.
 pub fn invert<I: GenericImage>(image: &mut I) {
+    // TODO why is this not just `for pixel in image.pixels_mut() { pixel.invert(); }`
     let (width, height) = image.dimensions();
 
     for y in 0..height {
@@ -66,6 +67,7 @@ where
 
     let percent = ((100.0 + contrast) / 100.0).powi(2);
 
+    // TODO use pixels_mut?
     for y in 0..height {
         for x in 0..width {
             let f = image.get_pixel(x, y).map(|b| {
@@ -100,6 +102,7 @@ where
 
     let percent = ((100.0 + contrast) / 100.0).powi(2);
 
+    // TODO use pixels_mut?
     for y in 0..height {
         for x in 0..width {
             let f = image.get_pixel(x, y).map(|b| {
@@ -133,6 +136,7 @@ where
     let max = S::max_value();
     let max: i32 = NumCast::from(max).unwrap();
 
+    // TODO use pixels_mut?
     for y in 0..height {
         for x in 0..width {
             let e = image.get_pixel(x, y).map_with_alpha(
@@ -166,6 +170,7 @@ where
     let max = <<I::Pixel as Pixel>::Subpixel as Bounded>::max_value();
     let max: i32 = NumCast::from(max).unwrap();
 
+    // TODO use pixels_mut?
     for y in 0..height {
         for x in 0..width {
             let e = image.get_pixel(x, y).map_with_alpha(
@@ -275,6 +280,7 @@ where
         0.715 - cosv * 0.715 + sinv * 0.715,
         0.072 + cosv * 0.928 + sinv * 0.072,
     ];
+    // TODO use pixels_mut?
     for y in 0..height {
         for x in 0..width {
             let pixel = image.get_pixel(x, y);


### PR DESCRIPTION
_Work in progress | Depends on other Issues to be resolved first_

Adds F32 support to the DynamicImage.

Points to be discussed:
- [ ] `grayscale(image)` returns `Luma<T>`, but `Luma<f32>` isn't a supported color type, so... `f32` images will panic?
- [ ] `impl GenericImage for DynamicImage { type SubPixel = u8; }` is difficult for float images, as it is unclear how `f32` colors should be converted to `u8` colors. Maybe the default subpixel type should be `f32` for best quality, instead of `u8`?

(couldn't resist to add other changes as well, they are of course to be discussed)

