### PR TITLE
Add adaptive filter option to png encoder

### DIFF
--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -457,8 +457,7 @@ pub enum CompressionType {
 
 /// Filter algorithms used to process image data to improve compression.
 ///
-/// The default filter is `Sub` though this default may change in the future, most notable if an
-/// adaptive encoding option is implemented.
+/// The default filter is `Adaptive`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum FilterType {
     /// No processing done, best used for low bit depth greyscale or data with a
@@ -472,6 +471,9 @@ pub enum FilterType {
     Avg,
     /// Algorithm that takes into account the left, upper left, and above pixels
     Paeth,
+    /// Uses a heuristic to select one of the preceding filters for each
+    /// scanline rather than one filter for the entire image
+    Adaptive,
 
     #[doc(hidden)]
     __NonExhaustive(crate::utils::NonExhaustiveMarker),
@@ -482,8 +484,8 @@ impl<W: Write> PngEncoder<W> {
     pub fn new(w: W) -> PngEncoder<W> {
         PngEncoder {
             w,
-            compression: CompressionType::Fast,
-            filter: FilterType::Sub,
+            compression: CompressionType::default(),
+            filter: FilterType::default(),
         }
     }
 
@@ -496,11 +498,9 @@ impl<W: Write> PngEncoder<W> {
     /// mapping may be interpreted differently in minor versions. The exact output is expressly
     /// __not__ part the SemVer stability guarantee.
     ///
-    /// Note that it is not optimal to use a single filter type. It is likely that the library used
-    /// will at some point gain the ability to use adaptive filtering methods per pixel row (or
-    /// even interlaced row). We might make it the new default variant in which case choosing a
-    /// particular filter method likely produces larger images. Be sure to check the release notes
-    /// once in a while.
+    /// Note that it is not optimal to use a single filter type, so an adaptive
+    /// filter type is selected as the default. The filter which best minimizes
+    /// file size may change with the type of compression used.
     pub fn new_with_quality(w: W, compression: CompressionType, filter: FilterType) -> PngEncoder<W> {
         PngEncoder {
             w,
@@ -533,12 +533,13 @@ impl<W: Write> PngEncoder<W> {
             CompressionType::Rle => png::Compression::Rle,
             CompressionType::__NonExhaustive(marker) => match marker._private {},
         };
-        let filt = match self.filter {
-            FilterType::NoFilter => png::FilterType::NoFilter,
-            FilterType::Sub => png::FilterType::Sub,
-            FilterType::Up => png::FilterType::Up,
-            FilterType::Avg => png::FilterType::Avg,
-            FilterType::Paeth => png::FilterType::Paeth,
+        let (filter, adaptive_filter) = match self.filter {
+            FilterType::NoFilter => (png::FilterType::NoFilter, png::AdaptiveFilterType::NonAdaptive),
+            FilterType::Sub => (png::FilterType::Sub, png::AdaptiveFilterType::NonAdaptive),
+            FilterType::Up => (png::FilterType::Up, png::AdaptiveFilterType::NonAdaptive),
+            FilterType::Avg => (png::FilterType::Avg, png::AdaptiveFilterType::NonAdaptive),
+            FilterType::Paeth => (png::FilterType::Paeth, png::AdaptiveFilterType::NonAdaptive),
+            FilterType::Adaptive => (png::FilterType::Sub, png::AdaptiveFilterType::Adaptive),
             FilterType::__NonExhaustive(marker) => match marker._private {},
         };
 
@@ -546,7 +547,8 @@ impl<W: Write> PngEncoder<W> {
         encoder.set_color(ct);
         encoder.set_depth(bits);
         encoder.set_compression(comp);
-        encoder.set_filter(filt);
+        encoder.set_filter(filter);
+        encoder.set_adaptive_filter(adaptive_filter);
         let mut writer = encoder.write_header().map_err(|e| ImageError::IoError(e.into()))?;
         writer.write_image_data(data).map_err(|e| ImageError::IoError(e.into()))
     }
@@ -616,7 +618,7 @@ impl Default for CompressionType {
 
 impl Default for FilterType {
     fn default() -> Self {
-        FilterType::Sub
+        FilterType::Adaptive
     }
 }
 


### PR DESCRIPTION
- Add `Adaptive` to `codecs::png::FilterType` enum
- Make `Adaptive` the default `FilterType`
- Use `CompressionType::default` and `FilterType::default` in `codecs::png::PngEncoder::new`

png 0.17 includes the Adaptive filtering method for encoding which helps reduce file size.

I've updated the doc comments in `codecs::png::FilterType` and `codecs::png::PngEncoder::new_with_quality` which mentioned changing the filter type to adaptive filtering when it became available.