### PR TITLE
Bump ravif version from 0.7.0 to 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ jpeg = { package = "jpeg-decoder", version = "0.1.22", default-features = false,
 png = { version = "0.16.5", optional = true }
 scoped_threadpool = { version = "0.1", optional = true }
 tiff = { version = "0.6.0", optional = true }
-ravif = { version = "0.7.0", optional = true }
+ravif = { version = "0.8.0", optional = true }
 rgb = { version = "0.8.25", optional = true }
 mp4parse = { version = "0.11.5", optional = true }
 dav1d = { version = "0.6.0", optional = true }

--- a/src/codecs/avif/encoder.rs
+++ b/src/codecs/avif/encoder.rs
@@ -72,8 +72,8 @@ impl<W: Write> AvifEncoder<W> {
             inner: w,
             fallback: vec![],
             config: Config {
-                quality,
-                alpha_quality: quality,
+                quality: f32::from(quality),
+                alpha_quality: f32::from(quality),
                 speed,
                 premultiplied_alpha: false,
                 color_space: ravif::ColorSpace::RGB,


### PR DESCRIPTION
Fixes: #1562 

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.
