### PR TITLE
Optimize Rgba blend

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -734,7 +734,7 @@ impl<T: Primitive> Blend for Rgba<T> {
         if other.0[3].is_zero() {
             return;
         }
-        if other.0[3].to_i32().unwrap() == 255 {
+        if other.0[3] == T::DEFAULT_MAX_VALUE {
             *self = *other;
             return;
         }

--- a/src/color.rs
+++ b/src/color.rs
@@ -731,6 +731,14 @@ impl<T: Primitive> Blend for Rgba<T> {
     fn blend(&mut self, other: &Rgba<T>) {
         // http://stackoverflow.com/questions/7438263/alpha-compositing-algorithm-blend-modes#answer-11163848
 
+        if other.0[3].is_zero() {
+            return;
+        }
+        if other.0[3].to_i32().unwrap() == 255 {
+            *self = *other;
+            return;
+        }
+
         // First, as we don't know what type our pixel is, we have to convert to floats between 0.0 and 1.0
         let max_t = T::DEFAULT_MAX_VALUE;
         let max_t = max_t.to_f32().unwrap();


### PR DESCRIPTION
This optimizes the blend method of Rgba<T> by checking for two very common cases. I didn't benchmark this function specifically, but I got my program that makes heavy use of it to be around twice as fast with this change.

Something I'm not sure about is the `other.0[3].to_i32().unwrap() == 255`, since it looks like 255 might not always be the maximum alpha?

---

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.