### PR TITLE
Remove exception for old flate2 version

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -26,7 +26,6 @@ wildcards = "allow" # at least until https://github.com/EmbarkStudios/cargo-deny
 deny = []
 skip = []
 skip-tree = [
-    { name = "flate2", version = "=1.0.24" }, # until a new version is published
     { name = "criterion" },  # dev-dependency
     { name = "quickcheck" }, # dev-dependency
 ]


### PR DESCRIPTION
The skip-tree entry should no longer be needed.