### PR TITLE
Improve usage of `Vec::extend`

### DIFF
--- a/src/codecs/bmp/decoder.rs
+++ b/src/codecs/bmp/decoder.rs
@@ -286,8 +286,7 @@ fn extend_buffer(buffer: &mut Vec<u8>, full_size: usize, blank: bool) -> &mut [u
     let old_size = buffer.len();
     let extend = full_size - buffer.len();
 
-    buffer.extend(repeat(0xFF).take(extend));
-    assert_eq!(buffer.len(), full_size);
+    buffer.resize(full_size, 0xFF);
 
     let ret = if extend >= old_size {
         // If the full buffer length is more or equal to twice the initial one, we can simply
@@ -354,8 +353,7 @@ where
         if buffer.len() < full_image_size {
             // If the image is stored in top-down order, we can simply use the extend function
             // from vec to extend the buffer..
-            let extend = full_image_size - buffer.len();
-            buffer.extend(repeat(0xFF).take(extend));
+            buffer.resize(full_image_size, 0xFF);
             let len = buffer.len();
             for row in buffer[len - row_width..].chunks_mut(row_width) {
                 func(row)?;

--- a/src/codecs/tga/decoder.rs
+++ b/src/codecs/tga/decoder.rs
@@ -223,7 +223,7 @@ impl<R: Read + Seek> TgaDecoder<R> {
         for chunk in pixel_data.chunks(self.bytes_per_pixel) {
             let index = bytes_to_index(chunk);
             if let Some(color) = color_map.get(index) {
-                result.extend(color.iter().cloned());
+                result.extend_from_slice(color);
             } else {
                 return Err(io::ErrorKind::Other.into());
             }
@@ -251,7 +251,7 @@ impl<R: Read + Seek> TgaDecoder<R> {
                     .take(self.bytes_per_pixel as u64)
                     .read_to_end(&mut data)?;
                 for _ in 0usize..repeat_count {
-                    pixel_data.extend(data.iter().cloned());
+                    pixel_data.extend_from_slice(&data);
                 }
             } else {
                 // not set, so `run_packet+1` is the number of non-encoded pixels


### PR DESCRIPTION
Just a few random improvements I noticed could be made.

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.