### PR TITLE
Bump gif dependency to 0.11.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ byteorder = "1.3.2"
 num-iter = "0.1.32"
 num-rational = { version = "0.4", default-features = false }
 num-traits = "0.2.0"
-gif = { version = "0.11.1", optional = true }
+gif = { version = "0.11.3", optional = true }
 jpeg = { package = "jpeg-decoder", version = "0.1.22", default-features = false, optional = true }
 png = { version = "0.17.0", optional = true }
 scoped_threadpool = { version = "0.1", optional = true }


### PR DESCRIPTION
I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.

"image" currently uses gif 0.11.1, which is a little over a year old. I suggest bumping onto the latest version (that just happens to include a bug fix I care about. ;).