### PR TITLE
Make it possible to provide a pre-encoded image to the .ico encoder

### DIFF
--- a/src/codecs/ico/decoder.rs
+++ b/src/codecs/ico/decoder.rs
@@ -12,11 +12,7 @@ use crate::image::{self, ImageDecoder, ImageFormat};
 
 use self::InnerDecoder::*;
 use crate::codecs::bmp::BmpDecoder;
-use crate::codecs::png::PngDecoder;
-
-// http://www.w3.org/TR/PNG-Structure.html
-// The first eight bytes of a PNG file always contain the following (decimal) values:
-const PNG_SIGNATURE: [u8; 8] = [137, 80, 78, 71, 13, 10, 26, 10];
+use crate::codecs::png::{PngDecoder, PNG_SIGNATURE};
 
 /// Errors that can occur during decoding and parsing an ICO image or one of its enclosed images.
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/src/codecs/ico/encoder.rs
+++ b/src/codecs/ico/encoder.rs
@@ -1,11 +1,12 @@
 use byteorder::{LittleEndian, WriteBytesExt};
-use std::io::{self, Write};
+use std::io::{self, Cursor, Write};
 
 use crate::color::ColorType;
 use crate::error::ImageResult;
-use crate::image::ImageEncoder;
+use crate::image::{ImageDecoder, ImageEncoder};
 
-use crate::codecs::png::PngEncoder;
+use crate::codecs::bmp::BmpDecoder;
+use crate::codecs::png::{PngDecoder, PngEncoder, PNG_SIGNATURE};
 
 // Enum value indicating an ICO image (as opposed to a CUR image):
 const ICO_IMAGE_TYPE: u16 = 1;
@@ -54,6 +55,48 @@ impl<W: Write> IcoEncoder<W> {
         self.w.write_all(&image_data)?;
         Ok(())
     }
+
+    /// Takes an already encoded PNG or BMP image and encodes it into an ICO.
+    ///
+    /// The dimensions of the image must be between 1 and 256 (inclusive) or
+    /// an error will be returned.
+    pub fn write_pre_encoded_image(self, encoded_image: &[u8]) -> ImageResult<()> {
+        let (width, height, color_type) = if encoded_image.starts_with(&PNG_SIGNATURE) {
+            let decoder = PngDecoder::new(Cursor::new(encoded_image))?;
+
+            let (width, height) = decoder.dimensions();
+            let color_type = decoder.color_type();
+            (width, height, color_type)
+        } else {
+            let decoder = BmpDecoder::new(Cursor::new(encoded_image))?;
+
+            let (width, height) = decoder.dimensions();
+            let color_type = decoder.color_type();
+            (width, height, color_type)
+        };
+
+        self.write_pre_encoded_image_impl(encoded_image, width, height, color_type)
+    }
+
+    fn write_pre_encoded_image_impl(
+        mut self,
+        encoded_image: &[u8],
+        width: u32,
+        height: u32,
+        color_type: ColorType,
+    ) -> ImageResult<()> {
+        write_icondir(&mut self.w, 1)?;
+        write_direntry(
+            &mut self.w,
+            width,
+            height,
+            color_type,
+            ICO_ICONDIR_SIZE + ICO_DIRENTRY_SIZE,
+            encoded_image.len() as u32,
+        )?;
+        self.w.write_all(&encoded_image)?;
+        Ok(())
+    }
 }
 
 impl<W: Write> ImageEncoder for IcoEncoder<W> {
@@ -64,7 +107,7 @@ impl<W: Write> ImageEncoder for IcoEncoder<W> {
     ///
     /// WARNING: In image 0.23.14 and earlier this method erroneously expected buf to be in big endian.
     fn write_image(
-        mut self,
+        self,
         buf: &[u8],
         width: u32,
         height: u32,
@@ -73,17 +116,7 @@ impl<W: Write> ImageEncoder for IcoEncoder<W> {
         let mut image_data: Vec<u8> = Vec::new();
         PngEncoder::new(&mut image_data).write_image(buf, width, height, color_type)?;
 
-        write_icondir(&mut self.w, 1)?;
-        write_direntry(
-            &mut self.w,
-            width,
-            height,
-            color_type,
-            ICO_ICONDIR_SIZE + ICO_DIRENTRY_SIZE,
-            image_data.len() as u32,
-        )?;
-        self.w.write_all(&image_data)?;
-        Ok(())
+        self.write_pre_encoded_image_impl(&image_data, width, height, color_type)
     }
 }
 

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -21,6 +21,10 @@ use crate::error::{
 use crate::image::{AnimationDecoder, ImageDecoder, ImageEncoder, ImageFormat};
 use crate::{DynamicImage, GenericImage, ImageBuffer, Luma, LumaA, Rgb, Rgba, RgbaImage};
 
+// http://www.w3.org/TR/PNG-Structure.html
+// The first eight bytes of a PNG file always contain the following (decimal) values:
+pub(crate) const PNG_SIGNATURE: [u8; 8] = [137, 80, 78, 71, 13, 10, 26, 10];
+
 /// Png Reader
 ///
 /// This reader will try to read the png one row at a time,


### PR DESCRIPTION
As mentioned in the second step of https://github.com/image-rs/image/issues/884#issuecomment-985755468.

Makes it possible to use a pre-encoded .png or .bmp file without having to first decode it. Also opens the ability to use something like oxipng to those who want to have fun with extremely small favicons :smiley: 

I haven't added any tests yet.

---

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.


