### PR TITLE
Don't run CI on rustc older than 1.46

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: ["1.34.2", stable, beta, nightly]
+        rust: ["1.46.0", stable, beta, nightly]
         features: [ gif, jpeg, png, pnm, tga, dds, tiff, webp, hdr, farbfeld, '' ]
     steps:
     - uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
       run: >
         cargo test -v --no-default-features --features "$FEATURES" &&
         cargo doc -v --no-default-features --features "$FEATURES"
-      if: ${{ matrix.rust != '1.34.2' }}
+      if: ${{ matrix.rust != '1.46.0' }}
       env:
         FEATURES: ${{ matrix.features }}
   test_defaults:


### PR DESCRIPTION
This should prevent CI failures and allow us to merge other pull requests