### PR TITLE
0.24.1 bugfix release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,12 @@ Rust image aims to be a pure-Rust implementation of various popular image format
   results, but not operation directly, will be added in the future. The plan
   is for these to use a byte-based interface similar to `ImageDecoder`.
 
+### Version 0.24.1
+
+Bug Fixes:
+- ImageBuffer::get_pixel_checked would sometimes return the incorrect pixel.
+- PNG encoding would sometimes not recognize unsupported color.
+
 ### Version 0.24.0
 
 Breaking changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "image"
-version = "0.24.0"
+version = "0.24.1"
 edition = "2018"
 rust-version = "1.56"
 


### PR DESCRIPTION
We should probably release a version incorporating https://github.com/image-rs/image/pull/1674 sooner rather than later.