### PR TITLE
Upgrade TIFF to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ gif = { version = "0.11.1", optional = true }
 jpeg = { package = "jpeg-decoder", version = "0.1.22", default-features = false, optional = true }
 png = { version = "0.16.5", optional = true }
 scoped_threadpool = { version = "0.1", optional = true }
-tiff = { version = "0.6.0", optional = true }
+tiff = { version = "0.7.1", optional = true }
 ravif = { version = "0.8.0", optional = true }
 rgb = { version = "0.8.25", optional = true }
 mp4parse = { version = "0.11.5", optional = true }

--- a/Cargo.toml.public-private-dependencies
+++ b/Cargo.toml.public-private-dependencies
@@ -34,7 +34,7 @@ gif = { version = "0.11.1", optional = true }
 jpeg = { package = "jpeg-decoder", version = "0.1.17", default-features = false, optional = true }
 png = { version = "0.16.0", optional = true }
 scoped_threadpool = { version = "0.1", optional = true }
-tiff = { version = "0.6.0", optional = true }
+tiff = { version = "0.7.1", optional = true }
 ravif = { version = "0.6.0", optional = true }
 rgb = { version = "0.8.25", optional = true }
 color_quant = { version = "1.1", public = true }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -72,27 +72,6 @@ pub(crate) fn check_dimension_overflow(width: u32, height: u32, bytes_per_pixel:
 
 #[allow(dead_code)]
 // When no image formats that use it are enabled
-pub(crate) fn vec_u16_into_u8(vec: Vec<u16>) -> Vec<u8> {
-    // Do this way until we find a way to not alloc/dealloc but get llvm to realloc instead.
-    vec_copy_to_u8(&vec)
-}
-
-#[allow(dead_code)]
-// When no image formats that use it are enabled
-pub(crate) fn vec_u32_into_u8(vec: Vec<u32>) -> Vec<u8> {
-    // Do this way until we find a way to not alloc/dealloc but get llvm to realloc instead.
-    vec_copy_to_u8(&vec)
-}
-
-#[allow(dead_code)]
-// When no image formats that use it are enabled
-pub(crate) fn vec_u64_into_u8(vec: Vec<u64>) -> Vec<u8> {
-    // Do this way until we find a way to not alloc/dealloc but get llvm to realloc instead.
-    vec_copy_to_u8(&vec)
-}
-
-#[allow(dead_code)]
-// When no image formats that use it are enabled
 pub(crate) fn vec_copy_to_u8<T>(vec: &[T]) -> Vec<u8>
 where
     T: bytemuck::Pod,


### PR DESCRIPTION
Among other things, adds support for TIFF images with Deflate tag (commonly produced by tools like imagemagick) and improves memory consumption.

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

<!-- 
If you are a new contributor, consent to licensing by including this text:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

Thank you for contributing, you can delete this comment.
-->

