### PR TITLE
Changes and release notes for 0.24.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,6 @@ Rust image aims to be a pure-Rust implementation of various popular image format
 
 ### Unreleased
 
-- The `as_rgb32f` function of `DynamicImage` is now correctly documented
 - More convenient to use buffers will be added in the future. In particular,
   improving initialization, passing of output buffers, and adding a more
   complete representation for layouts. The plan is for these to interact with
@@ -19,6 +18,32 @@ Rust image aims to be a pure-Rust implementation of various popular image format
   `ImageDecoder`.
   See ongoing work on [`image-canvas`](https://github.com/image-rs/canvas) if
   you want to participate.
+
+### Version 0.24.5
+
+Structural changes:
+- Increased the minimum supported Rust version (MSRV) to 1.61.
+- Increased the version requirement for the `tiff` crate to 0.8.0.
+- Increased the version requirement for the `jpeg` crate to 0.3.0.
+
+Bug fixes:
+- The `as_rgb32f` function of `DynamicImage` is now correctly documented.
+- Fixed a crash when decoding ICO images. Added a regression test.
+- Fixed a panic when transforming webp images. Added a regression test.
+- Added a check to prevent integer overflow when calculating file size for BMP
+  images. The missing check could panic in debug mode or else set an incorrect
+  file size in release mode.
+- Upgraded the PNG image encoder to use the newer `PngEncoder::write_image`
+  instead of the deprecated `PngEncoder::encode` which did not account for byte
+  order and could result in images with incorrect colors.
+- Fixed `InsufficientMemory` error when trying to decode a PNG image.
+- Fix warnings and CI issues.
+- Typos and links in the documentation have been corrected.
+
+Performance:
+- Added check for dynamic image dimensions before resizing. This improves
+  performance in cases where the image does not need to be resized or has
+  already been resized.
 
 ### Version 0.24.4
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "image"
-version = "0.24.4"
+version = "0.24.5"
 edition = "2018"
 resolver = "2"
 
@@ -38,7 +38,7 @@ gif = { version = "0.11.1", optional = true }
 jpeg = { package = "jpeg-decoder", version = "0.3.0", default-features = false, optional = true }
 png = { version = "0.17.6", optional = true }
 scoped_threadpool = { version = "0.1", optional = true }
-tiff = { version = "0.7.1", optional = true }
+tiff = { version = "0.8.0", optional = true }
 ravif = { version = "0.8.0", optional = true }
 rgb = { version = "0.8.25", optional = true }
 mp4parse = { version = "0.12.0", optional = true }


### PR DESCRIPTION
I hope this isn't too forward.  I am eager to get panic fixes in the tiff and jpeg crates, as well as the unpublished fixes in this crate. 

Based on these lines in CHANGES.md, I bumped the minor/patch version instead of the major version:
https://github.com/image-rs/image/blob/d026f701b603b9781cd33954fe05b1b6da5ee785/CHANGES.md?plain=1#L75-L76 

So, 0.24.5 instead of 0.25.0.

Also increase the version requirement for
- `tiff` to 0.8.0
- `jpeg` to 0.3.0

I believe I may be a first time contributor for this crate and from my personal email/computer, so:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.
