### PR TITLE
Added overflow handling to multiplication of width and components

### DIFF
--- a/src/codecs/pnm/decoder.rs
+++ b/src/codecs/pnm/decoder.rs
@@ -629,7 +629,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for PnmDecoder<R> {
 }
 
 impl<R: Read> PnmDecoder<R> {
-    fn read_samples<S: Sample>(&mut self, components: u32, buf: &mut [u8]) -> ImageResult<()> {
+    fn read_samples<S: Sample>(&mut self, components: usize, buf: &mut [u8]) -> ImageResult<()> {
         match self.subtype().sample_encoding() {
             SampleEncoding::Binary => {
                 let width = self.header.width();
@@ -648,7 +648,7 @@ impl<R: Read> PnmDecoder<R> {
                     return Err(DecoderError::InputTooShort.into());
                 }
 
-                S::from_bytes(&bytes, width * components, buf)
+                S::from_bytes(&bytes, usize::checked_mul(width, components), buf)
             }
             SampleEncoding::Ascii => self.read_ascii::<S>(buf),
         }

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -1,6 +1,6 @@
 //! Functions for altering and converting the color of pixelbufs
 
-use num_traits::{Num, NumCast};
+use num_traits::NumCast;
 use std::f64::consts::PI;
 
 use crate::color::{FromColor, IntoColor, Luma, LumaA, Rgba};


### PR DESCRIPTION
<!-- 
If you are a new contributor, consent to licensing by including this text:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

Thank you for contributing, you can delete this comment.
-->
Greetings of the day @fintelia,

I've fixed the issue as suggested, kindly review the pull and suggest changes if any.

Thanks & Regards
@shikharvashistha
Fixes : #1616 
