### PR TITLE
External test data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ exclude = [
     "tests/*",
 ]
 include = [
-    "tests/reference_images.rs"
+    "tests/reference_images.rs",
+    "benches"
 ]
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ num-complex = "0.3"
 glob = "0.3"
 quickcheck = "0.9"
 criterion = "0.3"
-xtest-data = "0.0.2"
+xtest-data = "0.0.3"
 
 [features]
 # TODO: Add "avif" to this list while preparing for 0.24.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ exclude = [
     "examples/*",
     "tests/*",
 ]
+include = [
+    "tests/reference_images.rs"
+]
+
 
 [lib]
 name = "image"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ num-complex = "0.3"
 glob = "0.3"
 quickcheck = "0.9"
 criterion = "0.3"
-xtest-data = "0.0.3"
+xtest-data = "0.0.4"
 
 [features]
 # TODO: Add "avif" to this list while preparing for 0.24.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,9 @@ categories = ["multimedia::images", "multimedia::encoding"]
 exclude = [
     "src/png/testdata/*",
     "examples/*",
-    "tests/*",
-]
-include = [
-    "tests/reference_images.rs",
-    "benches"
+    "tests/output",
+    "tests/images",
+    "tests/reference",
 ]
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ jpeg = { package = "jpeg-decoder", version = "0.1.22", default-features = false,
 png = { version = "0.16.5", optional = true }
 scoped_threadpool = { version = "0.1", optional = true }
 tiff = { version = "0.6.0", optional = true }
-ravif = { version = "0.7.0", optional = true }
+ravif = { version = "0.8.7", optional = true }
 rgb = { version = "0.8.25", optional = true }
 mp4parse = { version = "0.11.5", optional = true }
 dav1d = { version = "0.6.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ glob = "0.3"
 quickcheck = "0.9"
 criterion = "0.3"
 
+xtest-data = "0.0.1"
+
 [features]
 # TODO: Add "avif" to this list while preparing for 0.24.0
 default = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "dds", "farbfeld", "jpeg_rayon", "openexr"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,7 @@ num-complex = "0.3"
 glob = "0.3"
 quickcheck = "0.9"
 criterion = "0.3"
-
-xtest-data = "0.0.1"
+xtest-data = "0.0.2"
 
 [features]
 # TODO: Add "avif" to this list while preparing for 0.24.0

--- a/src/codecs/bmp/decoder.rs
+++ b/src/codecs/bmp/decoder.rs
@@ -1478,6 +1478,7 @@ impl<'a, R: 'a + Read + Seek> ImageDecoderExt<'a> for BmpDecoder<R> {
 
 #[cfg(test)]
 mod test {
+    use crate::codecs::test_images;
     use super::*;
 
     #[test]
@@ -1497,7 +1498,8 @@ mod test {
 
     #[test]
     fn read_rect() {
-        let f = std::fs::File::open("tests/images/bmp/images/Core_8_Bit.bmp").unwrap();
+        let images = test_images("bmp/images");
+        let f = std::fs::File::open(images.join("Core_8_Bit.bmp")).unwrap();
         let mut decoder = super::BmpDecoder::new(f).unwrap();
 
         let mut buf: Vec<u8> = vec![0; 8 * 8 * 3];

--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -341,7 +341,6 @@ mod test {
     use super::*;
     use crate::codecs::test_images;
 
-
     /// Write an `Rgb32FImage`.
     /// Assumes the writer is buffered. In most cases,
     /// you should wrap your writer in a `BufWriter` for best performance.

--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -339,10 +339,7 @@ fn to_image_err(exr_error: Error) -> ImageError {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::path::PathBuf;
-
-    const BASE_PATH: &[&str] = &[".", "tests", "images", "exr"];
-
+    use crate::codecs::test_images;
 
 
     /// Write an `Rgb32FImage`.
@@ -411,9 +408,9 @@ mod test {
 
         #[cfg(feature = "hdr")]
         {
-            let folder = BASE_PATH.iter().collect::<PathBuf>();
-            let reference_path = folder.clone().join("overexposed gradient.hdr");
-            let exr_path = folder.clone().join("overexposed gradient - data window equals display window.exr");
+            let folder = test_images("exr");
+            let reference_path = folder.join("overexposed gradient.hdr");
+            let exr_path = folder.join("overexposed gradient - data window equals display window.exr");
 
             let hdr: Vec<Rgb<f32>> = crate::codecs::hdr::HdrDecoder::new(
                 std::io::BufReader::new(std::fs::File::open(&reference_path).unwrap())
@@ -466,7 +463,7 @@ mod test {
 
     #[test]
     fn compare_rgba_rgb() {
-        let exr_path = BASE_PATH.iter().collect::<PathBuf>()
+        let exr_path = test_images("exr")
             .join("overexposed gradient - data window equals display window.exr");
 
         let rgb: Rgb32FImage = read_as_rgb_image_from_file(&exr_path).unwrap();
@@ -490,9 +487,9 @@ mod test {
         // in this test we want to make sure that an
         // auto-cropped image will be reproduced to the original.
 
-        let exr_path = BASE_PATH.iter().collect::<PathBuf>();
-        let original = exr_path.clone().join("cropping - uncropped original.exr");
-        let cropped = exr_path.clone().join("cropping - data window differs display window.exr");
+        let exr_path = test_images("exr");
+        let original = exr_path.join("cropping - uncropped original.exr");
+        let cropped = exr_path.join("cropping - data window differs display window.exr");
 
         // smoke-check that the exr files are actually not the same
         {

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -649,12 +649,14 @@ impl Default for FilterType {
 #[cfg(test)]
 mod tests {
     use crate::image::ImageDecoder;
+    use crate::codecs::test_images;
     use std::io::Read;
     use super::*;
 
     #[test]
     fn ensure_no_decoder_off_by_one() {
-        let dec = PngDecoder::new(std::fs::File::open("tests/images/png/bugfixes/debug_triangle_corners_widescreen.png").unwrap())
+        let bugfixes = test_images("png/bugfixes");
+        let dec = PngDecoder::new(std::fs::File::open(bugfixes.join("debug_triangle_corners_widescreen.png")).unwrap())
             .expect("Unable to read PNG file (does it exist?)");
 
         assert_eq![(2000, 1000), dec.dimensions()];
@@ -678,8 +680,8 @@ mod tests {
     #[test]
     fn underlying_error() {
         use std::error::Error;
-
-        let mut not_png = std::fs::read("tests/images/png/bugfixes/debug_triangle_corners_widescreen.png").unwrap();
+        let bugfixes = test_images("png/bugfixes");
+        let mut not_png = std::fs::read(bugfixes.join("debug_triangle_corners_widescreen.png")).unwrap();
         not_png[0] = 0;
 
         let error = PngDecoder::new(&not_png[..]).err().unwrap();

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -1392,6 +1392,8 @@ mod bench {
 
 #[cfg(test)]
 mod test {
+    use crate::codecs::test_images;
+
     #[test]
     fn test_empty_file() {
         assert!(super::load_from_memory(b"").is_err());
@@ -1400,16 +1402,16 @@ mod test {
     #[cfg(feature = "jpeg")]
     #[test]
     fn image_dimensions() {
-        let im_path = "./tests/images/jpg/progressive/cat.jpg";
-        let dims = super::image_dimensions(im_path).unwrap();
+        let im_path = test_images("jpg/progressive");
+        let dims = super::image_dimensions(im_path.join("cat.jpg")).unwrap();
         assert_eq!(dims, (320, 240));
     }
 
     #[cfg(feature = "png")]
     #[test]
     fn open_16bpc_png() {
-        let im_path = "./tests/images/png/16bpc/basn6a16.png";
-        let image = super::open(im_path).unwrap();
+        let im_path = test_images("png/16bpc");
+        let image = super::open(im_path.join("basn6a16.png")).unwrap();
         assert_eq!(image.color(), super::color::ColorType::Rgba16);
     }
 }

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -856,15 +856,18 @@ where
 #[cfg(test)]
 mod tests {
     use super::{resize, FilterType};
-    use crate::{ImageBuffer, RgbImage};
+    use crate::{ImageBuffer, RgbImage, codecs::test_images};
     #[cfg(feature = "benchmarks")]
     use test;
 
     #[bench]
     #[cfg(all(feature = "benchmarks", feature = "png"))]
     fn bench_resize(b: &mut test::Bencher) {
-        use std::path::Path;
-        let img = crate::open(&Path::new("./examples/fractal.png")).unwrap();
+        use std::path::PathBuf;
+        use xtest_data::{setup, FsItem};
+        let mut img = PathBuf::from("examples/fractal.png");
+        setup!().fiter([FsItem::File(&mut img)]).build();
+        let img = crate::open(img).unwrap();
         b.iter(|| {
             test::black_box(resize(&img, 200, 200, FilterType::Nearest));
         });
@@ -880,7 +883,8 @@ mod tests {
     #[bench]
     #[cfg(all(feature = "benchmarks", feature = "tiff"))]
     fn bench_thumbnail(b: &mut test::Bencher) {
-        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/images/tiff/testsuite/mandrill.tiff");
+        let testsuite = test_images("tiff/testsuite");
+        let path = testsuite.join("mandrill.tiff");
         let image = crate::open(path).unwrap();
         b.iter(|| {
             test::black_box(image.thumbnail(256, 256));
@@ -891,7 +895,8 @@ mod tests {
     #[bench]
     #[cfg(all(feature = "benchmarks", feature = "tiff"))]
     fn bench_thumbnail_upsize(b: &mut test::Bencher) {
-        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/images/tiff/testsuite/mandrill.tiff");
+        let testsuite = test_images("tiff/testsuite");
+        let path = testsuite.join("mandrill.tiff");
         let image = crate::open(path).unwrap().thumbnail(256, 256);
         b.iter(|| {
             test::black_box(image.thumbnail(512, 512));
@@ -902,7 +907,8 @@ mod tests {
     #[bench]
     #[cfg(all(feature = "benchmarks", feature = "tiff"))]
     fn bench_thumbnail_upsize_irregular(b: &mut test::Bencher) {
-        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/images/tiff/testsuite/mandrill.tiff");
+        let testsuite = test_images("tiff/testsuite");
+        let path = testsuite.join("mandrill.tiff");
         let image = crate::open(path).unwrap().thumbnail(193, 193);
         b.iter(|| {
             test::black_box(image.thumbnail(256, 256));
@@ -929,11 +935,8 @@ mod tests {
             }
         }
 
-        let path = concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/tests/images/png/transparency/tp1n3p08.png"
-        );
-        let img = crate::open(path).unwrap();
+        let images = test_images("png/transparency");
+        let img = crate::open(images.join("tp1n3p08.png")).unwrap();
         let rgba8 = img.as_rgba8().unwrap();
         let filters = &[Nearest, Triangle, CatmullRom, Gaussian, Lanczos3];
         for filter in filters {

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -864,9 +864,8 @@ mod tests {
     #[cfg(all(feature = "benchmarks", feature = "png"))]
     fn bench_resize(b: &mut test::Bencher) {
         use std::path::PathBuf;
-        use xtest_data::{setup, FsItem};
         let mut img = PathBuf::from("examples/fractal.png");
-        setup!().fiter([FsItem::File(&mut img)]).build();
+        xtest_data::setup!().rewrite([&mut img]).build();
         let img = crate::open(img).unwrap();
         b.iter(|| {
             test::black_box(resize(&img, 200, 200, FilterType::Nearest));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,9 +258,7 @@ pub mod codecs {
         const BASE_PATH: &[&str] = &["tests", "images"];
         let mut path = BASE_PATH.iter().collect::<std::path::PathBuf>();
         path = path.join(kind);
-        xtest_data::setup!()
-            .filter([xtest_data::FsItem::Tree(&mut path)])
-            .build();
+        xtest_data::setup!().rewrite([&mut path]).build();
         path
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,6 +250,20 @@ pub mod codecs {
     pub mod webp;
     #[cfg(feature = "openexr")]
     pub mod openexr;
+
+    #[cfg(test)]
+    pub(crate) fn test_images(kind: &str)
+        -> impl std::ops::Deref<Target=std::path::Path>
+    {
+        const BASE_PATH: &[&str] = &["tests", "images"];
+        let mut path = BASE_PATH.iter().collect::<std::path::PathBuf>();
+        path = path.join(kind);
+        xtest_data::setup!()
+            .filter([xtest_data::FsItem::Tree(&mut path)])
+            .build();
+        path
+    }
+
 }
 
 #[cfg(feature = "avif-encoder")]

--- a/tests/reference_images.rs
+++ b/tests/reference_images.rs
@@ -25,23 +25,23 @@ where
 
     let mut xsetup = xtest_data::setup!();
     // Ensure those are always available.
-    let _ = xsetup.tree(&base.join(IMAGE_DIR));
-    let _ = xsetup.tree(&base.join(REFERENCE_DIR));
+    let _ = xsetup.add(&base.join(IMAGE_DIR));
+    let _ = xsetup.add(&base.join(REFERENCE_DIR));
 
-    let xbase = xsetup.tree(&base.join(dir));
+    let xbase = xsetup.add(&base.join(dir));
     let trees = decoders
         .iter()
         .map(|decoder| {
             let mut base = base.to_owned();
             base.push(dir);
             base.push(decoder);
-            xsetup.tree(&base)
+            xsetup.add(&base)
         })
         .collect::<Vec<_>>();
     let xdata = xsetup.build();
 
     for (decoder, base) in decoders.iter().zip(trees) {
-        let decoder_base = xdata.tree(&base);
+        let decoder_base = xdata.path(&base);
         let mut path = decoder_base.to_owned();
         path.push("**");
         path.push(
@@ -52,7 +52,7 @@ where
         );
         let pattern = &*format!("{}", path.display());
         let base = xdata
-            .tree(&xbase)
+            .path(&xbase)
             .parent()
             .unwrap();
         for path in glob::glob(pattern).unwrap().filter_map(Result::ok) {

--- a/tests/reference_images.rs
+++ b/tests/reference_images.rs
@@ -11,7 +11,7 @@ use std::u32;
 
 use crc32fast::Hasher as Crc32;
 
-const BASE_PATH: [&str; 2] = [".", "tests"];
+const BASE_PATH: [&str; 1] = ["tests"];
 const IMAGE_DIR: &str = "images";
 const OUTPUT_DIR: &str = "output";
 const REFERENCE_DIR: &str = "reference";
@@ -20,7 +20,9 @@ fn process_images<F>(dir: &str, input_decoder: Option<&str>, func: F)
 where
     F: Fn(&Path, PathBuf, &str),
 {
-    let base: PathBuf = BASE_PATH.iter().collect();
+    let mut base: PathBuf = BASE_PATH.iter().collect();
+    base.push(dir);
+
     let decoders = &["tga", "tiff", "png", "gif", "bmp", "ico", "jpg", "hdr", "pbm", "webp"];
 
     let mut xsetup = xtest_data::setup!();
@@ -29,7 +31,6 @@ where
         .iter()
         .map(|decoder| {
             let mut base = base.to_owned();
-            base.push(dir);
             base.push(decoder);
             xsetup.tree(&base)
         })
@@ -47,7 +48,10 @@ where
             },
         );
         let pattern = &*format!("{}", path.display());
-        let base = xdata.tree(&xbase);
+        let base = xdata
+            .tree(&xbase)
+            .parent()
+            .unwrap();
         for path in glob::glob(pattern).unwrap().filter_map(Result::ok) {
             func(&base, path, decoder)
         }

--- a/tests/reference_images.rs
+++ b/tests/reference_images.rs
@@ -21,16 +21,19 @@ where
     F: Fn(&Path, PathBuf, &str),
 {
     let mut base: PathBuf = BASE_PATH.iter().collect();
-    base.push(dir);
-
     let decoders = &["tga", "tiff", "png", "gif", "bmp", "ico", "jpg", "hdr", "pbm", "webp"];
 
     let mut xsetup = xtest_data::setup!();
-    let xbase = xsetup.tree(&base);
+    // Ensure those are always available.
+    let _ = xsetup.tree(&base.join(IMAGE_DIR));
+    let _ = xsetup.tree(&base.join(REFERENCE_DIR));
+
+    let xbase = xsetup.tree(&base.join(dir));
     let trees = decoders
         .iter()
         .map(|decoder| {
             let mut base = base.to_owned();
+            base.push(dir);
             base.push(decoder);
             xsetup.tree(&base)
         })

--- a/tests/reference_images.rs
+++ b/tests/reference_images.rs
@@ -20,7 +20,7 @@ fn process_images<F>(dir: &str, input_decoder: Option<&str>, func: F)
 where
     F: Fn(&Path, PathBuf, &str),
 {
-    let mut base: PathBuf = BASE_PATH.iter().collect();
+    let base: PathBuf = BASE_PATH.iter().collect();
     let decoders = &["tga", "tiff", "png", "gif", "bmp", "ico", "jpg", "hdr", "pbm", "webp"];
 
     let mut xsetup = xtest_data::setup!();

--- a/tests/save_jpeg.rs
+++ b/tests/save_jpeg.rs
@@ -1,12 +1,14 @@
 //! Test saving "default" and specific quality jpeg.
 #![cfg(all(feature = "jpeg", feature = "tiff"))]
-extern crate image;
-
+use std::path::PathBuf;
 use image::{ImageOutputFormat, ImageFormat};
+use xtest_data::{setup, FsItem};
 
 #[test]
 fn jqeg_qualitys() {
-    let img = image::open("tests/images/tiff/testsuite/mandrill.tiff").unwrap();
+    let mut path = PathBuf::from("tests/images/tiff/testsuite/mandrill.tiff");
+    setup!().filter([FsItem::File(&mut path)]).build();
+    let img = image::open(path).unwrap();
 
     let mut default = vec![];
     img.write_to(&mut default, ImageFormat::Jpeg).unwrap();

--- a/tests/save_jpeg.rs
+++ b/tests/save_jpeg.rs
@@ -2,12 +2,11 @@
 #![cfg(all(feature = "jpeg", feature = "tiff"))]
 use std::path::PathBuf;
 use image::{ImageOutputFormat, ImageFormat};
-use xtest_data::{setup, FsItem};
 
 #[test]
 fn jqeg_qualitys() {
     let mut path = PathBuf::from("tests/images/tiff/testsuite/mandrill.tiff");
-    setup!().filter([FsItem::File(&mut path)]).build();
+    xtest_data::setup!().rewrite([&mut path]).build();
     let img = image::open(path).unwrap();
 
     let mut default = vec![];


### PR DESCRIPTION
This is a draft for a system that would allow _external_ packagers to run our test suite based on the published packages, without requiring us to add that test data into the packages. This is based on a recent idea of mine which I published as [`xtest-data`](https://crates.io/crates/xtest-data). Comment of all sorts welcome on the approach.

I'm hoping to quickly arrive at a stable version—maybe even `1.0`—of the linked crate by prototyping it with `image` or its sub-crates. These should be a decent reflection of real world testing and we certainly have a relatively heavy test suite in terms of file sizes. One particular pain point which I haven't been able to integrate yet would be to move data out-of-tree altogether but I imagine this to be feasible with submodules—indeed, submodules should already work without requiring everyone to download all data—but more interesting would be `git lfs` etc.

## How to run the tests

* Manually package the crate: `cargo package --no-verify`
* Unpack the crate at some location:
  ```bash
  gunzip -c target/package/image-0.23.14.crate | tar -C /tmp --extract --file -
  cd /tmp/image-0.23.14
  ```
* Do the dance for the crate (note that only `reference_images` works atm):
  ```bash
  # Note the error output here, no network connection yet.
  cargo test --tests check_references -- --nocapture
  # Instruct the crate to auto-setup the directories
  CARGO_XTEST_DATA_FETCH=1 cargo test --tests check_references -- --nocapture
  ```