### PR TITLE
Add new magic byte

### DIFF
--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -252,7 +252,7 @@ pub(crate) fn write_buffer_impl<W: std::io::Write + Seek>(
     }
 }
 
-static MAGIC_BYTES: [(&[u8], ImageFormat); 21] = [
+static MAGIC_BYTES: [(&[u8], ImageFormat); 22] = [
     (b"\x89PNG\r\n\x1a\n", ImageFormat::Png),
     (&[0xff, 0xd8, 0xff], ImageFormat::Jpeg),
     (b"GIF89a", ImageFormat::Gif),
@@ -273,6 +273,7 @@ static MAGIC_BYTES: [(&[u8], ImageFormat); 21] = [
     (b"P7", ImageFormat::Pnm),
     (b"farbfeld", ImageFormat::Farbfeld),
     (b"\0\0\0 ftypavif", ImageFormat::Avif),
+    (b"\0\0\0\x1cftypavif", ImageFormat::Avif),
     (&[0x76, 0x2f, 0x31, 0x01], ImageFormat::OpenExr), // = &exr::meta::magic_number::BYTES
 ];
 


### PR DESCRIPTION
Add compatibility with .avif files created via libheif

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.