### PR TITLE
Export Enlargeable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ pub use crate::buffer_::{
 pub use crate::flat::FlatSamples;
 
 // Traits
-pub use crate::traits::{EncodableLayout, Pixel, PixelWithColorType, Primitive};
+pub use crate::traits::{EncodableLayout, Enlargeable, Pixel, PixelWithColorType, Primitive};
 
 // Opening and loading images
 pub use crate::dynimage::{


### PR DESCRIPTION
This is required for e.g. imageproc.

Previously:
```rust
impl<T, U> WithChannel<U> for Rgb<T>
where
    T: Primitive + 'static,
    U: Primitive + 'static,
{
    type Pixel = Rgb<U>;
}
```

Now:
```rust
impl<T, U> WithChannel<U> for Rgb<T>
where
    T: Primitive + Enlargeable + 'static,
    U: Primitive + Enlargeable + 'static,
{
    type Pixel = Rgb<U>;
}
```

The trait is `pub`, but not exported anywhere.
