### PR TITLE
Image Encoder: write with progress

### DIFF
--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -152,10 +152,10 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for OpenExrDecoder<R> {
     }
 
     // reads with or without alpha, depending on `self.alpha_preference` and `self.alpha_present_in_file`
-    fn read_image_with_progress<F: Fn(Progress)>(
+    fn read_image_with_progress<F: FnMut(Progress)>(
         self,
         unaligned_bytes: &mut [u8],
-        progress_callback: F,
+        mut progress_callback: F,
     ) -> ImageResult<()> {
         let blocks_in_header = self.selected_exr_header().chunk_count as u64;
         let channel_count = self.color_type().channel_count() as usize;

--- a/src/image.rs
+++ b/src/image.rs
@@ -688,10 +688,10 @@ pub trait ImageDecoder<'a>: Sized {
 
     /// Same as `read_image` but periodically calls the provided callback to give updates on loading
     /// progress.
-    fn read_image_with_progress<F: Fn(Progress)>(
+    fn read_image_with_progress<F: FnMut(Progress)>(
         self,
         buf: &mut [u8],
-        progress_callback: F,
+        mut progress_callback: F,
     ) -> ImageResult<()> {
         assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -802,6 +802,27 @@ pub trait ImageEncoder {
         width: u32,
         height: u32,
         color_type: ColorType,
+    ) -> ImageResult<()> {
+        self.write_image_with_progress(buf, width, height, color_type, |_|{})
+    }
+
+    /// Writes all the bytes in an image to the encoder.
+    ///
+    /// This function takes a slice of bytes of the pixel data of the image
+    /// and encodes them. Unlike particular format encoders inherent impl encode
+    /// methods where endianness is not specified, here image data bytes should
+    /// always be in native endian. The implementor will reorder the endianess
+    /// as necessary for the target encoding format.
+    ///
+    /// See also `ImageDecoder::read_image` which reads byte buffers into
+    /// native endian.
+    fn write_image_with_progress<F: FnMut(Progress)>(
+        self,
+        buf: &[u8],
+        width: u32,
+        height: u32,
+        color_type: ColorType,
+        progress: F,
     ) -> ImageResult<()>;
 }
 


### PR DESCRIPTION
see #1488 

Note: For backwards compatibility, unlike the reader, the writer adds a default implementation for `write_with_progress`, instead of implementing `write` in terms of `write_with_progress`. This way, we can add progress tracking to the individual image writers one by one.
