### PR TITLE
cargo-deny

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -159,3 +159,8 @@ jobs:
       with:
         command: fmt
         args: -- --check
+  cargo-deny:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: EmbarkStudios/cargo-deny-action@v1

--- a/deny.toml
+++ b/deny.toml
@@ -26,7 +26,8 @@ wildcards = "allow" # at least until https://github.com/EmbarkStudios/cargo-deny
 deny = []
 skip = []
 skip-tree = [
-    { name = "criterion" }, # dev-dependnecy
+    { name = "criterion" },  # dev-dependency
+    { name = "quickcheck" }, # dev-dependency
 ]
 
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,56 @@
+# https://embarkstudios.github.io/cargo-deny/
+
+targets = [
+    { triple = "aarch64-apple-darwin" },
+    { triple = "aarch64-linux-android" },
+    { triple = "x86_64-apple-darwin" },
+    { triple = "x86_64-pc-windows-msvc" },
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "x86_64-unknown-linux-musl" },
+]
+
+
+[advisories]
+vulnerability = "deny"
+unmaintained = "warn"
+yanked = "deny"
+ignore = []
+
+
+[bans]
+multiple-versions = "deny"
+wildcards = "allow" # at least until https://github.com/EmbarkStudios/cargo-deny/issues/241 is fixed
+deny = []
+skip = [
+    { name = "jpeg-decoder" }, # Duplicated by tiff crate; awaiting patch release: https://github.com/image-rs/image-tiff/pull/155
+    { name = "miniz_oxide" },  # Used by tiff/flate2; awaiting patch release: https://github.com/rust-lang/flate2-rs/pull/293
+]
+skip-tree = [
+    { name = "criterion" }, # dev-dependnecy
+]
+
+
+[licenses]
+unlicensed = "deny"
+allow-osi-fsf-free = "neither"
+confidence-threshold = 0.92 # We want really high confidence when inferring licenses from text
+copyleft = "deny"
+allow = [
+    # "Apache-2.0 WITH LLVM-exception", # https://spdx.org/licenses/LLVM-exception.html
+    "Apache-2.0", # https://tldrlegal.com/license/apache-license-2.0-(apache-2.0)
+    # "BSD-2-Clause", # https://tldrlegal.com/license/bsd-2-clause-license-(freebsd)
+    "BSD-3-Clause", # https://tldrlegal.com/license/bsd-3-clause-license-(revised)
+    "BSL-1.0",      # https://tldrlegal.com/license/boost-software-license-1.0-explained
+    # "CC0-1.0",      # https://creativecommons.org/publicdomain/zero/1.0/
+    # "ISC",          # https://tldrlegal.com/license/-isc-license
+    "MIT", # https://tldrlegal.com/license/mit-license
+    # "MPL-2.0",      # https://www.mozilla.org/en-US/MPL/2.0/FAQ/ - see Q11
+    # "OpenSSL",      # https://www.openssl.org/source/license.html
+    "Zlib", # https://tldrlegal.com/license/zlib-libpng-license-(zlib)
+]
+
+[[licenses.clarify]]
+name = "exr"
+expression = "BSD-3-Clause"
+license-files = [{ path = "LICENSE.md", hash = 0xf0600744 }]
+# https://github.com/johannesvollmer/exrs/blob/master/LICENSE.md

--- a/deny.toml
+++ b/deny.toml
@@ -28,26 +28,6 @@ skip-tree = [
 
 
 [licenses]
-unlicensed = "deny"
-allow-osi-fsf-free = "neither"
-confidence-threshold = 0.92 # We want really high confidence when inferring licenses from text
-copyleft = "deny"
-allow = [
-    # "Apache-2.0 WITH LLVM-exception", # https://spdx.org/licenses/LLVM-exception.html
-    "Apache-2.0", # https://tldrlegal.com/license/apache-license-2.0-(apache-2.0)
-    # "BSD-2-Clause", # https://tldrlegal.com/license/bsd-2-clause-license-(freebsd)
-    "BSD-3-Clause", # https://tldrlegal.com/license/bsd-3-clause-license-(revised)
-    "BSL-1.0",      # https://tldrlegal.com/license/boost-software-license-1.0-explained
-    # "CC0-1.0",      # https://creativecommons.org/publicdomain/zero/1.0/
-    # "ISC",          # https://tldrlegal.com/license/-isc-license
-    "MIT", # https://tldrlegal.com/license/mit-license
-    # "MPL-2.0",      # https://www.mozilla.org/en-US/MPL/2.0/FAQ/ - see Q11
-    # "OpenSSL",      # https://www.openssl.org/source/license.html
-    "Zlib", # https://tldrlegal.com/license/zlib-libpng-license-(zlib)
-]
-
-[[licenses.clarify]]
-name = "exr"
-expression = "BSD-3-Clause"
-license-files = [{ path = "LICENSE.md", hash = 0xf0600744 }]
-# https://github.com/johannesvollmer/exrs/blob/master/LICENSE.md
+unlicensed = "allow"
+allow-osi-fsf-free = "allow"
+copyleft = "allow"

--- a/deny.toml
+++ b/deny.toml
@@ -33,5 +33,5 @@ skip-tree = [
 
 [licenses]
 unlicensed = "allow"
-allow-osi-fsf-free = "allow"
+allow-osi-fsf-free = "either"
 copyleft = "allow"

--- a/deny.toml
+++ b/deny.toml
@@ -21,10 +21,7 @@ ignore = []
 multiple-versions = "deny"
 wildcards = "allow" # at least until https://github.com/EmbarkStudios/cargo-deny/issues/241 is fixed
 deny = []
-skip = [
-    { name = "jpeg-decoder" }, # Duplicated by tiff crate; awaiting patch release: https://github.com/image-rs/image-tiff/pull/155
-    { name = "miniz_oxide" },  # Used by tiff/flate2; awaiting patch release: https://github.com/rust-lang/flate2-rs/pull/293
-]
+skip = []
 skip-tree = [
     { name = "criterion" }, # dev-dependnecy
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -14,7 +14,10 @@ targets = [
 vulnerability = "deny"
 unmaintained = "warn"
 yanked = "deny"
-ignore = []
+ignore = [
+    "RUSTSEC-2020-0071", # https://rustsec.org/advisories/RUSTSEC-2020-0071 - Potential segfault in the time crate.
+    "RUSTSEC-2020-0159", # https://rustsec.org/advisories/RUSTSEC-2020-0159 - Potential segfault in `localtime_r` invocations.
+]
 
 
 [bans]


### PR DESCRIPTION
[cargo-deny](https://github.com/EmbarkStudios/cargo-deny) is an amazing tool that protects from:

* duplicated crates (code bloat)
* copy-left licenses in the dependency tree
* RUSTSEC advisories

In this case it discovered the duplication of `jpeg-decoder` and `miniz_oxide`, caused by the `tiff` and `flate2` crates. ~Until new releases of `tiff` and `flate2` are published I opted to ignore these duplicated crates in the `deny.toml` file.~ **EDIT:** new versions of `tiff` and `flate2` have been published, removing the duplication.

Adding cargo-deny to the CI will prevent more dependency duplication, hence this unsolicited PR.

--- 
I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.
