### PR TITLE
Update afl to 0.10, fix run issue

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -101,6 +101,8 @@ jobs:
         cargo check --bin reproduce_pnm
         cargo afl check --bin fuzz_webp
         cargo afl check --bin fuzz_pnm
+      env:
+        RUSTFLAGS: "-Znew-llvm-pass-manager=no"
   build_fuzz_cargo-fuzz:
     name: "Fuzz targets (cargo-fuzz)"
     runs-on: ubuntu-latest
@@ -114,7 +116,7 @@ jobs:
       run: |
         cargo install cargo-fuzz
         cargo fuzz build
-    - name: fuuz
+    - name: fuzz
       run: |
         for format in $(cargo fuzz list); do
           cargo fuzz run "$format" -- -runs=0;

--- a/fuzz-afl/.cargo/config
+++ b/fuzz-afl/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-Znew-llvm-pass-manager=no"]

--- a/fuzz-afl/Cargo.toml
+++ b/fuzz-afl/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 path = ".."
 
 [dependencies.afl]
-version = "0.4.3"
+version = "0.10.1"
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/fuzz-afl/README.md
+++ b/fuzz-afl/README.md
@@ -21,3 +21,12 @@ Run afl:
 To reproduce a crash:
 
     $ cargo run --bin reproduce_<format>
+
+
+## Known issues
+
+Since about Oct. 2021 the nightly Rust builds use an llvm version that no
+longer accepts one of the sanitizer passes. As a temporary workaround you must
+adjust the flags passed to `afl`:
+
+    $ RUSTFLAGS="-Znew-llvm-pass-manager=no" cargo +nightly afl run …

--- a/fuzz-afl/fuzzers/fuzz_pnm.rs
+++ b/fuzz-afl/fuzzers/fuzz_pnm.rs
@@ -17,7 +17,7 @@ fn pnm_decode(data: &[u8]) -> ImageResult<DynamicImage> {
 }
 
 fn main() {
-    afl::fuzz(|data| {
+    afl::fuzz(true, |data| {
         let _ = pnm_decode(data);
     });
 }

--- a/fuzz-afl/fuzzers/fuzz_webp.rs
+++ b/fuzz-afl/fuzzers/fuzz_webp.rs
@@ -17,7 +17,7 @@ fn webp_decode(data: &[u8]) -> ImageResult<DynamicImage> {
 }
 
 fn main() {
-    afl::fuzz(|data| {
+    afl::fuzz(true, |data| {
         let _ = webp_decode(data);
     });
 }


### PR DESCRIPTION
Work around an issue due to new pass-manager, as mentioned here:
<https://github.com/rust-fuzz/afl.rs/issues/192#issuecomment-931803722>

This affords us some time (until LLVM 14 or 15 iirc) for a more
permanent fix to appear upstream.

<!-- 
If you are a new contributor, consent to licensing by including this text:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

Thank you for contributing, you can delete this comment.
-->

