### PR TITLE
Adds Into<Container> for ImageBuffer

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -659,6 +659,14 @@ pub struct ImageBuffer<P: Pixel, Container> {
     data: Container,
 }
 
+// transformation into the container - useful for things that want to
+// transform a buffer back into a Vec
+impl<P: Pixel, Container> Into<Container> for ImageBuffer<P, Container> {
+    fn into(self) -> Container {
+        self.data
+    }
+}
+
 // generic implementation, shared along all image buffers
 impl<P, Container> ImageBuffer<P, Container>
 where


### PR DESCRIPTION
I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.

# Summary

Hello, I'd like to be able to transform `ImageBuffer` into `Vec<u8>` generically. As of now there is the `to_vec` and `into_vec` methods, but they don't necessarily work in a generic context.

More concretely I'd like to be able to use ImageBuffer with anything that requires a `T: Into<Vec<u8>>`. For example:

```rust
pub fn do_something<T: Into<Vec<u8>>>(t: T) -> Vec<u8> { t.into() }
```