### PR TITLE
Use consistent spelling of the word 'gray' in the docs

### DIFF
--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -488,7 +488,7 @@ pub enum CompressionType {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum FilterType {
-    /// No processing done, best used for low bit depth greyscale or data with a
+    /// No processing done, best used for low bit depth grayscale or data with a
     /// low color count
     NoFilter,
     /// Filters based on previous pixel in the same scanline

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -118,12 +118,12 @@ macro_rules! dynamic_map(
 );
 
 impl DynamicImage {
-    /// Creates a dynamic image backed by a buffer of grey pixels.
+    /// Creates a dynamic image backed by a buffer of gray pixels.
     pub fn new_luma8(w: u32, h: u32) -> DynamicImage {
         DynamicImage::ImageLuma8(ImageBuffer::new(w, h))
     }
 
-    /// Creates a dynamic image backed by a buffer of grey
+    /// Creates a dynamic image backed by a buffer of gray
     /// pixels with transparency.
     pub fn new_luma_a8(w: u32, h: u32) -> DynamicImage {
         DynamicImage::ImageLumaA8(ImageBuffer::new(w, h))
@@ -139,12 +139,12 @@ impl DynamicImage {
         DynamicImage::ImageRgba8(ImageBuffer::new(w, h))
     }
 
-    /// Creates a dynamic image backed by a buffer of grey pixels.
+    /// Creates a dynamic image backed by a buffer of gray pixels.
     pub fn new_luma16(w: u32, h: u32) -> DynamicImage {
         DynamicImage::ImageLuma16(ImageBuffer::new(w, h))
     }
 
-    /// Creates a dynamic image backed by a buffer of grey
+    /// Creates a dynamic image backed by a buffer of gray
     /// pixels with transparency.
     pub fn new_luma_a16(w: u32, h: u32) -> DynamicImage {
         DynamicImage::ImageLumaA16(ImageBuffer::new(w, h))
@@ -605,7 +605,7 @@ impl DynamicImage {
 
     /// Return a grayscale version of this image.
     /// Returns `Luma` images in most cases. However, for `f32` images,
-    /// this will return a greyscale `Rgb/Rgba` image instead.
+    /// this will return a grayscale `Rgb/Rgba` image instead.
     pub fn grayscale(&self) -> DynamicImage {
         match *self {
             DynamicImage::ImageLuma8(ref p) => DynamicImage::ImageLuma8(p.clone()),


### PR DESCRIPTION
While both are correct (depending on which side of the pond one lives), most documentation uses gray instead of grey, and, the imageops also uses the method name grayscale().

I became aware of the two different spellings used when reading the DynamicImage::grayscale() docs, where both variants were used within the same documentation item :).

<!-- 
If you are a new contributor, consent to licensing by including this text:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

Thank you for contributing, you can delete this comment.
-->

