### PR TITLE
Add ICC profile to ImageDecoder

### DIFF
--- a/src/codecs/avif/decoder.rs
+++ b/src/codecs/avif/decoder.rs
@@ -27,6 +27,7 @@ pub struct AvifDecoder<R> {
     inner: PhantomData<R>,
     picture: dav1d::Picture,
     alpha_picture: Option<dav1d::Picture>,
+    icc_profile: Option<Vec<u8>>,
 }
 
 impl<R: Read> AvifDecoder<R> {
@@ -49,11 +50,13 @@ impl<R: Read> AvifDecoder<R> {
         } else {
             None
         };
+        let icc_profile = ctx.icc_colour_information().ok().map(|x| x.to_vec());
         assert_eq!(picture.bit_depth(), 8);
         Ok(AvifDecoder {
             inner: PhantomData,
             picture,
             alpha_picture,
+            icc_profile,
         })
     }
 }
@@ -83,6 +86,10 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for AvifDecoder<R> {
 
     fn color_type(&self) -> ColorType {
         ColorType::Rgba8
+    }
+
+    fn icc_profile(&mut self) -> Option<Vec<u8>> {
+        self.icc_profile.clone()
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {

--- a/src/codecs/jpeg/decoder.rs
+++ b/src/codecs/jpeg/decoder.rs
@@ -93,6 +93,10 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for JpegDecoder<R> {
         ColorType::from_jpeg(self.metadata.pixel_format)
     }
 
+    fn icc_profile(&mut self) -> Option<Vec<u8>> {
+        self.decoder.icc_profile().clone()
+    }
+
     fn into_reader(mut self) -> ImageResult<Self::Reader> {
         let mut data = self.decoder.decode().map_err(ImageError::from_jpeg)?;
         data = match self.decoder.info().unwrap().pixel_format {

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -237,6 +237,10 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for PngDecoder<R> {
         self.color_type
     }
 
+    fn icc_profile(&mut self) -> Option<Vec<u8>> {
+        self.reader.info().icc_profile.as_ref().map(|x| x.to_vec())
+    }
+
     fn into_reader(self) -> ImageResult<Self::Reader> {
         PngReader::new(self.reader)
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -660,6 +660,14 @@ pub trait ImageDecoder<'a>: Sized {
         self.color_type().into()
     }
 
+    /// Returns the ICC color profile embedded in the image
+    ///
+    /// For formats that don't support embedded profiles this function will always return `None`.
+    /// This feature is currently only supported for the JPEG, PNG, and AVIF formats.
+    fn icc_profile(&mut self) -> Option<Vec<u8>> {
+        None
+    }
+
     /// Returns a reader that can be used to obtain the bytes of the image. For the best
     /// performance, always try to read at least `scanline_bytes` from the reader at a time. Reading
     /// fewer bytes will cause the reader to perform internal buffering.


### PR DESCRIPTION
I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.

---

Giving this a go. Not sure why `&mut self` was suggested in the issue

Closes #1832 