### PR TITLE
impl `GenericImageView` for `SubImage<I>`

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -1164,6 +1164,42 @@ impl<I> SubImage<I> {
     }
 }
 
+impl<I> GenericImageView for SubImage<I>
+where
+    I: Deref,
+    I::Target: GenericImageView,
+{
+    type Pixel = <<I as Deref>::Target as GenericImageView>::Pixel;
+    fn dimensions(&self) -> (u32, u32) {
+        (self.xstride, self.ystride)
+    }
+
+    fn get_pixel(&self, x: u32, y: u32) -> Self::Pixel {
+        if x > self.xstride || y > self.ystride {
+            panic!(
+                "Image index {:?} out of bounds {:?}",
+                (x, y),
+                self.dimensions()
+            );
+        }
+        self.inner.get_pixel(x + self.xoffset, y + self.yoffset)
+    }
+
+    fn bounds(&self) -> (u32, u32, u32, u32) {
+        (
+            self.xoffset,
+            self.yoffset,
+            self.xoffset + self.xstride,
+            self.yoffset + self.ystride,
+        )
+    }
+
+    unsafe fn unsafe_get_pixel(&self, x: u32, y: u32) -> Self::Pixel {
+        self.inner
+            .unsafe_get_pixel(x + self.xoffset, y + self.yoffset)
+    }
+}
+
 /// Methods for readable images.
 impl<I> SubImage<I>
 where


### PR DESCRIPTION
Motivation:
While using a 3rd party package which takes a `GenericImageView`, I found that a SubImage does
not actually implement `GenericImageView`, despite being a `GenericImageView` view :).

Thus, I added an implementation, delegating most of the functionality to the inner
`GenericImageView`.




I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.


