### PR TITLE
AVIF encoder changes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ jpeg = { package = "jpeg-decoder", version = "0.3.0", default-features = false, 
 png = { version = "0.17.6", optional = true }
 scoped_threadpool = { version = "0.1", optional = true }
 tiff = { version = "0.8.0", optional = true }
-ravif = { version = "0.8.0", optional = true }
+ravif = { version = "0.11.0", optional = true }
 rgb = { version = "0.8.25", optional = true }
 mp4parse = { version = "0.12.0", optional = true }
 dav1d = { version = "0.6.0", optional = true }


### PR DESCRIPTION
As noted in #1760, AVIF encoding is very slow. In looking at _why_, I noticed that the default encoder settings are very different from what the `cavif` CLI provided by upstream uses - in particular, upstream documentation suggests that a quality setting of 100 is not a useful configuration.

The majority of the changes here are to upgrade the `ravif` dependency. The images I was using for testing appear to compress _significantly_ better using the new version.

The project requests this statement to be made:

> I license past and future contributions under the dual MIT/Apache-2.0 license,
> allowing licensees to choose either at their option.

I would like to add that I do not believe the changes in question to be significant enough to warrant copyright.