### PR TITLE
docs: Specify the width/height order from image_dimensions

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -1106,7 +1106,7 @@ where
     free_functions::open_impl(path.as_ref())
 }
 
-/// Read the dimensions of the image located at the specified path.
+/// Read a tuple containing the (width, height) of the image located at the specified path.
 /// This is faster than fully loading the image and then getting its dimensions.
 ///
 /// Try [`io::Reader`] for more advanced uses, including guessing the format based on the file's


### PR DESCRIPTION
Returning width/height is what feels like the norm to me, but it's not specified [in the public docs](https://docs.rs/image/0.24.2/image/fn.image_dimensions.html) – making it explicit avoids somebody having to guess or experiment.

If you trace it through the codebase, this eventually ends up calling `dimensions()` on an ImageDecoder, which [the README says is a (width, height)](https://github.com/image-rs/image/blob/144ea599fcda523956604b3733751beee6b8d5cb/README.md#the-imagedecoder-and-imagedecoderrect-traits) tuple.

## Licensing agreement

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.