### PR TITLE
Fix GIF transparency

### DIFF
--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -489,7 +489,7 @@ impl<W: Write> GifEncoder<W> {
         )))
     }
 
-    pub(crate) fn encode_gif(&mut self, frame: Frame) -> ImageResult<()> {
+    pub(crate) fn encode_gif(&mut self, mut frame: Frame) -> ImageResult<()> {
         let gif_encoder;
         if let Some(ref mut encoder) = self.gif_encoder {
             gif_encoder = encoder;
@@ -503,6 +503,8 @@ impl<W: Write> GifEncoder<W> {
             self.gif_encoder = Some(encoder);
             gif_encoder = self.gif_encoder.as_mut().unwrap()
         }
+
+        frame.dispose = gif::DisposalMethod::Background;
 
         gif_encoder.write_frame(&frame).map_err(ImageError::from_encoding)
     }


### PR DESCRIPTION
Resolves #1531.

This changes causes alpha=0 pixels in a GIF frame to be transparent in the output image instead of having them use the color from the previous frame. This behavior could be controlled via an option, but I think the new approach is what most users want/expect.