### PR TITLE
Reduce allocations and `memcpy`s

### DIFF
--- a/src/codecs/dxt.rs
+++ b/src/codecs/dxt.rs
@@ -534,7 +534,7 @@ fn encode_dxt_colors(source: &[u8], dest: &mut [u8], is_dxt1: bool) {
     let mut colorspace_ = [[0u8; 3]; 16];
     let mut colorspace_len = 0;
     for color in &targets {
-        if !colorspace_.contains(color) {
+        if !colorspace_[..colorspace_len].contains(color) {
             colorspace_[colorspace_len] = *color;
             colorspace_len += 1;
         }

--- a/src/codecs/dxt.rs
+++ b/src/codecs/dxt.rs
@@ -525,16 +525,21 @@ fn encode_dxt_colors(source: &[u8], dest: &mut [u8], is_dxt1: bool) {
         *d = [s[0], s[1], s[2]];
     }
 
-    // and a set of colors to pick from.
-    let mut colorspace = targets.to_vec();
-
     // roundtrip all colors through the r5g6b5 encoding
-    for rgb in &mut colorspace {
+    for rgb in &mut targets {
         *rgb = enc565_decode(enc565_encode(*rgb));
     }
 
     // and deduplicate the set of colors to choose from as the algorithm is O(N^2) in this
-    colorspace.dedup();
+    let mut colorspace_ = [[0u8; 3]; 16];
+    let mut colorspace_len = 0;
+    for color in &targets {
+        if !colorspace_.contains(color) {
+            colorspace_[colorspace_len] = *color;
+            colorspace_len += 1;
+        }
+    }
+    let mut colorspace = &colorspace_[..colorspace_len];
 
     // in case of slight gradients it can happen that there's only one entry left in the color table.
     // as the resulting banding can be quite bad if we would just left the block at the closest
@@ -574,7 +579,8 @@ fn encode_dxt_colors(source: &[u8], dest: &mut [u8], is_dxt1: bool) {
 
         // we did find a separate value: add it to the options so after one round of quantization
         // we're done
-        colorspace.push(rgb);
+        colorspace_[1] = rgb;
+        colorspace = &colorspace_[..2];
     }
 
     // block quantization loop: we basically just try every possible combination, returning

--- a/src/codecs/tga/decoder.rs
+++ b/src/codecs/tga/decoder.rs
@@ -307,7 +307,9 @@ impl<R: Read + Seek> TgaDecoder<R> {
         pixel_data.append(&mut self.line_remain_buff);
         pixel_data.extend_from_slice(&line_data[..num_bytes]);
 
-        // put the remain data to line_remain_buff
+        // put the remain data to line_remain_buff.
+        // expects `self.line_remain_buff` to be empty from
+        // the above `pixel_data.append` call
         debug_assert!(self.line_remain_buff.is_empty());
         self.line_remain_buff.extend_from_slice(&line_data[num_bytes..]);
 

--- a/src/codecs/tga/encoder.rs
+++ b/src/codecs/tga/encoder.rs
@@ -66,18 +66,21 @@ impl<W: Write> TgaEncoder<W> {
         header.write_to(&mut self.writer)?;
 
         // Write out Bgr(a)8 or L(a)8 image data.
-        let mut image = Vec::from(buf);
-
         match color_type {
             ColorType::Rgb8 | ColorType::Rgba8 => {
+                let mut image = Vec::from(buf);
+
                 for chunk in image.chunks_mut(usize::from(color_type.bytes_per_pixel())) {
                     chunk.swap(0, 2);
                 }
+
+                self.writer.write_all(&image)?;
             }
-            _ => {}
+            _ => {
+                self.writer.write_all(buf)?;
+            }
         }
 
-        self.writer.write_all(&image)?;
         Ok(())
     }
 }

--- a/src/codecs/webp/vp8.rs
+++ b/src/codecs/webp/vp8.rs
@@ -1903,11 +1903,8 @@ fn predict_4x4(ws: &mut [u8], stride: usize, modes: &[IntraMode], resdata: &[i32
                 IntraMode::HU => predict_bhupred(ws, x0, y0, stride),
             }
 
-            // Create a [i32; 16] array for add_residue by copying the
-            // slice from resdata into rb (slices do not work).
-            let mut rb = [0i32; 16];
-            rb.copy_from_slice(&resdata[i * 16..i * 16 + 16]);
-            add_residue(ws, &rb, y0, x0, stride);
+            let rb: &[i32; 16] = resdata[i * 16..][..16].try_into().unwrap();
+            add_residue(ws, rb, y0, x0, stride);
         }
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -396,11 +396,11 @@ impl ImageReadBuffer {
         // Finally, copy bytes into output buffer.
         let bytes_buffered = self.buffer.len() - self.consumed;
         if bytes_buffered > buf.len() {
-            crate::copy_memory(&self.buffer[self.consumed..][..buf.len()], &mut buf[..]);
+            buf.copy_from_slice(&self.buffer[self.consumed..][..buf.len()]);
             self.consumed += buf.len();
             Ok(buf.len())
         } else {
-            crate::copy_memory(&self.buffer[self.consumed..], &mut buf[..bytes_buffered]);
+            buf[..bytes_buffered].copy_from_slice(&self.buffer[self.consumed..][..bytes_buffered]);
             self.consumed = self.buffer.len();
             Ok(bytes_buffered)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,8 +101,6 @@ extern crate test;
 #[macro_use]
 extern crate quickcheck;
 
-use std::io::Write;
-
 pub use crate::color::{ColorType, ExtendedColorType};
 
 pub use crate::color::{Luma, LumaA, Rgb, Rgba, Bgr, Bgra};
@@ -392,12 +390,3 @@ macro_rules! insert_as_doc {
 // Provides the README.md as doc, to ensure the example works!
 insert_as_doc!(include_str!("../README.md"));
 
-// Copies data from `src` to `dst`
-//
-// Panics if the length of `dst` is less than the length of `src`.
-#[inline]
-fn copy_memory(src: &[u8], mut dst: &mut [u8]) {
-    let len_src = src.len();
-    assert!(dst.len() >= len_src);
-    dst.write_all(src).unwrap();
-}


### PR DESCRIPTION
In the same style as #1537 - a few random improvements I noticed could be made.

I haven't run a benchmark on these but:

* `encode_dxt_colors` gets called in a for loop so it's probably worth it to remove the `.to_vec()`
* The `Vec::split_to` optimization removes 2 allocations and 2 `memcpy`s
* [comparing](https://rust.godbolt.org/z/37aj341dn) `crate::copy_memory` with `slice::copy_from_slice` shows that they generate the same assembly

---

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.