### PR TITLE
feat: less restrictive FlatSamples layout - 

### DIFF
--- a/src/flat.rs
+++ b/src/flat.rs
@@ -53,7 +53,7 @@ use crate::error::{
     UnsupportedError, UnsupportedErrorKind,
 };
 use crate::image::{GenericImage, GenericImageView};
-use crate::traits::{Pixel, PixelWithColorType};
+use crate::traits::Pixel;
 use crate::ImageBuffer;
 
 /// A flat buffer over a (multi channel) image.
@@ -593,11 +593,14 @@ impl<Buffer> FlatSamples<Buffer> {
     /// There is no automatic conversion.
     pub fn as_view<P>(&self) -> Result<View<&[P::Subpixel], P>, Error>
     where
-        P: PixelWithColorType,
+        P: Pixel,
         Buffer: AsRef<[P::Subpixel]>,
     {
         if self.layout.channels != P::CHANNEL_COUNT {
-            return Err(Error::WrongColor(P::COLOR_TYPE));
+            return Err(Error::ChannelCountMismatch(
+                self.layout.channels,
+                P::CHANNEL_COUNT,
+            ));
         }
 
         let as_ref = self.samples.as_ref();
@@ -632,11 +635,14 @@ impl<Buffer> FlatSamples<Buffer> {
     /// intended.
     pub fn as_view_with_mut_samples<P>(&mut self) -> Result<View<&mut [P::Subpixel], P>, Error>
     where
-        P: PixelWithColorType,
+        P: Pixel,
         Buffer: AsMut<[P::Subpixel]>,
     {
         if self.layout.channels != P::CHANNEL_COUNT {
-            return Err(Error::WrongColor(P::COLOR_TYPE));
+            return Err(Error::ChannelCountMismatch(
+                self.layout.channels,
+                P::CHANNEL_COUNT,
+            ));
         }
 
         let as_mut = self.samples.as_mut();
@@ -667,7 +673,7 @@ impl<Buffer> FlatSamples<Buffer> {
     /// `ImageBuffer::from_raw`.
     pub fn as_view_mut<P>(&mut self) -> Result<ViewMut<&mut [P::Subpixel], P>, Error>
     where
-        P: PixelWithColorType,
+        P: Pixel,
         Buffer: AsMut<[P::Subpixel]>,
     {
         if !self.layout.is_normal(NormalForm::PixelPacked) {
@@ -675,7 +681,10 @@ impl<Buffer> FlatSamples<Buffer> {
         }
 
         if self.layout.channels != P::CHANNEL_COUNT {
-            return Err(Error::WrongColor(P::COLOR_TYPE));
+            return Err(Error::ChannelCountMismatch(
+                self.layout.channels,
+                P::CHANNEL_COUNT,
+            ));
         }
 
         let as_mut = self.samples.as_mut();
@@ -762,7 +771,7 @@ impl<Buffer> FlatSamples<Buffer> {
     /// not release any allocation.
     pub fn try_into_buffer<P>(self) -> Result<ImageBuffer<P, Buffer>, (Error, Self)>
     where
-        P: PixelWithColorType + 'static,
+        P: Pixel + 'static,
         P::Subpixel: 'static,
         Buffer: Deref<Target = [P::Subpixel]>,
     {
@@ -771,7 +780,10 @@ impl<Buffer> FlatSamples<Buffer> {
         }
 
         if self.layout.channels != P::CHANNEL_COUNT {
-            return Err((Error::WrongColor(P::COLOR_TYPE), self));
+            return Err((
+                Error::ChannelCountMismatch(self.layout.channels, P::CHANNEL_COUNT),
+                self,
+            ));
         }
 
         if !self.fits(self.samples.deref().len()) {
@@ -1026,6 +1038,9 @@ pub enum Error {
     /// directly memory unsafe although that will likely alias pixels. One scenario is when you
     /// want to construct an `Rgba` image but have only 3 bytes per pixel and for some reason don't
     /// care about the value of the alpha channel even though you need `Rgba`.
+    ChannelCountMismatch(u8, u8),
+   
+    /// Deprecated - ChannelCountMismatch is used instead
     WrongColor(ColorType),
 }
 
@@ -1493,6 +1508,9 @@ impl From<Error> for ImageError {
                 ImageFormatHint::Unknown,
                 NormalFormRequiredError(form),
             )),
+            Error::ChannelCountMismatch(_lc, _pc) => ImageError::Parameter(
+                ParameterError::from_kind(ParameterErrorKind::DimensionMismatch),
+            ),
             Error::WrongColor(color) => {
                 ImageError::Unsupported(UnsupportedError::from_format_and_kind(
                     ImageFormatHint::Unknown,
@@ -1517,6 +1535,11 @@ impl fmt::Display for Error {
                     NormalForm::RowMajorPacked => "be packed and in row major form",
                     NormalForm::Unaliased => "not have any aliasing channels",
                 }
+            ),
+            Error::ChannelCountMismatch(layout_channels, pixel_channels) => write!(
+                f,
+                "The channel count of the chosen pixel (={}) does agree with the layout (={})",
+                pixel_channels, layout_channels
             ),
             Error::WrongColor(color) => write!(
                 f,

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -1039,7 +1039,7 @@ pub enum Error {
     /// want to construct an `Rgba` image but have only 3 bytes per pixel and for some reason don't
     /// care about the value of the alpha channel even though you need `Rgba`.
     ChannelCountMismatch(u8, u8),
-   
+
     /// Deprecated - ChannelCountMismatch is used instead
     WrongColor(ColorType),
 }


### PR DESCRIPTION
Just require Pixel and not PixelWithColorType to create views etc.

At first glance - the PixelWithColorType seems overly restrictive and the trait is merely used here to populate the Error::WrongColor return on failure. 


Test seems to pass:

```
running 36 tests
test src/buffer.rs - buffer_::ImageBuffer (line 648) - compile ... ok
test src/buffer.rs - buffer_::ImageBuffer<FromType,Container>::convert (line 1358) - compile ... ok
test src/codecs/gif.rs - codecs::gif (line 9) - compile ... ok
test src/flat.rs - flat (line 9) - compile ... ok
test src/buffer.rs - buffer_::ImageBuffer (line 631) - compile ... ok
test src/animation.rs - animation::Delay::from_saturating_duration (line 129) ... ok
test src/animation.rs - animation::Delay::from_numer_denom_ms (line 112) ... ok
test src/image.rs - image::GenericImage::get_pixel_mut (line 973) ... ignored
test src/buffer.rs - buffer_::ImageBuffer (line 616) ... ok
test src/dynimage.rs - dynimage::DynamicImage (line 42) ... ok
test src/flat.rs - flat::FlatSamples<&'buf[Subpixel]>::with_monocolor (line 933) ... ok
test src/flat.rs - flat::SampleLayout::column_major_packed (line 163) ... ok
test src/flat.rs - flat::FlatSamples<Buffer>::get_mut_sample (line 562) ... ok
test src/codecs/jpeg/encoder.rs - codecs::jpeg::encoder::PixelDensity (line 303) ... ok
test src/imageops/mod.rs - imageops::horizontal_gradient (line 300) - compile ... ok
test src/imageops/mod.rs - imageops::tile (line 241) - compile ... ok
test src/flat.rs - flat::FlatSamples<Buffer>::get_sample (line 528) ... ok
test src/imageops/mod.rs - imageops::vertical_gradient (line 267) - compile ... ok
test src/io/reader.rs - io::reader::Reader (line 22) - compile ... ok
test src/io/reader.rs - io::reader::Reader<R>::with_guessed_format (line 180) - compile ... ok
test src/flat.rs - flat::SampleLayout::row_major_packed (line 133) ... ok
test src/lib.rs - (line 18) - compile ... ok
test src/lib.rs - (line 32) - compile ... ok
test src/flat.rs - flat::View<Buffer,P>::try_upgrade (line 1194) ... ok
test src/lib.rs - (line 444) - compile ... ok
test src/lib.rs - (line 465) - compile ... ok
test src/image.rs - image::GenericImageView (line 871) ... ok
test src/lib.rs - (line 517) - compile ... ok
test src/image.rs - image::ImageFormat::from_extension (line 80) ... ok
test src/image.rs - image::ImageFormat::from_mime_type (line 156) ... ok
test src/image.rs - image::ImageFormat::from_path (line 122) ... ok
test src/image.rs - image::SubImage<I>::view (line 1204) ... ok
test src/imageops/colorops.rs - imageops::colorops::BiLevel (line 374) ... ok
test src/lib.rs - (line 361) ... ok
test src/lib.rs - (line 406) ... ok
test src/io/reader.rs - io::reader::Reader (line 35) ... ok

test result: ok. 35 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 2.15s
```
