### PR TITLE
Deprecate DXT support

### DIFF
--- a/src/codecs/dds.rs
+++ b/src/codecs/dds.rs
@@ -8,8 +8,10 @@
 use std::io::Read;
 use std::{error, fmt};
 
+use bytemuck::bytes_of;
 use byteorder::{LittleEndian, ReadBytesExt};
 
+#[allow(deprecated)]
 use crate::codecs::dxt::{DxtDecoder, DxtReader, DxtVariant};
 use crate::color::ColorType;
 use crate::error::{
@@ -154,6 +156,7 @@ impl Header {
 
 /// The representation of a DDS decoder
 pub struct DdsDecoder<R: Read> {
+    #[allow(deprecated)]
     inner: DxtDecoder<R>,
 }
 
@@ -169,6 +172,7 @@ impl<R: Read> DdsDecoder<R> {
         let header = Header::from_reader(&mut r)?;
 
         if header.pixel_format.flags & 0x4 != 0 {
+            #[allow(deprecated)]
             let variant = match &header.pixel_format.fourcc {
                 b"DXT1" => DxtVariant::DXT1,
                 b"DXT3" => DxtVariant::DXT3,
@@ -186,10 +190,13 @@ impl<R: Read> DdsDecoder<R> {
                 }
             };
 
+            #[allow(deprecated)]
+            let bytes_per_pixel = variant.color_type().bytes_per_pixel();
+
             if crate::utils::check_dimension_overflow(
                 header.width,
                 header.height,
-                variant.color_type().bytes_per_pixel(),
+                bytes_per_pixel,
             ) {
                 return Err(ImageError::Unsupported(
                     UnsupportedError::from_format_and_kind(
@@ -202,6 +209,7 @@ impl<R: Read> DdsDecoder<R> {
                 ));
             }
 
+            #[allow(deprecated)]
             let inner = DxtDecoder::new(r, header.width, header.height, variant)?;
             Ok(Self { inner })
         } else {
@@ -217,6 +225,7 @@ impl<R: Read> DdsDecoder<R> {
 }
 
 impl<'a, R: 'a + Read> ImageDecoder<'a> for DdsDecoder<R> {
+    #[allow(deprecated)]
     type Reader = DxtReader<R>;
 
     fn dimensions(&self) -> (u32, u32) {

--- a/src/codecs/dds.rs
+++ b/src/codecs/dds.rs
@@ -8,7 +8,6 @@
 use std::io::Read;
 use std::{error, fmt};
 
-use bytemuck::bytes_of;
 use byteorder::{LittleEndian, ReadBytesExt};
 
 #[allow(deprecated)]
@@ -193,11 +192,8 @@ impl<R: Read> DdsDecoder<R> {
             #[allow(deprecated)]
             let bytes_per_pixel = variant.color_type().bytes_per_pixel();
 
-            if crate::utils::check_dimension_overflow(
-                header.width,
-                header.height,
-                bytes_per_pixel,
-            ) {
+            if crate::utils::check_dimension_overflow(header.width, header.height, bytes_per_pixel)
+            {
                 return Err(ImageError::Unsupported(
                     UnsupportedError::from_format_and_kind(
                         ImageFormat::Dds.into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,6 +222,7 @@ pub mod codecs {
     #[cfg(feature = "dds")]
     pub mod dds;
     #[cfg(feature = "dxt")]
+    #[deprecated = "DXT support will be removed in a future version. See https://github.com/image-rs/image/issues/1623"]
     pub mod dxt;
     #[cfg(feature = "farbfeld")]
     pub mod farbfeld;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,7 @@ pub mod codecs {
     #[cfg(feature = "dds")]
     pub mod dds;
     #[cfg(feature = "dxt")]
-    #[deprecated = "DXT support will be removed in a future version. See https://github.com/image-rs/image/issues/1623"]
+    #[deprecated = "DXT support will be removed or reworked in a future version. Prefer the `squish` crate instead. See https://github.com/image-rs/image/issues/1623"]
     pub mod dxt;
     #[cfg(feature = "farbfeld")]
     pub mod farbfeld;


### PR DESCRIPTION
https://github.com/image-rs/image/issues/1623 describes the motivation:

> > Right now our GPU compressed texture handling is really not all that great. For decoding we don't support any of the newer formats like BC6, BC7 or ASTC, And for encoding, our code is slow, low quality, and doesn't support any of the newer formats.
> 
> As a result, pretty much any use of the module would be better served by squish-rs which implements faster and higher quality encoding (though be sure to use 2.0.0-beta1 or later to get the recent bugfixes).
> 
> Additionally, unlike the other codecs, DXT is not actually an image file format but rather a compression format. This distinction matters for instance because it means that the DxtDecoder::new() has to be passed the image metadata unlike all our other decoders which don't need that. My suggestion is to just completely deprecate (and eventually remove) the codecs::dxt module. We can still keep the codecs::dds by porting it to rely on squish-rs instead.