### PR TITLE
Enable the platform_independent feature under test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,7 @@ jobs:
     - name: build
       run: cargo build -v --release
     - name: test
-      run: cargo test -v --release --features jpeg/platform_independent
+      run: cargo test -v --release
   test_avif:
     runs-on: ubuntu-20.04
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "image"
 version = "0.24.1"
 edition = "2018"
 rust-version = "1.56"
+resolver = "2"
 
 license = "MIT"
 description = "Imaging library written in Rust. Provides basic filters and decoders for the most common image formats."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,9 @@ num-complex = "0.4"
 glob = "0.3"
 quickcheck = "1"
 criterion = "0.3"
+# Keep this in sync with the jpeg dependency above. This is used to enable the platform_independent
+# feature when testing, so `cargo test` works correctly.
+jpeg = { package = "jpeg-decoder", version = "0.2.1", default-features = false, features = ["platform_independent"] }
 
 [features]
 # TODO: Add "avif" to this list while preparing for 0.24.0


### PR DESCRIPTION
This removes the need for `--features jpeg/platform_independent` when
using cargo test

This was a point of confusion when developing locally. I still need to test that it actually doesn't get enabled when using this as a normal dependency, but it shouldn't, with the resolver 2.
