### PR TITLE
Lets talk about buffering

### DIFF
--- a/fuzz/fuzzers/fuzzer_script_exr.rs
+++ b/fuzz/fuzzers/fuzzer_script_exr.rs
@@ -10,10 +10,11 @@ use std::convert::TryFrom;
 use image::ImageDecoder;
 use image::ImageEncoder;
 use image::ColorType;
+use std::io::Write;
+use std::io::Read;
 
 // "just dont panic"
 fn roundtrip(bytes: &[u8]) -> ImageResult<()> {
-    use std::io::Write;
 
     /// Read the file from the specified path into an `Rgba32FImage`.
     // TODO this method should probably already exist in the main image crate

--- a/fuzz/fuzzers/fuzzer_script_exr.rs
+++ b/fuzz/fuzzers/fuzzer_script_exr.rs
@@ -6,7 +6,6 @@ use std::io::Cursor;
 use image::ImageResult;
 use image::codecs::openexr::*;
 use std::io::Seek;
-use std::io::BufRead;
 use std::convert::TryFrom;
 use image::ImageDecoder;
 use image::ImageEncoder;
@@ -18,7 +17,7 @@ fn roundtrip(bytes: &[u8]) -> ImageResult<()> {
 
     /// Read the file from the specified path into an `Rgba32FImage`.
     // TODO this method should probably already exist in the main image crate
-    fn read_as_rgba_byte_image(read: impl BufRead + Seek) -> ImageResult<(u32,u32,Vec<u8>)> {
+    fn read_as_rgba_byte_image(read: impl Read + Seek) -> ImageResult<(u32,u32,Vec<u8>)> {
         let decoder = OpenExrDecoder::with_alpha_preference(read, Some(true))?;
         let (width, height) = decoder.dimensions();
 

--- a/src/codecs/farbfeld.rs
+++ b/src/codecs/farbfeld.rs
@@ -18,7 +18,7 @@
 
 use std::convert::TryFrom;
 use std::i64;
-use std::io::{self, Seek, SeekFrom, Read, Write, BufWriter, BufRead};
+use std::io::{self, Seek, SeekFrom, Read, Write, BufRead};
 
 use byteorder::{BigEndian, ByteOrder, NativeEndian};
 
@@ -183,8 +183,8 @@ pub struct FarbfeldDecoder<R: BufRead> {
 
 impl<R: BufRead> FarbfeldDecoder<R> {
     /// Creates a new decoder that decodes from the stream ```r```
-    pub fn new(r: R) -> ImageResult<FarbfeldDecoder<R>> {
-        Ok(FarbfeldDecoder { reader: FarbfeldReader::new(r)? })
+    pub fn new(buffered_read: R) -> ImageResult<FarbfeldDecoder<R>> {
+        Ok(FarbfeldDecoder { reader: FarbfeldReader::new(buffered_read)? })
     }
 }
 
@@ -231,13 +231,13 @@ impl<'a, R: 'a + BufRead + Seek> ImageDecoderExt<'a> for FarbfeldDecoder<R> {
 
 /// farbfeld encoder
 pub struct FarbfeldEncoder<W: Write> {
-    w: BufWriter<W>,
+    w: W,
 }
 
 impl<W: Write> FarbfeldEncoder<W> {
-    /// Create a new encoder that writes its output to ```w```
-    pub fn new(w: W) -> FarbfeldEncoder<W> {
-        FarbfeldEncoder { w: BufWriter::new(w) }
+    /// Create a new encoder that writes its output to ```w```. The writer should be buffered.
+    pub fn new(buffered_writer: W) -> FarbfeldEncoder<W> {
+        FarbfeldEncoder { w: buffered_writer }
     }
 
     /// Encodes the image ```data``` (native endian)

--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -25,7 +25,7 @@ extern crate exr;
 use exr::prelude::*;
 
 use crate::{ImageDecoder, ImageResult, ColorType, Progress, ImageError, ImageFormat, ImageBuffer, Rgba, Rgb, ImageEncoder, ExtendedColorType};
-use std::io::{Write, Seek, BufRead, Cursor, BufReader};
+use std::io::{Write, Seek, Cursor, BufReader, Read};
 use crate::error::{DecodingError, ImageFormatHint, LimitError, LimitErrorKind, EncodingError};
 use crate::image::decoder_to_vec;
 use std::path::Path;
@@ -51,7 +51,7 @@ pub struct OpenExrDecoder<R> {
 }
 
 
-impl<R: BufRead + Seek> OpenExrDecoder<R> {
+impl<R: Read + Seek> OpenExrDecoder<R> {
 
 
     /// Create a decoder. Consumes the first few bytes of the source to extract image dimensions.
@@ -109,7 +109,7 @@ impl<R: BufRead + Seek> OpenExrDecoder<R> {
 }
 
 
-impl<'a, R: 'a + BufRead + Seek> ImageDecoder<'a> for OpenExrDecoder<R> {
+impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for OpenExrDecoder<R> {
     type Reader = Cursor<Vec<u8>>;
 
     fn dimensions(&self) -> (u32, u32) {
@@ -380,7 +380,7 @@ mod test {
     }
 
     /// Read the file from the specified path into an `Rgb32FImage`.
-    fn read_as_rgb_image(read: impl BufRead + Seek) -> ImageResult<Rgb32FImage> {
+    fn read_as_rgb_image(read: impl Read + Seek) -> ImageResult<Rgb32FImage> {
         let decoder = OpenExrDecoder::with_alpha_preference(read, Some(false))?;
         let (width, height) = decoder.dimensions();
         let buffer: Vec<f32> = decoder_to_vec(decoder)?;
@@ -393,7 +393,7 @@ mod test {
     }
 
     /// Read the file from the specified path into an `Rgba32FImage`.
-    fn read_as_rgba_image(read: impl BufRead + Seek) -> ImageResult<Rgba32FImage> {
+    fn read_as_rgba_image(read: impl Read + Seek) -> ImageResult<Rgba32FImage> {
         let decoder = OpenExrDecoder::with_alpha_preference(read, Some(true))?;
         let (width, height) = decoder.dimensions();
         let buffer: Vec<f32> = decoder_to_vec(decoder)?;

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -1131,7 +1131,7 @@ where
 /// **Note**: TIFF encoding uses buffered writing,
 /// which can lead to unexpected use of resources
 pub fn write_buffer_with_format<W, F>(
-    writer: &mut W,
+    buffered_writer: &mut W,
     buf: &[u8],
     width: u32,
     height: u32,
@@ -1143,7 +1143,7 @@ where
     F: Into<ImageOutputFormat>,
 {
     // thin wrapper function to strip generics
-    free_functions::write_buffer_impl(writer, buf, width, height, color, format.into())
+    free_functions::write_buffer_impl(buffered_writer, buf, width, height, color, format.into())
 }
 
 /// Create a new image from a byte slice

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::{BufRead, BufReader, BufWriter, Seek};
+use std::io::{BufReader, BufWriter, Seek, Read, BufRead};
 use std::path::Path;
 use std::u32;
 
@@ -14,107 +14,100 @@ use crate::image::ImageFormat;
 use crate::image::{ImageDecoder, ImageEncoder};
 
 pub(crate) fn open_impl(path: &Path) -> ImageResult<DynamicImage> {
-    let fin = match File::open(path) {
-        Ok(f) => f,
-        Err(err) => return Err(ImageError::IoError(err)),
-    };
-    let fin = BufReader::new(fin);
+    let buffered_read = BufReader::new(
+        File::open(path).map_err(ImageError::IoError)?
+    );
 
-    load(fin, ImageFormat::from_path(path)?)
+    load(buffered_read, ImageFormat::from_path(path)?)
 }
 
 /// Create a new image from a Reader.
 ///
 /// Assumes the reader is already buffered. For optimal performance,
-/// consider wrapping the reader with a `BufRead::new()`.
+/// consider wrapping the reader with a `BufReader::new()`.
 ///
 /// Try [`io::Reader`] for more advanced uses.
 ///
 /// [`io::Reader`]: io/struct.Reader.html
 #[allow(unused_variables)]
 // r is unused if no features are supported.
-pub fn load<R: BufRead + Seek>(r: R, format: ImageFormat) -> ImageResult<DynamicImage> {
+pub fn load<R: BufRead + Seek>(buffered_reader: R, format: ImageFormat) -> ImageResult<DynamicImage> {
     #[allow(unreachable_patterns)]
     // Default is unreachable if all features are supported.
     match format {
         #[cfg(feature = "avif-decoder")]
-        image::ImageFormat::Avif => DynamicImage::from_decoder(avif::AvifDecoder::new(r)?),
+        image::ImageFormat::Avif => DynamicImage::from_decoder(avif::AvifDecoder::new(buffered_reader)?),
         #[cfg(feature = "png")]
-        image::ImageFormat::Png => DynamicImage::from_decoder(png::PngDecoder::new(r)?),
+        image::ImageFormat::Png => DynamicImage::from_decoder(png::PngDecoder::new(buffered_reader)?),
         #[cfg(feature = "gif")]
-        image::ImageFormat::Gif => DynamicImage::from_decoder(gif::GifDecoder::new(r)?),
+        image::ImageFormat::Gif => DynamicImage::from_decoder(gif::GifDecoder::new(buffered_reader)?),
         #[cfg(feature = "jpeg")]
-        image::ImageFormat::Jpeg => DynamicImage::from_decoder(jpeg::JpegDecoder::new(r)?),
+        image::ImageFormat::Jpeg => DynamicImage::from_decoder(jpeg::JpegDecoder::new(buffered_reader)?),
         #[cfg(feature = "webp")]
-        image::ImageFormat::WebP => DynamicImage::from_decoder(webp::WebPDecoder::new(r)?),
+        image::ImageFormat::WebP => DynamicImage::from_decoder(webp::WebPDecoder::new(buffered_reader)?),
         #[cfg(feature = "tiff")]
-        image::ImageFormat::Tiff => DynamicImage::from_decoder(tiff::TiffDecoder::new(r)?),
+        image::ImageFormat::Tiff => DynamicImage::from_decoder(tiff::TiffDecoder::new(buffered_reader)?),
         #[cfg(feature = "tga")]
-        image::ImageFormat::Tga => DynamicImage::from_decoder(tga::TgaDecoder::new(r)?),
+        image::ImageFormat::Tga => DynamicImage::from_decoder(tga::TgaDecoder::new(buffered_reader)?),
         #[cfg(feature = "dds")]
-        image::ImageFormat::Dds => DynamicImage::from_decoder(dds::DdsDecoder::new(r)?),
+        image::ImageFormat::Dds => DynamicImage::from_decoder(dds::DdsDecoder::new(buffered_reader)?),
         #[cfg(feature = "bmp")]
-        image::ImageFormat::Bmp => DynamicImage::from_decoder(bmp::BmpDecoder::new(r)?),
+        image::ImageFormat::Bmp => DynamicImage::from_decoder(bmp::BmpDecoder::new(buffered_reader)?),
         #[cfg(feature = "ico")]
-        image::ImageFormat::Ico => DynamicImage::from_decoder(ico::IcoDecoder::new(r)?),
+        image::ImageFormat::Ico => DynamicImage::from_decoder(ico::IcoDecoder::new(buffered_reader)?),
         #[cfg(feature = "hdr")]
-        image::ImageFormat::Hdr => DynamicImage::from_decoder(hdr::HdrAdapter::new(BufReader::new(r))?),
+        image::ImageFormat::Hdr => DynamicImage::from_decoder(hdr::HdrAdapter::new(buffered_reader)?),
         #[cfg(feature = "openexr")]
-        image::ImageFormat::OpenExr => DynamicImage::from_decoder(openexr::OpenExrDecoder::new(r)?),
+        image::ImageFormat::OpenExr => DynamicImage::from_decoder(openexr::OpenExrDecoder::new(buffered_reader)?),
         #[cfg(feature = "pnm")]
-        image::ImageFormat::Pnm => DynamicImage::from_decoder(pnm::PnmDecoder::new(BufReader::new(r))?),
+        image::ImageFormat::Pnm => DynamicImage::from_decoder(pnm::PnmDecoder::new(buffered_reader)?),
         #[cfg(feature = "farbfeld")]
-        image::ImageFormat::Farbfeld => DynamicImage::from_decoder(farbfeld::FarbfeldDecoder::new(r)?),
+        image::ImageFormat::Farbfeld => DynamicImage::from_decoder(farbfeld::FarbfeldDecoder::new(buffered_reader)?),
         _ => Err(ImageError::Unsupported(ImageFormatHint::Exact(format).into())),
     }
 }
 
 pub(crate) fn image_dimensions_impl(path: &Path) -> ImageResult<(u32, u32)> {
     let format = image::ImageFormat::from_path(path)?;
-
-    let fin = File::open(path)?;
-    let fin = BufReader::new(fin);
-
-    image_dimensions_with_format_impl(fin, format)
+    let reader = BufReader::new(File::open(path)?);
+    image_dimensions_with_format_impl(reader, format)
 }
 
 #[allow(unused_variables)]
 // fin is unused if no features are supported.
-pub(crate) fn image_dimensions_with_format_impl<R: BufRead + Seek>(fin: R, format: ImageFormat)
-    -> ImageResult<(u32, u32)>
+pub(crate) fn image_dimensions_with_format_impl<R: BufRead + Seek>(buffered_read: R, format: ImageFormat)
+                                                                   -> ImageResult<(u32, u32)>
 {
     #[allow(unreachable_patterns,unreachable_code)]
     // Default is unreachable if all features are supported.
     // Code after the match is unreachable if none are.
     Ok(match format {
         #[cfg(feature = "avif-decoder")]
-        image::ImageFormat::Avif => avif::AvifDecoder::new(fin)?.dimensions(),
+        image::ImageFormat::Avif => avif::AvifDecoder::new(buffered_read)?.dimensions(),
         #[cfg(feature = "jpeg")]
-        image::ImageFormat::Jpeg => jpeg::JpegDecoder::new(fin)?.dimensions(),
+        image::ImageFormat::Jpeg => jpeg::JpegDecoder::new(buffered_read)?.dimensions(),
         #[cfg(feature = "png")]
-        image::ImageFormat::Png => png::PngDecoder::new(fin)?.dimensions(),
+        image::ImageFormat::Png => png::PngDecoder::new(buffered_read)?.dimensions(),
         #[cfg(feature = "gif")]
-        image::ImageFormat::Gif => gif::GifDecoder::new(fin)?.dimensions(),
+        image::ImageFormat::Gif => gif::GifDecoder::new(buffered_read)?.dimensions(),
         #[cfg(feature = "webp")]
-        image::ImageFormat::WebP => webp::WebPDecoder::new(fin)?.dimensions(),
+        image::ImageFormat::WebP => webp::WebPDecoder::new(buffered_read)?.dimensions(),
         #[cfg(feature = "tiff")]
-        image::ImageFormat::Tiff => tiff::TiffDecoder::new(fin)?.dimensions(),
+        image::ImageFormat::Tiff => tiff::TiffDecoder::new(buffered_read)?.dimensions(),
         #[cfg(feature = "tga")]
-        image::ImageFormat::Tga => tga::TgaDecoder::new(fin)?.dimensions(),
+        image::ImageFormat::Tga => tga::TgaDecoder::new(buffered_read)?.dimensions(),
         #[cfg(feature = "dds")]
-        image::ImageFormat::Dds => dds::DdsDecoder::new(fin)?.dimensions(),
+        image::ImageFormat::Dds => dds::DdsDecoder::new(buffered_read)?.dimensions(),
         #[cfg(feature = "bmp")]
-        image::ImageFormat::Bmp => bmp::BmpDecoder::new(fin)?.dimensions(),
+        image::ImageFormat::Bmp => bmp::BmpDecoder::new(buffered_read)?.dimensions(),
         #[cfg(feature = "ico")]
-        image::ImageFormat::Ico => ico::IcoDecoder::new(fin)?.dimensions(),
+        image::ImageFormat::Ico => ico::IcoDecoder::new(buffered_read)?.dimensions(),
         #[cfg(feature = "hdr")]
-        image::ImageFormat::Hdr => hdr::HdrAdapter::new(fin)?.dimensions(),
+        image::ImageFormat::Hdr => hdr::HdrAdapter::new(buffered_read)?.dimensions(),
         #[cfg(feature = "openexr")]
-        image::ImageFormat::OpenExr => openexr::OpenExrDecoder::new(fin)?.dimensions(),
+        image::ImageFormat::OpenExr => openexr::OpenExrDecoder::new(buffered_read)?.dimensions(),
         #[cfg(feature = "pnm")]
-        image::ImageFormat::Pnm => {
-            pnm::PnmDecoder::new(fin)?.dimensions()
-        }
+        image::ImageFormat::Pnm => pnm::PnmDecoder::new(buffered_read)?.dimensions(),
         format => return Err(ImageError::Unsupported(ImageFormatHint::Exact(format).into())),
     })
 }
@@ -129,7 +122,6 @@ pub(crate) fn save_buffer_impl(
     color: color::ColorType,
 ) -> ImageResult<()> {
     let format =  ImageFormat::from_path(path)?;
-    let fout = &mut BufWriter::new(File::create(path)?);
     save_buffer_with_format_impl(path, buf, width, height, color, format)
 }
 

--- a/src/io/reader.rs
+++ b/src/io/reader.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::{self, BufRead, BufReader, Cursor, Read, Seek, SeekFrom};
+use std::io::{self, BufReader, Cursor, Read, Seek, SeekFrom, BufRead};
 use std::path::Path;
 
 use crate::dynimage::DynamicImage;
@@ -69,7 +69,7 @@ impl<R: Read> Reader<R> {
     /// Create a new image reader without a preset format.
     ///
     /// Assumes the reader is already buffered. For optimal performance,
-    /// consider wrapping the reader with a `BufRead::new()`.
+    /// consider wrapping the reader with a `BufReader::new()`.
     ///
     /// It is possible to guess the format based on the content of the read object with
     /// [`with_guessed_format`], or to set the format directly with [`set_format`].
@@ -86,7 +86,7 @@ impl<R: Read> Reader<R> {
     /// Construct a reader with specified format.
     ///
     /// Assumes the reader is already buffered. For optimal performance,
-    /// consider wrapping the reader with a `BufRead::new()`.
+    /// consider wrapping the reader with a `BufReader::new()`.
     pub fn with_format(buffered_reader: R, format: ImageFormat) -> Self {
         Reader {
             inner: buffered_reader,
@@ -132,9 +132,8 @@ impl Reader<BufReader<File>> {
     }
 
     fn open_impl(path: &Path) -> io::Result<Self> {
-        let file = File::open(path)?;
         Ok(Reader {
-            inner: BufReader::new(file),
+            inner: BufReader::new(File::open(path)?),
             format: ImageFormat::from_path(path).ok(),
         })
     }


### PR DESCRIPTION
While scrolling through the code, I noticed that `BufReader` and `BufWriter` are used more than expected. 

1. Sometimes, an already buffered reader or writer is buffered again. Where this is desired, we should add documentation that explains why this is useful. If not, we should remove the unnecessary buffering.
2. `BufRead` is an overly strict trait bound. Most of the time, we should use `Read` instead, with proper documentation. The `BufRead` trait has super specialized methods like `fn fill_buf(&mut self) -> Result<&[u8]>;`. Where these methods are not used, the trait bound is not required.
3. Whether a reader should be buffered or not is sometimes not documented

- [x] farbfeld: removed unnecessary buffering in writer and reader
- [x] use plain read instead of bufread where possible (not possible in pnm and hdr codecs)
- [x] rename identifiers and add documentation to clarify whether a reader or writer is expected to be buffered
- [x] do not buffer only hdr and pmn again in `fn load`  