### PR TITLE
Bump the 'jpeg' version requirement to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ byteorder = "1.3.2"
 num-rational = { version = "0.4", default-features = false }
 num-traits = "0.2.0"
 gif = { version = "0.11.1", optional = true }
-jpeg = { package = "jpeg-decoder", version = "0.2.1", default-features = false, optional = true }
+jpeg = { package = "jpeg-decoder", version = "0.3.0", default-features = false, optional = true }
 png = { version = "0.17.6", optional = true }
 scoped_threadpool = { version = "0.1", optional = true }
 tiff = { version = "0.7.1", optional = true }
@@ -56,7 +56,7 @@ quickcheck = "1"
 criterion = "0.3"
 # Keep this in sync with the jpeg dependency above. This is used to enable the platform_independent
 # feature when testing, so `cargo test` works correctly.
-jpeg = { package = "jpeg-decoder", version = "0.2.1", default-features = false, features = ["platform_independent"] }
+jpeg = { package = "jpeg-decoder", version = "0.3.0", default-features = false, features = ["platform_independent"] }
 
 [features]
 # TODO: Add "avif" to this list while preparing for 0.24.0


### PR DESCRIPTION
Per @HeroicKatora 
> It seems like jpeg had some incompatible changes in this version bump.

Reviewing separately from https://github.com/image-rs/image/pull/1819/