### PR TITLE
Update bytemuck dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "image"
 path = "./src/lib.rs"
 
 [dependencies]
-bytemuck = "1"
+bytemuck = "1.7.2"
 byteorder = "1.3.2"
 num-iter = "0.1.32"
 num-rational = { version = "0.4", default-features = false }


### PR DESCRIPTION
Specify the most recent bytemuck version since 1.7.0 has been yanked.

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.