### PR TITLE
Improve performance of grayscale function and better clone standards

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -629,27 +629,24 @@ impl DynamicImage {
     pub fn grayscale(&self) -> DynamicImage {
         match *self {
             DynamicImage::ImageLuma8(ref p) => DynamicImage::ImageLuma8(p.clone()),
-            DynamicImage::ImageLumaA8(ref p) => {
-                DynamicImage::ImageLumaA8(imageops::grayscale_alpha(p))
-            }
-            DynamicImage::ImageRgb8(ref p) => DynamicImage::ImageLuma8(imageops::grayscale(p)),
-            DynamicImage::ImageRgba8(ref p) => {
-                DynamicImage::ImageLumaA8(imageops::grayscale_alpha(p))
-            }
+
+            DynamicImage::ImageLumaA8(ref p) => DynamicImage::ImageLumaA8(p.clone()),
+
+            DynamicImage::ImageRgb8(_) => dynamic_map!(*self, |ref p| DynamicImage::ImageLuma8(p.convert())), 
+
+            DynamicImage::ImageRgba8(_) => dynamic_map!(*self, |ref p| DynamicImage::ImageLumaA8(p.convert())),
+
             DynamicImage::ImageLuma16(ref p) => DynamicImage::ImageLuma16(p.clone()),
-            DynamicImage::ImageLumaA16(ref p) => {
-                DynamicImage::ImageLumaA16(imageops::grayscale_alpha(p))
-            }
-            DynamicImage::ImageRgb16(ref p) => DynamicImage::ImageLuma16(imageops::grayscale(p)),
-            DynamicImage::ImageRgba16(ref p) => {
-                DynamicImage::ImageLumaA16(imageops::grayscale_alpha(p))
-            }
-            DynamicImage::ImageRgb32F(ref p) => {
-                DynamicImage::ImageRgb32F(imageops::grayscale_with_type(p))
-            }
-            DynamicImage::ImageRgba32F(ref p) => {
-                DynamicImage::ImageRgba32F(imageops::grayscale_with_type_alpha(p))
-            }
+
+            DynamicImage::ImageLumaA16(ref p) => DynamicImage::ImageLumaA16(p.clone()),
+
+            DynamicImage::ImageRgb16(_) => dynamic_map!(*self, |ref p| DynamicImage::ImageLuma16(p.convert())),
+
+            DynamicImage::ImageRgba16(_) => dynamic_map!(*self, |ref p| DynamicImage::ImageLumaA16(p.convert())),
+
+            DynamicImage::ImageRgb32F(ref p) => DynamicImage::ImageRgb32F(imageops::grayscale_with_type(p)),
+
+            DynamicImage::ImageRgba32F(ref p) => DynamicImage::ImageRgba32F(imageops::grayscale_with_type_alpha(p)),
         }
     }
 


### PR DESCRIPTION
Hey! I was working with your library and found out that the grayscale function was too slow, specially, compared to the examples you use, for example:
`DynamicImage::ImageLuma8(image.into_luma8());`

After some investigation I found the issue inside the grayscale function, when using the code above there's a call to the dynamic map function which works much faster than the imageops::grayscale generic function.

I also changed a few unneeded conversions to just clone since the type is already the same (in this case for example ImageLumaA8 was being converted with imageops even though it's not needed)

After those changes the DynamicImage grayscale function is now faster than the example code above.

Pictures proving the new grayscale is faster: 

Old performance:
![OldPerformance](https://user-images.githubusercontent.com/14263211/213161500-c1cd7dae-0574-4791-bfb2-c4c3db8b0fff.png)

New performance:
![NewPerformance](https://user-images.githubusercontent.com/14263211/213161516-9c886d26-8e2f-4632-bb28-35cc1bc3c3a7.png)


Edit: Forgot to remove comment from license agreement

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.