### PR TITLE
feature: Implement `load_lossy`

### DIFF
--- a/src/codecs/bmp/decoder.rs
+++ b/src/codecs/bmp/decoder.rs
@@ -1514,7 +1514,7 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for BmpDecoder<R> {
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
         Ok(BmpReader(
-            Cursor::new(image::decoder_to_vec(self)?),
+            Cursor::new(image::decoder_to_vec(self).map_err(|(_, e)| e)?),
             PhantomData,
         ))
     }

--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -109,7 +109,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for GifDecoder<R> {
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
         Ok(GifReader(
-            Cursor::new(image::decoder_to_vec(self)?),
+            Cursor::new(image::decoder_to_vec(self).map_err(|(_, e)| e)?),
             PhantomData,
         ))
     }

--- a/src/codecs/hdr/decoder.rs
+++ b/src/codecs/hdr/decoder.rs
@@ -201,7 +201,7 @@ impl<'a, R: 'a + BufRead> ImageDecoder<'a> for HdrAdapter<R> {
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
         Ok(HdrReader(
-            Cursor::new(image::decoder_to_vec(self)?),
+            Cursor::new(image::decoder_to_vec(self).map_err(|(_, e)| e)?),
             PhantomData,
         ))
     }

--- a/src/codecs/ico/decoder.rs
+++ b/src/codecs/ico/decoder.rs
@@ -296,7 +296,7 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for IcoDecoder<R> {
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
         Ok(IcoReader(
-            Cursor::new(image::decoder_to_vec(self)?),
+            Cursor::new(image::decoder_to_vec(self).map_err(|(_, e)| e)?),
             PhantomData,
         ))
     }

--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -138,7 +138,7 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for OpenExrDecoder<R> {
     /// Use `read_image` instead if possible,
     /// as this method creates a whole new buffer just to contain the entire image.
     fn into_reader(self) -> ImageResult<Self::Reader> {
-        Ok(Cursor::new(decoder_to_vec(self)?))
+        Ok(Cursor::new(decoder_to_vec(self).map_err(|(_, e)| e)?))
     }
 
     fn scanline_bytes(&self) -> u64 {
@@ -429,7 +429,7 @@ mod test {
     fn read_as_rgb_image(read: impl Read + Seek) -> ImageResult<Rgb32FImage> {
         let decoder = OpenExrDecoder::with_alpha_preference(read, Some(false))?;
         let (width, height) = decoder.dimensions();
-        let buffer: Vec<f32> = decoder_to_vec(decoder)?;
+        let buffer: Vec<f32> = decoder_to_vec(decoder).map_err(|(_, e)| e)?;
 
         ImageBuffer::from_raw(width, height, buffer)
             // this should be the only reason for the "from raw" call to fail,
@@ -443,7 +443,7 @@ mod test {
     fn read_as_rgba_image(read: impl Read + Seek) -> ImageResult<Rgba32FImage> {
         let decoder = OpenExrDecoder::with_alpha_preference(read, Some(true))?;
         let (width, height) = decoder.dimensions();
-        let buffer: Vec<f32> = decoder_to_vec(decoder)?;
+        let buffer: Vec<f32> = decoder_to_vec(decoder).map_err(|(_, e)| e)?;
 
         ImageBuffer::from_raw(width, height, buffer)
             // this should be the only reason for the "from raw" call to fail,

--- a/src/codecs/pnm/decoder.rs
+++ b/src/codecs/pnm/decoder.rs
@@ -615,7 +615,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for PnmDecoder<R> {
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
         Ok(PnmReader(
-            Cursor::new(image::decoder_to_vec(self)?),
+            Cursor::new(image::decoder_to_vec(self).map_err(|(_, e)| e)?),
             PhantomData,
         ))
     }

--- a/src/io/reader.rs
+++ b/src/io/reader.rs
@@ -6,6 +6,7 @@ use crate::dynimage::DynamicImage;
 use crate::error::{ImageFormatHint, UnsupportedError, UnsupportedErrorKind};
 use crate::image::ImageFormat;
 use crate::{ImageError, ImageResult};
+use crate::io::free_functions::LoadErrorHandling;
 
 use super::free_functions;
 
@@ -225,7 +226,7 @@ impl<R: BufRead + Seek> Reader<R> {
     /// If no format was determined, returns an `ImageError::Unsupported`.
     pub fn decode(mut self) -> ImageResult<DynamicImage> {
         let format = self.require_format()?;
-        free_functions::load_inner(self.inner, self.limits, format)
+        free_functions::load_inner(self.inner, self.limits, format, LoadErrorHandling::Strict)
     }
 
     fn require_format(&mut self) -> ImageResult<ImageFormat> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@ pub use crate::dynimage::{
     image_dimensions, load_from_memory, load_from_memory_with_format, open, save_buffer,
     save_buffer_with_format, write_buffer_with_format,
 };
-pub use crate::io::free_functions::{guess_format, load};
+pub use crate::io::free_functions::{guess_format, load, load_lossy};
 
 pub use crate::dynimage::DynamicImage;
 


### PR DESCRIPTION
Add support for lossy image loading.

The new `load_lossy` function adds error recovery.

If loading reaches the step where it allocates the pixel buffer, then it always succeeds: any error following this step will result in a partially filled buffer where the missing pixels will use their default "zero" value.

This allows for example to read truncated files or other minor issues.

- Closes image-rs/image#1752

---

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.
