### PR TITLE
Dont run huge_files_return_error test on 32-bit to avoid overflow

### DIFF
--- a/src/codecs/bmp/encoder.rs
+++ b/src/codecs/bmp/encoder.rs
@@ -319,6 +319,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn huge_files_return_error() {
         let mut encoded_data = Vec::new();
         let image = vec![0u8; 3 * 40_000 * 40_000]; // 40_000x40_000 pixels, 3 bytes per pixel, allocated on the heap


### PR DESCRIPTION
Origin: <https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/image/debian/patches/avoid-test-overflow-32-bit.patch>
Reviewed-By: Andreas Molzer <HeroicKatora@users.noreply.github.com>
Last-Update: 2022-05-26

Closes: #1707, Thanks for the patch.

---

~~I had some trouble with `git am` because apparently it _must_ be ran interactively if it every tries to access gpg, and will fail with an error that indicates it doesn't find committer credentials otherwise. A bit confusing.~~ No, still sometimes works and sometimes doesn't. Im super confused.