### PR TITLE
Add PngDecoder::with_limits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ num-rational = { version = "0.4", default-features = false }
 num-traits = "0.2.0"
 gif = { version = "0.11.1", optional = true }
 jpeg = { package = "jpeg-decoder", version = "0.2.1", default-features = false, optional = true }
-png = { version = "0.17.0", optional = true }
+png = { version = "0.17.6", optional = true }
 scoped_threadpool = { version = "0.1", optional = true }
 tiff = { version = "0.7.1", optional = true }
 ravif = { version = "0.8.0", optional = true }


### PR DESCRIPTION
This isn't the most elegant solution given that other decoders use `ImageDecoder::set_limits`, but idiosyncrasies of the PNG format make that interface non-ideal. Specifically, finding out whether the image is animated (contains an acTL chunk) or has a "simple alpha channel" (contains a tRNS chunk) potentially requires scanning a nearly unbounded number of chunks. Worse, we currently don't have a Seek bound on the reader, so we have to _store_ all the chunks we read in case we need them later.

Fixes #1788