### PR TITLE
Check if resizing to the same size

### DIFF
--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -888,6 +888,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "png")]
     fn test_resize_same_size() {
         use std::path::Path;
         let img = crate::open(&Path::new("./examples/fractal.png")).unwrap();

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -7,7 +7,7 @@ use std::f32;
 
 use num_traits::{NumCast, ToPrimitive, Zero};
 
-use crate::image::{GenericImageView, GenericImage};
+use crate::image::{GenericImage, GenericImageView};
 use crate::traits::{Enlargeable, Pixel, Primitive};
 use crate::utils::clamp;
 use crate::{ImageBuffer, Rgba32FImage};
@@ -757,15 +757,17 @@ pub fn resize<I, P, S>(
     filter: FilterType,
 ) -> ImageBuffer<P, Vec<S>>
 where
-    I: GenericImageView<Pixel=P>,
-    P: Pixel<Subpixel=S> + 'static,
+    I: GenericImageView<Pixel = P>,
+    P: Pixel<Subpixel = S> + 'static,
     S: Primitive + 'static,
 {
     // check if the new dimensions are the same as the old. if they are, make a copy instead of resampling
     if (nwidth, nheight) == image.dimensions() {
         let mut tmp = ImageBuffer::<P, Vec<S>>::new(image.width(), image.height());
         match tmp.copy_from(image, 0, 0) {
-            Ok(_) => { return tmp; }
+            Ok(_) => {
+                return tmp;
+            }
             Err(_) => {} // something has gone wrong doing a direct copy, continue with normal path
         };
     }
@@ -889,9 +891,10 @@ mod tests {
     fn test_resize_same_size() {
         use std::path::Path;
         let img = crate::open(&Path::new(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/tests/images/tiff/testsuite/mandrill.tiff"
-        ))).unwrap();
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/images/tiff/testsuite/mandrill.tiff"
+        )))
+        .unwrap();
         let resize = img.resize(img.width(), img.height(), FilterType::Triangle);
         assert!(img.pixels().eq(resize.pixels()))
     }
@@ -900,8 +903,8 @@ mod tests {
     #[cfg(all(feature = "benchmarks", feature = "tiff"))]
     fn bench_resize_same_size(b: &mut test::Bencher) {
         let path = concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/tests/images/tiff/testsuite/mandrill.tiff"
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/images/tiff/testsuite/mandrill.tiff"
         );
         let image = crate::open(path).unwrap();
         b.iter(|| {

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -750,16 +750,15 @@ where
 /// Resize the supplied image to the specified dimensions.
 /// ```nwidth``` and ```nheight``` are the new dimensions.
 /// ```filter``` is the sampling filter to use.
-pub fn resize<I, P, S>(
+pub fn resize<I: GenericImageView>(
     image: &I,
     nwidth: u32,
     nheight: u32,
     filter: FilterType,
-) -> ImageBuffer<P, Vec<S>>
+) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
 where
-    I: GenericImageView<Pixel = P>,
-    P: Pixel<Subpixel = S> + 'static,
-    S: Primitive + 'static,
+    I::Pixel: 'static,
+    <I::Pixel as Pixel>::Subpixel: 'static,
 {
     // check if the new dimensions are the same as the old. if they are, make a copy instead of resampling
     if (nwidth, nheight) == image.dimensions() {

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -890,11 +890,7 @@ mod tests {
     #[test]
     fn test_resize_same_size() {
         use std::path::Path;
-        let img = crate::open(&Path::new(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/tests/images/tiff/testsuite/mandrill.tiff"
-        )))
-        .unwrap();
+        let img = crate::open(&Path::new("./examples/fractal.png")).unwrap();
         let resize = img.resize(img.width(), img.height(), FilterType::Triangle);
         assert!(img.pixels().eq(resize.pixels()))
     }

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -870,7 +870,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::{resize, FilterType};
-    use crate::{ImageBuffer, RgbImage};
+    use crate::{GenericImageView, ImageBuffer, RgbImage};
     #[cfg(feature = "benchmarks")]
     use test;
 
@@ -907,7 +907,7 @@ mod tests {
         b.iter(|| {
             test::black_box(image.resize(image.width(), image.height(), FilterType::CatmullRom));
         });
-        b.bytes = (image.width() * image.height() * 4) as u64;
+        b.bytes = (image.width() * image.height() * 3) as u64;
     }
 
     #[test]

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -763,7 +763,7 @@ where
 {
     // check if the new dimensions are the same as the old. if they are, make a copy instead of resampling
     if (nwidth, nheight) == image.dimensions() {
-        let mut tmp = ImageBuffer::<P, Vec<S>>::new(image.width(), image.height());
+        let mut tmp = ImageBuffer::new(image.width(), image.height());
         tmp.copy_from(image, 0, 0).unwrap();
         return tmp;
     }

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -764,12 +764,8 @@ where
     // check if the new dimensions are the same as the old. if they are, make a copy instead of resampling
     if (nwidth, nheight) == image.dimensions() {
         let mut tmp = ImageBuffer::<P, Vec<S>>::new(image.width(), image.height());
-        match tmp.copy_from(image, 0, 0) {
-            Ok(_) => {
-                return tmp;
-            }
-            Err(_) => {} // something has gone wrong doing a direct copy, continue with normal path
-        };
+        tmp.copy_from(image, 0, 0).unwrap();
+        return tmp;
     }
 
     let mut method = match filter {


### PR DESCRIPTION
<!-- 
If you are a new contributor, consent to licensing by including this text:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

Thank you for contributing, you can delete this comment.
-->
Addresses #1738 by checking if resizing is to the same size the image already is. 

there's a lot more optimizations that could be made here, such as detecting integer scaling or a Pillow-style ["reduce gap"](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.resize) method (maybe as an additional filter mode, since it only makes sense for bilinear). However from #1718 it looks like you may be planning a refactor of the backing data structures for pixels? 
