### PR TITLE
Update mp4parse to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ scoped_threadpool = { version = "0.1", optional = true }
 tiff = { version = "0.7.1", optional = true }
 ravif = { version = "0.8.0", optional = true }
 rgb = { version = "0.8.25", optional = true }
-mp4parse = { version = "0.11.6", optional = true }
+mp4parse = { version = "0.12.0", optional = true }
 dav1d = { version = "0.6.0", optional = true }
 dcv-color-primitives = { version = "0.1.16", optional = true }
 exr = { version = "1.3.0", optional = true }


### PR DESCRIPTION
Follow up on #1583 

The maintainers have kindly done a yank+reupload of the version that had
a breaking change in the 0.11 series. This means we should bump too, on
top of the temporary fix done previously.

Now all builds (both with 0.11.5 and after this PR) should compile.
