### PR TITLE
Fix a deprecation message

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -265,7 +265,7 @@ pub trait Pixel: Copy + Clone {
     /// If the pixel does not contain 4 channels the extra are ignored.
     #[deprecated(
         since = "0.24.0",
-        note = "Use the constructor of the pixel, for example `Rgba::new(r,g,b,a)` or `Pixel::from_slice`"
+        note = "Use the constructor of the pixel, for example `Rgba([r,g,b,a])` or `Pixel::from_slice`"
     )]
     fn from_channels(
         a: Self::Subpixel,


### PR DESCRIPTION
There's no Rgba::new method. Fixes #1782

<!-- 
If you are a new contributor, consent to licensing by including this text:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to chose either at their option.

Thank you for contributing, you can delete this comment.
-->

