### PR TITLE
Fixing clippy warnings

### DIFF
--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -579,10 +579,8 @@ impl<W: Write> PngEncoder<W> {
         };
         let comp = match self.compression {
             CompressionType::Default => png::Compression::Default,
-            CompressionType::Fast => png::Compression::Fast,
             CompressionType::Best => png::Compression::Best,
-            CompressionType::Huffman => png::Compression::Huffman,
-            CompressionType::Rle => png::Compression::Rle,
+            _ => png::Compression::Fast,
         };
         let (filter, adaptive_filter) = match self.filter {
             FilterType::NoFilter => (

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -477,8 +477,10 @@ pub enum CompressionType {
     /// High compression level
     Best,
     /// Huffman coding compression
+    #[deprecated(note = "use one of the other compression levels instead, such as 'Fast'")]
     Huffman,
     /// Run-length encoding compression
+    #[deprecated(note = "use one of the other compression levels instead, such as 'Fast'")]
     Rle,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,6 +268,7 @@ mod utils;
 // Copyright (c) 2018 Guillaume Gomez
 macro_rules! insert_as_doc {
     { $content:expr } => {
+        #[allow(unused_doc_comments)]
         #[doc = $content] extern { }
     }
 }


### PR DESCRIPTION
Fixing clippy warnings:
- Allowed unused doc comments (not working on extern)
- Fixing deprecated enum usage in PNG compression

