### PR TITLE
Restrict openexr to little endian platforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,12 @@ rgb = { version = "0.8.25", optional = true }
 mp4parse = { version = "0.12.0", optional = true }
 dav1d = { version = "0.6.0", optional = true }
 dcv-color-primitives = { version = "0.4.0", optional = true }
-exr = { version = "1.4.2", optional = true }
 color_quant = "1.1"
+
+# These appear as an empty dependency on other platforms.
+# See: <https://github.com/rust-lang/cargo/issues/1197#issuecomment-901794879>
+[target.'cfg(target_endian = "little")'.dependencies]
+exr = { version = "1.4.2", optional = true }
 
 [dev-dependencies]
 crc32fast = "1.2.0"

--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -20,8 +20,6 @@
 //!     - meta data is lost
 //!     - dwaa/dwab compressed images not supported yet by the exr library
 //!     - (chroma) subsampling not supported yet by the exr library
-
-extern crate exr;
 use exr::prelude::*;
 
 use crate::error::{DecodingError, EncodingError, ImageFormatHint};

--- a/src/image.rs
+++ b/src/image.rs
@@ -291,6 +291,7 @@ pub enum ImageOutputFormat {
     Tga,
 
     #[cfg(feature = "exr")]
+    #[cfg(target_endian = "little")]
     /// An Image in OpenEXR Format
     OpenExr,
 
@@ -328,6 +329,7 @@ impl From<ImageFormat> for ImageOutputFormat {
             #[cfg(feature = "tga")]
             ImageFormat::Tga => ImageOutputFormat::Tga,
             #[cfg(feature = "exr")]
+            #[cfg(target_endian = "little")]
             ImageFormat::OpenExr => ImageOutputFormat::OpenExr,
             #[cfg(feature = "tiff")]
             ImageFormat::Tiff => ImageOutputFormat::Tiff,

--- a/src/image.rs
+++ b/src/image.rs
@@ -290,7 +290,7 @@ pub enum ImageOutputFormat {
     /// An Image in TGA Format
     Tga,
 
-    #[cfg(feature = "openexr")]
+    #[cfg(feature = "exr")]
     /// An Image in OpenEXR Format
     OpenExr,
 
@@ -327,7 +327,7 @@ impl From<ImageFormat> for ImageOutputFormat {
             ImageFormat::Farbfeld => ImageOutputFormat::Farbfeld,
             #[cfg(feature = "tga")]
             ImageFormat::Tga => ImageOutputFormat::Tga,
-            #[cfg(feature = "openexr")]
+            #[cfg(feature = "exr")]
             ImageFormat::OpenExr => ImageOutputFormat::OpenExr,
             #[cfg(feature = "tiff")]
             ImageFormat::Tiff => ImageOutputFormat::Tiff,

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -73,6 +73,7 @@ pub(crate) fn load_decoder<R: BufRead + Seek, V: DecoderVisitor>(
         #[cfg(feature = "hdr")]
         image::ImageFormat::Hdr => visitor.visit_decoder(hdr::HdrAdapter::new(BufReader::new(r))?),
         #[cfg(feature = "exr")]
+        #[cfg(target_endian = "little")]
         image::ImageFormat::OpenExr => visitor.visit_decoder(openexr::OpenExrDecoder::new(r)?),
         #[cfg(feature = "pnm")]
         image::ImageFormat::Pnm => visitor.visit_decoder(pnm::PnmDecoder::new(r)?),
@@ -231,6 +232,7 @@ pub(crate) fn write_buffer_impl<W: std::io::Write + Seek>(
             tga::TgaEncoder::new(buffered_write).write_image(buf, width, height, color)
         }
         #[cfg(feature = "exr")]
+        #[cfg(target_endian = "little")]
         ImageOutputFormat::OpenExr => {
             openexr::OpenExrEncoder::new(buffered_write).write_image(buf, width, height, color)
         }

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -72,7 +72,7 @@ pub(crate) fn load_decoder<R: BufRead + Seek, V: DecoderVisitor>(
         image::ImageFormat::Ico => visitor.visit_decoder(ico::IcoDecoder::new(r)?),
         #[cfg(feature = "hdr")]
         image::ImageFormat::Hdr => visitor.visit_decoder(hdr::HdrAdapter::new(BufReader::new(r))?),
-        #[cfg(feature = "openexr")]
+        #[cfg(feature = "exr")]
         image::ImageFormat::OpenExr => visitor.visit_decoder(openexr::OpenExrDecoder::new(r)?),
         #[cfg(feature = "pnm")]
         image::ImageFormat::Pnm => visitor.visit_decoder(pnm::PnmDecoder::new(r)?),
@@ -230,7 +230,7 @@ pub(crate) fn write_buffer_impl<W: std::io::Write + Seek>(
         ImageOutputFormat::Tga => {
             tga::TgaEncoder::new(buffered_write).write_image(buf, width, height, color)
         }
-        #[cfg(feature = "openexr")]
+        #[cfg(feature = "exr")]
         ImageOutputFormat::OpenExr => {
             openexr::OpenExrEncoder::new(buffered_write).write_image(buf, width, height, color)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,6 +235,7 @@ pub mod codecs {
     #[cfg(feature = "jpeg")]
     pub mod jpeg;
     #[cfg(feature = "exr")]
+    #[cfg(target_endian = "little")]
     pub mod openexr;
     #[cfg(feature = "png")]
     pub mod png;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,7 @@ pub mod codecs {
     pub mod ico;
     #[cfg(feature = "jpeg")]
     pub mod jpeg;
-    #[cfg(feature = "openexr")]
+    #[cfg(feature = "exr")]
     pub mod openexr;
     #[cfg(feature = "png")]
     pub mod png;


### PR DESCRIPTION
Supposed to fix: #1715 

Not certain if this works correctly, at least it appears to not make a difference for little endian architectures. We would do well to test on a big-endian platform in CI in any case.

cc: @botovq