### PR TITLE
Fix broken speed explanation link in doc for GifEncode::new_with_speed function

### DIFF
--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -422,7 +422,7 @@ impl<W: Write> GifEncoder<W> {
     }
 
     /// Create a new GIF encoder, and has the speed parameter `speed`. See
-    /// [`Frame::from_rgba_speed`](/gif/struct.Frame.html#method.from_rgb_speed)
+    /// [`Frame::from_rgba_speed`](https://docs.rs/gif/latest/gif/struct.Frame.html#method.from_rgba_speed)
     /// for more information.
     pub fn new_with_speed(w: W, speed: i32) -> GifEncoder<W> {
         assert!(


### PR DESCRIPTION
Closes https://github.com/image-rs/image/issues/1724

Corrects the link which goes nowhere to latest image-gif doc.

Verified the link by generating the docs via `cargo doc` and clicking on it

---
I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

