### PR TITLE
Remove multithreading in HDR decoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ num-traits = "0.2.0"
 gif = { version = "0.12", optional = true }
 jpeg = { package = "jpeg-decoder", version = "0.3.0", default-features = false, optional = true }
 png = { version = "0.17.6", optional = true }
-scoped_threadpool = { version = "0.1", optional = true }
 tiff = { version = "0.8.0", optional = true }
 ravif = { version = "0.11.0", optional = true }
 rgb = { version = "0.8.25", optional = true }
@@ -67,7 +66,7 @@ ico = ["bmp", "png"]
 pnm = []
 tga = []
 bmp = []
-hdr = ["scoped_threadpool"]
+hdr = []
 dxt = []
 dds = ["dxt"]
 farbfeld = []

--- a/Cargo.toml.public-private-dependencies
+++ b/Cargo.toml.public-private-dependencies
@@ -37,7 +37,6 @@ num-traits = { version = "0.2.0", public = true }
 gif = { version = "0.11.1", optional = true }
 jpeg = { package = "jpeg-decoder", version = "0.2.1", default-features = false, optional = true }
 png = { version = "0.17.0", optional = true }
-scoped_threadpool = { version = "0.1", optional = true }
 tiff = { version = "0.7.1", optional = true }
 ravif = { version = "0.8.0", optional = true }
 rgb = { version = "0.8.25", optional = true }
@@ -63,7 +62,7 @@ pnm = []
 tga = []
 webp = []
 bmp = []
-hdr = ["scoped_threadpool"]
+hdr = []
 dxt = []
 dds = ["dxt"]
 farbfeld = []

--- a/src/codecs/hdr/decoder.rs
+++ b/src/codecs/hdr/decoder.rs
@@ -462,12 +462,12 @@ impl<R: BufRead> HdrDecoder<R> {
 
         let mut buf = vec![Default::default(); self.width as usize];
         for chunk in chunks_iter {
+            // read_scanline overwrites the entire buffer or returns an Err,
+            // so not resetting the buffer here is ok.
             read_scanline(&mut self.r, &mut buf[..])?;
             for (dst, &pix) in chunk.iter_mut().zip(buf.iter()) {
                 *dst = f(pix);
             }
-            buf.clear();
-            buf.resize(self.width as usize, Default::default());
         }
         Ok(())
     }

--- a/src/codecs/hdr/decoder.rs
+++ b/src/codecs/hdr/decoder.rs
@@ -460,12 +460,14 @@ impl<R: BufRead> HdrDecoder<R> {
 
         let chunks_iter = output_slice.chunks_mut(self.width as usize);
 
+        let mut buf = vec![Default::default(); self.width as usize];
         for chunk in chunks_iter {
-            let mut buf = vec![Default::default(); self.width as usize];
             read_scanline(&mut self.r, &mut buf[..])?;
             for (dst, &pix) in chunk.iter_mut().zip(buf.iter()) {
                 *dst = f(pix);
             }
+            buf.clear();
+            buf.resize(self.width as usize, Default::default());
         }
         Ok(())
     }


### PR DESCRIPTION
As discussed in https://github.com/image-rs/image/issues/772#issuecomment-1382406241. This also makes it work on WASM.

---

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.