### PR TITLE
Add big-endian CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,11 +6,12 @@ on:
     branches: [ master, next ]
 jobs:
   build:
+    name: Build and Run the features using a combination of features and rust toolchains
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust: ["1.51.0", stable, beta, nightly]
-        features: [ gif, jpeg, png, pnm, tga, dds, tiff, webp, hdr, farbfeld, '' ]
+        features: [ gif, jpeg, png, tiff, ico, pnm, tga, webp, bmp, hdr, dxt, dds, farbfeld, openexr, jpeg_rayon, '' ]
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
@@ -28,6 +29,43 @@ jobs:
         cargo doc -v --no-default-features --features "$FEATURES"
       env:
         FEATURES: ${{ matrix.features }}
+
+  test_defaults_big_endian:
+    # github actions does not support big endian systems directly, but it does support QEMU.
+    # so we install qemu, then build and run the tests in an emulated mips system.
+    # note: you can also use this approach to test for big endian locally.
+    runs-on: ubuntu-20.04
+    name: Run tests on an emulated big endian mips system using stable toolchain (exluding doc tests)
+    strategy:
+      matrix:
+        features: [ gif, jpeg, png, tiff, ico, pnm, tga, webp, bmp, hdr, dxt, dds, farbfeld, openexr, jpeg_rayon, '' ]
+
+    # we are using the cross project for cross compilation to mips:
+    # https://github.com/cross-rs/cross
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install or use cached cross-rs/cross
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cross
+
+      - name: Start Docker (required for cross-rs)
+        run: sudo systemctl start docker
+
+      - name: Cross-Compile project to mips-unknown-linux-gnu for ${{ matrix.features }}
+        run: |
+          cross build --target=mips-unknown-linux-gnu --verbose -v --no-default-features --features "$FEATURES"
+        env:
+          FEATURES: ${{ matrix.features }}
+
+      # https://github.com/cross-rs/cross#supported-targets
+      - name: Cross-Run Tests in mips-unknown-linux-gnu using Qemu for ${{ matrix.features }}
+        run: |
+          cross test --target mips-unknown-linux-gnu --verbose -v --no-default-features --features "$FEATURES"
+        env:
+          FEATURES: ${{ matrix.features }}
+
   test_defaults:
     runs-on: ubuntu-latest
     steps:
@@ -40,6 +78,7 @@ jobs:
       run: cargo build -v --release
     - name: test
       run: cargo test -v --release
+
   test_avif:
     runs-on: ubuntu-20.04
     steps:
@@ -52,6 +91,7 @@ jobs:
         override: true
     - name: build
       run: cargo build -v --no-default-features --features="avif"
+
   test_avif_decoding:
     runs-on: ubuntu-20.04
     steps:
@@ -66,6 +106,7 @@ jobs:
       run: cargo build -v --no-default-features --features="avif-decoder"
       env:
         SYSTEM_DEPS_DAV1D_BUILD_INTERNAL: always
+
   clippy:
     runs-on: ubuntu-20.04
     steps:
@@ -82,6 +123,7 @@ jobs:
         args: clippy --all-features -- -D warnings
       env:
         SYSTEM_DEPS_DAV1D_BUILD_INTERNAL: always
+
   build_fuzz_afl:
     name: "Fuzz targets (afl)"
     runs-on: ubuntu-latest
@@ -103,6 +145,7 @@ jobs:
         cargo afl check --bin fuzz_pnm
       env:
         RUSTFLAGS: "-Znew-llvm-pass-manager=no"
+
   build_fuzz_cargo-fuzz:
     name: "Fuzz targets (cargo-fuzz)"
     runs-on: ubuntu-latest
@@ -121,6 +164,7 @@ jobs:
         for format in $(cargo fuzz list); do
           cargo fuzz run "$format" -- -runs=0;
         done
+
   public_private_dependencies:
     name: "Public private dependencies"
     runs-on: ubuntu-latest
@@ -136,6 +180,7 @@ jobs:
         echo "#![deny(exported_private_dependencies)]" | cat - src/lib.rs > src/lib.rs.0
         mv src/lib.rs.0 src/lib.rs
         cargo check
+
   build_benchmarks:
     runs-on: ubuntu-latest
     steps:
@@ -146,6 +191,7 @@ jobs:
         override: true
     - name: build
       run: cargo build -v --benches --features=benchmarks
+
   rustfmt:
     runs-on: ubuntu-latest
     steps:
@@ -160,6 +206,7 @@ jobs:
       with:
         command: fmt
         args: -- --check
+
   cargo-deny:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,16 +1,22 @@
 name: Rust CI
+
 on:
   push:
     branches: [ master, next ]
   pull_request:
     branches: [ master, next ]
+
+# here we group some parameters for later
+env:
+  MINIMUM_SUPPORTED_RUST_VERSION: 1.56.0
+
 jobs:
   build:
-    name: Run tests and doctests
+    name: Run tests and doctests on ubuntu
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: ["1.51.0", stable, beta, nightly]
+        rust: [$MINIMUM_SUPPORTED_RUST_VERSION, stable, beta, nightly]
         features: [ gif, jpeg, png, tiff, ico, pnm, tga, webp, bmp, hdr, dxt, dds, farbfeld, openexr, jpeg_rayon, '' ]
     steps:
     - uses: actions/checkout@v2
@@ -34,7 +40,7 @@ jobs:
       env:
         FEATURES: ${{ matrix.features }}
 
-  test_defaults_big_endian:
+  build_big_endian:
     name: Run tests on big endian architecture
 
     # github actions does not support big endian systems directly, but it does support QEMU.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,14 +31,20 @@ jobs:
         FEATURES: ${{ matrix.features }}
 
   test_defaults_big_endian:
+    name: Run tests on big endian architecture
+
     # github actions does not support big endian systems directly, but it does support QEMU.
     # so we install qemu, then build and run the tests in an emulated mips system.
     # note: you can also use this approach to test for big endian locally.
     runs-on: ubuntu-20.04
-    name: Run tests on big endian architecture
     strategy:
       matrix:
         features: [ gif, jpeg, png, tiff, ico, pnm, tga, webp, bmp, hdr, dxt, dds, farbfeld, openexr, jpeg_rayon, '' ]
+
+    # we need to limit the number of parallel jobs
+    # so we artificially depend on another job
+    # to make this whole thing sequential
+    needs: build
 
     # we are using the cross project for cross compilation to mips:
     # https://github.com/cross-rs/cross

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,9 @@ on:
 
 # here we group some parameters for later
 env:
+  # see rust-version in Cargo.toml
   MINIMUM_SUPPORTED_RUST_VERSION: 1.56.0
+  CRATE_FEATURES: (gif, jpeg, png, tiff, ico, pnm, tga, webp, bmp, hdr, dxt, dds, farbfeld, openexr, jpeg_rayon, '')
 
 jobs:
   build:
@@ -16,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [$MINIMUM_SUPPORTED_RUST_VERSION, stable, beta, nightly]
-        features: [ gif, jpeg, png, tiff, ico, pnm, tga, webp, bmp, hdr, dxt, dds, farbfeld, openexr, jpeg_rayon, '' ]
+        rust: [${{ env.MINIMUM_SUPPORTED_RUST_VERSION }}, stable, beta, nightly]
+        features: ${{ env.CRATE_FEATURES }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
@@ -49,7 +51,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        features: [ gif, jpeg, png, tiff, ico, pnm, tga, webp, bmp, hdr, dxt, dds, farbfeld, openexr, jpeg_rayon, '' ]
+        features: ${{ env.CRATE_FEATURES }}
 
     # we need to limit the number of parallel jobs
     # so we artificially depend on another job

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
         toolchain: ${{ matrix.rust }}
         override: true
     - name: Cache Cargo Dependencies
-      uses: Swatinem/rust-cache@v1.3.0
+      uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: true
     - name: build
@@ -63,7 +63,7 @@ jobs:
           crate: cross
 
       - name: Cache Cargo Dependencies
-        uses: Swatinem/rust-cache@v1.3.0
+        uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,10 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
         override: true
+    - name: Cache Cargo Dependencies
+      uses: Swatinem/rust-cache@v1.3.0
+      with:
+        cache-on-failure: true
     - name: build
       run: cargo build -v --no-default-features --features "$FEATURES"
       env:
@@ -55,6 +59,11 @@ jobs:
         uses: baptiste0928/cargo-install@v1
         with:
           crate: cross
+
+      - name: Cache Cargo Dependencies
+        uses: Swatinem/rust-cache@v1.3.0
+        with:
+          cache-on-failure: true
 
       - name: Start Docker (required for cross-rs)
         run: sudo systemctl start docker

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: ["1.56.0", stable, beta, nightly]
+        rust: ["1.56.1", stable, beta, nightly]
         features: [gif, jpeg, png, tiff, ico, pnm, tga, webp, bmp, hdr, dxt, dds, farbfeld, openexr, jpeg_rayon, '']
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,11 +47,6 @@ jobs:
       matrix:
         features: [gif, jpeg, png, tiff, ico, pnm, tga, webp, bmp, hdr, dxt, dds, farbfeld, openexr, jpeg_rayon, '']
 
-    # we need to limit the number of parallel jobs
-    # so we artificially depend on another job
-    # to make this whole thing sequential
-    needs: build
-
     # we are using the cross project for cross compilation to mips:
     # https://github.com/cross-rs/cross
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,7 +6,7 @@ on:
     branches: [ master, next ]
 jobs:
   build:
-    name: Build and Run the features using a combination of features and rust toolchains
+    name: Run tests and doctests
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -35,7 +35,7 @@ jobs:
     # so we install qemu, then build and run the tests in an emulated mips system.
     # note: you can also use this approach to test for big endian locally.
     runs-on: ubuntu-20.04
-    name: Run tests on an emulated big endian mips system using stable toolchain (exluding doc tests)
+    name: Run tests on big endian architecture
     strategy:
       matrix:
         features: [ gif, jpeg, png, tiff, ico, pnm, tga, webp, bmp, hdr, dxt, dds, farbfeld, openexr, jpeg_rayon, '' ]
@@ -53,14 +53,14 @@ jobs:
       - name: Start Docker (required for cross-rs)
         run: sudo systemctl start docker
 
-      - name: Cross-Compile project to mips-unknown-linux-gnu for ${{ matrix.features }}
+      - name: Cross-Compile project to mips-unknown-linux-gnu
         run: |
           cross build --target=mips-unknown-linux-gnu --verbose -v --no-default-features --features "$FEATURES"
         env:
           FEATURES: ${{ matrix.features }}
 
       # https://github.com/cross-rs/cross#supported-targets
-      - name: Cross-Run Tests in mips-unknown-linux-gnu using Qemu for ${{ matrix.features }}
+      - name: Cross-Run Tests in mips-unknown-linux-gnu using Qemu
         run: |
           cross test --target mips-unknown-linux-gnu --verbose -v --no-default-features --features "$FEATURES"
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ on:
 # here we group some parameters for later
 env:
   # see rust-version in Cargo.toml
-  MINIMUM_SUPPORTED_RUST_VERSION: 1.56.0
+  MINIMUM_SUPPORTED_RUST_VERSION: "1.56.0"
 
 jobs:
   build:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,6 +73,7 @@ jobs:
 
       # https://github.com/cross-rs/cross#supported-targets
       - name: Cross-Run Tests in mips-unknown-linux-gnu using Qemu
+        continue-on-error: true
         run: |
           cross test --target mips-unknown-linux-gnu --verbose -v --no-default-features --features "$FEATURES"
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,6 @@ on:
 env:
   # see rust-version in Cargo.toml
   MINIMUM_SUPPORTED_RUST_VERSION: 1.56.0
-  CRATE_FEATURES: (gif, jpeg, png, tiff, ico, pnm, tga, webp, bmp, hdr, dxt, dds, farbfeld, openexr, jpeg_rayon, '')
 
 jobs:
   build:
@@ -19,7 +18,7 @@ jobs:
     strategy:
       matrix:
         rust: [${{ env.MINIMUM_SUPPORTED_RUST_VERSION }}, stable, beta, nightly]
-        features: ${{ env.CRATE_FEATURES }}
+        features: [gif, jpeg, png, tiff, ico, pnm, tga, webp, bmp, hdr, dxt, dds, farbfeld, openexr, jpeg_rayon, '']
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
@@ -51,7 +50,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        features: ${{ env.CRATE_FEATURES }}
+        features: [gif, jpeg, png, tiff, ico, pnm, tga, webp, bmp, hdr, dxt, dds, farbfeld, openexr, jpeg_rayon, '']
 
     # we need to limit the number of parallel jobs
     # so we artificially depend on another job
@@ -235,3 +234,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: EmbarkStudios/cargo-deny-action@v1
+
+  verify_msrv:
+    name: Verify Minimum Supported Rust Version in Cargo.toml
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install or use cached `cargo-msrv`
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-msrv
+
+      - name: Verify Minimum Rust Version
+        run: cargo-msrv verify

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,18 +6,13 @@ on:
   pull_request:
     branches: [ master, next ]
 
-# here we group some parameters for later
-env:
-  # see rust-version in Cargo.toml
-  MINIMUM_SUPPORTED_RUST_VERSION: "1.56.0"
-
 jobs:
   build:
     name: Run tests and doctests on ubuntu
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [${{ env.MINIMUM_SUPPORTED_RUST_VERSION }}, stable, beta, nightly]
+        rust: ["1.56.0", stable, beta, nightly]
         features: [gif, jpeg, png, tiff, ico, pnm, tga, webp, bmp, hdr, dxt, dds, farbfeld, openexr, jpeg_rayon, '']
     steps:
     - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 resolver = "2"
 
 # note: when changed, also update test runner in `.github/workflows/rust.yml`
-rust-version = "1.56"
+rust-version = "1.56.1"
 
 license = "MIT"
 description = "Imaging library written in Rust. Provides basic filters and decoders for the most common image formats."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,10 @@
 name = "image"
 version = "0.24.3"
 edition = "2018"
-rust-version = "1.56"
 resolver = "2"
+
+# note: when changed, also update test runner in `.github/workflows/rust.yml`
+rust-version = "1.56"
 
 license = "MIT"
 description = "Imaging library written in Rust. Provides basic filters and decoders for the most common image formats."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,11 +43,7 @@ mp4parse = { version = "0.12.0", optional = true }
 dav1d = { version = "0.6.0", optional = true }
 dcv-color-primitives = { version = "0.4.0", optional = true }
 color_quant = "1.1"
-
-# These appear as an empty dependency on other platforms.
-# See: <https://github.com/rust-lang/cargo/issues/1197#issuecomment-901794879>
-[target.'cfg(target_endian = "little")'.dependencies]
-exr = { version = "1.4.2", optional = true }
+exr = { version = "1.5.0", optional = true }
 
 [dev-dependencies]
 crc32fast = "1.2.0"

--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -455,10 +455,9 @@ mod test {
 
     #[test]
     fn compare_exr_hdr() {
-        assert!(
-            cfg!(feature = "hdr"),
-            "to run all the openexr tests, activate the hdr feature flag"
-        );
+        if cfg!(not(feature = "hdr")) {
+            eprintln!("warning: to run all the openexr tests, activate the hdr feature flag");
+        }
 
         #[cfg(feature = "hdr")]
         {

--- a/src/image.rs
+++ b/src/image.rs
@@ -291,7 +291,6 @@ pub enum ImageOutputFormat {
     Tga,
 
     #[cfg(feature = "exr")]
-    #[cfg(target_endian = "little")]
     /// An Image in OpenEXR Format
     OpenExr,
 
@@ -329,7 +328,6 @@ impl From<ImageFormat> for ImageOutputFormat {
             #[cfg(feature = "tga")]
             ImageFormat::Tga => ImageOutputFormat::Tga,
             #[cfg(feature = "exr")]
-            #[cfg(target_endian = "little")]
             ImageFormat::OpenExr => ImageOutputFormat::OpenExr,
             #[cfg(feature = "tiff")]
             ImageFormat::Tiff => ImageOutputFormat::Tiff,

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -73,7 +73,6 @@ pub(crate) fn load_decoder<R: BufRead + Seek, V: DecoderVisitor>(
         #[cfg(feature = "hdr")]
         image::ImageFormat::Hdr => visitor.visit_decoder(hdr::HdrAdapter::new(BufReader::new(r))?),
         #[cfg(feature = "exr")]
-        #[cfg(target_endian = "little")]
         image::ImageFormat::OpenExr => visitor.visit_decoder(openexr::OpenExrDecoder::new(r)?),
         #[cfg(feature = "pnm")]
         image::ImageFormat::Pnm => visitor.visit_decoder(pnm::PnmDecoder::new(r)?),
@@ -232,7 +231,6 @@ pub(crate) fn write_buffer_impl<W: std::io::Write + Seek>(
             tga::TgaEncoder::new(buffered_write).write_image(buf, width, height, color)
         }
         #[cfg(feature = "exr")]
-        #[cfg(target_endian = "little")]
         ImageOutputFormat::OpenExr => {
             openexr::OpenExrEncoder::new(buffered_write).write_image(buf, width, height, color)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,7 +235,6 @@ pub mod codecs {
     #[cfg(feature = "jpeg")]
     pub mod jpeg;
     #[cfg(feature = "exr")]
-    #[cfg(target_endian = "little")]
     pub mod openexr;
     #[cfg(feature = "png")]
     pub mod png;


### PR DESCRIPTION
- [x] taken from the working big-endian CI in [exrs](https://github.com/johannesvollmer/exrs/blob/master/.github/workflows/rust.yml)
- [x] added all currently supported image formats to list of features tested in CI
- [x] use new version and re-enabled `exrs` for big endian architecture (tested on big-endian locally, compiles and passes)
- [x] openexr tests currently relies on hdr feature being turned on, but the ci features matrix only tests isolated features
- [ ] decide whether to also run doc tests & clippy and any of the other workflows for big endian systems
