### PR TITLE
Rename ImageDecoderExt

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ All image processing functions provided operate on types that implement the `Gen
 | OpenEXR  | Rgb32F, Rgba32F (no dwa compression) | Rgb32F, Rgba32F (no dwa compression) |
 | farbfeld | Yes | Yes |
 
-### The [`ImageDecoder`](https://docs.rs/image/*/image/trait.ImageDecoder.html) and [`ImageDecoderExt`](https://docs.rs/image/*/image/trait.ImageDecoderExt.html) Traits
+### The [`ImageDecoder`](https://docs.rs/image/*/image/trait.ImageDecoder.html) and [`ImageDecoderRect`](https://docs.rs/image/*/image/trait.ImageDecoderRect.html) Traits
 
 All image format decoders implement the `ImageDecoder` trait which provide
 basic methods for getting image metadata and decoding images. Some formats
-additionally provide `ImageDecoderExt` implementations which allow for
+additionally provide `ImageDecoderRect` implementations which allow for
 decoding only part of an image at once.
 
 The most important methods for decoders are...

--- a/src/codecs/bmp/decoder.rs
+++ b/src/codecs/bmp/decoder.rs
@@ -12,7 +12,7 @@ use crate::color::ColorType;
 use crate::error::{
     DecodingError, ImageError, ImageResult, UnsupportedError, UnsupportedErrorKind,
 };
-use crate::image::{self, ImageDecoder, ImageDecoderExt, ImageFormat, Progress};
+use crate::image::{self, ImageDecoder, ImageDecoderRect, ImageFormat, Progress};
 
 const BITMAPCOREHEADER_SIZE: u32 = 12;
 const BITMAPINFOHEADER_SIZE: u32 = 40;
@@ -1481,7 +1481,7 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for BmpDecoder<R> {
     }
 }
 
-impl<'a, R: 'a + Read + Seek> ImageDecoderExt<'a> for BmpDecoder<R> {
+impl<'a, R: 'a + Read + Seek> ImageDecoderRect<'a> for BmpDecoder<R> {
     fn read_rect_with_progress<F: Fn(Progress)>(
         &mut self,
         x: u32,

--- a/src/codecs/dxt.rs
+++ b/src/codecs/dxt.rs
@@ -12,7 +12,7 @@ use std::io::{self, Read, Seek, SeekFrom, Write};
 
 use crate::color::ColorType;
 use crate::error::{ImageError, ImageResult, ParameterError, ParameterErrorKind};
-use crate::image::{self, ImageDecoder, ImageDecoderExt, ImageReadBuffer, Progress};
+use crate::image::{self, ImageDecoder, ImageDecoderRect, ImageReadBuffer, Progress};
 
 /// What version of DXT compression are we using?
 /// Note that DXT2 and DXT4 are left away as they're
@@ -149,7 +149,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for DxtDecoder<R> {
     }
 }
 
-impl<'a, R: 'a + Read + Seek> ImageDecoderExt<'a> for DxtDecoder<R> {
+impl<'a, R: 'a + Read + Seek> ImageDecoderRect<'a> for DxtDecoder<R> {
     fn read_rect_with_progress<F: Fn(Progress)>(
         &mut self,
         x: u32,

--- a/src/codecs/farbfeld.rs
+++ b/src/codecs/farbfeld.rs
@@ -24,7 +24,7 @@ use byteorder::{BigEndian, ByteOrder, NativeEndian};
 
 use crate::color::ColorType;
 use crate::error::{DecodingError, ImageError, ImageResult, UnsupportedError, UnsupportedErrorKind};
-use crate::image::{self, ImageDecoder, ImageDecoderExt, ImageEncoder, ImageFormat, Progress};
+use crate::image::{self, ImageDecoder, ImageDecoderRect, ImageEncoder, ImageFormat, Progress};
 
 /// farbfeld Reader
 pub struct FarbfeldReader<R: Read> {
@@ -208,7 +208,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for FarbfeldDecoder<R> {
     }
 }
 
-impl<'a, R: 'a + Read + Seek> ImageDecoderExt<'a> for FarbfeldDecoder<R> {
+impl<'a, R: 'a + Read + Seek> ImageDecoderRect<'a> for FarbfeldDecoder<R> {
     fn read_rect_with_progress<F: Fn(Progress)>(
         &mut self,
         x: u32,
@@ -288,7 +288,7 @@ impl<W: Write> ImageEncoder for FarbfeldEncoder<W> {
 #[cfg(test)]
 mod tests {
     use crate::codecs::farbfeld::FarbfeldDecoder;
-    use crate::ImageDecoderExt;
+    use crate::ImageDecoderRect;
     use std::io::{Cursor, Seek, SeekFrom};
     use byteorder::{ByteOrder, NativeEndian};
 

--- a/src/codecs/hdr/decoder.rs
+++ b/src/codecs/hdr/decoder.rs
@@ -13,7 +13,7 @@ use crate::Primitive;
 
 use crate::color::{ColorType, Rgb};
 use crate::error::{DecodingError, ImageError, ImageFormatHint, ImageResult, ParameterError, ParameterErrorKind, UnsupportedError, UnsupportedErrorKind};
-use crate::image::{self, ImageDecoder, ImageDecoderExt, ImageFormat, Progress};
+use crate::image::{self, ImageDecoder, ImageDecoderRect, ImageFormat, Progress};
 
 /// Errors that can occur during decoding and parsing of a HDR image
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -197,7 +197,7 @@ impl<'a, R: 'a + BufRead> ImageDecoder<'a> for HdrAdapter<R> {
     }
 }
 
-impl<'a, R: 'a + BufRead + Seek> ImageDecoderExt<'a> for HdrAdapter<R> {
+impl<'a, R: 'a + BufRead + Seek> ImageDecoderRect<'a> for HdrAdapter<R> {
     fn read_rect_with_progress<F: Fn(Progress)>(
         &mut self,
         x: u32,

--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -26,7 +26,7 @@ use exr::prelude::*;
 
 use crate::{ImageDecoder, ImageResult, ColorType, Progress, ImageError, ImageFormat, ImageEncoder, ExtendedColorType};
 use std::io::{Write, Seek, Read, Cursor};
-use crate::error::{DecodingError, ImageFormatHint, LimitError, LimitErrorKind, EncodingError};
+use crate::error::{DecodingError, ImageFormatHint, EncodingError};
 use crate::image::decoder_to_vec;
 use std::convert::TryInto;
 

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -117,7 +117,7 @@ impl<R: Read> PngDecoder<R> {
         // transformations must be set. EXPAND preserves the default behavior
         // expanding bpc < 8 to 8 bpc.
         decoder.set_transformations(png::Transformations::EXPAND);
-        let mut reader = decoder.read_info().map_err(ImageError::from_png)?;
+        let reader = decoder.read_info().map_err(ImageError::from_png)?;
         let (color_type, bits) = reader.output_color_type();
         let color_type = match (color_type, bits) {
             (png::ColorType::Grayscale, png::BitDepth::Eight) => ColorType::L8,

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -1017,6 +1017,8 @@ fn decoder_to_image<'a, I: ImageDecoder<'a>>(decoder: I) -> ImageResult<DynamicI
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLumaA16)
         }
 
+        // An internal #[non_exhaustive]
+        #[allow(unreachable_patterns)]
         _ => return Err(ImageError::Unsupported(UnsupportedError::from_format_and_kind(
             ImageFormatHint::Unknown,
             UnsupportedErrorKind::Color(color_type.into()),

--- a/src/image.rs
+++ b/src/image.rs
@@ -837,8 +837,6 @@ pub trait GenericImageView {
     /// # Panics
     ///
     /// Panics if `(x, y)` is out of bounds.
-    ///
-    /// TODO: change this signature to &P
     fn get_pixel(&self, x: u32, y: u32) -> Self::Pixel;
 
     /// Returns the pixel located at (x, y). Indexed from top left.
@@ -895,9 +893,20 @@ pub trait GenericImage: GenericImageView {
     /// Panics if `(x, y)` is out of bounds.
     ///
     /// Panics for dynamic images (this method is deprecated and will be removed).
+    ///
+    /// ## Known issues
+    ///
+    /// This requires the buffer to contain a unique set of continuous channels in the exact order
+    /// and byte representation that the pixel type requires. This is somewhat restrictive.
+    ///
+    /// TODO: Maybe use some kind of entry API? this would allow pixel type conversion on the fly
+    /// while still doing only one array lookup:
+    ///
+    /// ```ignore
+    /// let px = image.pixel_entry_at(x,y);
+    /// px.set_from_rgba(rgba)
+    /// ```
     #[deprecated(since = "0.24.0", note="Use `get_pixel` and `put_pixel` instead.")]
-    // TODO: Maybe use some kind of entry API? this would allow pixel type conversion on the fly while still doing only one array lookup
-    //  `let px = image.pixel_entry_at(x,y); px.set_from_rgba(rgba)`
     fn get_pixel_mut(&mut self, x: u32, y: u32) -> &mut Self::Pixel;
 
     /// Put a pixel at location (x, y). Indexed from top left.

--- a/src/image.rs
+++ b/src/image.rs
@@ -697,7 +697,7 @@ pub trait ImageDecoder<'a>: Sized {
 }
 
 /// Specialized image decoding not be supported by all formats
-pub trait ImageDecoderExt<'a>: ImageDecoder<'a> + Sized {
+pub trait ImageDecoderRect<'a>: ImageDecoder<'a> + Sized {
     /// Decode a rectangular section of the image; see [`read_rect_with_progress()`](#fn.read_rect_with_progress).
     fn read_rect(
         &mut self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,14 +73,14 @@
 //!
 //! # Low level encoding/decoding API
 //!
-//! The [`ImageDecoder`] and [`ImageDecoderExt`] traits are implemented for many image file
+//! The [`ImageDecoder`] and [`ImageDecoderRect`] traits are implemented for many image file
 //! formats. They decode image data by directly on raw byte slices. Given an ImageDecoder, you can
 //! produce a DynamicImage via [`DynamicImage::from_decoder`].
 //!
 //! [`ImageEncoder`] provides the analogous functionality for encoding image data.
 //!
 //! [`DynamicImage::from_decoder`]: enum.DynamicImage.html#method.from_decoder
-//! [`ImageDecoderExt`]: trait.ImageDecoderExt.html
+//! [`ImageDecoderRect`]: trait.ImageDecoderRect.html
 //! [`ImageDecoder`]: trait.ImageDecoder.html
 //! [`ImageEncoder`]: trait.ImageEncoder.html
 #![warn(missing_docs)]
@@ -112,7 +112,7 @@ pub use crate::image::{
     GenericImage,
     GenericImageView,
     ImageDecoder,
-    ImageDecoderExt,
+    ImageDecoderRect,
     ImageEncoder,
     ImageFormat,
     ImageOutputFormat,


### PR DESCRIPTION
Closes: #1046 

Since there is no way to introduce aliases for traits we must do this in a major change, and can't have a backwards compatible, hidden way for migration.