### PR TITLE
Add DX10 extended header support for DDS

### DIFF
--- a/src/codecs/dds.rs
+++ b/src/codecs/dds.rs
@@ -30,6 +30,8 @@ enum DecoderError {
 
     /// Invalid DXGI format in DX10 header
     DxgiFormatInvalid(u32),
+    /// Invalid resource dimension
+    ResourceDimensionInvalid(u32),
     /// Invalid flags in DX10 header
     Dx10FlagsInvalid(u32),
     /// Invalid array size in DX10 header
@@ -53,6 +55,9 @@ impl fmt::Display for DecoderError {
             }
             DecoderError::DxgiFormatInvalid(df) => {
                 f.write_fmt(format_args!("Invalid DDS DXGI format: {}", df))
+            }
+            DecoderError::ResourceDimensionInvalid(d) => {
+                f.write_fmt(format_args!("Invalid DDS resource dimension: {}", d))
             }
             DecoderError::Dx10FlagsInvalid(fs) => {
                 f.write_fmt(format_args!("Invalid DDS DX10 header flags: {:#010X}", fs))
@@ -206,7 +211,13 @@ impl DX10Header {
             return Err(DecoderError::DxgiFormatInvalid(self.dxgi_format).into());
         }
 
-        if self.misc_flag != 0x4 && self.misc_flag != 0x4 {
+        if self.resource_dimension < 2 || self.resource_dimension > 4 {
+            // Invalid dimension
+            // Only 1D (2), 2D (3) and 3D (4) resource dimensions are allowed
+            return Err(DecoderError::ResourceDimensionInvalid(self.resource_dimension).into());
+        }
+
+        if self.misc_flag != 0x0 && self.misc_flag != 0x4 {
             // Invalid flag
             // Only no (0x0) and DDS_RESOURCE_MISC_TEXTURECUBE (0x4) flags are allowed
             return Err(DecoderError::Dx10FlagsInvalid(self.misc_flag).into());

--- a/src/codecs/dds.rs
+++ b/src/codecs/dds.rs
@@ -210,15 +210,17 @@ impl<R: Read> DdsDecoder<R> {
                         70 | 71 | 72 => DxtVariant::DXT1,
                         73 | 74 | 75 => DxtVariant::DXT3,
                         76 | 77 | 78 => DxtVariant::DXT5,
-                        _ => return Err(ImageError::Unsupported(
-                            UnsupportedError::from_format_and_kind(
-                                ImageFormat::Dds.into(),
-                                UnsupportedErrorKind::GenericFeature(format!(
-                                    "DDS DXGI Format {}",
-                                    dx10_header.dxgi_format
-                                )),
-                            ),
-                        ))
+                        _ => {
+                            return Err(ImageError::Unsupported(
+                                UnsupportedError::from_format_and_kind(
+                                    ImageFormat::Dds.into(),
+                                    UnsupportedErrorKind::GenericFeature(format!(
+                                        "DDS DXGI Format {}",
+                                        dx10_header.dxgi_format
+                                    )),
+                                ),
+                            ))
+                        }
                     }
                 }
                 fourcc => {

--- a/src/codecs/dds.rs
+++ b/src/codecs/dds.rs
@@ -51,6 +51,15 @@ impl fmt::Display for DecoderError {
             DecoderError::HeaderFlagsInvalid(fs) => {
                 f.write_fmt(format_args!("Invalid DDS header flags: {:#010X}", fs))
             }
+            DecoderError::DxgiFormatInvalid(df) => {
+                f.write_fmt(format_args!("Invalid DDS DXGI format: {}", df))
+            }
+            DecoderError::Dx10FlagsInvalid(fs) => {
+                f.write_fmt(format_args!("Invalid DDS DX10 header flags: {:#010X}", fs))
+            }
+            DecoderError::Dx10ArraySizeInvalid(s) => {
+                f.write_fmt(format_args!("Invalid DDS DX10 array size: {}", s))
+            }
             DecoderError::DdsSignatureInvalid => f.write_str("DDS signature not found"),
         }
     }

--- a/src/codecs/dds.rs
+++ b/src/codecs/dds.rs
@@ -192,26 +192,26 @@ impl DX10Header {
 
     fn validate(&self) -> Result<(), ImageError> {
         // Note: see https://docs.microsoft.com/en-us/windows/win32/direct3ddds/dds-header-dxt10 for info on valid values
-        if dxgi_format < 0 || dxgi_format > 132 {
+        if self.dxgi_format < 0 || self.dxgi_format > 132 {
             // Invalid format
-            return Err(DecoderError::DxgiFormatInvalid(dxgi_format).into());
+            return Err(DecoderError::DxgiFormatInvalid(self.dxgi_format).into());
         }
 
-        if misc_flag != 0x4 && misc_flag != 0x4 {
+        if self.misc_flag != 0x4 && self.misc_flag != 0x4 {
             // Invalid flag
             // Only no (0x0) and DDS_RESOURCE_MISC_TEXTURECUBE (0x4) flags are allowed
-            return Err(DecoderError::Dx10FlagsInvalid(misc_flag).into());
+            return Err(DecoderError::Dx10FlagsInvalid(self.misc_flag).into());
         }
 
-        if resource_dimension == 4 && array_size != 1 {
+        if self.resource_dimension == 4 && self.array_size != 1 {
             // Invalid array size
             // 3D textures (resource dimension == 4) must have an array size of 1
-            return Err(DecoderError::Dx10ArraySizeInvalid(array_size).into());
+            return Err(DecoderError::Dx10ArraySizeInvalid(self.array_size).into());
         }
 
-        if misc_flags_2 < 0x0 || misc_flags_2 > 0x4 {
+        if self.misc_flags_2 < 0x0 || self.misc_flags_2 > 0x4 {
             // Invalid alpha flags
-            return Err(DecoderError::Dx10FlagsInvalid(misc_flags_2).into());
+            return Err(DecoderError::Dx10FlagsInvalid(self.misc_flags_2).into());
         }
 
         Ok(())

--- a/src/codecs/dds.rs
+++ b/src/codecs/dds.rs
@@ -243,10 +243,13 @@ impl<R: Read> DdsDecoder<R> {
                 b"DXT5" => DxtVariant::DXT5,
                 b"DX10" => {
                     let dx10_header = DX10Header::from_reader(&mut r)?;
+                    // Format equivalents were taken from https://docs.microsoft.com/en-us/windows/win32/direct3d11/texture-block-compression-in-direct3d-11
+                    // The enum integer values were taken from https://docs.microsoft.com/en-us/windows/win32/api/dxgiformat/ne-dxgiformat-dxgi_format
+                    // DXT1 represents the different BC1 variants, DTX3 represents the different BC2 variants and DTX5 represents the different BC3 variants
                     match dx10_header.dxgi_format {
-                        70 | 71 | 72 => DxtVariant::DXT1,
-                        73 | 74 | 75 => DxtVariant::DXT3,
-                        76 | 77 | 78 => DxtVariant::DXT5,
+                        70 | 71 | 72 => DxtVariant::DXT1, // DXGI_FORMAT_BC1_TYPELESS, DXGI_FORMAT_BC1_UNORM or DXGI_FORMAT_BC1_UNORM_SRGB
+                        73 | 74 | 75 => DxtVariant::DXT3, // DXGI_FORMAT_BC2_TYPELESS, DXGI_FORMAT_BC2_UNORM or DXGI_FORMAT_BC2_UNORM_SRGB
+                        76 | 77 | 78 => DxtVariant::DXT5, // DXGI_FORMAT_BC3_TYPELESS, DXGI_FORMAT_BC3_UNORM or DXGI_FORMAT_BC3_UNORM_SRGB
                         _ => {
                             return Err(ImageError::Unsupported(
                                 UnsupportedError::from_format_and_kind(


### PR DESCRIPTION
Allows the DDS decoder to load DXT-format files with the additional DX10 header, as described in <https://docs.microsoft.com/en-us/windows/win32/direct3ddds/dx-graphics-dds-pguide#dds-variants>.

The DX10 header struct was taken from [Microsoft's DX10 docs](https://docs.microsoft.com/en-us/windows/win32/direct3ddds/dds-header-dxt10), and the equivalent DXT1/3/5 DXGI types were taken from [here](https://docs.microsoft.com/en-us/windows/win32/direct3d11/texture-block-compression-in-direct3d-11) and [here](https://docs.microsoft.com/en-us/windows/win32/api/dxgiformat/ne-dxgiformat-dxgi_format).

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.