### PR TITLE
Export PixelWithColorType

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ pub use crate::buffer_::{
 pub use crate::flat::FlatSamples;
 
 // Traits
-pub use crate::traits::{EncodableLayout, Primitive, Pixel};
+pub use crate::traits::{EncodableLayout, Primitive, Pixel, PixelWithColorType};
 
 // Opening and loading images
 pub use crate::io::free_functions::{guess_format, load};


### PR DESCRIPTION
This is required for end user implementions of e.g. generic PNG encoding using `P::COLOR_TYPE`.

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.
