### PR TITLE
Support ICO files with dimensions larger than 256

### DIFF
--- a/src/codecs/ico/decoder.rs
+++ b/src/codecs/ico/decoder.rs
@@ -231,7 +231,8 @@ impl DirEntry {
     }
 
     fn matches_dimensions(&self, width: u32, height: u32) -> bool {
-        u32::from(self.real_width()) == width && u32::from(self.real_height()) == height
+        u32::from(self.real_width()) == width.min(256)
+            && u32::from(self.real_height()) == height.min(256)
     }
 
     fn seek_to_start<R: Read + Seek>(&self, r: &mut R) -> ImageResult<()> {


### PR DESCRIPTION
[Wikipedia claims](https://en.wikipedia.org/wiki/ICO_(file_format)#Structure_of_image_directory) that a value of 0 for the width or height in an image directory means 256 _or more_. This crate previously assumed it meant exactly 256. If anyone knows of a more definitive spec reference, that would be nice to include.

Fixes #1836 