### PR TITLE
Dyn generic image

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,6 @@ While some of the methods for `GenericImage` are...
 An image parameterised by its Pixel types, represented by a width and height and a vector of pixels. It provides direct access to its pixels and implements the `GenericImageView` and `GenericImage` traits.
 
 ```rust
-extern crate image;
-
 use image::{GenericImage, GenericImageView, ImageBuffer, RgbImage};
 
 // Construct a new RGB ImageBuffer with the specified width and height.
@@ -125,8 +123,6 @@ The coordinates given set the position of the top left corner of the rectangle.
 This is used to perform image processing functions on a subregion of an image.
 
 ```rust
-extern crate image;
-
 use image::{GenericImageView, ImageBuffer, RgbImage, imageops};
 
 let mut img: RgbImage = ImageBuffer::new(512, 512);
@@ -165,8 +161,6 @@ format is determined from the path's file extension. An `io` module provides a
 reader which offer some more control.
 
 ```rust,no_run
-extern crate image;
-
 use image::GenericImageView;
 
 fn main() {
@@ -189,9 +183,6 @@ fn main() {
 
 ```rust,no_run
 //! An example of generating julia fractals.
-extern crate image;
-extern crate num_complex;
-
 fn main() {
     let imgx = 800;
     let imgy = 800;
@@ -243,8 +234,6 @@ Example output:
 If the high level interface is not needed because the image was obtained by other means, `image` provides the function `save_buffer` to save a buffer to a file.
 
 ```rust,no_run
-extern crate image;
-
 fn main() {
 
     let buffer: &[u8] = unimplemented!(); // Generate the image data
@@ -252,5 +241,4 @@ fn main() {
     // Save the buffer as "image.png"
     image::save_buffer("image.png", buffer, 800, 600, image::ColorType::Rgb8).unwrap()
 }
-
 ```

--- a/examples/concat/main.rs
+++ b/examples/concat/main.rs
@@ -1,4 +1,4 @@
-extern crate image;
+
 
 use image::{GenericImage, GenericImageView, ImageBuffer, Pixel, Primitive};
 

--- a/examples/decode.rs
+++ b/examples/decode.rs
@@ -1,0 +1,17 @@
+//! An example of opening an image.
+use std::env;
+use std::path::Path;
+
+fn main() {
+    let from = if env::args_os().count() == 2 {
+        env::args_os().nth(1).unwrap()
+    } else {
+        println!("Please enter a from and into path.");
+        std::process::exit(1);
+    };
+
+    // Use the open function to load an image from a Path.
+    // ```open``` returns a dynamic image.
+    let im = image::open(&Path::new(&from)).unwrap();
+    println!("{}", im.as_bytes().len());
+}

--- a/examples/scaledown/main.rs
+++ b/examples/scaledown/main.rs
@@ -1,4 +1,4 @@
-extern crate image;
+
 
 use image::ImageFormat;
 use image::imageops::FilterType;

--- a/examples/scaleup/main.rs
+++ b/examples/scaleup/main.rs
@@ -1,4 +1,4 @@
-extern crate image;
+
 
 use image::ImageFormat;
 use image::imageops::FilterType;

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1081,7 +1081,6 @@ where
     Container: Deref<Target = [P::Subpixel]> + Deref,
 {
     type Pixel = P;
-    type InnerImageView = Self;
 
     fn dimensions(&self) -> (u32, u32) {
         self.dimensions()
@@ -1100,10 +1099,6 @@ where
     unsafe fn unsafe_get_pixel(&self, x: u32, y: u32) -> P {
         let indices = self.pixel_indices_unchecked(x, y);
         *<P as Pixel>::from_slice(self.data.get_unchecked(indices))
-    }
-
-    fn inner(&self) -> &Self::InnerImageView {
-        self
     }
 }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1107,8 +1107,6 @@ where
     P: Pixel,
     Container: Deref<Target = [P::Subpixel]> + DerefMut,
 {
-    type InnerImage = Self;
-
     fn get_pixel_mut(&mut self, x: u32, y: u32) -> &mut P {
         self.get_pixel_mut(x, y)
     }
@@ -1162,10 +1160,6 @@ where
             }
         }
         true
-    }
-
-    fn inner_mut(&mut self) -> &mut Self::InnerImage {
-        self
     }
 }
 

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -914,8 +914,6 @@ impl GenericImageView for DynamicImage {
 
 #[allow(deprecated)]
 impl GenericImage for DynamicImage {
-    type InnerImage = DynamicImage;
-
     fn put_pixel(&mut self, x: u32, y: u32, pixel: color::Rgba<u8>) {
         match *self {
             DynamicImage::ImageLuma8(ref mut p) => p.put_pixel(x, y, pixel.to_luma()),
@@ -949,10 +947,6 @@ impl GenericImage for DynamicImage {
     /// Do not use is function: It is unimplemented!
     fn get_pixel_mut(&mut self, _: u32, _: u32) -> &mut color::Rgba<u8> {
         unimplemented!()
-    }
-
-    fn inner_mut(&mut self) -> &mut Self::InnerImage {
-        self
     }
 }
 

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -898,7 +898,6 @@ impl From<ImageBuffer<LumaA<f32>, Vec<f32>>> for DynamicImage {
 #[allow(deprecated)]
 impl GenericImageView for DynamicImage {
     type Pixel = color::Rgba<u8>; // TODO use f32 as default for best precision and unbounded color?
-    type InnerImageView = Self;
 
     fn dimensions(&self) -> (u32, u32) {
         dynamic_map!(*self, |ref p| p.dimensions())
@@ -910,10 +909,6 @@ impl GenericImageView for DynamicImage {
 
     fn get_pixel(&self, x: u32, y: u32) -> color::Rgba<u8> {
         dynamic_map!(*self, |ref p| p.get_pixel(x, y).to_rgba().into_color())
-    }
-
-    fn inner(&self) -> &Self::InnerImageView {
-        self
     }
 }
 

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -1390,8 +1390,6 @@ impl<Buffer, P: Pixel> GenericImageView for ViewMut<Buffer, P>
 impl<Buffer, P: Pixel> GenericImage for ViewMut<Buffer, P>
     where Buffer: AsMut<[P::Subpixel]> + AsRef<[P::Subpixel]>,
 {
-    type InnerImage = Self;
-
     fn get_pixel_mut(&mut self, x: u32, y: u32) -> &mut Self::Pixel {
         if !self.inner.in_bounds(0, x, y) {
             panic_pixel_out_of_bounds((x, y), self.dimensions())
@@ -1411,10 +1409,6 @@ impl<Buffer, P: Pixel> GenericImage for ViewMut<Buffer, P>
     #[allow(deprecated)]
     fn blend_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel) {
         self.get_pixel_mut(x, y).blend(&pixel);
-    }
-
-    fn inner_mut(&mut self) -> &mut Self {
-        self
     }
 }
 

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -1316,9 +1316,6 @@ impl<Buffer, P: Pixel> GenericImageView for View<Buffer, P>
 {
     type Pixel = P;
 
-    // We don't proxy an inner image.
-    type InnerImageView = Self;
-
     fn dimensions(&self) -> (u32, u32) {
         (self.inner.layout.width, self.inner.layout.height)
     }
@@ -1349,10 +1346,6 @@ impl<Buffer, P: Pixel> GenericImageView for View<Buffer, P>
         });
 
         *P::from_slice(&buffer[..channels])
-    }
-
-    fn inner(&self) -> &Self {
-        self // There is no other inner image.
     }
 }
 
@@ -1361,9 +1354,6 @@ impl<Buffer, P: Pixel> GenericImageView for ViewMut<Buffer, P>
 {
     type Pixel = P;
 
-    // We don't proxy an inner image.
-    type InnerImageView = Self;
-
     fn dimensions(&self) -> (u32, u32) {
         (self.inner.layout.width, self.inner.layout.height)
     }
@@ -1394,10 +1384,6 @@ impl<Buffer, P: Pixel> GenericImageView for ViewMut<Buffer, P>
         });
 
         *P::from_slice(&buffer[..channels])
-    }
-
-    fn inner(&self) -> &Self {
-        self // There is no other inner image.
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,7 @@ pub use crate::image::{
     AnimationDecoder,
     GenericImage,
     GenericImageView,
+    GenericSubImageView,
     ImageDecoder,
     ImageDecoderRect,
     ImageEncoder,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,7 @@ pub use crate::image::{
     AnimationDecoder,
     GenericImage,
     GenericImageView,
+    GenericSubImage,
     GenericSubImageView,
     ImageDecoder,
     ImageDecoderRect,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,8 +111,6 @@ pub use crate::image::{
     AnimationDecoder,
     GenericImage,
     GenericImageView,
-    GenericSubImage,
-    GenericSubImageView,
     ImageDecoder,
     ImageDecoderRect,
     ImageEncoder,


### PR DESCRIPTION
Splits `view` and `sub_image` from the main image traits to a different set of traits, removing the need for `InnerImage` associated types. Also bounds the relevant method that prevented the current implementation from being used as a `dyn` trait object.

Related: #1118, #1406