### PR TITLE
Remove 'static bound from traits and impls

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -614,13 +614,9 @@ pub struct ImageBuffer<P: Pixel, Container> {
 }
 
 // generic implementation, shared along all image buffers
-//
-// TODO: Is the 'static bound on `I::Pixel` really required? Can we avoid it?  Remember to remove
-// the bounds on `imageops` in case this changes!
 impl<P, Container> ImageBuffer<P, Container>
 where
-    P: Pixel + 'static,
-    P::Subpixel: 'static,
+    P: Pixel,
     Container: Deref<Target = [P::Subpixel]>,
 {
     /// Contructs a buffer from a generic container
@@ -830,8 +826,7 @@ where
 
 impl<P, Container> ImageBuffer<P, Container>
 where
-    P: Pixel + 'static,
-    P::Subpixel: 'static,
+    P: Pixel,
     Container: Deref<Target = [P::Subpixel]> + DerefMut,
 {
     // TODO: choose name under which to expose.
@@ -921,7 +916,7 @@ where
 
 impl<P, Container> ImageBuffer<P, Container>
 where
-    P: Pixel + 'static,
+    P: Pixel,
     [P::Subpixel]: EncodableLayout,
     Container: Deref<Target = [P::Subpixel]>,
 {
@@ -949,7 +944,7 @@ where
 
 impl<P, Container> ImageBuffer<P, Container>
 where
-    P: Pixel + 'static,
+    P: Pixel,
     [P::Subpixel]: EncodableLayout,
     Container: Deref<Target = [P::Subpixel]>,
 {
@@ -977,7 +972,7 @@ where
 
 impl<P, Container> ImageBuffer<P, Container>
 where
-    P: Pixel + 'static,
+    P: Pixel,
     [P::Subpixel]: EncodableLayout,
     Container: Deref<Target = [P::Subpixel]>,
 {
@@ -1023,8 +1018,7 @@ where
 
 impl<P, Container> Deref for ImageBuffer<P, Container>
 where
-    P: Pixel + 'static,
-    P::Subpixel: 'static,
+    P: Pixel,
     Container: Deref<Target = [P::Subpixel]>,
 {
     type Target = [P::Subpixel];
@@ -1036,8 +1030,7 @@ where
 
 impl<P, Container> DerefMut for ImageBuffer<P, Container>
 where
-    P: Pixel + 'static,
-    P::Subpixel: 'static,
+    P: Pixel,
     Container: Deref<Target = [P::Subpixel]> + DerefMut,
 {
     fn deref_mut(&mut self) -> &mut <Self as Deref>::Target {
@@ -1047,8 +1040,7 @@ where
 
 impl<P, Container> Index<(u32, u32)> for ImageBuffer<P, Container>
 where
-    P: Pixel + 'static,
-    P::Subpixel: 'static,
+    P: Pixel,
     Container: Deref<Target = [P::Subpixel]>,
 {
     type Output = P;
@@ -1060,8 +1052,7 @@ where
 
 impl<P, Container> IndexMut<(u32, u32)> for ImageBuffer<P, Container>
 where
-    P: Pixel + 'static,
-    P::Subpixel: 'static,
+    P: Pixel,
     Container: Deref<Target = [P::Subpixel]> + DerefMut,
 {
     fn index_mut(&mut self, (x, y): (u32, u32)) -> &mut P {
@@ -1086,9 +1077,8 @@ where
 
 impl<P, Container> GenericImageView for ImageBuffer<P, Container>
 where
-    P: Pixel + 'static,
+    P: Pixel,
     Container: Deref<Target = [P::Subpixel]> + Deref,
-    P::Subpixel: 'static,
 {
     type Pixel = P;
     type InnerImageView = Self;
@@ -1119,9 +1109,8 @@ where
 
 impl<P, Container> GenericImage for ImageBuffer<P, Container>
 where
-    P: Pixel + 'static,
+    P: Pixel,
     Container: Deref<Target = [P::Subpixel]> + DerefMut,
-    P::Subpixel: 'static,
 {
     type InnerImage = Self;
 
@@ -1191,10 +1180,7 @@ where
 // there is no such function as `into_vec`, whereas `into_raw` did work, and
 // `into_vec` is redundant anyway, because `into_raw` will give you the vector,
 // and it is more generic.
-impl<P: Pixel + 'static> ImageBuffer<P, Vec<P::Subpixel>>
-where
-    P::Subpixel: 'static,
-{
+impl<P: Pixel> ImageBuffer<P, Vec<P::Subpixel>> {
     /// Creates a new image buffer based on a `Vec<P::Subpixel>`.
     ///
     /// # Panics
@@ -1306,13 +1292,11 @@ impl GrayImage {
 // TODO: Equality constraints are not yet supported in where clauses, when they
 // are, the T parameter should be removed in favor of ToType::Subpixel, which
 // will then be FromType::Subpixel.
-impl<'a, 'b, Container, FromType: Pixel + 'static, ToType: Pixel + 'static>
+impl<'a, 'b, Container, FromType: Pixel, ToType: Pixel>
     ConvertBuffer<ImageBuffer<ToType, Vec<ToType::Subpixel>>> for ImageBuffer<FromType, Container>
 where
     Container: Deref<Target = [FromType::Subpixel]>,
     ToType: FromColor<FromType>,
-    FromType::Subpixel: 'static,
-    ToType::Subpixel: 'static,
 {
     /// # Examples
     /// Convert RGB image to gray image.

--- a/src/color.rs
+++ b/src/color.rs
@@ -219,7 +219,7 @@ $( // START Structure definitions
 #[allow(missing_docs)]
 pub struct $ident<T: Primitive> (pub [T; $channels]);
 
-impl<T: Primitive + 'static> Pixel for $ident<T> {
+impl<T: Primitive> Pixel for $ident<T> {
     type Subpixel = T;
 
     const CHANNEL_COUNT: u8 = $channels;
@@ -347,7 +347,7 @@ impl<T: Primitive> IndexMut<usize> for $ident<T> {
     }
 }
 
-impl<T: Primitive + 'static> From<[T; $channels]> for $ident<T> {
+impl<T: Primitive> From<[T; $channels]> for $ident<T> {
     fn from(c: [T; $channels]) -> Self {
         Self(c)
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -34,7 +34,7 @@ impl EncodableLayout for [f32] {
 
 /// The type of each channel in a pixel. For example, this can be `u8`, `u16`, `f32`.
 // TODO rename to `PixelComponent`? Split up into separate traits? Seal?
-pub trait Primitive: Copy + NumCast + Num + PartialOrd<Self> + Clone + Bounded + 'static {
+pub trait Primitive: Copy + NumCast + Num + PartialOrd<Self> + Clone + Bounded {
 
     /// The maximum value for this type of primitive within the context of color.
     /// For floats, the maximum is `1.0`, whereas the integer types inherit their usual maximum values.
@@ -71,7 +71,7 @@ declare_primitive!(f64: (0.0)..1.0);
 /// An Enlargable::Larger value should be enough to calculate
 /// the sum (average) of a few hundred or thousand Enlargeable values.
 pub trait Enlargeable: Sized + Bounded + NumCast {
-    type Larger: Primitive + AddAssign + 'static;
+    type Larger: Primitive + AddAssign;
 
     fn clamp_from(n: Self::Larger) -> Self {
         // Note: Only unsigned value types supported.


### PR DESCRIPTION
The 'from traits' part is the breaking change. Downstream consumers
could have previously made use of this additional bound.

This is not required, we never utilize types `&'static [Subpixel]` or
similar and if we would then it could be a local bound. But the bound is
infectious in that it requires placing several additional bounds in
every place where the `Pixel` trait is being used.

This does not clean up all usage sites (in `imageops`).

