### PR TITLE
Consistent definition of Rgba

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The most important methods for decoders are...
 
 `image` provides the following pixel types:
 + **Rgb**: RGB pixel
-+ **Rgba**: RGBA pixel
++ **Rgba**: RGB with alpha (RGBA pixel)
 + **Luma**: Grayscale pixel
 + **LumaA**: Grayscale with alpha
 


### PR DESCRIPTION
Proposing a change to make `Rgba` type definition similar to how `LumaA` is defined. It makes it easier to distinguish the difference with `Rgb` type.

<!--
If you are a new contributor, consent to licensing by including this text:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.

Thank you for contributing, you can delete this comment.
-->

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.