### PR TITLE
optimise resize

### DIFF
--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -110,14 +110,28 @@ struct FloatNearest(f32);
 // to_i64, to_u64, and to_f64 implicitly affect all other lower conversions.
 // Note that to_f64 by default calls to_i64 and thus needs to be overridden.
 impl ToPrimitive for FloatNearest {
+    // to_{i,u}64 is required, to_{i,u}{8,16} are usefull.
+    // If a usecase for full 32 bits is found its trivial to add
+    fn to_i8(&self) -> Option<i8> {
+        self.0.round().to_i8()
+    }
+    fn to_i16(&self) -> Option<i16> {
+        self.0.round().to_i16()
+    }
     fn to_i64(&self) -> Option<i64> {
-        NumCast::from(self.0.round())
+        self.0.round().to_i64()
+    }
+    fn to_u8(&self) -> Option<u8> {
+        self.0.round().to_u8()
+    }
+    fn to_u16(&self) -> Option<u16> {
+        self.0.round().to_u16()
     }
     fn to_u64(&self) -> Option<u64> {
-        NumCast::from(self.0.round())
+        self.0.round().to_u64()
     }
     fn to_f64(&self) -> Option<f64> {
-        NumCast::from(self.0)
+        self.0.to_f64()
     }
 }
 
@@ -282,10 +296,10 @@ where
 
             // Keeping the clamp improves performance.
             let t: P = Pixel::from_channels(
-                NumCast::from(clamp(t.0.round(), min, max)).unwrap(),
-                NumCast::from(clamp(t.1.round(), min, max)).unwrap(),
-                NumCast::from(clamp(t.2.round(), min, max)).unwrap(),
-                NumCast::from(clamp(t.3.round(), min, max)).unwrap(),
+                NumCast::from(FloatNearest(clamp(t.0, min, max))).unwrap(),
+                NumCast::from(FloatNearest(clamp(t.1, min, max))).unwrap(),
+                NumCast::from(FloatNearest(clamp(t.2, min, max))).unwrap(),
+                NumCast::from(FloatNearest(clamp(t.3, min, max))).unwrap(),
             );
 
             out.put_pixel(outx, y, t);
@@ -369,10 +383,10 @@ where
                 });
 
             let t: P = Pixel::from_channels(
-                NumCast::from(clamp(t.0.round(), min, max)).unwrap(),
-                NumCast::from(clamp(t.1.round(), min, max)).unwrap(),
-                NumCast::from(clamp(t.2.round(), min, max)).unwrap(),
-                NumCast::from(clamp(t.3.round(), min, max)).unwrap(),
+                NumCast::from(FloatNearest(clamp(t.0, min, max))).unwrap(),
+                NumCast::from(FloatNearest(clamp(t.1, min, max))).unwrap(),
+                NumCast::from(FloatNearest(clamp(t.2, min, max))).unwrap(),
+                NumCast::from(FloatNearest(clamp(t.3, min, max))).unwrap(),
             );
 
             out.put_pixel(x, outy, t);

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -277,10 +277,10 @@ where
 
             let (t1, t2, t3, t4) = (t.0 / sum, t.1 / sum, t.2 / sum, t.3 / sum);
             let t = Pixel::from_channels(
-                NumCast::from(FloatNearest(clamp(t1, 0.0, max))).unwrap(),
-                NumCast::from(FloatNearest(clamp(t2, 0.0, max))).unwrap(),
-                NumCast::from(FloatNearest(clamp(t3, 0.0, max))).unwrap(),
-                NumCast::from(FloatNearest(clamp(t4, 0.0, max))).unwrap(),
+                NumCast::from((clamp(t1, 0.0, max)).round()).unwrap(),
+                NumCast::from((clamp(t2, 0.0, max)).round()).unwrap(),
+                NumCast::from((clamp(t3, 0.0, max)).round()).unwrap(),
+                NumCast::from((clamp(t4, 0.0, max)).round()).unwrap(),
             );
 
             out.put_pixel(outx, y, t);
@@ -360,10 +360,10 @@ where
 
             let (t1, t2, t3, t4) = (t.0 / sum, t.1 / sum, t.2 / sum, t.3 / sum);
             let t = Pixel::from_channels(
-                NumCast::from(FloatNearest(clamp(t1, 0.0, max))).unwrap(),
-                NumCast::from(FloatNearest(clamp(t2, 0.0, max))).unwrap(),
-                NumCast::from(FloatNearest(clamp(t3, 0.0, max))).unwrap(),
-                NumCast::from(FloatNearest(clamp(t4, 0.0, max))).unwrap(),
+                NumCast::from((clamp(t1, 0.0, max)).round()).unwrap(),
+                NumCast::from((clamp(t2, 0.0, max)).round()).unwrap(),
+                NumCast::from((clamp(t3, 0.0, max)).round()).unwrap(),
+                NumCast::from((clamp(t4, 0.0, max)).round()).unwrap(),
             );
 
             out.put_pixel(x, outy, t);

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -255,6 +255,7 @@ where
             ws.push(w);
             sum += w;
         }
+        ws.iter_mut().for_each(|w| *w /= sum);
 
         for y in 0..height {
             let t = ws
@@ -279,13 +280,12 @@ where
                     )
                 });
 
-            let (t1, t2, t3, t4) = (t.0 / sum, t.1 / sum, t.2 / sum, t.3 / sum);
             // Keeping the clamp improves performance.
             let t: P = Pixel::from_channels(
-                NumCast::from(clamp(t1.round(), min, max)).unwrap(),
-                NumCast::from(clamp(t2.round(), min, max)).unwrap(),
-                NumCast::from(clamp(t3.round(), min, max)).unwrap(),
-                NumCast::from(clamp(t4.round(), min, max)).unwrap(),
+                NumCast::from(clamp(t.0.round(), min, max)).unwrap(),
+                NumCast::from(clamp(t.1.round(), min, max)).unwrap(),
+                NumCast::from(clamp(t.2.round(), min, max)).unwrap(),
+                NumCast::from(clamp(t.3.round(), min, max)).unwrap(),
             );
 
             out.put_pixel(outx, y, t);
@@ -343,6 +343,7 @@ where
             ws.push(w);
             sum += w;
         }
+        ws.iter_mut().for_each(|w| *w /= sum);
 
         for x in 0..width {
             let t = ws
@@ -367,12 +368,11 @@ where
                     )
                 });
 
-            let (t1, t2, t3, t4) = (t.0 / sum, t.1 / sum, t.2 / sum, t.3 / sum);
             let t: P = Pixel::from_channels(
-                NumCast::from(clamp(t1.round(), min, max)).unwrap(),
-                NumCast::from(clamp(t2.round(), min, max)).unwrap(),
-                NumCast::from(clamp(t3.round(), min, max)).unwrap(),
-                NumCast::from(clamp(t4.round(), min, max)).unwrap(),
+                NumCast::from(clamp(t.0.round(), min, max)).unwrap(),
+                NumCast::from(clamp(t.1.round(), min, max)).unwrap(),
+                NumCast::from(clamp(t.2.round(), min, max)).unwrap(),
+                NumCast::from(clamp(t.3.round(), min, max)).unwrap(),
             );
 
             out.put_pixel(x, outy, t);


### PR DESCRIPTION
A lot of time in resizing is spend on the float conversions. This is partially because `.round()` is slow but also because the type used for the rounding caused unnecessary overhead. This simplifies this, and adds some other performance improvements.

The first commit is a format (oops, I left one comment in. ), I dont know what your policy is on this in PRs. I kept this as a separate commit to make sure it would be easy to review.