### PR TITLE
tests/regression.rs: force bad_bmps test to load files as Bmp, fix #1633

### DIFF
--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{fs::File, io::BufReader, path::PathBuf};
 
 const BASE_PATH: [&str; 2] = [".", "tests"];
 const IMAGE_DIR: &str = "images";
@@ -49,7 +49,11 @@ fn bad_bmps() {
 
     let pattern = &*format!("{}", path.display());
     for path in glob::glob(pattern).unwrap().filter_map(Result::ok) {
-        let im = image::open(path);
+
+        // Manually reading the file so we can use load() instead of open()
+        // We have to use load() so we can override the format
+        let im_file = BufReader::new(File::open(path).unwrap());
+        let im = image::load(im_file, image::ImageFormat::Bmp);
         assert!(im.is_err());
     }
 }


### PR DESCRIPTION
Fixing the issue that I just noticed in the regression test, #1633

My first inclination was to just force it to load the images as `ImageFormat::Bmp`, which is what I've done here, but it would also be valid to just make a subdirectory in `tests/images/bmp/images/bad` and put the bad images there, with a proper `.bmp` extension.

This feels cleaner than creating a five-layer-deep directory soup where each folder has a special, different meaning though.

---

Also, because this is my first contribution :)

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.