### PR TITLE
Fix breakage from mp4parse update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ scoped_threadpool = { version = "0.1", optional = true }
 tiff = { version = "0.7.1", optional = true }
 ravif = { version = "0.8.0", optional = true }
 rgb = { version = "0.8.25", optional = true }
-mp4parse = { version = "0.11.5", optional = true }
+mp4parse = { version = "0.11.6", optional = true }
 dav1d = { version = "0.6.0", optional = true }
 dcv-color-primitives = { version = "0.1.16", optional = true }
 exr = { version = "1.3.0", optional = true }

--- a/src/codecs/avif/decoder.rs
+++ b/src/codecs/avif/decoder.rs
@@ -14,7 +14,7 @@ use crate::{ColorType, ImageDecoder, ImageError, ImageFormat, ImageResult};
 
 use dav1d::{PixelLayout, PlanarImageComponent};
 use dcv_color_primitives as dcp;
-use mp4parse::read_avif;
+use mp4parse::{ParseStrictness, read_avif};
 
 fn error_map<E: Into<Box<dyn Error + Send + Sync>>>(err: E) -> ImageError {
     ImageError::Decoding(DecodingError::new(ImageFormat::Avif.into(), err))
@@ -32,13 +32,15 @@ pub struct AvifDecoder<R> {
 impl<R: Read> AvifDecoder<R> {
     /// Create a new decoder that reads its input from `r`.
     pub fn new(mut r: R) -> ImageResult<Self> {
-        let ctx = read_avif(&mut r).map_err(error_map)?;
+        let ctx = read_avif(&mut r, ParseStrictness::Normal).map_err(error_map)?;
         let mut primary_decoder = dav1d::Decoder::new();
+        let coded = ctx.primary_item_coded_data();
         primary_decoder
-            .send_data(ctx.primary_item(), None, None, None)
+            .send_data(coded, None, None, None)
             .map_err(error_map)?;
         let picture = primary_decoder.get_picture().map_err(error_map)?;
-        let alpha_picture = if let Some(alpha_item) = ctx.alpha_item() {
+        let alpha_item = ctx.alpha_item_coded_data();
+        let alpha_picture = if !alpha_item.is_empty() {
             let mut alpha_decoder = dav1d::Decoder::new();
             alpha_decoder
                 .send_data(alpha_item, None, None, None)


### PR DESCRIPTION
This was a breaking release published in a minor version. We used two
APIs that had breakage: AvifDecoder no longer has a public `alpha_item`
and we now interpret the length of the alpha data instead (following the
documentation of the C-API) and `read_avif` takes a parameter on how to
handle decoding failure where we used the normal mode for now until we
get indicated to be strict or lenient.

