### PR TITLE
fix clippy warnings

### DIFF
--- a/src/codecs/dxt.rs
+++ b/src/codecs/dxt.rs
@@ -422,7 +422,7 @@ fn decode_dxt3_block(source: &[u8], dest: &mut [u8]) {
 /// Decodes a 8-byte bock of dxt5 data to a 16xRGB block
 fn decode_dxt1_block(source: &[u8], dest: &mut [u8]) {
     assert!(source.len() == 8 && dest.len() == 48);
-    decode_dxt_colors(&source, dest, true);
+    decode_dxt_colors(source, dest, true);
 }
 
 /// Decode a row of DXT1 data to four rows of RGB data.

--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -74,7 +74,7 @@ impl<R: BufRead + Seek> OpenExrDecoder<R> {
         // read meta data, then wait for further instructions, keeping the file open and ready
         let exr_reader = exr::block::read(source, false).map_err(to_image_err)?;
 
-        let header_index = exr_reader.headers().into_iter()
+        let header_index = exr_reader.headers().iter()
             .position(|header|{
                 let has_rgb = ["R","G","B"].iter().all( // alpha will be optional
                     // check if r/g/b exists in the channels

--- a/src/codecs/pnm/decoder.rs
+++ b/src/codecs/pnm/decoder.rs
@@ -352,7 +352,7 @@ trait HeaderReader: BufRead {
             Some((cur_enabled, Ok(byte)))
         });
 
-        for (_, byte) in mark_comments.filter(|ref e| e.0) {
+        for (_, byte) in mark_comments.filter(|e| e.0) {
             match byte {
                 Ok(b'\t') | Ok(b'\n') | Ok(b'\x0b') | Ok(b'\x0c') | Ok(b'\r') | Ok(b' ') => {
                     if !bytes.is_empty() {
@@ -714,7 +714,7 @@ impl Sample for PbmBit {
         let mut bytes = reader.bytes();
         for b in output_buf {
             loop {
-                let byte = bytes.next().ok_or::<ImageError>(DecoderError::InputTooShort.into())??;
+                let byte = bytes.next().ok_or_else::<ImageError, _>(|| DecoderError::InputTooShort.into())??;
                 match byte {
                     b'\t' | b'\n' | b'\x0b' | b'\x0c' | b'\r' | b' ' => continue,
                     b'0' => *b = 255,

--- a/src/codecs/tiff.rs
+++ b/src/codecs/tiff.rs
@@ -252,9 +252,9 @@ impl<W: Write + Seek> TiffEncoder<W> {
             ColorType::L8 => encoder.write_image::<tiff::encoder::colortype::Gray8>(width, height, data),
             ColorType::Rgb8 => encoder.write_image::<tiff::encoder::colortype::RGB8>(width, height, data),
             ColorType::Rgba8 => encoder.write_image::<tiff::encoder::colortype::RGBA8>(width, height, data),
-            ColorType::L16 => encoder.write_image::<tiff::encoder::colortype::Gray16>(width, height, &u8_slice_as_u16(data)?),
-            ColorType::Rgb16 => encoder.write_image::<tiff::encoder::colortype::RGB16>(width, height, &u8_slice_as_u16(data)?),
-            ColorType::Rgba16 => encoder.write_image::<tiff::encoder::colortype::RGBA16>(width, height, &u8_slice_as_u16(data)?),
+            ColorType::L16 => encoder.write_image::<tiff::encoder::colortype::Gray16>(width, height, u8_slice_as_u16(data)?),
+            ColorType::Rgb16 => encoder.write_image::<tiff::encoder::colortype::RGB16>(width, height, u8_slice_as_u16(data)?),
+            ColorType::Rgba16 => encoder.write_image::<tiff::encoder::colortype::RGBA16>(width, height, u8_slice_as_u16(data)?),
             _ => {
                 return Err(ImageError::Unsupported(
                     UnsupportedError::from_format_and_kind(

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -938,7 +938,7 @@ impl DynamicImage {
                     }
                     _ => {}
                 }
-                p.encode(&bytes, width, height, color)?;
+                p.encode(bytes, width, height, color)?;
                 Ok(())
             }
 


### PR DESCRIPTION
`src/codecs/openexr.rs`: use `iter` rather than `into_iter`, which reduced unnecessary constructings

`src/codecs/pnm/decoder.rs`: use ok_or_else rather than `ok_or`, which reduced constructings unnecessary