### PR TITLE
inline get_pixel and get_pixel_mut for >2x speedup

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -715,6 +715,7 @@ where
     /// # Panics
     ///
     /// Panics if `(x, y)` is out of the bounds `(width, height)`.
+    #[inline]
     pub fn get_pixel(&self, x: u32, y: u32) -> &P {
         match self.pixel_indices(x, y) {
             None => panic!(
@@ -891,6 +892,7 @@ where
     /// # Panics
     ///
     /// Panics if `(x, y)` is out of the bounds `(width, height)`.
+    #[inline]
     pub fn get_pixel_mut(&mut self, x: u32, y: u32) -> &mut P {
         match self.pixel_indices(x, y) {
             None => panic!(


### PR DESCRIPTION
Hello, I'm new to Rust and decided to try hacking on some other projects I intend to use as part of my own. This stemmed from a failed attempt to optimize the resize() function by using generic parameters for kernels instead of a boxed function which turned out to have no impact at all, however I noticed from a profile run that the code was spending a lot of time in get_pixel, and inlining it has a >2x speedup on resize(), and no doubt more speedups elsewhere in the code

before (on an M1 Max):
```
Scaled by near in 7 ms
Scaled by tri in 97 ms
Scaled by cmr in 178 ms
Scaled by gauss in 265 ms
Scaled by lcz2 in 265 ms
Thumbnailed to 20 in 22 ms
Thumbnailed to 40 in 22 ms
Thumbnailed to 100 in 24 ms
Thumbnailed to 200 in 25 ms
Thumbnailed to 400 in 22 ms
```
After:
```
Scaled by near in 5 ms
Scaled by tri in 40 ms
Scaled by cmr in 74 ms
Scaled by gauss in 111 ms
Scaled by lcz2 in 110 ms
Thumbnailed to 20 in 15 ms
Thumbnailed to 40 in 17 ms
Thumbnailed to 100 in 16 ms
Thumbnailed to 200 in 15 ms
Thumbnailed to 400 in 15 ms
```

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

