### PR TITLE
Dev

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Rust image aims to be a pure-Rust implementation of various popular image format
 
 ### Unreleased
 
+- The `as_rgb32f` function of `DynamicImage` is now correctly documented
 - More convenient to use buffers will be added in the future. In particular,
   improving initialization, passing of output buffers, and adding a more
   complete representation for layouts. The plan is for these to interact with

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -454,7 +454,7 @@ impl DynamicImage {
         }
     }
 
-    /// Return a reference to an 16bit RGB image
+    /// Return a reference to an 32bit RGB image
     pub fn as_rgb32f(&self) -> Option<&Rgb32FImage> {
         match *self {
             DynamicImage::ImageRgb32F(ref p) => Some(p),


### PR DESCRIPTION
Simple fix to #1764 issue.

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.
