### PR TITLE
Fix CI failure

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,7 @@ jobs:
     - name: build
       run: cargo build -v --release
     - name: test
-      run: cargo test -v --release
+      run: cargo test -v --release --features jpeg/platform_independent
   test_avif:
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
Run tests with jpeg's "platform_independent" feature to get deterministic results.