### PR TITLE
expand on documentation for ImageOutputFormat::Jpeg quality

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -273,7 +273,7 @@ pub enum ImageOutputFormat {
     Png,
 
     #[cfg(feature = "jpeg")]
-    /// An Image in JPEG Format with specified quality
+    /// An Image in JPEG Format with specified quality, up to 100
     Jpeg(u8),
 
     #[cfg(feature = "pnm")]


### PR DESCRIPTION
Hey, this is my first contribution here!

It took me some trial and error to realise that the JPEG output quality is clamped at 100 and not scaled from the u8 max of 255. Thought that expanding on the documentation here might be useful. Any suggestions for better wording would be great.

Cheers!

---

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.