### PR TITLE
Upgrade and fixes for 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,15 +35,15 @@ ravif = { version = "0.8.0", optional = true }
 rgb = { version = "0.8.25", optional = true }
 mp4parse = { version = "0.12.0", optional = true }
 dav1d = { version = "0.6.0", optional = true }
-dcv-color-primitives = { version = "0.3.0", optional = true }
+dcv-color-primitives = { version = "0.4.0", optional = true }
 exr = { version = "1.4.1", optional = true }
 color_quant = "1.1"
 
 [dev-dependencies]
 crc32fast = "1.2.0"
-num-complex = "0.3"
+num-complex = "0.4"
 glob = "0.3"
-quickcheck = "0.9"
+quickcheck = "1"
 criterion = "0.3"
 
 [features]

--- a/Cargo.toml.public-private-dependencies
+++ b/Cargo.toml.public-private-dependencies
@@ -2,16 +2,22 @@ cargo-features = ["public-dependency"]
 
 [package]
 name = "image"
-version = "0.23.2"
+version = "0.24.0-alpha"
 edition = "2018"
+rust-version = "1.56"
+
 license = "MIT"
 description = "Imaging library written in Rust. Provides basic filters and decoders for the most common image formats."
 authors = ["The image-rs Developers"]
 readme = "README.md"
+
+# crates.io metadata
 documentation = "https://docs.rs/image"
 repository = "https://github.com/image-rs/image"
 homepage = "https://github.com/image-rs/image"
 categories = ["multimedia::images", "multimedia::encoding"]
+
+# Crate build related
 exclude = [
     "src/png/testdata/*",
     "examples/*",
@@ -23,31 +29,34 @@ name = "image"
 path = "./src/lib.rs"
 
 [dependencies]
-# Not yet public.
 bytemuck = { version = "1.7.0", features = ["extern_crate_alloc"] } # includes cast_vec
 byteorder = "1.3.2"
 num-iter = "0.1.32"
-num-rational = "0.3"
-# Public due to Pixel, otherwise quite useless.
+num-rational = { version = "0.4", default-features = false }
 num-traits = { version = "0.2.0", public = true }
 gif = { version = "0.11.1", optional = true }
 jpeg = { package = "jpeg-decoder", version = "0.2.1", default-features = false, optional = true }
 png = { version = "0.17.0", optional = true }
 scoped_threadpool = { version = "0.1", optional = true }
 tiff = { version = "0.7.1", optional = true }
-ravif = { version = "0.6.0", optional = true }
+ravif = { version = "0.8.0", optional = true }
 rgb = { version = "0.8.25", optional = true }
+mp4parse = { version = "0.12.0", optional = true }
+dav1d = { version = "0.6.0", optional = true }
+dcv-color-primitives = { version = "0.4.0", optional = true }
+exr = { version = "1.4.1", optional = true }
 color_quant = { version = "1.1", public = true }
-exr = { version = "1.3.0", optional = true }
 
 [dev-dependencies]
 crc32fast = "1.2.0"
-num-complex = "0.2.0"
+num-complex = "0.4"
 glob = "0.3"
-quickcheck = "0.9"
+quickcheck = "1"
+criterion = "0.3"
 
 [features]
-default = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "dds", "jpeg_rayon", "openexr"]
+# TODO: Add "avif" to this list while preparing for 0.24.0
+default = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "dds", "farbfeld", "jpeg_rayon", "openexr"]
 
 ico = ["bmp", "png"]
 pnm = []
@@ -57,7 +66,34 @@ bmp = []
 hdr = ["scoped_threadpool"]
 dxt = []
 dds = ["dxt"]
-jpeg_rayon = ["jpeg/rayon"]
+farbfeld = []
 openexr = ["exr"]
 
+# Enables multi-threading.
+# Requires latest stable Rust.
+jpeg_rayon = ["jpeg/rayon"]
+# Non-default, enables avif support.
+# Requires latest stable Rust.
+avif = ["avif-encoder"]
+# Requires latest stable Rust and recent nasm (>= 2.14).
+avif-encoder = ["ravif", "rgb"]
+# Non-default, even in `avif`. Requires stable Rust and native dependency libdav1d.
+avif-decoder = ["mp4parse", "dcv-color-primitives", "dav1d"]
+
+# Build some inline benchmarks. Useful only during development.
+# Requires rustc nightly for feature test.
 benchmarks = []
+
+[[bench]]
+path = "benches/decode.rs"
+name = "decode"
+harness = false
+
+[[bench]]
+path = "benches/encode.rs"
+name = "encode"
+harness = false
+
+[[bench]]
+name = "copy_from"
+harness = false

--- a/src/math/utils.rs
+++ b/src/math/utils.rs
@@ -44,6 +44,8 @@ mod test {
     quickcheck! {
         fn resize_bounds_correctly_width(old_w: u32, new_w: u32) -> bool {
             if old_w == 0 || new_w == 0 { return true; }
+            // In this case, the scaling is limited by scaling of height.
+            // We could check that case separately but it does not conform to the same expectation.
             if new_w as u64 * 400u64 >= old_w as u64 * u64::from(u32::MAX) { return true; }
 
             let result = super::resize_dimensions(old_w, 400, new_w, ::std::u32::MAX, false);
@@ -55,6 +57,8 @@ mod test {
     quickcheck! {
         fn resize_bounds_correctly_height(old_h: u32, new_h: u32) -> bool {
             if old_h == 0 || new_h == 0 { return true; }
+            // In this case, the scaling is limited by scaling of width.
+            // We could check that case separately but it does not conform to the same expectation.
             if 400u64 * new_h as u64 >= old_h as u64 * u64::from(u32::MAX) { return true; }
 
             let result = super::resize_dimensions(400, old_h, ::std::u32::MAX, new_h, false);

--- a/src/math/utils.rs
+++ b/src/math/utils.rs
@@ -7,7 +7,7 @@ use std::cmp::max;
 /// will either fill the dimensions to fit inside the smaller constraint
 /// (will overflow the specified bounds on one axis to preserve
 /// aspect ratio), or will shrink so that both dimensions are
-/// completely contained with in the given `width` and `height`,
+/// completely contained within the given `width` and `height`,
 /// with empty space on one axis.
 pub(crate) fn resize_dimensions(
     width: u32,
@@ -44,16 +44,22 @@ mod test {
     quickcheck! {
         fn resize_bounds_correctly_width(old_w: u32, new_w: u32) -> bool {
             if old_w == 0 || new_w == 0 { return true; }
+            if new_w as u64 * 400u64 >= old_w as u64 * u64::from(u32::MAX) { return true; }
+
             let result = super::resize_dimensions(old_w, 400, new_w, ::std::u32::MAX, false);
-            result.0 == new_w && result.1 == (400 as f64 * new_w as f64 / old_w as f64).round() as u32
+            let exact = (400 as f64 * new_w as f64 / old_w as f64).round() as u32;
+            result.0 == new_w && result.1 == exact.max(1)
         }
     }
 
     quickcheck! {
         fn resize_bounds_correctly_height(old_h: u32, new_h: u32) -> bool {
             if old_h == 0 || new_h == 0 { return true; }
+            if 400u64 * new_h as u64 >= old_h as u64 * u64::from(u32::MAX) { return true; }
+
             let result = super::resize_dimensions(400, old_h, ::std::u32::MAX, new_h, false);
-            result.1 == new_h && result.0 == (400 as f64 * new_h as f64 / old_h as f64).round() as u32
+            let exact = (400 as f64 * new_h as f64 / old_h as f64).round() as u32;
+            result.1 == new_h && result.0 == exact.max(1)
         }
     }
 


### PR DESCRIPTION
Extract and rebase all the version upgrades for 0.24. This ensures we have patch notes in one single commit chain, not interrupted by fixes and upgrades.