### PR TITLE
update exr version to 1.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ rgb = { version = "0.8.25", optional = true }
 mp4parse = { version = "0.12.0", optional = true }
 dav1d = { version = "0.6.0", optional = true }
 dcv-color-primitives = { version = "0.1.16", optional = true }
-exr = { version = "1.4.0", optional = true }
+exr = { version = "1.4.1", optional = true }
 color_quant = "1.1"
 
 [dev-dependencies]


### PR DESCRIPTION
fixed a fuzzing panic by validating the tile size earlier
and removed an unused field
