### PR TITLE
Add Rgb64FImage and Rgba64FImage

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1401,6 +1401,14 @@ pub type Rgb32FImage = ImageBuffer<Rgb<f32>, Vec<f32>>;
 /// where the backing container is a flattened vector of floats.
 pub type Rgba32FImage = ImageBuffer<Rgba<f32>, Vec<f32>>;
 
+/// An image buffer for 64-bit float RGB pixels,
+/// where the backing container is a flattened vector of floats.
+pub type Rgb64FImage = ImageBuffer<Rgb<f64>, Vec<f64>>;
+
+/// An image buffer for 64-bit float RGBA pixels,
+/// where the backing container is a flattened vector of floats.
+pub type Rgba64FImage = ImageBuffer<Rgba<f64>, Vec<f64>>;
+
 #[cfg(test)]
 mod test {
     use super::{GrayImage, ImageBuffer, ImageOutputFormat, RgbImage};

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -10,7 +10,10 @@ use crate::codecs::png;
 #[cfg(feature = "pnm")]
 use crate::codecs::pnm;
 
-use crate::buffer_::{ConvertBuffer, Gray16Image, GrayAlpha16Image, GrayAlphaImage, GrayImage, ImageBuffer, Rgb16Image, RgbImage, Rgba16Image, RgbaImage};
+use crate::buffer_::{
+    ConvertBuffer, Gray16Image, GrayAlpha16Image, GrayAlphaImage, GrayImage, ImageBuffer,
+    Rgb16Image, RgbImage, Rgba16Image, RgbaImage,
+};
 use crate::color::{self, IntoColor};
 use crate::error::{ImageError, ImageResult, ParameterError, ParameterErrorKind};
 // FIXME: These imports exist because we don't support all of our own color types.
@@ -22,7 +25,7 @@ use crate::io::free_functions;
 use crate::math::resize_dimensions;
 use crate::traits::Pixel;
 use crate::{image, Luma, LumaA};
-use crate::{Rgb32FImage, Rgba32FImage, Rgb64FImage, Rgba64FImage};
+use crate::{Rgb32FImage, Rgb64FImage, Rgba32FImage, Rgba64FImage};
 
 /// A Dynamic Image
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,8 +128,10 @@ pub use crate::buffer_::{
     // Image types
     ImageBuffer,
     Rgb32FImage,
+    Rgb64FImage,
     RgbImage,
     Rgba32FImage,
+    Rgba64FImage,
     RgbaImage,
 };
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -32,6 +32,12 @@ impl EncodableLayout for [f32] {
     }
 }
 
+impl EncodableLayout for [f64] {
+    fn as_bytes(&self) -> &[u8] {
+        bytemuck::cast_slice(self)
+    }
+}
+
 /// The type of each channel in a pixel. For example, this can be `u8`, `u16`, `f32`.
 // TODO rename to `PixelComponent`? Split up into separate traits? Seal?
 pub trait Primitive: Copy + NumCast + Num + PartialOrd<Self> + Clone + Bounded {
@@ -185,6 +191,9 @@ impl PixelWithColorType for Rgb<u16> {
 impl PixelWithColorType for Rgb<f32> {
     const COLOR_TYPE: ColorType = ColorType::Rgb32F;
 }
+impl PixelWithColorType for Rgb<f64> {
+    const COLOR_TYPE: ColorType = ColorType::Rgb64F;
+}
 
 impl PixelWithColorType for Rgba<u8> {
     const COLOR_TYPE: ColorType = ColorType::Rgba8;
@@ -194,6 +203,9 @@ impl PixelWithColorType for Rgba<u16> {
 }
 impl PixelWithColorType for Rgba<f32> {
     const COLOR_TYPE: ColorType = ColorType::Rgba32F;
+}
+impl PixelWithColorType for Rgba<f64> {
+    const COLOR_TYPE: ColorType = ColorType::Rgba64F;
 }
 
 impl PixelWithColorType for Luma<u8> {
@@ -217,10 +229,12 @@ mod private {
     impl SealedPixelWithColorType for Rgb<u8> {}
     impl SealedPixelWithColorType for Rgb<u16> {}
     impl SealedPixelWithColorType for Rgb<f32> {}
+    impl SealedPixelWithColorType for Rgb<f64> {}
 
     impl SealedPixelWithColorType for Rgba<u8> {}
     impl SealedPixelWithColorType for Rgba<u16> {}
     impl SealedPixelWithColorType for Rgba<f32> {}
+    impl SealedPixelWithColorType for Rgba<f64> {}
 
     impl SealedPixelWithColorType for Luma<u8> {}
     impl SealedPixelWithColorType for LumaA<u8> {}
@@ -367,4 +381,5 @@ mod seals {
     impl EncodableLayout for [u8] {}
     impl EncodableLayout for [u16] {}
     impl EncodableLayout for [f32] {}
+    impl EncodableLayout for [f64] {}
 }


### PR DESCRIPTION
I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to choose either at their option.