### PR TITLE
Make imageops::{overlay, replace} take coordinates as i64's

### DIFF
--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -1,8 +1,6 @@
 //! Image Processing Functions
 use std::cmp;
 
-use num_traits::{NumCast};
-
 use crate::image::{GenericImage, GenericImageView, SubImage};
 use crate::traits::{Lerp, Primitive, Pixel};
 
@@ -145,8 +143,73 @@ pub fn overlay_bounds(
     (x_range, y_range)
 }
 
+/// Calculate the region that can be copied from top to bottom.
+///
+/// Given image size of bottom and top image, and a point at which we want to place the top image
+/// onto the bottom image, how large can we be? Have to wary of the following issues:
+/// * Top might be larger than bottom
+/// * Overflows in the computation
+/// * Coordinates could be completely out of bounds
+///
+/// The returned value is of the form:
+///
+/// `(origin_bottom_x, origin_bottom_y, origin_top_x, origin_top_y, x_range, y_range)`
+///
+/// The main idea is to do computations on i64's and then clamp to image dimensions.
+/// In particular, we want to ensure that all these coordinate accesses are safe:
+/// 1. `bottom.get_pixel(origin_bottom_x + [0..x_range), origin_bottom_y + [0..y_range))`
+/// 2. `top.get_pixel(origin_top_y + [0..x_range), origin_top_y + [0..y_range))`
+///
+fn overlay_bounds_ext(
+    (bottom_width, bottom_height): (u32, u32),
+    (top_width, top_height): (u32, u32),
+    x: i64,
+    y: i64,
+) -> (u32, u32, u32, u32, u32, u32) {
+    // Return a predictable value if the two images don't overlap at all.
+    if x > i64::from(bottom_width)
+        || y > i64::from(bottom_height)
+        || x.saturating_add(i64::from(top_width)) <= 0
+        || y.saturating_add(i64::from(top_height)) <= 0
+    {
+        return (0, 0, 0, 0, 0, 0);
+    }
+
+    // Find the maximum x and y coordinates in terms of the bottom image.
+    let max_x = x.saturating_add(i64::from(top_width));
+    let max_y = y.saturating_add(i64::from(top_height));
+
+    // Clip the origin and maximum coordinates to the bounds of the bottom image.
+    // Casting to a u32 is safe because both 0 and `bottom_{width,height}` fit
+    // into 32-bits.
+    let max_inbounds_x = max_x.clamp(0, i64::from(bottom_width)) as u32;
+    let max_inbounds_y = max_y.clamp(0, i64::from(bottom_height)) as u32;
+    let origin_bottom_x = x.clamp(0, i64::from(bottom_width)) as u32;
+    let origin_bottom_y = y.clamp(0, i64::from(bottom_height)) as u32;
+
+    // The range is the difference between the maximum inbounds coordinates and
+    // the clipped origin. Unchecked subtraction is safe here because both are
+    // always positive and `max_inbounds_{x,y}` >= `origin_{x,y}` due to
+    // `top_{width,height}` being >= 0.
+    let x_range = max_inbounds_x - origin_bottom_x;
+    let y_range = max_inbounds_y - origin_bottom_y;
+
+    // If x (or y) is negative, then the origin of the top image is shifted by -x (or -y).
+    let origin_top_x = x.saturating_mul(-1).clamp(0, i64::from(top_width)) as u32;
+    let origin_top_y = y.saturating_mul(-1).clamp(0, i64::from(top_height)) as u32;
+
+    (
+        origin_bottom_x,
+        origin_bottom_y,
+        origin_top_x,
+        origin_top_y,
+        x_range,
+        y_range,
+    )
+}
+
 /// Overlay an image at a given coordinate (x, y)
-pub fn overlay<I, J>(bottom: &mut I, top: &J, x: u32, y: u32)
+pub fn overlay<I, J>(bottom: &mut I, top: &J, x: i64, y: i64)
 where
     I: GenericImage,
     J: GenericImageView<Pixel = I::Pixel>,
@@ -155,15 +218,16 @@ where
     let top_dims = top.dimensions();
 
     // Crop our top image if we're going out of bounds
-    let (range_width, range_height) = overlay_bounds(bottom_dims, top_dims, x, y);
+    let (origin_bottom_x, origin_bottom_y, origin_top_x, origin_top_y, range_width, range_height) =
+        overlay_bounds_ext(bottom_dims, top_dims, x, y);
 
-    for top_y in 0..range_height {
-        for top_x in 0..range_width {
-            let p = top.get_pixel(top_x, top_y);
-            let mut bottom_pixel = bottom.get_pixel(x + top_x, y + top_y);
+    for y in 0..range_height {
+        for x in 0..range_width {
+            let p = top.get_pixel(origin_top_x + x, origin_top_y + y);
+            let mut bottom_pixel = bottom.get_pixel(origin_bottom_x + x, origin_bottom_y + y);
             bottom_pixel.blend(&p);
 
-            bottom.put_pixel(x + top_x, y + top_y, bottom_pixel);
+            bottom.put_pixel(origin_bottom_x + x, origin_bottom_y + y, bottom_pixel);
         }
     }
 }
@@ -187,38 +251,38 @@ where
 {
     for x in (0..bottom.width()).step_by(top.width() as usize) {
         for y in (0..bottom.height()).step_by(top.height() as usize) {
-            overlay(bottom, top, x, y);
+            overlay(bottom, top, i64::from(x), i64::from(y));
         }
     }
 }
 
 /// Fill the image with a linear vertical gradient
-/// 
+///
 /// This function assumes a linear color space.
-/// 
+///
 /// # Examples
 /// ```no_run
 /// use image::{Rgba, RgbaImage, Pixel};
-/// 
+///
 /// let mut img = RgbaImage::new(100, 100);
 /// let start = Rgba::from_slice(&[0, 128, 0, 0]);
 /// let end = Rgba::from_slice(&[255, 255, 255, 255]);
-/// 
+///
 /// image::imageops::vertical_gradient(&mut img, start, end);
 /// img.save("vertical_gradient.png").unwrap();
 pub fn vertical_gradient<S, P, I>(img: &mut I, start: &P, stop: &P)
 where
     I: GenericImage<Pixel = P>,
     P: Pixel<Subpixel = S> + 'static,
-    S: Primitive + Lerp + 'static
+    S: Primitive + Lerp + 'static,
 {
     for y in 0..img.height() {
         let pixel = start.map2(stop, |a, b| {
-            let y = <S::Ratio as NumCast>::from(y).unwrap();
-            let height = <S::Ratio as NumCast>::from(img.height() - 1).unwrap();
+            let y = <S::Ratio as num_traits::NumCast>::from(y).unwrap();
+            let height = <S::Ratio as num_traits::NumCast>::from(img.height() - 1).unwrap();
             S::lerp(a, b, y / height)
         });
-        
+
         for x in 0..img.width() {
             img.put_pixel(x, y, pixel);
         }
@@ -226,32 +290,32 @@ where
 }
 
 /// Fill the image with a linear horizontal gradient
-/// 
+///
 /// This function assumes a linear color space.
 ///
 /// # Examples
 /// ```no_run
 /// use image::{Rgba, RgbaImage, Pixel};
-/// 
+///
 /// let mut img = RgbaImage::new(100, 100);
 /// let start = Rgba::from_slice(&[0, 128, 0, 0]);
 /// let end = Rgba::from_slice(&[255, 255, 255, 255]);
-/// 
+///
 /// image::imageops::horizontal_gradient(&mut img, start, end);
 /// img.save("horizontal_gradient.png").unwrap();
 pub fn horizontal_gradient<S, P, I>(img: &mut I, start: &P, stop: &P)
 where
     I: GenericImage<Pixel = P>,
     P: Pixel<Subpixel = S> + 'static,
-    S: Primitive + Lerp + 'static
+    S: Primitive + Lerp + 'static,
 {
     for x in 0..img.width() {
         let pixel = start.map2(stop, |a, b| {
-            let x = <S::Ratio as NumCast>::from(x).unwrap();
-            let width = <S::Ratio as NumCast>::from(img.width() - 1).unwrap();
+            let x = <S::Ratio as num_traits::NumCast>::from(x).unwrap();
+            let width = <S::Ratio as num_traits::NumCast>::from(img.width() - 1).unwrap();
             S::lerp(a, b, x / width)
         });
-        
+
         for y in 0..img.height() {
             img.put_pixel(x, y, pixel);
         }
@@ -259,7 +323,7 @@ where
 }
 
 /// Replace the contents of an image at a given coordinate (x, y)
-pub fn replace<I, J>(bottom: &mut I, top: &J, x: u32, y: u32)
+pub fn replace<I, J>(bottom: &mut I, top: &J, x: i64, y: i64)
 where
     I: GenericImage,
     J: GenericImageView<Pixel = I::Pixel>,
@@ -268,12 +332,13 @@ where
     let top_dims = top.dimensions();
 
     // Crop our top image if we're going out of bounds
-    let (range_width, range_height) = overlay_bounds(bottom_dims, top_dims, x, y);
+    let (origin_bottom_x, origin_bottom_y, origin_top_x, origin_top_y, range_width, range_height) =
+        overlay_bounds_ext(bottom_dims, top_dims, x, y);
 
-    for top_y in 0..range_height {
-        for top_x in 0..range_width {
-            let p = top.get_pixel(top_x, top_y);
-            bottom.put_pixel(x + top_x, y + top_y, p);
+    for y in 0..range_height {
+        for x in 0..range_width {
+            let p = top.get_pixel(origin_top_x + x, origin_top_y + y);
+            bottom.put_pixel(origin_bottom_x + x, origin_bottom_y + y, p);
         }
     }
 }
@@ -281,10 +346,46 @@ where
 #[cfg(test)]
 mod tests {
 
-    use super::overlay;
-    use crate::RgbaImage;
-    use crate::ImageBuffer;
+    use super::{overlay, overlay_bounds_ext};
     use crate::color::Rgb;
+    use crate::ImageBuffer;
+    use crate::RgbaImage;
+
+    #[test]
+    fn test_overlay_bounds_ext() {
+        assert_eq!(
+            overlay_bounds_ext((10, 10), (10, 10), 0, 0),
+            (0, 0, 0, 0, 10, 10)
+        );
+        assert_eq!(
+            overlay_bounds_ext((10, 10), (10, 10), 1, 0),
+            (1, 0, 0, 0, 9, 10)
+        );
+        assert_eq!(
+            overlay_bounds_ext((10, 10), (10, 10), 0, 11),
+            (0, 0, 0, 0, 0, 0)
+        );
+        assert_eq!(
+            overlay_bounds_ext((10, 10), (10, 10), -1, 0),
+            (0, 0, 1, 0, 9, 10)
+        );
+        assert_eq!(
+            overlay_bounds_ext((10, 10), (10, 10), -10, 0),
+            (0, 0, 0, 0, 0, 0)
+        );
+        assert_eq!(
+            overlay_bounds_ext((10, 10), (10, 10), 1i64 << 50, 0),
+            (0, 0, 0, 0, 0, 0)
+        );
+        assert_eq!(
+            overlay_bounds_ext((10, 10), (10, 10), -(1i64 << 50), 0),
+            (0, 0, 0, 0, 0, 0)
+        );
+        assert_eq!(
+            overlay_bounds_ext((10, 10), (u32::MAX, 10), 10 - i64::from(u32::MAX), 0),
+            (0, 0, u32::MAX - 10, 0, 10, 10)
+        );
+    }
 
     #[test]
     /// Test that images written into other images works
@@ -328,7 +429,12 @@ mod tests {
         let mut target = ImageBuffer::new(16, 16);
         let source = ImageBuffer::from_pixel(32, 32, Rgb([255u8, 0, 0]));
         // Overflows to 'sane' coordinates but top is larger than bot.
-        overlay(&mut target, &source, u32::max_value() - 31, u32::max_value() - 31);
+        overlay(
+            &mut target,
+            &source,
+            i64::from(u32::max_value() - 31),
+            i64::from(u32::max_value() - 31),
+        );
         assert!(*target.get_pixel(0, 0) == Rgb([0, 0, 0]));
         assert!(*target.get_pixel(1, 1) == Rgb([0, 0, 0]));
         assert!(*target.get_pixel(15, 15) == Rgb([0, 0, 0]));


### PR DESCRIPTION
Fixes #1575