### PR TITLE
Error when decoding unsupported animated webp, instead of panic

### DIFF
--- a/src/codecs/webp/decoder.rs
+++ b/src/codecs/webp/decoder.rs
@@ -322,6 +322,17 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for WebPDecoder<R> {
                 lossless_frame.fill_rgba(buf);
             }
             WebPImage::Extended(extended) => {
+                if !extended.is_supported_format() {
+                    use crate::error::*;
+                    let format_hint = ImageFormatHint::Exact(ImageFormat::WebP);
+                    return ImageResult::Err(
+                        ImageError::Unsupported(
+                        UnsupportedError::from_format_and_kind(
+                            format_hint.clone(),
+                            UnsupportedErrorKind::Format(format_hint),
+                        ),
+                    ));
+                }
                 extended.fill_buf(buf);
             }
         }

--- a/src/codecs/webp/extended.rs
+++ b/src/codecs/webp/extended.rs
@@ -332,7 +332,7 @@ impl ExtendedImage {
                 //will always have at least one frame
                 let first_fame = &frames[0];
                 //Currently only animated images where the canvas size matches the first frame size is supported
-                self.info.canvas_width  == first_fame.width && self.info.canvas_height == first_fame.height
+                self.info.canvas_width  == first_fame.width && self.info.canvas_height == first_fame.height && self.info.alpha == first_fame.use_alpha_blending
             }
             ExtendedImageData::Static(_) => true
         }

--- a/src/codecs/webp/extended.rs
+++ b/src/codecs/webp/extended.rs
@@ -325,6 +325,18 @@ impl ExtendedImage {
             ExtendedImageData::Static(image) => image.get_buf_size(),
         }
     }
+
+    pub(crate) fn is_supported_format(&self) -> bool{
+        match &self.image {
+            ExtendedImageData::Animation { frames, .. } => {
+                //will always have at least one frame
+                let first_fame = &frames[0];
+                //Currently only animated images where the canvas size matches the first frame size is supported
+                self.info.canvas_width  == first_fame.width && self.info.canvas_height == first_fame.height
+            }
+            ExtendedImageData::Static(_) => true
+        }
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This solves a panic that would happen if a frame was not the same height and width as the image info

This solves the following issue:
https://github.com/image-rs/image/issues/1775

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to chose either at their option.