### PR TITLE
feat: add PixelWithColorType for Luma<f32> and LumaA<f32>

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -26,6 +26,10 @@ pub enum ColorType {
     /// Pixel is 16-bit RGBA
     Rgba16,
 
+    /// Pixel is 8-bit luminance
+    L32F,
+    /// Pixel is 8-bit luminance with an alpha channel
+    La32F,
     /// Pixel is 32-bit float RGB
     Rgb32F,
     /// Pixel is 32-bit float RGBA
@@ -42,6 +46,8 @@ impl ColorType {
             ColorType::Rgba8 | ColorType::La16 => 4,
             ColorType::Rgb16 => 6,
             ColorType::Rgba16 => 8,
+            ColorType::L32F => 1 * 4,
+            ColorType::La32F => 2 * 4,
             ColorType::Rgb32F => 3 * 4,
             ColorType::Rgba32F => 4 * 4,
         }
@@ -51,8 +57,8 @@ impl ColorType {
     pub fn has_alpha(self) -> bool {
         use ColorType::*;
         match self {
-            L8 | L16 | Rgb8 | Rgb16 | Rgb32F => false,
-            La8 | Rgba8 | La16 | Rgba16 | Rgba32F => true,
+            L8 | L16 | L32F | Rgb8 | Rgb16 | Rgb32F => false,
+            La8 | Rgba8 | La16 | Rgba16 | La32F | Rgba32F => true,
         }
     }
 
@@ -60,7 +66,7 @@ impl ColorType {
     pub fn has_color(self) -> bool {
         use ColorType::*;
         match self {
-            L8 | L16 | La8 | La16 => false,
+            L8 | L16 | La8 | La16 | L32F | La32F => false,
             Rgb8 | Rgb16 | Rgba8 | Rgba16 | Rgb32F | Rgba32F => true,
         }
     }
@@ -137,6 +143,10 @@ pub enum ExtendedColorType {
     Bgra8,
 
     // TODO f16 types?
+    /// Pixel is 16-bit luminance
+    L32F,
+    /// Pixel is 16-bit luminance with an alpha channel
+    La32F,
     /// Pixel is 32-bit float RGB
     Rgb32F,
     /// Pixel is 32-bit float RGBA
@@ -161,12 +171,14 @@ impl ExtendedColorType {
             | ExtendedColorType::L4
             | ExtendedColorType::L8
             | ExtendedColorType::L16
+            | ExtendedColorType::L32F
             | ExtendedColorType::Unknown(_) => 1,
             ExtendedColorType::La1
             | ExtendedColorType::La2
             | ExtendedColorType::La4
             | ExtendedColorType::La8
-            | ExtendedColorType::La16 => 2,
+            | ExtendedColorType::La16
+            | ExtendedColorType::La32F => 2,
             ExtendedColorType::Rgb1
             | ExtendedColorType::Rgb2
             | ExtendedColorType::Rgb4
@@ -195,6 +207,8 @@ impl From<ColorType> for ExtendedColorType {
             ColorType::La16 => ExtendedColorType::La16,
             ColorType::Rgb16 => ExtendedColorType::Rgb16,
             ColorType::Rgba16 => ExtendedColorType::Rgba16,
+            ColorType::L32F => ExtendedColorType::L32F,
+            ColorType::La32F => ExtendedColorType::La32F,
             ColorType::Rgb32F => ExtendedColorType::Rgb32F,
             ColorType::Rgba32F => ExtendedColorType::Rgba32F,
         }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -202,11 +202,18 @@ impl PixelWithColorType for Luma<u8> {
 impl PixelWithColorType for Luma<u16> {
     const COLOR_TYPE: ColorType = ColorType::L16;
 }
+impl PixelWithColorType for Luma<f32> {
+    const COLOR_TYPE: ColorType = ColorType::L32F;
+}
+
 impl PixelWithColorType for LumaA<u8> {
     const COLOR_TYPE: ColorType = ColorType::La8;
 }
 impl PixelWithColorType for LumaA<u16> {
     const COLOR_TYPE: ColorType = ColorType::La16;
+}
+impl PixelWithColorType for LumaA<f32> {
+    const COLOR_TYPE: ColorType = ColorType::La32F;
 }
 
 /// Prevents down-stream users from implementing the `Primitive` trait
@@ -223,10 +230,12 @@ mod private {
     impl SealedPixelWithColorType for Rgba<f32> {}
 
     impl SealedPixelWithColorType for Luma<u8> {}
-    impl SealedPixelWithColorType for LumaA<u8> {}
-
     impl SealedPixelWithColorType for Luma<u16> {}
+    impl SealedPixelWithColorType for Luma<f32> {}
+
+    impl SealedPixelWithColorType for LumaA<u8> {}
     impl SealedPixelWithColorType for LumaA<u16> {}
+    impl SealedPixelWithColorType for LumaA<f32> {}
 }
 
 /// A generalized pixel.


### PR DESCRIPTION
This PR merely includes these two types:
 - ``Luma<f32>``
 - ``LumaA<f32>``

Motivating use-case:

```
image::flat::FlatSamples { ... }.as_view::<image::Luma<f32>>()
```

Single channel floating point images are pretty common, e.g. in computer vision. LumaA<f32> is mainly added for symmetry - but there are some more niche use-cases too (e.g. flow field representation).

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.