### PR TITLE
Use seekable writer

### DIFF
--- a/fuzz/fuzzers/fuzzer_script_exr.rs
+++ b/fuzz/fuzzers/fuzzer_script_exr.rs
@@ -32,7 +32,7 @@ fn roundtrip(bytes: &[u8]) -> ImageResult<()> {
     /// Assumes the writer is buffered. In most cases,
     /// you should wrap your writer in a `BufWriter` for best performance.
     // TODO this method should probably already exist in the main image crate
-    fn write_rgba_image(write: impl Write/* + Seek*/, (width, height, data): &(u32,u32,Vec<u8>)) -> ImageResult<()> {
+    fn write_rgba_image(write: impl Write + Seek, (width, height, data): &(u32,u32,Vec<u8>)) -> ImageResult<()> {
         OpenExrEncoder::new(write).write_image(
             data.as_slice(), *width, *height,
             ColorType::Rgba32F

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -986,9 +986,6 @@ where
     ///
     /// See [`ImageOutputFormat`](../enum.ImageOutputFormat.html) for
     /// supported types.
-    ///
-    /// **Note**: TIFF encoding uses buffered writing,
-    /// which can lead to unexpected use of resources
     pub fn write_to<W, F>(&self, writer: &mut W, format: F) -> ImageResult<()>
     where
         W: std::io::Write + std::io::Seek,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -991,7 +991,7 @@ where
     /// which can lead to unexpected use of resources
     pub fn write_to<W, F>(&self, writer: &mut W, format: F) -> ImageResult<()>
     where
-        W: std::io::Write,
+        W: std::io::Write + std::io::Seek,
         F: Into<ImageOutputFormat>,
     {
         // This is valid as the subpixel is u8.

--- a/src/codecs/jpeg/encoder.rs
+++ b/src/codecs/jpeg/encoder.rs
@@ -849,7 +849,7 @@ mod tests {
     #[cfg(feature = "benchmarks")]
     use test::{Bencher};
 
-    use crate::{ImageBuffer, ImageEncoder, ImageError};
+    use crate::{ImageEncoder, ImageError};
     use crate::color::ColorType;
     use crate::error::ParameterErrorKind::DimensionMismatch;
     use crate::image::ImageDecoder;

--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -24,12 +24,10 @@
 extern crate exr;
 use exr::prelude::*;
 
-use crate::{ImageDecoder, ImageResult, ColorType, Progress, ImageError, ImageFormat, ImageBuffer, Rgba, Rgb, ImageEncoder, ExtendedColorType};
-use std::io::{Write, Seek, BufRead, Cursor, BufReader};
+use crate::{ImageDecoder, ImageResult, ColorType, Progress, ImageError, ImageFormat, ImageEncoder, ExtendedColorType};
+use std::io::{Write, Seek, BufRead, Cursor};
 use crate::error::{DecodingError, ImageFormatHint, LimitError, LimitErrorKind, EncodingError};
 use crate::image::decoder_to_vec;
-use std::path::Path;
-use crate::buffer_::{Rgb32FImage, Rgba32FImage};
 use std::convert::TryInto;
 
 
@@ -222,7 +220,7 @@ impl<'a, R: 'a + BufRead + Seek> ImageDecoder<'a> for OpenExrDecoder<R> {
 /// you should wrap your writer in a `BufWriter` for best performance.
 // private. access via `OpenExrEncoder`
 fn write_buffer(
-    mut buffered_write: impl Write/* + Seek*/, unaligned_bytes: &[u8],
+    mut buffered_write: impl Write + Seek, unaligned_bytes: &[u8],
     width: u32, height: u32, color_type: ColorType
 ) -> ImageResult<()>
 {
@@ -249,12 +247,12 @@ fn write_buffer(
         }
     }
 
-    let mut seekable_write = Cursor::new(Vec::with_capacity(width*height*3*4)); // TODO remove
 
     // bytes might be unaligned so we cannot cast the whole thing, instead lookup each f32 individually
     let lookup_f32 = move |f32_index: usize| {
-        let f32_bytes_slice = &unaligned_bytes[f32_index * 4 .. (f32_index + 1) * 4];
-        f32::from_ne_bytes(f32_bytes_slice.try_into().expect("indexing error"))
+        let unaligned_f32_bytes_slice = &unaligned_bytes[f32_index * 4 .. (f32_index + 1) * 4];
+        let f32_bytes_array = unaligned_f32_bytes_slice.try_into().expect("indexing error");
+        f32::from_ne_bytes(f32_bytes_array)
     };
 
     match color_type {
@@ -269,7 +267,7 @@ fn write_buffer(
                 )
                 .write()
                 // .on_progress(|progress| todo!())
-                .to_buffered(&mut seekable_write).map_err(to_image_err)?;
+                .to_buffered(&mut buffered_write).map_err(to_image_err)?;
         }
 
         ColorType::Rgba32F => {
@@ -286,17 +284,16 @@ fn write_buffer(
                 )
                 .write()
                 // .on_progress(|progress| todo!())
-                .to_buffered(&mut seekable_write).map_err(to_image_err)?;
+                .to_buffered(&mut buffered_write).map_err(to_image_err)?;
         }
 
         // TODO other color types and channel types
         unsupported_color_type => return Err(ImageError::Encoding(EncodingError::new(
             ImageFormatHint::Exact(ImageFormat::OpenExr),
-            format!("color type {:?} not yet supported", unsupported_color_type)
+            format!("writing color type {:?} not yet supported", unsupported_color_type)
         )))
     }
 
-    buffered_write.write_all(seekable_write.into_inner().as_slice())?;
     Ok(())
 }
 
@@ -313,7 +310,7 @@ impl<W> OpenExrEncoder<W> {
     pub fn new(write: W) -> Self { Self(write) }
 }
 
-impl<W> ImageEncoder for OpenExrEncoder<W> where W: Write /*+ Seek*/ {
+impl<W> ImageEncoder for OpenExrEncoder<W> where W: Write + Seek {
 
     /// Writes the complete image.
     ///
@@ -340,15 +337,17 @@ fn to_image_err(exr_error: Error) -> ImageError {
 mod test {
     use super::*;
     use std::path::PathBuf;
+    use std::path::Path;
+    use crate::buffer_::{Rgb32FImage, Rgba32FImage};
+    use crate::{ImageBuffer, Rgba, Rgb, };
+    use std::io::{BufReader};
 
     const BASE_PATH: &[&str] = &[".", "tests", "images", "exr"];
-
-
 
     /// Write an `Rgb32FImage`.
     /// Assumes the writer is buffered. In most cases,
     /// you should wrap your writer in a `BufWriter` for best performance.
-    fn write_rgb_image(write: impl Write/* + Seek*/, image: &Rgb32FImage) -> ImageResult<()> {
+    fn write_rgb_image(write: impl Write + Seek, image: &Rgb32FImage) -> ImageResult<()> {
         write_buffer(
             write,
             bytemuck::cast_slice(image.as_raw().as_slice()),
@@ -360,7 +359,7 @@ mod test {
     /// Write an `Rgba32FImage`.
     /// Assumes the writer is buffered. In most cases,
     /// you should wrap your writer in a `BufWriter` for best performance.
-    fn write_rgba_image(write: impl Write/* + Seek*/, image: &Rgba32FImage) -> ImageResult<()> {
+    fn write_rgba_image(write: impl Write + Seek, image: &Rgba32FImage) -> ImageResult<()> {
         write_buffer(
             write,
             bytemuck::cast_slice(image.as_raw().as_slice()),

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -758,9 +758,6 @@ impl DynamicImage {
     ///
     /// Assumes the writer is buffered. In most cases,
     /// you should wrap your writer in a `BufWriter` for best performance.
-    ///
-    /// **Note**: TIFF encoding uses buffered writing,
-    /// which can lead to unexpected use of resources
     pub fn write_to<W: Write + Seek, F: Into<ImageOutputFormat>>(
         &self,
         w: &mut W,
@@ -1127,9 +1124,6 @@ where
 ///
 /// Assumes the writer is buffered. In most cases,
 /// you should wrap your writer in a `BufWriter` for best performance.
-///
-/// **Note**: TIFF encoding uses buffered writing,
-/// which can lead to unexpected use of resources
 pub fn write_buffer_with_format<W, F>(
     writer: &mut W,
     buf: &[u8],

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -1139,7 +1139,7 @@ pub fn write_buffer_with_format<W, F>(
     format: F,
 ) -> ImageResult<()>
 where
-    W: Write,
+    W: Write + Seek,
     F: Into<ImageOutputFormat>,
 {
     // thin wrapper function to strip generics

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::{BufReader, BufWriter, Seek, Read, BufRead};
+use std::io::{BufReader, BufWriter, Seek, BufRead};
 use std::path::Path;
 use std::u32;
 
@@ -153,10 +153,6 @@ pub(crate) fn save_buffer_with_format_impl(
         },
         // #[cfg(feature = "hdr")]
         // image::ImageFormat::Hdr => hdr::HdrEncoder::new(fout).encode(&[Rgb<f32>], width, height), // usize
-        #[cfg(feature = "tiff")]
-        image::ImageFormat::Tiff => {
-            return tiff::TiffEncoder::new(buffered_file_write).write_image(buf, width, height, color);
-        },
         format => format.into(),
     };
 

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -161,10 +161,6 @@ pub(crate) fn save_buffer_with_format_impl(
         },
         // #[cfg(feature = "hdr")]
         // image::ImageFormat::Hdr => hdr::HdrEncoder::new(fout).encode(&[Rgb<f32>], width, height), // usize
-        #[cfg(feature = "tiff")]
-        image::ImageFormat::Tiff => {
-            return tiff::TiffEncoder::new(fout).write_image(buf, width, height, color);
-        },
         format => format.into(),
     };
 
@@ -204,13 +200,7 @@ pub(crate) fn write_buffer_impl<W: std::io::Write + Seek>(
         #[cfg(feature = "openexr")]
         ImageOutputFormat::OpenExr => openexr::OpenExrEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "tiff")]
-        ImageOutputFormat::Tiff => {
-            let mut cursor = std::io::Cursor::new(Vec::new());
-            tiff::TiffEncoder::new(&mut cursor).write_image(buf, width, height, color)?;
-            fout.write(&cursor.into_inner()[..])
-                .map(|_| ())
-                .map_err(ImageError::IoError)
-        }
+        ImageOutputFormat::Tiff => tiff::TiffEncoder::new(fout).write_image(buf, width, height, color),
         #[cfg(feature = "avif-encoder")]
         ImageOutputFormat::Avif => avif::AvifEncoder::new(fout).write_image(buf, width, height, color),
 

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -173,7 +173,7 @@ pub(crate) fn save_buffer_with_format_impl(
 
 #[allow(unused_variables)]
 // Most variables when no features are supported
-pub(crate) fn write_buffer_impl<W: std::io::Write>(
+pub(crate) fn write_buffer_impl<W: std::io::Write + Seek>(
     fout: &mut W,
     buf: &[u8],
     width: u32,


### PR DESCRIPTION
Use the seekable writer to improve performance and to simplify code. Also, cleaned up some imports in the openexr module.

__The writers were not seekable, even though we had already merged seekable writers into `next`. I had to re-add seekable trait bounds to all methods.__ Maybe those changes got lost?

Modules that benefit from seekable writers, because they had to write to an intermediate `Cursor<Vec<u8>>` previously:
- [x] openexr
- [x] tiff

Closes #1489
