### PR TITLE
Fix typos

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,8 @@
-<!-- 
+<!--
 If you are a new contributor, consent to licensing by including this text:
 
 I license past and future contributions under the dual MIT/Apache-2.0 license,
-allowing licensees to chose either at their option.
+allowing licensees to choose either at their option.
 
 Thank you for contributing, you can delete this comment.
 -->
-

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -411,7 +411,7 @@ formats, first. We'll get to color spaces in a later major version.
 - Changed color structs to tuple types with single component. Improves
   ergonomics of destructuring assignment and construction.
 - Add lifetime parameter on `ImageDecoder` trait.
-- Remove unecessary `'static` bounds on affine operations
+- Remove unnecessary `'static` bounds on affine operations
 - Add function to retrieve image dimensions without loading full image
 - Allow different image types in overlay and replace
 - Iterators over rows of `ImageBuffer`, mutable variants

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -53,7 +53,7 @@ pub struct Delay {
 }
 
 impl Frame {
-    /// Contructs a new frame without any delay.
+    /// Constructs a new frame without any delay.
     pub fn new(buffer: RgbaImage) -> Frame {
         Frame {
             delay: Delay::from_ratio(Ratio::from_integer(0)),
@@ -63,7 +63,7 @@ impl Frame {
         }
     }
 
-    /// Contructs a new frame
+    /// Constructs a new frame
     pub fn from_parts(buffer: RgbaImage, left: u32, top: u32, delay: Delay) -> Frame {
         Frame {
             delay,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -665,7 +665,7 @@ where
     P: Pixel,
     Container: Deref<Target = [P::Subpixel]>,
 {
-    /// Contructs a buffer from a generic container
+    /// Constructs a buffer from a generic container
     /// (for example a `Vec` or a slice)
     ///
     /// Returns `None` if the container is not big enough (including when the image dimensions
@@ -833,7 +833,7 @@ where
 
     /// Return the raw sample buffer with its stride an dimension information.
     ///
-    /// The returned buffer is guaranteed to be well formed in all cases. It is layed out by
+    /// The returned buffer is guaranteed to be well formed in all cases. It is laid out by
     /// colors, width then height, meaning `channel_stride <= width_stride <= height_stride`. All
     /// strides are in numbers of elements but those are mostly `u8` in which case the strides are
     /// also byte strides.

--- a/src/codecs/bmp/decoder.rs
+++ b/src/codecs/bmp/decoder.rs
@@ -270,7 +270,7 @@ fn num_bytes(width: i32, length: i32, channels: usize) -> Option<usize> {
 ///
 /// For images that specify large sizes, we don't allocate the full buffer right away
 /// to somewhat mitigate trying to make the decoder run out of memory by sending a bogus image.
-/// This is somewhat of a workaroud as ideally we would check against the expected file size
+/// This is somewhat of a workaround as ideally we would check against the expected file size
 /// but that's not possible through the Read and Seek traits alone and would require the encoder
 /// to provided with it from the caller.
 ///

--- a/src/codecs/dxt.rs
+++ b/src/codecs/dxt.rs
@@ -478,7 +478,7 @@ fn decode_dxt5_row(source: &[u8], dest: &mut [u8]) {
 /// Another way to perform this analysis would be to perform a
 /// singular value decomposition of the different colors, and
 /// then pick 2 points on this line as the base colors. But
-/// this is still rather unwieldly math and has issues
+/// this is still rather unwieldy math and has issues
 /// with the 3-linear-colors-and-0 case, it's also worse
 /// at conserving the original colors.
 ///

--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -183,7 +183,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for GifDecoder<R> {
             let frame_buffer = ImageBuffer::from_raw(frame.width, frame.height, frame_buffer);
             let image_buffer = ImageBuffer::from_raw(width, height, buf);
 
-            // `buffer_size` uses wrapping arithmetics, thus might not report the
+            // `buffer_size` uses wrapping arithmetic, thus might not report the
             // correct storage requirement if the result does not fit in `usize`.
             // `ImageBuffer::from_raw` detects overflow and reports by returning `None`.
             if frame_buffer.is_none() || image_buffer.is_none() {
@@ -272,7 +272,7 @@ impl<R: Read> Iterator for GifFrameIterator<R> {
         }
 
         // create the image buffer from the raw frame.
-        // `buffer_size` uses wrapping arithmetics, thus might not report the
+        // `buffer_size` uses wrapping arithmetic, thus might not report the
         // correct storage requirement if the result does not fit in `usize`.
         // on the other hand, `ImageBuffer::from_raw` detects overflow and
         // reports by returning `None`.

--- a/src/codecs/pnm/decoder.rs
+++ b/src/codecs/pnm/decoder.rs
@@ -1080,7 +1080,7 @@ ENDHDR
         }
     }
 
-    /// A previous inifite loop.
+    /// A previous infinite loop.
     #[test]
     fn pbm_binary_ascii_termination() {
         use std::io::{BufReader, Cursor, Error, ErrorKind, Read, Result};

--- a/src/codecs/pnm/encoder.rs
+++ b/src/codecs/pnm/encoder.rs
@@ -351,7 +351,7 @@ impl<'a> UncheckedHeader<'a> {
 
 impl<'a> CheckedDimensions<'a> {
     // Check color compatibility with the header. This will only error when we are certain that
-    // the comination is bogus (e.g. combining Pixmap and Palette) but allows uncertain
+    // the combination is bogus (e.g. combining Pixmap and Palette) but allows uncertain
     // combinations (basically a ArbitraryTuplType::Custom with any color of fitting depth).
     fn check_header_color(self, color: ExtendedColorType) -> ImageResult<CheckedHeaderColor<'a>> {
         let components = u32::from(color.channel_count());

--- a/src/codecs/pnm/mod.rs
+++ b/src/codecs/pnm/mod.rs
@@ -1,7 +1,7 @@
 //! Decoding of netpbm image formats (pbm, pgm, ppm and pam).
 //!
 //! The formats pbm, pgm and ppm are fully supported. The pam decoder recognizes the tuple types
-//! `BLACKANDWHITE`, `GRAYSCALE` and `RGB` and explicitely recognizes but rejects their `_ALPHA`
+//! `BLACKANDWHITE`, `GRAYSCALE` and `RGB` and explicitly recognizes but rejects their `_ALPHA`
 //! variants for now as alpha color types are unsupported.
 use self::autobreak::AutoBreak;
 pub use self::decoder::PnmDecoder;

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -140,7 +140,7 @@ impl SampleLayout {
     ///
     /// On platforms where `usize` has the same size as `u32` this panics when the resulting stride
     /// in the `height` direction would be larger than `usize::max_value()`. On other platforms
-    /// where it can surely accomodate `u8::max_value() * u32::max_value(), this can never happen.
+    /// where it can surely accommodate `u8::max_value() * u32::max_value(), this can never happen.
     pub fn row_major_packed(channels: u8, width: u32, height: u32) -> Self {
         let height_stride = (channels as usize).checked_mul(width as usize).expect(
             "Row major packed image can not be described because it does not fit into memory",
@@ -170,7 +170,7 @@ impl SampleLayout {
     ///
     /// On platforms where `usize` has the same size as `u32` this panics when the resulting stride
     /// in the `width` direction would be larger than `usize::max_value()`. On other platforms
-    /// where it can surely accomodate `u8::max_value() * u32::max_value(), this can never happen.
+    /// where it can surely accommodate `u8::max_value() * u32::max_value(), this can never happen.
     pub fn column_major_packed(channels: u8, width: u32, height: u32) -> Self {
         let width_stride = (channels as usize).checked_mul(height as usize).expect(
             "Column major packed image can not be described because it does not fit into memory",
@@ -384,7 +384,7 @@ impl SampleLayout {
     ///
     /// An in-bound coordinate does not yet guarantee that the corresponding calculation of a
     /// buffer index does not overflow. However, if such a buffer large enough to hold all samples
-    /// actually exists in memory, this porperty of course follows.
+    /// actually exists in memory, this property of course follows.
     pub fn in_bounds(&self, channel: u8, x: u32, y: u32) -> bool {
         channel < self.channels && x < self.width && y < self.height
     }
@@ -870,7 +870,7 @@ impl<Buffer> FlatSamples<Buffer> {
     ///
     /// An in-bound coordinate does not yet guarantee that the corresponding calculation of a
     /// buffer index does not overflow. However, if such a buffer large enough to hold all samples
-    /// actually exists in memory, this porperty of course follows.
+    /// actually exists in memory, this property of course follows.
     pub fn in_bounds(&self, channel: u8, x: u32, y: u32) -> bool {
         self.layout.in_bounds(channel, x, y)
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -470,7 +470,7 @@ where
 
     {
         // Read a range of the image starting from byte number `start` and continuing until byte
-        // number `end`. Updates `current_scanline` and `bytes_read` appropiately.
+        // number `end`. Updates `current_scanline` and `bytes_read` appropriately.
         let mut read_image_range = |mut start: u64, end: u64| -> ImageResult<()> {
             // If the first scanline we need is already stored in the temporary buffer, then handle
             // it first.
@@ -638,7 +638,7 @@ pub trait ImageDecoder<'a>: Sized {
     /// Returns the color type of the image data produced by this decoder
     fn color_type(&self) -> ColorType;
 
-    /// Retuns the color type of the image file before decoding
+    /// Returns the color type of the image file before decoding
     fn original_color_type(&self) -> ExtendedColorType {
         self.color_type().into()
     }
@@ -797,7 +797,7 @@ pub trait ImageEncoder {
     /// This function takes a slice of bytes of the pixel data of the image
     /// and encodes them. Unlike particular format encoders inherent impl encode
     /// methods where endianness is not specified, here image data bytes should
-    /// always be in native endian. The implementor will reorder the endianess
+    /// always be in native endian. The implementor will reorder the endianness
     /// as necessary for the target encoding format.
     ///
     /// See also `ImageDecoder::read_image` which reads byte buffers into

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -474,7 +474,7 @@ mod tests {
     }
 
     #[test]
-    /// Test blur doens't panick when passed 0.0
+    /// Test blur doesn't panick when passed 0.0
     fn test_blur_zero() {
         let image = RgbaImage::new(50, 50);
         let _ = super::blur(&image, 0.0);

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -110,7 +110,7 @@ struct FloatNearest(f32);
 // to_i64, to_u64, and to_f64 implicitly affect all other lower conversions.
 // Note that to_f64 by default calls to_i64 and thus needs to be overridden.
 impl ToPrimitive for FloatNearest {
-    // to_{i,u}64 is required, to_{i,u}{8,16} are usefull.
+    // to_{i,u}64 is required, to_{i,u}{8,16} are useful.
     // If a usecase for full 32 bits is found its trivial to add
     fn to_i8(&self) -> Option<i8> {
         self.0.round().to_i8()

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -52,7 +52,7 @@ pub struct Limits {
     pub max_image_width: Option<u32>,
     /// The maximum allowed image height. This limit is strict. The default is no limit.
     pub max_image_height: Option<u32>,
-    /// The maximum allowed sum of allocations allocated by the decoder at any one time exluding
+    /// The maximum allowed sum of allocations allocated by the decoder at any one time excluding
     /// allocator overhead. This limit is non-strict by default and some decoders may ignore it.
     /// The default is 512MiB.
     pub max_alloc: Option<u64>,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -31,7 +31,7 @@ where
 }
 
 /// Expand a buffer of packed 1, 2, or 4 bits integers into u8's. Assumes that
-/// every `row_size` entries there are padding bits up to the next byte boundry.
+/// every `row_size` entries there are padding bits up to the next byte boundary.
 #[allow(dead_code)]
 // When no image formats that use it are enabled
 pub(crate) fn expand_bits(bit_depth: u8, row_size: u32, buf: &[u8]) -> Vec<u8> {


### PR DESCRIPTION
Found via `codespell -L crate,alph,numer,nd,readed,ect,paeth,clen`

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.

