### PR TITLE
Exhaustively match in ColorType -> DynamicImage conversion

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -1075,17 +1075,6 @@ fn decoder_to_image<'a, I: ImageDecoder<'a>>(decoder: I) -> ImageResult<DynamicI
             let buf = image::decoder_to_vec(decoder)?;
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLumaA16)
         }
-
-        // An internal #[non_exhaustive]
-        #[allow(unreachable_patterns)]
-        _ => {
-            return Err(ImageError::Unsupported(
-                UnsupportedError::from_format_and_kind(
-                    ImageFormatHint::Unknown,
-                    UnsupportedErrorKind::Color(color_type.into()),
-                ),
-            ))
-        }
     };
 
     match image {


### PR DESCRIPTION
This ensures that `ColorType` and `DynamicImage` variants don't accidentally get out of sync