### PR TITLE
Check dimensions of dynamic image before resizing it

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -668,7 +668,7 @@ impl DynamicImage {
             return self.clone();
         }
         let (width2, height2) =
-        resize_dimensions(self.width(), self.height(), nwidth, nheight, false);
+            resize_dimensions(self.width(), self.height(), nwidth, nheight, false);
 
         self.resize_exact(width2, height2, filter)
     }

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -658,22 +658,17 @@ impl DynamicImage {
     }
 
     /// Resize this image using the specified filter algorithm.
+    /// Returns a new image. The image's aspect ratio is preserved.
     /// The image is scaled to the maximum possible size that fits
     /// within the bounds specified by `nwidth` and `nheight`.
-    /// The image's aspect ratio is preserved.
-    /// Returns a new image if the requested image size is different than the already existing one.
-    /// Otherwise the function returns a copy of self.
     pub fn resize(&self, nwidth: u32, nheight: u32, filter: imageops::FilterType) -> DynamicImage {
         if (nwidth, nheight) == self.dimensions() {
-            // Image is already in the desired dimensions --> no need to resize.
             return self.clone();
         }
-        else {
-            let (width2, height2) =
-            resize_dimensions(self.width(), self.height(), nwidth, nheight, false);
+        let (width2, height2) =
+        resize_dimensions(self.width(), self.height(), nwidth, nheight, false);
 
-            return self.resize_exact(width2, height2, filter);
-        }
+        self.resize_exact(width2, height2, filter)
     }
 
     /// Resize this image using the specified filter algorithm.

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -658,14 +658,22 @@ impl DynamicImage {
     }
 
     /// Resize this image using the specified filter algorithm.
-    /// Returns a new image. The image's aspect ratio is preserved.
     /// The image is scaled to the maximum possible size that fits
     /// within the bounds specified by `nwidth` and `nheight`.
+    /// The image's aspect ratio is preserved.
+    /// Returns a new image if the requested image size is different than the already existing one.
+    /// Otherwise the function returns a copy of self.
     pub fn resize(&self, nwidth: u32, nheight: u32, filter: imageops::FilterType) -> DynamicImage {
-        let (width2, height2) =
+        if (nwidth, nheight) == self.dimensions() {
+            // Image is already in the desired dimensions --> no need to resize.
+            return self.clone();
+        }
+        else {
+            let (width2, height2) =
             resize_dimensions(self.width(), self.height(), nwidth, nheight, false);
 
-        self.resize_exact(width2, height2, filter)
+            return self.resize_exact(width2, height2, filter);
+        }
     }
 
     /// Resize this image using the specified filter algorithm.


### PR DESCRIPTION
Should fix the issue: https://github.com/image-rs/image/issues/1738

Not super happy with it since I'm cloning self but I didn't want to change the return type to &DynamicImage e.g.
Let me know if you have a better idea on how to make this more efficient :)
