### PR TITLE
create an `ImageFormat` from a MIME type

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -138,6 +138,35 @@ impl ImageFormat {
         inner(path.as_ref())
     }
 
+    /// Return the image format specified a MIME type.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use image::ImageFormat;
+    ///
+    /// let format = ImageFormat::from_mime_type("image/png").unwrap();
+    /// assert_eq!(format, ImageFormat::Png);
+    /// ```
+    pub fn from_mime_type<M>(mime_type: M) -> Option<Self> where M : AsRef<str> {
+        match mime_type.as_ref() {
+            "image/avif" => Some(ImageFormat::Avif),
+            "image/jpeg" => Some(ImageFormat::Jpeg),
+            "image/png" => Some(ImageFormat::Png),
+            "image/gif" => Some(ImageFormat::Gif),
+            "image/webp" => Some(ImageFormat::WebP),
+            "image/tiff"  => Some(ImageFormat::Tiff),
+            "image/x-targa" | "image/x-tga" => Some(ImageFormat::Tga),
+            "image/vnd-ms.dds" => Some(ImageFormat::Dds),
+            "image/bmp" => Some(ImageFormat::Bmp),
+            "image/x-icon" => Some(ImageFormat::Ico),
+            "image/vnd.radiance" => Some(ImageFormat::Hdr),
+            "image/x-exr" => Some(ImageFormat::OpenExr),
+            "image/x-portable-bitmap" | "image/x-portable-graymap" | "image/x-portable-pixmap" | "image/x-portable-anymap" => Some(ImageFormat::Pnm),
+            _ => None
+        }
+    }
+
     /// Return if the ImageFormat can be decoded by the lib.
     #[inline]
     pub fn can_read(&self) -> bool {

--- a/src/image.rs
+++ b/src/image.rs
@@ -138,7 +138,7 @@ impl ImageFormat {
         inner(path.as_ref())
     }
 
-    /// Return the image format specified a MIME type.
+    /// Return the image format specified by a MIME type.
     ///
     /// # Example
     ///


### PR DESCRIPTION
i used mime type assigned by [iana](https://www.iana.org/assignments/media-types/media-types.xhtml#image) for:
- avif
- jpeg
- png
- gif
- webp
- tiff
- bmp
- hdr

i used mime type value found on wikipedia for:
- tga,
- dds,
- ico,
- OpenExr,
- pnm,

i didn't find any mime type of farbfeld

close #1528 

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.


