### PR TITLE
Improve ImageDecoder trait

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        features: ['', default, gif, jpeg, png, tiff, ico, pnm, tga, webp, bmp, hdr, dxt, dds, farbfeld, openexr, jpeg_rayon, webp-encoder]
+        features: ['', default, gif, jpeg, png, tiff, ico, pnm, tga, webp, bmp, hdr, dds, farbfeld, openexr, jpeg_rayon, webp-encoder]
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,8 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: ["1.61.0", stable, beta, nightly]
-        features: [gif, jpeg, png, tiff, ico, pnm, tga, webp, bmp, hdr, dds, farbfeld, openexr, jpeg_rayon, webp-encoder, '']
+        features: ['', default, gif, jpeg, png, tiff, ico, pnm, tga, webp, bmp, hdr, dxt, dds, farbfeld, openexr, jpeg_rayon, webp-encoder]
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        features: ['', default, gif, jpeg, png, tiff, ico, pnm, tga, webp, bmp, hdr, dxt, dds, farbfeld, openexr, jpeg_rayon, webp-encoder]
+        rust: ["1.61.0", stable, beta, nightly]
+        features: [gif, jpeg, png, tiff, ico, pnm, tga, webp, bmp, hdr, dds, farbfeld, openexr, jpeg_rayon, webp-encoder, '']
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,15 +62,14 @@ jpeg = { package = "jpeg-decoder", version = "0.3.0", default-features = false, 
 
 [features]
 # TODO: Add "avif" to this list while preparing for 0.24.0
-default = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "dds", "farbfeld", "jpeg_rayon", "openexr", "qoi"]
+default = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dds", "farbfeld", "jpeg_rayon", "openexr", "qoi"]
 
 ico = ["bmp", "png"]
 pnm = []
 tga = []
 bmp = []
 hdr = []
-dxt = []
-dds = ["dxt"]
+dds = []
 farbfeld = []
 openexr = ["exr"]
 qoi = ["dep:qoi"]

--- a/src/codecs/avif/decoder.rs
+++ b/src/codecs/avif/decoder.rs
@@ -5,9 +5,9 @@
 /// [AVIF]: https://aomediacodec.github.io/av1-avif/
 use std::convert::TryFrom;
 use std::error::Error;
-use std::io::{self, Cursor, Read};
+use std::io::{Read};
 use std::marker::PhantomData;
-use std::mem;
+
 
 use crate::error::{DecodingError, UnsupportedError, UnsupportedErrorKind};
 use crate::{ColorType, ImageDecoder, ImageError, ImageFormat, ImageResult};
@@ -66,26 +66,7 @@ impl<R: Read> AvifDecoder<R> {
     }
 }
 
-/// Wrapper struct around a `Cursor<Vec<u8>>`
-pub struct AvifReader<R>(Cursor<Vec<u8>>, PhantomData<R>);
-
-impl<R> Read for AvifReader<R> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.0.read(buf)
-    }
-    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
-        if self.0.position() == 0 && buf.is_empty() {
-            mem::swap(buf, self.0.get_mut());
-            Ok(buf.len())
-        } else {
-            self.0.read_to_end(buf)
-        }
-    }
-}
-
-impl<'a, R: 'a + Read> ImageDecoder<'a> for AvifDecoder<R> {
-    type Reader = AvifReader<R>;
-
+impl<R: Read> ImageDecoder for AvifDecoder<R> {
     fn dimensions(&self) -> (u32, u32) {
         (self.picture.width(), self.picture.height())
     }
@@ -94,16 +75,8 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for AvifDecoder<R> {
         ColorType::Rgba8
     }
 
-    fn icc_profile(&mut self) -> Option<Vec<u8>> {
-        self.icc_profile.clone()
-    }
-
-    fn into_reader(self) -> ImageResult<Self::Reader> {
-        let plane = self.picture.plane(PlanarImageComponent::Y);
-        Ok(AvifReader(
-            Cursor::new(plane.as_ref().to_vec()),
-            PhantomData,
-        ))
+    fn icc_profile(&mut self) -> ImageResult<Option<Vec<u8>>> {
+        Ok(self.icc_profile.clone())
     }
 
     fn read_image(self, buf: &mut [u8]) -> ImageResult<()> {
@@ -181,6 +154,10 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for AvifDecoder<R> {
         }
 
         Ok(())
+    }
+
+    fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
+        (*self).read_image(buf)
     }
 }
 

--- a/src/codecs/avif/decoder.rs
+++ b/src/codecs/avif/decoder.rs
@@ -5,9 +5,8 @@
 /// [AVIF]: https://aomediacodec.github.io/av1-avif/
 use std::convert::TryFrom;
 use std::error::Error;
-use std::io::{Read};
+use std::io::Read;
 use std::marker::PhantomData;
-
 
 use crate::error::{DecodingError, UnsupportedError, UnsupportedErrorKind};
 use crate::{ColorType, ImageDecoder, ImageError, ImageFormat, ImageResult};

--- a/src/codecs/bmp/decoder.rs
+++ b/src/codecs/bmp/decoder.rs
@@ -7,12 +7,12 @@ use std::{error, fmt};
 
 use byteorder::{LittleEndian, ReadBytesExt};
 
-use crate::ImageDecoderRect;
 use crate::color::ColorType;
 use crate::error::{
     DecodingError, ImageError, ImageResult, UnsupportedError, UnsupportedErrorKind,
 };
-use crate::image::{ImageDecoder, ImageFormat, self};
+use crate::image::{self, ImageDecoder, ImageFormat};
+use crate::ImageDecoderRect;
 
 const BITMAPCOREHEADER_SIZE: u32 = 12;
 const BITMAPINFOHEADER_SIZE: u32 = 40;

--- a/src/codecs/bmp/decoder.rs
+++ b/src/codecs/bmp/decoder.rs
@@ -1385,6 +1385,8 @@ impl<R: Read + Seek> ImageDecoderRect for BmpDecoder<R> {
 
 #[cfg(test)]
 mod test {
+    use std::io::Cursor;
+
     use super::*;
 
     #[test]

--- a/src/codecs/dds.rs
+++ b/src/codecs/dds.rs
@@ -11,7 +11,7 @@ use std::{error, fmt};
 use byteorder::{LittleEndian, ReadBytesExt};
 
 #[allow(deprecated)]
-use crate::codecs::dxt::{DxtDecoder, DxtReader, DxtVariant};
+use crate::codecs::dxt::{DxtDecoder, DxtVariant};
 use crate::color::ColorType;
 use crate::error::{
     DecodingError, ImageError, ImageFormatHint, ImageResult, UnsupportedError, UnsupportedErrorKind,
@@ -327,10 +327,7 @@ impl<R: Read> DdsDecoder<R> {
     }
 }
 
-impl<'a, R: 'a + Read> ImageDecoder<'a> for DdsDecoder<R> {
-    #[allow(deprecated)]
-    type Reader = DxtReader<R>;
-
+impl<R: Read> ImageDecoder for DdsDecoder<R> {
     fn dimensions(&self) -> (u32, u32) {
         self.inner.dimensions()
     }
@@ -339,18 +336,12 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for DdsDecoder<R> {
         self.inner.color_type()
     }
 
-    fn scanline_bytes(&self) -> u64 {
-        #[allow(deprecated)]
-        self.inner.scanline_bytes()
-    }
-
-    fn into_reader(self) -> ImageResult<Self::Reader> {
-        #[allow(deprecated)]
-        self.inner.into_reader()
-    }
-
     fn read_image(self, buf: &mut [u8]) -> ImageResult<()> {
         self.inner.read_image(buf)
+    }
+
+    fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
+        (*self).read_image(buf)
     }
 }
 

--- a/src/codecs/dxt.rs
+++ b/src/codecs/dxt.rs
@@ -8,17 +8,17 @@
 //!  Note: this module only implements bare DXT encoding/decoding, it does not parse formats that can contain DXT files like .dds
 
 use std::convert::TryFrom;
-use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::io::{self, Read};
 
 use crate::color::ColorType;
 use crate::error::{ImageError, ImageResult, ParameterError, ParameterErrorKind};
-use crate::image::{self, ImageDecoder, ImageDecoderRect, ImageReadBuffer, Progress};
+use crate::image::ImageDecoder;
 
 /// What version of DXT compression are we using?
 /// Note that DXT2 and DXT4 are left away as they're
 /// just DXT3 and DXT5 with premultiplied alpha
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum DxtVariant {
+pub(crate) enum DxtVariant {
     /// The DXT1 format. 48 bytes of RGB data in a 4x4 pixel square is
     /// compressed into an 8 byte block of DXT1 data
     DXT1,
@@ -49,7 +49,7 @@ impl DxtVariant {
     }
 
     /// Returns the color type that is stored in this DXT variant
-    pub fn color_type(self) -> ColorType {
+    pub(crate) fn color_type(self) -> ColorType {
         match self {
             DxtVariant::DXT1 => ColorType::Rgb8,
             DxtVariant::DXT3 | DxtVariant::DXT5 => ColorType::Rgba8,
@@ -58,7 +58,7 @@ impl DxtVariant {
 }
 
 /// DXT decoder
-pub struct DxtDecoder<R: Read> {
+pub(crate) struct DxtDecoder<R: Read> {
     inner: R,
     width_blocks: u32,
     height_blocks: u32,
@@ -74,7 +74,7 @@ impl<R: Read> DxtDecoder<R> {
     /// DXT variant in ```variant```.
     /// width and height are required to be powers of 2 and at least 4.
     /// otherwise an error will be returned
-    pub fn new(
+    pub(crate) fn new(
         r: R,
         width: u32,
         height: u32,
@@ -97,6 +97,10 @@ impl<R: Read> DxtDecoder<R> {
             variant,
             row: 0,
         })
+    }
+
+    fn scanline_bytes(&self) -> u64 {
+        self.variant.decoded_bytes_per_block() as u64 * u64::from(self.width_blocks)
     }
 
     fn read_scanline(&mut self, buf: &mut [u8]) -> io::Result<usize> {
@@ -123,30 +127,13 @@ impl<R: Read> DxtDecoder<R> {
 
 // Note that, due to the way that DXT compression works, a scanline is considered to consist out of
 // 4 lines of pixels.
-impl<'a, R: 'a + Read> ImageDecoder<'a> for DxtDecoder<R> {
-    type Reader = DxtReader<R>;
-
+impl<R: Read> ImageDecoder for DxtDecoder<R> {
     fn dimensions(&self) -> (u32, u32) {
         (self.width_blocks * 4, self.height_blocks * 4)
     }
 
     fn color_type(&self) -> ColorType {
         self.variant.color_type()
-    }
-
-    fn scanline_bytes(&self) -> u64 {
-        self.variant.decoded_bytes_per_block() as u64 * u64::from(self.width_blocks)
-    }
-
-    fn into_reader(self) -> ImageResult<Self::Reader> {
-        Ok(DxtReader {
-            buffer: ImageReadBuffer::new(
-                #[allow(deprecated)]
-                self.scanline_bytes(),
-                self.total_bytes(),
-            ),
-            decoder: self,
-        })
     }
 
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
@@ -158,106 +145,15 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for DxtDecoder<R> {
         }
         Ok(())
     }
-}
 
-impl<'a, R: 'a + Read + Seek> ImageDecoderRect<'a> for DxtDecoder<R> {
-    fn read_rect_with_progress<F: Fn(Progress)>(
-        &mut self,
-        x: u32,
-        y: u32,
-        width: u32,
-        height: u32,
-        buf: &mut [u8],
-        progress_callback: F,
-    ) -> ImageResult<()> {
-        let encoded_scanline_bytes =
-            self.variant.encoded_bytes_per_block() as u64 * u64::from(self.width_blocks);
-
-        let start = self.inner.stream_position()?;
-        image::load_rect(
-            x,
-            y,
-            width,
-            height,
-            buf,
-            progress_callback,
-            self,
-            |s, scanline| {
-                s.inner
-                    .seek(SeekFrom::Start(start + scanline * encoded_scanline_bytes))?;
-                Ok(())
-            },
-            |s, buf| s.read_scanline(buf).map(|_| ()),
-        )?;
-        self.inner.seek(SeekFrom::Start(start))?;
-        Ok(())
-    }
-}
-
-/// DXT reader
-pub struct DxtReader<R: Read> {
-    buffer: ImageReadBuffer,
-    decoder: DxtDecoder<R>,
-}
-
-impl<R: Read> Read for DxtReader<R> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let decoder = &mut self.decoder;
-        self.buffer.read(buf, |buf| decoder.read_scanline(buf))
-    }
-}
-
-/// DXT encoder
-pub struct DxtEncoder<W: Write> {
-    w: W,
-}
-
-impl<W: Write> DxtEncoder<W> {
-    /// Create a new encoder that writes its output to ```w```
-    pub fn new(w: W) -> DxtEncoder<W> {
-        DxtEncoder { w }
-    }
-
-    /// Encodes the image data ```data```
-    /// that has dimensions ```width``` and ```height```
-    /// in ```DxtVariant``` ```variant```
-    /// data is assumed to be in variant.color_type()
-    pub fn encode(
-        mut self,
-        data: &[u8],
-        width: u32,
-        height: u32,
-        variant: DxtVariant,
-    ) -> ImageResult<()> {
-        if width % 4 != 0 || height % 4 != 0 {
-            // TODO: this is not very idiomatic yet. Should return an EncodingError.
-            return Err(ImageError::Parameter(ParameterError::from_kind(
-                ParameterErrorKind::DimensionMismatch,
-            )));
-        }
-        let width_blocks = width / 4;
-        let height_blocks = height / 4;
-
-        let stride = variant.decoded_bytes_per_block();
-
-        assert!(data.len() >= width_blocks as usize * height_blocks as usize * stride);
-
-        for chunk in data.chunks(width_blocks as usize * stride) {
-            let data = match variant {
-                DxtVariant::DXT1 => encode_dxt1_row(chunk),
-                DxtVariant::DXT3 => encode_dxt3_row(chunk),
-                DxtVariant::DXT5 => encode_dxt5_row(chunk),
-            };
-            self.w.write_all(&data)?;
-        }
-        Ok(())
+    fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
+        (*self).read_image(buf)
     }
 }
 
 /**
  * Actual encoding/decoding logic below.
  */
-use std::mem::swap;
 
 type Rgb = [u8; 3];
 
@@ -273,27 +169,6 @@ fn enc565_decode(value: u16) -> Rgb {
         (green * 0xFF / 0x3F) as u8,
         (blue * 0xFF / 0x1F) as u8,
     ]
-}
-
-/// encodes an 8-bit RGB value into a 5-bit R, 6-bit G, 5-bit B 16-bit packed color value
-/// mapping preserves min/max values. It is guaranteed that i == encode(decode(i)) for all i
-fn enc565_encode(rgb: Rgb) -> u16 {
-    let red = (u16::from(rgb[0]) * 0x1F + 0x7E) / 0xFF;
-    let green = (u16::from(rgb[1]) * 0x3F + 0x7E) / 0xFF;
-    let blue = (u16::from(rgb[2]) * 0x1F + 0x7E) / 0xFF;
-    (red << 11) | (green << 5) | blue
-}
-
-/// utility function: squares a value
-fn square(a: i32) -> i32 {
-    a * a
-}
-
-/// returns the squared error between two RGB values
-fn diff(a: Rgb, b: Rgb) -> i32 {
-    square(i32::from(a[0]) - i32::from(b[0]))
-        + square(i32::from(a[1]) - i32::from(b[1]))
-        + square(i32::from(a[2]) - i32::from(b[2]))
 }
 
 /*
@@ -471,410 +346,4 @@ fn decode_dxt5_row(source: &[u8], dest: &mut [u8]) {
             dest[offset..offset + 16].copy_from_slice(&decoded_block[line * 16..(line + 1) * 16]);
         }
     }
-}
-
-/*
- * Functions for encoding DXT compression
- */
-
-/// Tries to perform the color encoding part of dxt compression
-/// the approach taken is simple, it picks unique combinations
-/// of the colors present in the block, and attempts to encode the
-/// block with each, picking the encoding that yields the least
-/// squared error out of all of them.
-///
-/// This could probably be faster but is already reasonably fast
-/// and a good reference impl to optimize others against.
-///
-/// Another way to perform this analysis would be to perform a
-/// singular value decomposition of the different colors, and
-/// then pick 2 points on this line as the base colors. But
-/// this is still rather unwieldy math and has issues
-/// with the 3-linear-colors-and-0 case, it's also worse
-/// at conserving the original colors.
-///
-/// source: should be RGBAx16 or RGBx16 bytes of data,
-/// dest 8 bytes of resulting encoded color data
-fn encode_dxt_colors(source: &[u8], dest: &mut [u8], is_dxt1: bool) {
-    // sanity checks and determine stride when parsing the source data
-    assert!((source.len() == 64 || source.len() == 48) && dest.len() == 8);
-    let stride = source.len() / 16;
-
-    // reference colors array
-    let mut colors = [[0u8; 3]; 4];
-
-    // Put the colors we're going to be processing in an array with pure RGB layout
-    // note: we reverse the pixel order here. The reason for this is found in the inner quantization loop.
-    let mut targets = [[0u8; 3]; 16];
-    for (s, d) in source.chunks(stride).rev().zip(&mut targets) {
-        *d = [s[0], s[1], s[2]];
-    }
-
-    // roundtrip all colors through the r5g6b5 encoding
-    for rgb in &mut targets {
-        *rgb = enc565_decode(enc565_encode(*rgb));
-    }
-
-    // and deduplicate the set of colors to choose from as the algorithm is O(N^2) in this
-    let mut colorspace_ = [[0u8; 3]; 16];
-    let mut colorspace_len = 0;
-    for color in &targets {
-        if !colorspace_[..colorspace_len].contains(color) {
-            colorspace_[colorspace_len] = *color;
-            colorspace_len += 1;
-        }
-    }
-    let mut colorspace = &colorspace_[..colorspace_len];
-
-    // in case of slight gradients it can happen that there's only one entry left in the color table.
-    // as the resulting banding can be quite bad if we would just left the block at the closest
-    // encodable color, we have a special path here that tries to emulate the wanted color
-    // using the linear interpolation between gradients
-    if colorspace.len() == 1 {
-        // the base color we got from colorspace reduction
-        let ref_rgb = colorspace[0];
-        // the unreduced color in this block that's the furthest away from the actual block
-        let mut rgb = targets
-            .iter()
-            .cloned()
-            .max_by_key(|rgb| diff(*rgb, ref_rgb))
-            .unwrap();
-        // amplify differences by 2.5, which should push them to the next quantized value
-        // if possible without overshoot
-        for i in 0..3 {
-            rgb[i] =
-                ((i16::from(rgb[i]) - i16::from(ref_rgb[i])) * 5 / 2 + i16::from(ref_rgb[i])) as u8;
-        }
-
-        // roundtrip it through quantization
-        let encoded = enc565_encode(rgb);
-        let rgb = enc565_decode(encoded);
-
-        // in case this didn't land us a different color the best way to represent this field is
-        // as a single color block
-        if rgb == ref_rgb {
-            dest[0] = encoded as u8;
-            dest[1] = (encoded >> 8) as u8;
-
-            for d in dest.iter_mut().take(8).skip(2) {
-                *d = 0;
-            }
-            return;
-        }
-
-        // we did find a separate value: add it to the options so after one round of quantization
-        // we're done
-        colorspace_[1] = rgb;
-        colorspace = &colorspace_[..2];
-    }
-
-    // block quantization loop: we basically just try every possible combination, returning
-    // the combination with the least squared error
-    // stores the best candidate colors
-    let mut chosen_colors = [[0; 3]; 4];
-    // did this index table use the [0,0,0] variant
-    let mut chosen_use_0 = false;
-    // error calculated for the last entry
-    let mut chosen_error = 0xFFFF_FFFFu32;
-
-    // loop through unique permutations of the colorspace, where c1 != c2
-    'search: for (i, &c1) in colorspace.iter().enumerate() {
-        colors[0] = c1;
-
-        for &c2 in &colorspace[0..i] {
-            colors[1] = c2;
-
-            if is_dxt1 {
-                // what's inside here is ran at most 120 times.
-                for use_0 in 0..2 {
-                    // and 240 times here.
-
-                    if use_0 != 0 {
-                        // interpolate one color, set the other to 0
-                        for i in 0..3 {
-                            colors[2][i] =
-                                ((u16::from(colors[0][i]) + u16::from(colors[1][i]) + 1) / 2) as u8;
-                        }
-                        colors[3] = [0, 0, 0];
-                    } else {
-                        // interpolate to get 2 more colors
-                        for i in 0..3 {
-                            colors[2][i] =
-                                ((u16::from(colors[0][i]) * 2 + u16::from(colors[1][i]) + 1) / 3)
-                                    as u8;
-                            colors[3][i] =
-                                ((u16::from(colors[0][i]) + u16::from(colors[1][i]) * 2 + 1) / 3)
-                                    as u8;
-                        }
-                    }
-
-                    // calculate the total error if we were to quantize the block with these color combinations
-                    // both these loops have statically known iteration counts and are well vectorizable
-                    // note that the inside of this can be run about 15360 times worst case, i.e. 960 times per
-                    // pixel.
-                    let total_error = targets
-                        .iter()
-                        .map(|t| colors.iter().map(|c| diff(*c, *t) as u32).min().unwrap())
-                        .sum();
-
-                    // update the match if we found a better one
-                    if total_error < chosen_error {
-                        chosen_colors = colors;
-                        chosen_use_0 = use_0 != 0;
-                        chosen_error = total_error;
-
-                        // if we've got a perfect or at most 1 LSB off match, we're done
-                        if total_error < 4 {
-                            break 'search;
-                        }
-                    }
-                }
-            } else {
-                // what's inside here is ran at most 120 times.
-
-                // interpolate to get 2 more colors
-                for i in 0..3 {
-                    colors[2][i] =
-                        ((u16::from(colors[0][i]) * 2 + u16::from(colors[1][i]) + 1) / 3) as u8;
-                    colors[3][i] =
-                        ((u16::from(colors[0][i]) + u16::from(colors[1][i]) * 2 + 1) / 3) as u8;
-                }
-
-                // calculate the total error if we were to quantize the block with these color combinations
-                // both these loops have statically known iteration counts and are well vectorizable
-                // note that the inside of this can be run about 15360 times worst case, i.e. 960 times per
-                // pixel.
-                let total_error = targets
-                    .iter()
-                    .map(|t| colors.iter().map(|c| diff(*c, *t) as u32).min().unwrap())
-                    .sum();
-
-                // update the match if we found a better one
-                if total_error < chosen_error {
-                    chosen_colors = colors;
-                    chosen_error = total_error;
-
-                    // if we've got a perfect or at most 1 LSB off match, we're done
-                    if total_error < 4 {
-                        break 'search;
-                    }
-                }
-            }
-        }
-    }
-
-    // calculate the final indices
-    // note that targets is already in reverse pixel order, to make the index computation easy.
-    let mut chosen_indices = 0u32;
-    for t in &targets {
-        let (idx, _) = chosen_colors
-            .iter()
-            .enumerate()
-            .min_by_key(|&(_, c)| diff(*c, *t))
-            .unwrap();
-        chosen_indices = (chosen_indices << 2) | idx as u32;
-    }
-
-    // encode the colors
-    let mut color0 = enc565_encode(chosen_colors[0]);
-    let mut color1 = enc565_encode(chosen_colors[1]);
-
-    // determine encoding. Note that color0 == color1 is impossible at this point
-    if is_dxt1 {
-        if color0 > color1 {
-            if chosen_use_0 {
-                swap(&mut color0, &mut color1);
-                // Indexes are packed 2 bits wide, swap index 0/1 but preserve 2/3.
-                let filter = (chosen_indices & 0xAAAA_AAAA) >> 1;
-                chosen_indices ^= filter ^ 0x5555_5555;
-            }
-        } else if !chosen_use_0 {
-            swap(&mut color0, &mut color1);
-            // Indexes are packed 2 bits wide, swap index 0/1 and 2/3.
-            chosen_indices ^= 0x5555_5555;
-        }
-    }
-
-    // encode everything.
-    dest[0] = color0 as u8;
-    dest[1] = (color0 >> 8) as u8;
-    dest[2] = color1 as u8;
-    dest[3] = (color1 >> 8) as u8;
-    for i in 0..4 {
-        dest[i + 4] = (chosen_indices >> (i * 8)) as u8;
-    }
-}
-
-/// Encodes a buffer of 16 alpha bytes into a dxt5 alpha index table,
-/// where the alpha table they are indexed against is created by
-/// calling alpha_table_dxt5(alpha0, alpha1)
-/// returns the resulting error and alpha table
-fn encode_dxt5_alpha(alpha0: u8, alpha1: u8, alphas: &[u8; 16]) -> (i32, u64) {
-    // create a table for the given alpha ranges
-    let table = alpha_table_dxt5(alpha0, alpha1);
-    let mut indices = 0u64;
-    let mut total_error = 0i32;
-
-    // least error brute force search
-    for (i, &a) in alphas.iter().enumerate() {
-        let (index, error) = table
-            .iter()
-            .enumerate()
-            .map(|(i, &e)| (i, square(i32::from(e) - i32::from(a))))
-            .min_by_key(|&(_, e)| e)
-            .unwrap();
-        total_error += error;
-        indices |= (index as u64) << (i * 3);
-    }
-
-    (total_error, indices)
-}
-
-/// Encodes a RGBAx16 sequence of bytes to a 16 bytes DXT5 block
-fn encode_dxt5_block(source: &[u8], dest: &mut [u8]) {
-    assert!(source.len() == 64 && dest.len() == 16);
-
-    // perform dxt color encoding
-    encode_dxt_colors(source, &mut dest[8..16], false);
-
-    // copy out the alpha bytes
-    let mut alphas = [0; 16];
-    for i in 0..16 {
-        alphas[i] = source[i * 4 + 3];
-    }
-
-    // try both alpha compression methods, see which has the least error.
-    let alpha07 = alphas.iter().cloned().min().unwrap();
-    let alpha17 = alphas.iter().cloned().max().unwrap();
-    let (error7, indices7) = encode_dxt5_alpha(alpha07, alpha17, &alphas);
-
-    // if all alphas are 0 or 255 it doesn't particularly matter what we do here.
-    let alpha05 = alphas
-        .iter()
-        .cloned()
-        .filter(|&i| i != 255)
-        .max()
-        .unwrap_or(255);
-    let alpha15 = alphas
-        .iter()
-        .cloned()
-        .filter(|&i| i != 0)
-        .min()
-        .unwrap_or(0);
-    let (error5, indices5) = encode_dxt5_alpha(alpha05, alpha15, &alphas);
-
-    // pick the best one, encode the min/max values
-    let mut alpha_table = if error5 < error7 {
-        dest[0] = alpha05;
-        dest[1] = alpha15;
-        indices5
-    } else {
-        dest[0] = alpha07;
-        dest[1] = alpha17;
-        indices7
-    };
-
-    // encode the alphas
-    for byte in dest[2..8].iter_mut() {
-        *byte = alpha_table as u8;
-        alpha_table >>= 8;
-    }
-}
-
-/// Encodes a RGBAx16 sequence of bytes into a 16 bytes DXT3 block
-fn encode_dxt3_block(source: &[u8], dest: &mut [u8]) {
-    assert!(source.len() == 64 && dest.len() == 16);
-
-    // perform dxt color encoding
-    encode_dxt_colors(source, &mut dest[8..16], false);
-
-    // DXT3 alpha compression is very simple, just round towards the nearest value
-
-    // index the alpha values into the 64bit alpha table
-    let mut alpha_table = 0u64;
-    for i in 0..16 {
-        let alpha = u64::from(source[i * 4 + 3]);
-        let alpha = (alpha + 0x8) / 0x11;
-        alpha_table |= alpha << (i * 4);
-    }
-
-    // encode the alpha values
-    for byte in &mut dest[0..8] {
-        *byte = alpha_table as u8;
-        alpha_table >>= 8;
-    }
-}
-
-/// Encodes a RGBx16 sequence of bytes into a 8 bytes DXT1 block
-fn encode_dxt1_block(source: &[u8], dest: &mut [u8]) {
-    assert!(source.len() == 48 && dest.len() == 8);
-
-    // perform dxt color encoding
-    encode_dxt_colors(source, dest, true);
-}
-
-/// Decode a row of DXT1 data to four rows of RGBA data.
-/// source.len() should be a multiple of 8, otherwise this panics.
-fn encode_dxt1_row(source: &[u8]) -> Vec<u8> {
-    assert!(source.len() % 48 == 0);
-    let block_count = source.len() / 48;
-
-    let mut dest = vec![0u8; block_count * 8];
-    // contains the 16 decoded pixels per block
-    let mut decoded_block = [0u8; 48];
-
-    for (x, encoded_block) in dest.chunks_mut(8).enumerate() {
-        // copy the values from the decoded block to linewise RGB layout
-        for line in 0..4 {
-            let offset = (block_count * line + x) * 12;
-            decoded_block[line * 12..(line + 1) * 12].copy_from_slice(&source[offset..offset + 12]);
-        }
-
-        encode_dxt1_block(&decoded_block, encoded_block);
-    }
-    dest
-}
-
-/// Decode a row of DXT3 data to four rows of RGBA data.
-/// source.len() should be a multiple of 16, otherwise this panics.
-fn encode_dxt3_row(source: &[u8]) -> Vec<u8> {
-    assert!(source.len() % 64 == 0);
-    let block_count = source.len() / 64;
-
-    let mut dest = vec![0u8; block_count * 16];
-    // contains the 16 decoded pixels per block
-    let mut decoded_block = [0u8; 64];
-
-    for (x, encoded_block) in dest.chunks_mut(16).enumerate() {
-        // copy the values from the decoded block to linewise RGB layout
-        for line in 0..4 {
-            let offset = (block_count * line + x) * 16;
-            decoded_block[line * 16..(line + 1) * 16].copy_from_slice(&source[offset..offset + 16]);
-        }
-
-        encode_dxt3_block(&decoded_block, encoded_block);
-    }
-    dest
-}
-
-/// Decode a row of DXT5 data to four rows of RGBA data.
-/// source.len() should be a multiple of 16, otherwise this panics.
-fn encode_dxt5_row(source: &[u8]) -> Vec<u8> {
-    assert!(source.len() % 64 == 0);
-    let block_count = source.len() / 64;
-
-    let mut dest = vec![0u8; block_count * 16];
-    // contains the 16 decoded pixels per block
-    let mut decoded_block = [0u8; 64];
-
-    for (x, encoded_block) in dest.chunks_mut(16).enumerate() {
-        // copy the values from the decoded block to linewise RGB layout
-        for line in 0..4 {
-            let offset = (block_count * line + x) * 16;
-            decoded_block[line * 16..(line + 1) * 16].copy_from_slice(&source[offset..offset + 16]);
-        }
-
-        encode_dxt5_block(&decoded_block, encoded_block);
-    }
-    dest
 }

--- a/src/codecs/farbfeld.rs
+++ b/src/codecs/farbfeld.rs
@@ -196,7 +196,7 @@ impl<R: Read> FarbfeldDecoder<R> {
     }
 }
 
-impl<R:  Read> ImageDecoder for FarbfeldDecoder<R> {
+impl<R: Read> ImageDecoder for FarbfeldDecoder<R> {
     fn dimensions(&self) -> (u32, u32) {
         (self.reader.width, self.reader.height)
     }

--- a/src/codecs/farbfeld.rs
+++ b/src/codecs/farbfeld.rs
@@ -24,7 +24,7 @@ use crate::color::ColorType;
 use crate::error::{
     DecodingError, ImageError, ImageResult, UnsupportedError, UnsupportedErrorKind,
 };
-use crate::image::{self, ImageDecoder, ImageDecoderRect, ImageEncoder, ImageFormat, Progress};
+use crate::image::{self, ImageDecoder, ImageDecoderRect, ImageEncoder, ImageFormat};
 
 /// farbfeld Reader
 pub struct FarbfeldReader<R: Read> {
@@ -196,9 +196,7 @@ impl<R: Read> FarbfeldDecoder<R> {
     }
 }
 
-impl<'a, R: 'a + Read> ImageDecoder<'a> for FarbfeldDecoder<R> {
-    type Reader = FarbfeldReader<R>;
-
+impl<R:  Read> ImageDecoder for FarbfeldDecoder<R> {
     fn dimensions(&self) -> (u32, u32) {
         (self.reader.width, self.reader.height)
     }
@@ -207,24 +205,26 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for FarbfeldDecoder<R> {
         ColorType::Rgba16
     }
 
-    fn into_reader(self) -> ImageResult<Self::Reader> {
-        Ok(self.reader)
+    fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
+        assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
+        self.reader.read_exact(buf)?;
+        Ok(())
     }
 
-    fn scanline_bytes(&self) -> u64 {
-        2
+    fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
+        (*self).read_image(buf)
     }
 }
 
-impl<'a, R: 'a + Read + Seek> ImageDecoderRect<'a> for FarbfeldDecoder<R> {
-    fn read_rect_with_progress<F: Fn(Progress)>(
+impl<R: Read + Seek> ImageDecoderRect for FarbfeldDecoder<R> {
+    fn read_rect(
         &mut self,
         x: u32,
         y: u32,
         width: u32,
         height: u32,
         buf: &mut [u8],
-        progress_callback: F,
+        row_pitch: usize,
     ) -> ImageResult<()> {
         // A "scanline" (defined as "shortest non-caching read" in the doc) is just one channel in this case
 
@@ -235,8 +235,9 @@ impl<'a, R: 'a + Read + Seek> ImageDecoderRect<'a> for FarbfeldDecoder<R> {
             width,
             height,
             buf,
-            progress_callback,
+            row_pitch,
             self,
+            2,
             |s, scanline| s.reader.seek(SeekFrom::Start(scanline * 2)).map(|_| ()),
             |s, buf| s.reader.read_exact(buf),
         )?;
@@ -376,7 +377,7 @@ mod tests {
         let mut out_buf = [0u8; 64];
         FarbfeldDecoder::new(input_cur)
             .unwrap()
-            .read_rect(0, 2, 1, 1, &mut out_buf)
+            .read_rect(0, 2, 1, 1, &mut out_buf, 8)
             .unwrap();
         let exp = degenerate_pixels(RECTANGLE_OUT);
         assert_eq!(&out_buf[..exp.len()], &exp[..]);
@@ -393,7 +394,7 @@ mod tests {
         let mut out_buf = [0u8; 64];
         FarbfeldDecoder::new(Cursor::new(RECTANGLE_IN))
             .unwrap()
-            .read_rect(x, y, width, height, &mut out_buf)
+            .read_rect(x, y, width, height, &mut out_buf, width as usize * 8)
             .unwrap();
         let exp = degenerate_pixels(exp_wide);
         assert_eq!(&out_buf[..exp.len()], &exp[..]);

--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -105,6 +105,17 @@ impl<R: Read> ImageDecoder for GifDecoder<R> {
         ColorType::Rgba8
     }
 
+    fn set_limits(&mut self, limits: Limits) -> ImageResult<()> {
+        limits.check_support(&crate::io::LimitSupport::default())?;
+
+        let (width, height) = self.dimensions();
+        limits.check_dimensions(width, height)?;
+
+        self.limits = limits;
+
+        Ok(())
+    }
+
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
         assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
 

--- a/src/codecs/hdr/decoder.rs
+++ b/src/codecs/hdr/decoder.rs
@@ -969,7 +969,7 @@ fn read_line_u8<R: Read>(r: &mut R) -> ::std::io::Result<Option<Vec<u8>>> {
     let mut ret = Vec::with_capacity(16);
     loop {
         let mut byte = [0];
-        if r.read(&mut byte)? == 0 || byte[0] == b'\n'{
+        if r.read(&mut byte)? == 0 || byte[0] == b'\n' {
             if ret.is_empty() && byte[0] != b'\n' {
                 return Ok(None);
             } else {

--- a/src/codecs/hdr/decoder.rs
+++ b/src/codecs/hdr/decoder.rs
@@ -15,7 +15,7 @@ use crate::error::{
     DecodingError, ImageError, ImageFormatHint, ImageResult, ParameterError, ParameterErrorKind,
     UnsupportedError, UnsupportedErrorKind,
 };
-use crate::image::{self, ImageDecoder, ImageDecoderRect, ImageFormat, Progress};
+use crate::image::{self, ImageDecoder, ImageDecoderRect, ImageFormat};
 
 /// Errors that can occur during decoding and parsing of a HDR image
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -131,7 +131,7 @@ pub struct HdrAdapter<R: Read> {
     meta: HdrMetadata,
 }
 
-impl<R: BufRead> HdrAdapter<R> {
+impl<R: Read> HdrAdapter<R> {
     /// Creates adapter
     pub fn new(r: R) -> ImageResult<HdrAdapter<R>> {
         let decoder = HdrDecoder::new(r)?;
@@ -187,9 +187,7 @@ impl<R> Read for HdrReader<R> {
     }
 }
 
-impl<'a, R: 'a + BufRead> ImageDecoder<'a> for HdrAdapter<R> {
-    type Reader = HdrReader<R>;
-
+impl<R: Read> ImageDecoder for HdrAdapter<R> {
     fn dimensions(&self) -> (u32, u32) {
         (self.meta.width, self.meta.height)
     }
@@ -198,27 +196,24 @@ impl<'a, R: 'a + BufRead> ImageDecoder<'a> for HdrAdapter<R> {
         ColorType::Rgb8
     }
 
-    fn into_reader(self) -> ImageResult<Self::Reader> {
-        Ok(HdrReader(
-            Cursor::new(image::decoder_to_vec(self)?),
-            PhantomData,
-        ))
-    }
-
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
         self.read_image_data(buf)
     }
+
+    fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
+        (*self).read_image(buf)
+    }
 }
 
-impl<'a, R: 'a + BufRead + Seek> ImageDecoderRect<'a> for HdrAdapter<R> {
-    fn read_rect_with_progress<F: Fn(Progress)>(
+impl<R: BufRead + Seek> ImageDecoderRect for HdrAdapter<R> {
+    fn read_rect(
         &mut self,
         x: u32,
         y: u32,
         width: u32,
         height: u32,
         buf: &mut [u8],
-        progress_callback: F,
+        row_pitch: usize,
     ) -> ImageResult<()> {
         image::load_rect(
             x,
@@ -226,8 +221,9 @@ impl<'a, R: 'a + BufRead + Seek> ImageDecoderRect<'a> for HdrAdapter<R> {
             width,
             height,
             buf,
-            progress_callback,
+            row_pitch,
             self,
+            self.total_bytes() as usize,
             |_, _| unreachable!(),
             |s, buf| s.read_image_data(buf),
         )
@@ -327,8 +323,8 @@ impl Rgbe8Pixel {
     }
 }
 
-impl<R: BufRead> HdrDecoder<R> {
-    /// Reads Radiance HDR image header from stream `r`
+impl<R: Read> HdrDecoder<R> {
+    /// Reads Radiance HDR image header from stream ```r```
     /// if the header is valid, creates HdrDecoder
     /// strict mode is enabled
     pub fn new(reader: R) -> ImageResult<HdrDecoder<R>> {
@@ -969,17 +965,18 @@ fn split_at_first_test() {
 // Reads input until b"\n" or EOF
 // Returns vector of read bytes NOT including end of line characters
 //   or return None to indicate end of file
-fn read_line_u8<R: BufRead>(r: &mut R) -> ::std::io::Result<Option<Vec<u8>>> {
+fn read_line_u8<R: Read>(r: &mut R) -> ::std::io::Result<Option<Vec<u8>>> {
     let mut ret = Vec::with_capacity(16);
-    match r.read_until(b'\n', &mut ret) {
-        Ok(0) => Ok(None),
-        Ok(_) => {
-            if let Some(&b'\n') = ret[..].last() {
-                let _ = ret.pop();
+    loop {
+        let mut byte = [0];
+        if r.read(&mut byte)? == 0 || byte[0] == b'\n'{
+            if ret.is_empty() && byte[0] != b'\n' {
+                return Ok(None);
+            } else {
+                return Ok(Some(ret));
             }
-            Ok(Some(ret))
         }
-        Err(err) => Err(err),
+        ret.push(byte[0]);
     }
 }
 

--- a/src/codecs/ico/decoder.rs
+++ b/src/codecs/ico/decoder.rs
@@ -1,14 +1,13 @@
 use byteorder::{LittleEndian, ReadBytesExt};
 use std::convert::TryFrom;
-use std::io::{self, Cursor, Read, Seek, SeekFrom};
-use std::marker::PhantomData;
-use std::{error, fmt, mem};
+use std::io::{Read, Seek, SeekFrom};
+use std::{error, fmt};
 
 use crate::color::ColorType;
 use crate::error::{
     DecodingError, ImageError, ImageResult, UnsupportedError, UnsupportedErrorKind,
 };
-use crate::image::{self, ImageDecoder, ImageFormat};
+use crate::image::{ImageDecoder, ImageFormat};
 
 use self::InnerDecoder::*;
 use crate::codecs::bmp::BmpDecoder;
@@ -262,25 +261,7 @@ impl DirEntry {
     }
 }
 
-/// Wrapper struct around a `Cursor<Vec<u8>>`
-pub struct IcoReader<R>(Cursor<Vec<u8>>, PhantomData<R>);
-impl<R> Read for IcoReader<R> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.0.read(buf)
-    }
-    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
-        if self.0.position() == 0 && buf.is_empty() {
-            mem::swap(buf, self.0.get_mut());
-            Ok(buf.len())
-        } else {
-            self.0.read_to_end(buf)
-        }
-    }
-}
-
-impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for IcoDecoder<R> {
-    type Reader = IcoReader<R>;
-
+impl<R: Read + Seek> ImageDecoder for IcoDecoder<R> {
     fn dimensions(&self) -> (u32, u32) {
         match self.inner_decoder {
             Bmp(ref decoder) => decoder.dimensions(),
@@ -293,13 +274,6 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for IcoDecoder<R> {
             Bmp(ref decoder) => decoder.color_type(),
             Png(ref decoder) => decoder.color_type(),
         }
-    }
-
-    fn into_reader(self) -> ImageResult<Self::Reader> {
-        Ok(IcoReader(
-            Cursor::new(image::decoder_to_vec(self)?),
-            PhantomData,
-        ))
     }
 
     fn read_image(self, buf: &mut [u8]) -> ImageResult<()> {
@@ -403,6 +377,10 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for IcoDecoder<R> {
             }
         }
     }
+
+    fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
+        (*self).read_image(buf)
+    }
 }
 
 #[cfg(test)]
@@ -463,7 +441,7 @@ mod test {
             0x50, 0x37, 0x00, 0x00, 0x00, 0x00, 0x00, 0xc7, 0x37, 0x61,
         ];
 
-        let decoder = IcoDecoder::new(Cursor::new(&data)).unwrap();
+        let decoder = IcoDecoder::new(std::io::Cursor::new(&data)).unwrap();
         let mut buf = vec![0; usize::try_from(decoder.total_bytes()).unwrap()];
         assert!(decoder.read_image(&mut buf).is_err());
     }

--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -132,10 +132,7 @@ impl<R: Read + Seek> ImageDecoder for OpenExrDecoder<R> {
     }
 
     // reads with or without alpha, depending on `self.alpha_preference` and `self.alpha_present_in_file`
-    fn read_image(
-        self,
-        unaligned_bytes: &mut [u8],
-    ) -> ImageResult<()> {
+    fn read_image(self, unaligned_bytes: &mut [u8]) -> ImageResult<()> {
         let _blocks_in_header = self.selected_exr_header().chunk_count as u64;
         let channel_count = self.color_type().channel_count() as usize;
 
@@ -362,7 +359,7 @@ fn to_image_err(exr_error: Error) -> ImageError {
 mod test {
     use super::*;
 
-    use std::io::{Cursor, BufReader};
+    use std::io::{BufReader, Cursor};
     use std::path::{Path, PathBuf};
 
     use crate::buffer_::{Rgb32FImage, Rgba32FImage};

--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -23,12 +23,11 @@
 use exr::prelude::*;
 
 use crate::error::{DecodingError, EncodingError, ImageFormatHint};
-use crate::image::decoder_to_vec;
 use crate::{
     ColorType, ExtendedColorType, ImageDecoder, ImageEncoder, ImageError, ImageFormat, ImageResult,
-    Progress,
 };
-use std::io::{Cursor, Read, Seek, Write};
+
+use std::io::{Read, Seek, Write};
 
 /// An OpenEXR decoder. Immediately reads the meta data from the file.
 #[derive(Debug)]
@@ -105,9 +104,7 @@ impl<R: Read + Seek> OpenExrDecoder<R> {
     }
 }
 
-impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for OpenExrDecoder<R> {
-    type Reader = Cursor<Vec<u8>>;
-
+impl<R: Read + Seek> ImageDecoder for OpenExrDecoder<R> {
     fn dimensions(&self) -> (u32, u32) {
         let size = self
             .selected_exr_header()
@@ -134,27 +131,12 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for OpenExrDecoder<R> {
         }
     }
 
-    /// Use `read_image` instead if possible,
-    /// as this method creates a whole new buffer just to contain the entire image.
-    fn into_reader(self) -> ImageResult<Self::Reader> {
-        Ok(Cursor::new(decoder_to_vec(self)?))
-    }
-
-    fn scanline_bytes(&self) -> u64 {
-        // we cannot always read individual scan lines for every file,
-        // as the tiles or lines in the file could be in random or reversed order.
-        // therefore we currently read all lines at once
-        // Todo: optimize for specific exr.line_order?
-        self.total_bytes()
-    }
-
     // reads with or without alpha, depending on `self.alpha_preference` and `self.alpha_present_in_file`
-    fn read_image_with_progress<F: Fn(Progress)>(
+    fn read_image(
         self,
         unaligned_bytes: &mut [u8],
-        progress_callback: F,
     ) -> ImageResult<()> {
-        let blocks_in_header = self.selected_exr_header().chunk_count as u64;
+        let _blocks_in_header = self.selected_exr_header().chunk_count as u64;
         let channel_count = self.color_type().channel_count() as usize;
 
         let display_window = self.selected_exr_header().shared_attributes.display_window;
@@ -212,14 +194,6 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for OpenExrDecoder<R> {
             )
             .first_valid_layer() // TODO select exact layer by self.header_index?
             .all_attributes()
-            .on_progress(|progress| {
-                progress_callback(
-                    Progress::new(
-                        (progress * blocks_in_header as f64) as u64,
-                        blocks_in_header,
-                    ), // TODO precision errors?
-                );
-            })
             .from_chunks(self.exr_reader)
             .map_err(to_image_err)?;
 
@@ -231,6 +205,10 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for OpenExrDecoder<R> {
             result.layer_data.channel_data.pixels.as_slice(),
         ));
         Ok(())
+    }
+
+    fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
+        (*self).read_image(buf)
     }
 }
 
@@ -384,7 +362,7 @@ fn to_image_err(exr_error: Error) -> ImageError {
 mod test {
     use super::*;
 
-    use std::io::BufReader;
+    use std::io::{Cursor, BufReader};
     use std::path::{Path, PathBuf};
 
     use crate::buffer_::{Rgb32FImage, Rgba32FImage};
@@ -433,7 +411,7 @@ mod test {
     fn read_as_rgb_image(read: impl Read + Seek) -> ImageResult<Rgb32FImage> {
         let decoder = OpenExrDecoder::with_alpha_preference(read, Some(false))?;
         let (width, height) = decoder.dimensions();
-        let buffer: Vec<f32> = decoder_to_vec(decoder)?;
+        let buffer: Vec<f32> = crate::image::decoder_to_vec(decoder)?;
 
         ImageBuffer::from_raw(width, height, buffer)
             // this should be the only reason for the "from raw" call to fail,
@@ -447,7 +425,7 @@ mod test {
     fn read_as_rgba_image(read: impl Read + Seek) -> ImageResult<Rgba32FImage> {
         let decoder = OpenExrDecoder::with_alpha_preference(read, Some(true))?;
         let (width, height) = decoder.dimensions();
-        let buffer: Vec<f32> = decoder_to_vec(decoder)?;
+        let buffer: Vec<f32> = crate::image::decoder_to_vec(decoder)?;
 
         ImageBuffer::from_raw(width, height, buffer)
             // this should be the only reason for the "from raw" call to fail,

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -178,7 +178,6 @@ impl<R: Read> ImageDecoder for PngDecoder<R> {
         Ok(self.reader.info().icc_profile.as_ref().map(|x| x.to_vec()))
     }
 
-
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
         use byteorder::{BigEndian, ByteOrder, NativeEndian};
 

--- a/src/codecs/pnm/decoder.rs
+++ b/src/codecs/pnm/decoder.rs
@@ -429,8 +429,8 @@ trait HeaderReader: Read {
             buffer.push(byte[0]);
         }
 
-        Ok(String::from_utf8(buffer)
-            .map_err(|e| ImageError::Decoding(DecodingError::new(ImageFormat::Pnm.into(), e)))?)
+        String::from_utf8(buffer)
+            .map_err(|e| ImageError::Decoding(DecodingError::new(ImageFormat::Pnm.into(), e)))
     }
 
     fn read_next_u32(&mut self) -> ImageResult<u32> {

--- a/src/codecs/pnm/decoder.rs
+++ b/src/codecs/pnm/decoder.rs
@@ -2,9 +2,7 @@ use std::convert::TryFrom;
 use std::convert::TryInto;
 use std::error;
 use std::fmt::{self, Display};
-use std::io::{self, BufRead, Cursor, Read};
-use std::marker::PhantomData;
-use std::mem;
+use std::io::{self, Read};
 use std::num::ParseIntError;
 use std::str::{self, FromStr};
 
@@ -14,7 +12,7 @@ use crate::color::{ColorType, ExtendedColorType};
 use crate::error::{
     DecodingError, ImageError, ImageResult, UnsupportedError, UnsupportedErrorKind,
 };
-use crate::image::{self, ImageDecoder, ImageFormat};
+use crate::image::{ImageDecoder, ImageFormat};
 use crate::utils;
 
 use byteorder::{BigEndian, ByteOrder, NativeEndian};
@@ -264,7 +262,7 @@ pub struct PnmDecoder<R> {
     tuple: TupleType,
 }
 
-impl<R: BufRead> PnmDecoder<R> {
+impl<R: Read> PnmDecoder<R> {
     /// Create a new decoder that decodes from the stream ```read```
     pub fn new(mut buffered_read: R) -> ImageResult<PnmDecoder<R>> {
         let magic = buffered_read.read_magic_constant()?;
@@ -364,7 +362,7 @@ impl<R: BufRead> PnmDecoder<R> {
     }
 }
 
-trait HeaderReader: BufRead {
+trait HeaderReader: Read {
     /// Reads the two magic constant bytes
     fn read_magic_constant(&mut self) -> ImageResult<[u8; 2]> {
         let mut magic: [u8; 2] = [0, 0];
@@ -419,6 +417,20 @@ trait HeaderReader: BufRead {
             .unwrap_or_else(|_| unreachable!("Only ASCII characters should be decoded"));
 
         Ok(string)
+    }
+
+    fn read_next_line(&mut self) -> ImageResult<String> {
+        let mut buffer = Vec::new();
+        loop {
+            let mut byte = [0];
+            if self.read(&mut byte)? == 0 || byte[0] == b'\n' {
+                break;
+            }
+            buffer.push(byte[0]);
+        }
+
+        Ok(String::from_utf8(buffer)
+            .map_err(|e| ImageError::Decoding(DecodingError::new(ImageFormat::Pnm.into(), e)))?)
     }
 
     fn read_next_u32(&mut self) -> ImageResult<u32> {
@@ -489,16 +501,15 @@ trait HeaderReader: BufRead {
             Some(Ok(c)) => return Err(DecoderError::NotNewlineAfterP7Magic(c).into()),
         }
 
-        let mut line = String::new();
+        let mut line;
         let mut height: Option<u32> = None;
         let mut width: Option<u32> = None;
         let mut depth: Option<u32> = None;
         let mut maxval: Option<u32> = None;
         let mut tupltype: Option<String> = None;
         loop {
-            line.truncate(0);
-            let len = self.read_line(&mut line)?;
-            if len == 0 {
+            line = self.read_next_line()?;
+            if line.is_empty() {
                 return Err(DecoderError::UnexpectedPnmHeaderEnd.into());
             }
             if line.as_bytes()[0] == b'#' {
@@ -570,27 +581,9 @@ trait HeaderReader: BufRead {
     }
 }
 
-impl<R> HeaderReader for R where R: BufRead {}
+impl<R> HeaderReader for R where R: Read {}
 
-/// Wrapper struct around a `Cursor<Vec<u8>>`
-pub struct PnmReader<R>(Cursor<Vec<u8>>, PhantomData<R>);
-impl<R> Read for PnmReader<R> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.0.read(buf)
-    }
-    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
-        if self.0.position() == 0 && buf.is_empty() {
-            mem::swap(buf, self.0.get_mut());
-            Ok(buf.len())
-        } else {
-            self.0.read_to_end(buf)
-        }
-    }
-}
-
-impl<'a, R: 'a + Read> ImageDecoder<'a> for PnmDecoder<R> {
-    type Reader = PnmReader<R>;
-
+impl<R: Read> ImageDecoder for PnmDecoder<R> {
     fn dimensions(&self) -> (u32, u32) {
         (self.header.width(), self.header.height())
     }
@@ -617,13 +610,6 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for PnmDecoder<R> {
         }
     }
 
-    fn into_reader(self) -> ImageResult<Self::Reader> {
-        Ok(PnmReader(
-            Cursor::new(image::decoder_to_vec(self)?),
-            PhantomData,
-        ))
-    }
-
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
         assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
         match self.tuple {
@@ -634,6 +620,10 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for PnmDecoder<R> {
             TupleType::GrayU8 => self.read_samples::<U8>(1, buf),
             TupleType::GrayU16 => self.read_samples::<U16>(1, buf),
         }
+    }
+
+    fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
+        (*self).read_image(buf)
     }
 }
 

--- a/src/codecs/webp/decoder.rs
+++ b/src/codecs/webp/decoder.rs
@@ -321,6 +321,14 @@ impl<R: Read> ImageDecoder for WebPDecoder<R> {
     fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
         (*self).read_image(buf)
     }
+
+    fn icc_profile(&mut self) -> ImageResult<Option<Vec<u8>>> {
+        if let WebPImage::Extended(extended) = &self.image {
+            Ok(extended.icc_profile())
+        } else {
+            Ok(None)
+        }
+    }
 }
 
 impl<'a, R: 'a + Read> AnimationDecoder<'a> for WebPDecoder<R> {

--- a/src/codecs/webp/extended.rs
+++ b/src/codecs/webp/extended.rs
@@ -388,15 +388,6 @@ impl ExtendedImage {
         }
     }
 
-    pub(crate) fn get_buf_size(&self) -> usize {
-        match &self.image {
-            // will always have at least one frame
-            ExtendedImageData::Animation { first_frame, .. } => &first_frame.image,
-            ExtendedImageData::Static(image) => image,
-        }
-        .get_buf_size()
-    }
-
     pub(crate) fn set_background_color(&mut self, color: Rgba<u8>) -> ImageResult<()> {
         match &mut self.image {
             ExtendedImageData::Animation { anim_info, .. } => {

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -1,5 +1,4 @@
-use std::io;
-use std::io::{Seek, Write};
+use std::io::{self, Seek, Write};
 use std::path::Path;
 use std::u32;
 
@@ -189,7 +188,7 @@ impl DynamicImage {
     }
 
     /// Decodes an encoded image into a dynamic image.
-    pub fn from_decoder<'a>(decoder: impl ImageDecoder<'a>) -> ImageResult<Self> {
+    pub fn from_decoder(decoder: impl ImageDecoder) -> ImageResult<Self> {
         decoder_to_image(decoder)
     }
 
@@ -1040,7 +1039,7 @@ impl Default for DynamicImage {
 }
 
 /// Decodes an image and stores it into a dynamic image
-fn decoder_to_image<'a, I: ImageDecoder<'a>>(decoder: I) -> ImageResult<DynamicImage> {
+fn decoder_to_image<I: ImageDecoder>(decoder: I) -> ImageResult<DynamicImage> {
     let (w, h) = decoder.dimensions();
     let color_type = decoder.color_type();
 
@@ -1115,8 +1114,7 @@ pub fn open<P>(path: P) -> ImageResult<DynamicImage>
 where
     P: AsRef<Path>,
 {
-    // thin wrapper function to strip generics before calling open_impl
-    free_functions::open_impl(path.as_ref())
+    crate::io::Reader::open(path)?.decode()
 }
 
 /// Read a tuple containing the (width, height) of the image located at the specified path.
@@ -1130,8 +1128,7 @@ pub fn image_dimensions<P>(path: P) -> ImageResult<(u32, u32)>
 where
     P: AsRef<Path>,
 {
-    // thin wrapper function to strip generics before calling open_impl
-    free_functions::image_dimensions_impl(path.as_ref())
+    crate::io::Reader::open(path)?.into_dimensions()
 }
 
 /// Saves the supplied buffer to a file at the path specified.

--- a/src/image.rs
+++ b/src/image.rs
@@ -613,7 +613,7 @@ where
                         .min(end - position);
 
                     output
-                        .write(&tmp[offset as usize..][..len as usize])
+                        .write_all(&tmp[offset as usize..][..len as usize])
                         .unwrap();
                     start += len;
 
@@ -644,7 +644,7 @@ where
                             .min(end - position);
 
                         output
-                            .write(&tmp[offset as usize..][..len as usize])
+                            .write_all(&tmp[offset as usize..][..len as usize])
                             .unwrap();
                     }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,8 +1,7 @@
 #![allow(clippy::too_many_arguments)]
 use std::convert::TryFrom;
 use std::ffi::OsStr;
-use std::io;
-use std::io::Read;
+use std::io::{self, Write};
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
 use std::usize;
@@ -554,24 +553,27 @@ impl ImageReadBuffer {
 /// starting from ```x``` and ```y``` and having ```length``` and ```width```
 #[allow(dead_code)]
 // When no image formats that use it are enabled
-pub(crate) fn load_rect<'a, D, F, F1, F2, E>(
+pub(crate) fn load_rect<D, F1, F2, E>(
     x: u32,
     y: u32,
     width: u32,
     height: u32,
     buf: &mut [u8],
-    progress_callback: F,
+    row_pitch: usize,
     decoder: &mut D,
+    scanline_bytes: usize,
     mut seek_scanline: F1,
     mut read_scanline: F2,
 ) -> ImageResult<()>
 where
-    D: ImageDecoder<'a>,
-    F: Fn(Progress),
+    D: ImageDecoder,
     F1: FnMut(&mut D, u64) -> io::Result<()>,
     F2: FnMut(&mut D, &mut [u8]) -> Result<(), E>,
     ImageError: From<E>,
 {
+    let scanline_bytes = u64::try_from(scanline_bytes).unwrap();
+    let row_pitch = u64::try_from(row_pitch).unwrap();
+
     let (x, y, width, height) = (
         u64::from(x),
         u64::from(y),
@@ -581,8 +583,6 @@ where
     let dimensions = decoder.dimensions();
     let bytes_per_pixel = u64::from(decoder.color_type().bytes_per_pixel());
     let row_bytes = bytes_per_pixel * u64::from(dimensions.0);
-    #[allow(deprecated)]
-    let scanline_bytes = decoder.scanline_bytes();
     let total_bytes = width * height * bytes_per_pixel;
 
     if buf.len() < usize::try_from(total_bytes).unwrap_or(usize::max_value()) {
@@ -593,7 +593,6 @@ where
         );
     }
 
-    let mut bytes_read = 0u64;
     let mut current_scanline = 0;
     let mut tmp = Vec::new();
     let mut tmp_scanline = None;
@@ -601,70 +600,59 @@ where
     {
         // Read a range of the image starting from byte number `start` and continuing until byte
         // number `end`. Updates `current_scanline` and `bytes_read` appropriately.
-        let mut read_image_range = |mut start: u64, end: u64| -> ImageResult<()> {
-            // If the first scanline we need is already stored in the temporary buffer, then handle
-            // it first.
-            let target_scanline = start / scanline_bytes;
-            if tmp_scanline == Some(target_scanline) {
-                let position = target_scanline * scanline_bytes;
-                let offset = start.saturating_sub(position);
-                let len = (end - start)
-                    .min(scanline_bytes - offset)
-                    .min(end - position);
-
-                buf[(bytes_read as usize)..][..len as usize]
-                    .copy_from_slice(&tmp[offset as usize..][..len as usize]);
-                bytes_read += len;
-                start += len;
-
-                progress_callback(Progress {
-                    current: bytes_read,
-                    total: total_bytes,
-                });
-
-                if start == end {
-                    return Ok(());
-                }
-            }
-
-            let target_scanline = start / scanline_bytes;
-            if target_scanline != current_scanline {
-                seek_scanline(decoder, target_scanline)?;
-                current_scanline = target_scanline;
-            }
-
-            let mut position = current_scanline * scanline_bytes;
-            while position < end {
-                if position >= start && end - position >= scanline_bytes {
-                    read_scanline(
-                        decoder,
-                        &mut buf[(bytes_read as usize)..][..(scanline_bytes as usize)],
-                    )?;
-                    bytes_read += scanline_bytes;
-                } else {
-                    tmp.resize(scanline_bytes as usize, 0u8);
-                    read_scanline(decoder, &mut tmp)?;
-                    tmp_scanline = Some(current_scanline);
-
+        let mut read_image_range =
+            |mut start: u64, end: u64, mut output: &mut [u8]| -> ImageResult<()> {
+                // If the first scanline we need is already stored in the temporary buffer, then handle
+                // it first.
+                let target_scanline = start / scanline_bytes;
+                if tmp_scanline == Some(target_scanline) {
+                    let position = target_scanline * scanline_bytes;
                     let offset = start.saturating_sub(position);
                     let len = (end - start)
                         .min(scanline_bytes - offset)
                         .min(end - position);
 
-                    buf[(bytes_read as usize)..][..len as usize]
-                        .copy_from_slice(&tmp[offset as usize..][..len as usize]);
-                    bytes_read += len;
+                    output
+                        .write(&tmp[offset as usize..][..len as usize])
+                        .unwrap();
+                    start += len;
+
+                    if start == end {
+                        return Ok(());
+                    }
                 }
 
-                current_scanline += 1;
-                position += scanline_bytes;
-                progress_callback(Progress {
-                    current: bytes_read,
-                    total: total_bytes,
-                });
-            }
-            Ok(())
-        };
+                let target_scanline = start / scanline_bytes;
+                if target_scanline != current_scanline {
+                    seek_scanline(decoder, target_scanline)?;
+                    current_scanline = target_scanline;
+                }
+
+                let mut position = current_scanline * scanline_bytes;
+                while position < end {
+                    if position >= start && end - position >= scanline_bytes {
+                        read_scanline(decoder, &mut output[..(scanline_bytes as usize)])?;
+                        output = &mut output[scanline_bytes as usize..];
+                    } else {
+                        tmp.resize(scanline_bytes as usize, 0u8);
+                        read_scanline(decoder, &mut tmp)?;
+                        tmp_scanline = Some(current_scanline);
+
+                        let offset = start.saturating_sub(position);
+                        let len = (end - start)
+                            .min(scanline_bytes - offset)
+                            .min(end - position);
+
+                        output
+                            .write(&tmp[offset as usize..][..len as usize])
+                            .unwrap();
+                    }
+
+                    current_scanline += 1;
+                    position += scanline_bytes;
+                }
+                Ok(())
+            };
 
         if x + width > u64::from(dimensions.0)
             || y + height > u64::from(dimensions.1)
@@ -681,19 +669,15 @@ where
             )));
         }
 
-        progress_callback(Progress {
-            current: 0,
-            total: total_bytes,
-        });
-        if x == 0 && width == u64::from(dimensions.0) {
+        if x == 0 && width == u64::from(dimensions.0) && row_pitch == row_bytes {
             let start = x * bytes_per_pixel + y * row_bytes;
             let end = (x + width) * bytes_per_pixel + (y + height - 1) * row_bytes;
-            read_image_range(start, end)?;
+            read_image_range(start, end, buf)?;
         } else {
-            for row in y..(y + height) {
+            for (output_slice, row) in buf.chunks_mut(row_pitch as usize).zip(y..(y + height)) {
                 let start = x * bytes_per_pixel + row * row_bytes;
                 let end = (x + width) * bytes_per_pixel + row * row_bytes;
-                read_image_range(start, end)?;
+                read_image_range(start, end, output_slice)?;
             }
         }
     }
@@ -706,7 +690,7 @@ where
 /// of the output buffer is guaranteed.
 ///
 /// Panics if there isn't enough memory to decode the image.
-pub(crate) fn decoder_to_vec<'a, T>(decoder: impl ImageDecoder<'a>) -> ImageResult<Vec<T>>
+pub(crate) fn decoder_to_vec<T>(decoder: impl ImageDecoder) -> ImageResult<Vec<T>>
 where
     T: crate::traits::Primitive + bytemuck::Pod,
 {
@@ -722,46 +706,8 @@ where
     Ok(buf)
 }
 
-/// Represents the progress of an image operation.
-///
-/// Note that this is not necessarily accurate and no change to the values passed to the progress
-/// function during decoding will be considered breaking. A decoder could in theory report the
-/// progress `(0, 0)` if progress is unknown, without violating the interface contract of the type.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Progress {
-    current: u64,
-    total: u64,
-}
-
-impl Progress {
-    /// Create Progress. Result in invalid progress if you provide a greater `current` than `total`.
-    pub(crate) fn new(current: u64, total: u64) -> Self {
-        Self { current, total }
-    }
-
-    /// A measure of completed decoding.
-    pub fn current(self) -> u64 {
-        self.current
-    }
-
-    /// A measure of all necessary decoding work.
-    ///
-    /// This is in general greater or equal than `current`.
-    pub fn total(self) -> u64 {
-        self.total
-    }
-
-    /// Calculate a measure for remaining decoding work.
-    pub fn remaining(self) -> u64 {
-        self.total.max(self.current) - self.current
-    }
-}
-
 /// The trait that all decoders implement
-pub trait ImageDecoder<'a>: Sized {
-    /// The type of reader produced by `into_reader`.
-    type Reader: Read + 'a;
-
+pub trait ImageDecoder {
     /// Returns a tuple containing the width and height of the image
     fn dimensions(&self) -> (u32, u32);
 
@@ -773,19 +719,12 @@ pub trait ImageDecoder<'a>: Sized {
         self.color_type().into()
     }
 
-    /// Returns the ICC color profile embedded in the image
+    /// Returns the ICC color profile embedded in the image, or `Ok(None)` if the image does not have one.
     ///
-    /// For formats that don't support embedded profiles this function will always return `None`.
-    /// This feature is currently only supported for the JPEG, PNG, and AVIF formats.
-    fn icc_profile(&mut self) -> Option<Vec<u8>> {
-        None
+    /// For formats that don't support embedded profiles this function should always return `Ok(None)`.
+    fn icc_profile(&mut self) -> ImageResult<Option<Vec<u8>>> {
+        Ok(None)
     }
-
-    /// Returns a reader that can be used to obtain the bytes of the image. For the best
-    /// performance, always try to read at least `scanline_bytes` from the reader at a time. Reading
-    /// fewer bytes will cause the reader to perform internal buffering.
-    #[deprecated = "Planned for removal. See https://github.com/image-rs/image/issues/1989"]
-    fn into_reader(self) -> ImageResult<Self::Reader>;
 
     /// Returns the total number of bytes in the decoded image.
     ///
@@ -798,13 +737,6 @@ pub trait ImageDecoder<'a>: Sized {
         let total_pixels = u64::from(dimensions.0) * u64::from(dimensions.1);
         let bytes_per_pixel = u64::from(self.color_type().bytes_per_pixel());
         total_pixels.saturating_mul(bytes_per_pixel)
-    }
-
-    /// Returns the minimum number of bytes that can be efficiently read from this decoder. This may
-    /// be as few as 1 or as many as `total_bytes()`.
-    #[deprecated = "Planned for removal. See https://github.com/image-rs/image/issues/1989"]
-    fn scanline_bytes(&self) -> u64 {
-        self.total_bytes()
     }
 
     /// Returns all the bytes in the image.
@@ -828,49 +760,11 @@ pub trait ImageDecoder<'a>: Sized {
     ///     buf
     /// }
     /// ```
-    fn read_image(self, buf: &mut [u8]) -> ImageResult<()> {
-        #[allow(deprecated)]
-        self.read_image_with_progress(buf, |_| {})
-    }
+    fn read_image(self, buf: &mut [u8]) -> ImageResult<()>
+    where
+        Self: Sized;
 
-    /// Same as `read_image` but periodically calls the provided callback to give updates on loading
-    /// progress.
-    #[deprecated = "Use read_image instead. See https://github.com/image-rs/image/issues/1989"]
-    fn read_image_with_progress<F: Fn(Progress)>(
-        self,
-        buf: &mut [u8],
-        progress_callback: F,
-    ) -> ImageResult<()> {
-        assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
-
-        let total_bytes = self.total_bytes() as usize;
-        #[allow(deprecated)]
-        let scanline_bytes = self.scanline_bytes() as usize;
-        let target_read_size = if scanline_bytes < 4096 {
-            (4096 / scanline_bytes) * scanline_bytes
-        } else {
-            scanline_bytes
-        };
-
-        #[allow(deprecated)]
-        let mut reader = self.into_reader()?;
-
-        let mut bytes_read = 0;
-        while bytes_read < total_bytes {
-            let read_size = target_read_size.min(total_bytes - bytes_read);
-            reader.read_exact(&mut buf[bytes_read..][..read_size])?;
-            bytes_read += read_size;
-
-            progress_callback(Progress {
-                current: bytes_read as u64,
-                total: total_bytes as u64,
-            });
-        }
-
-        Ok(())
-    }
-
-    /// Set decoding limits for this decoder. See [`Limits`] for the different kinds of
+    /// Set the decoder to have the specified limits. See [`Limits`] for the different kinds of
     /// limits that is possible to set.
     ///
     /// Note to implementors: make sure you call [`Limits::check_support`] so that
@@ -883,17 +777,63 @@ pub trait ImageDecoder<'a>: Sized {
     /// [`Limits::check_dimensions`]: ./io/struct.Limits.html#method.check_dimensions
     fn set_limits(&mut self, limits: crate::io::Limits) -> ImageResult<()> {
         limits.check_support(&crate::io::LimitSupport::default())?;
-
         let (width, height) = self.dimensions();
         limits.check_dimensions(width, height)?;
-
         Ok(())
+    }
+
+    /// Use `read_image` instead; this method is an implementation detail needed so the trait can
+    /// be object safe.
+    ///
+    /// Note to implementors: This method should be implemented by calling `read_image` on
+    /// the boxed decoder...
+    /// ```no_build
+    ///     fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
+    ///        (*self).read_image(buf)
+    ///    }
+    /// ```
+    fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()>;
+}
+
+impl<T: ?Sized + ImageDecoder> ImageDecoder for Box<T> {
+    fn dimensions(&self) -> (u32, u32) {
+        (**self).dimensions()
+    }
+    fn color_type(&self) -> ColorType {
+        (**self).color_type()
+    }
+    fn original_color_type(&self) -> ExtendedColorType {
+        (**self).original_color_type()
+    }
+    fn icc_profile(&mut self) -> ImageResult<Option<Vec<u8>>> {
+        (**self).icc_profile()
+    }
+    fn total_bytes(&self) -> u64 {
+        (**self).total_bytes()
+    }
+    fn read_image(self, buf: &mut [u8]) -> ImageResult<()>
+    where
+        Self: Sized,
+    {
+        T::read_image_boxed(self, buf)
+    }
+    fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
+        T::read_image_boxed(*self, buf)
+    }
+    fn set_limits(&mut self, limits: crate::io::Limits) -> ImageResult<()> {
+        (**self).set_limits(limits)
     }
 }
 
 /// Specialized image decoding not be supported by all formats
-pub trait ImageDecoderRect<'a>: ImageDecoder<'a> + Sized {
-    /// Decode a rectangular section of the image; see [`read_rect_with_progress()`](#fn.read_rect_with_progress).
+pub trait ImageDecoderRect: ImageDecoder {
+    /// Decode a rectangular section of the image.
+    ///
+    /// This function takes a slice of bytes and writes the pixel data of the image into it.
+    /// The rectangle is specified by the x and y coordinates of the top left corner, the width
+    /// and height of the rectangle, and the row pitch of the buffer. The row pitch is the number
+    /// of bytes between the start of one row and the start of the next row. The row pitch must be
+    /// at least as large as the width of the rectangle in bytes.
     fn read_rect(
         &mut self,
         x: u32,
@@ -901,32 +841,7 @@ pub trait ImageDecoderRect<'a>: ImageDecoder<'a> + Sized {
         width: u32,
         height: u32,
         buf: &mut [u8],
-    ) -> ImageResult<()> {
-        #[allow(deprecated)]
-        self.read_rect_with_progress(x, y, width, height, buf, |_| {})
-    }
-
-    /// Decode a rectangular section of the image, periodically reporting progress.
-    ///
-    /// The output buffer will be filled with fields specified by
-    /// [`ImageDecoder::color_type()`](trait.ImageDecoder.html#fn.color_type),
-    /// in that order, each field represented in native-endian.
-    ///
-    /// The progress callback will be called at least once at the start and the end of decoding,
-    /// implementations are encouraged to call this more often,
-    /// with a frequency meaningful for display to the end-user.
-    ///
-    /// This function will panic if the output buffer isn't at least
-    /// `color_type().bytes_per_pixel() * color_type().channel_count() * width * height` bytes long.
-    #[deprecated = "Use read_image instead. See https://github.com/image-rs/image/issues/1989"]
-    fn read_rect_with_progress<F: Fn(Progress)>(
-        &mut self,
-        x: u32,
-        y: u32,
-        width: u32,
-        height: u32,
-        buf: &mut [u8],
-        progress_callback: F,
+        row_pitch: usize,
     ) -> ImageResult<()>;
 }
 
@@ -1597,19 +1512,18 @@ mod tests {
             scanline_number: u64,
             scanline_bytes: u64,
         }
-        impl<'a> ImageDecoder<'a> for MockDecoder {
-            type Reader = Box<dyn io::Read>;
+        impl ImageDecoder for MockDecoder {
             fn dimensions(&self) -> (u32, u32) {
                 (5, 5)
             }
             fn color_type(&self) -> ColorType {
                 ColorType::L8
             }
-            fn into_reader(self) -> ImageResult<Self::Reader> {
+            fn read_image(self, buf: &mut [u8]) -> ImageResult<()> {
                 unimplemented!()
             }
-            fn scanline_bytes(&self) -> u64 {
-                self.scanline_bytes
+            fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
+                (*self).read_image(buf)
             }
         }
 
@@ -1643,11 +1557,12 @@ mod tests {
                 5,
                 5,
                 &mut output,
-                |_| {},
+                5,
                 &mut MockDecoder {
                     scanline_number: 0,
                     scanline_bytes,
                 },
+                scanline_bytes as usize,
                 seek_scanline,
                 read_scanline,
             )
@@ -1662,11 +1577,12 @@ mod tests {
                 1,
                 1,
                 &mut output,
-                |_| {},
+                1,
                 &mut MockDecoder {
                     scanline_number: 0,
                     scanline_bytes,
                 },
+                scanline_bytes as usize,
                 seek_scanline,
                 read_scanline,
             )
@@ -1680,11 +1596,12 @@ mod tests {
                 2,
                 2,
                 &mut output,
-                |_| {},
+                2,
                 &mut MockDecoder {
                     scanline_number: 0,
                     scanline_bytes,
                 },
+                scanline_bytes as usize,
                 seek_scanline,
                 read_scanline,
             )
@@ -1698,11 +1615,12 @@ mod tests {
                 2,
                 4,
                 &mut output,
-                |_| {},
+                2,
                 &mut MockDecoder {
                     scanline_number: 0,
                     scanline_bytes,
                 },
+                scanline_bytes as usize,
                 seek_scanline,
                 read_scanline,
             )
@@ -1719,19 +1637,18 @@ mod tests {
         ];
 
         struct MockDecoder;
-        impl<'a> ImageDecoder<'a> for MockDecoder {
-            type Reader = Box<dyn io::Read>;
+        impl ImageDecoder for MockDecoder {
             fn dimensions(&self) -> (u32, u32) {
                 (5, 5)
             }
             fn color_type(&self) -> ColorType {
                 ColorType::L8
             }
-            fn into_reader(self) -> ImageResult<Self::Reader> {
+            fn read_image(self, buf: &mut [u8]) -> ImageResult<()> {
                 unimplemented!()
             }
-            fn scanline_bytes(&self) -> u64 {
-                25
+            fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
+                (*self).read_image(buf)
             }
         }
 
@@ -1756,8 +1673,9 @@ mod tests {
             2,
             4,
             &mut output,
-            |_| {},
+            2,
             &mut MockDecoder,
+            DATA.len(),
             seek_scanline,
             read_scanline,
         )
@@ -1961,16 +1879,18 @@ mod tests {
     #[test]
     fn total_bytes_overflow() {
         struct D;
-        impl<'a> ImageDecoder<'a> for D {
-            type Reader = std::io::Cursor<Vec<u8>>;
+        impl ImageDecoder for D {
             fn color_type(&self) -> ColorType {
                 ColorType::Rgb8
             }
             fn dimensions(&self) -> (u32, u32) {
                 (0xffffffff, 0xffffffff)
             }
-            fn into_reader(self) -> ImageResult<Self::Reader> {
-                unreachable!()
+            fn read_image(self, buf: &mut [u8]) -> ImageResult<()> {
+                unimplemented!()
+            }
+            fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
+                (*self).read_image(buf)
             }
         }
         assert_eq!(D.total_bytes(), u64::max_value());

--- a/src/image.rs
+++ b/src/image.rs
@@ -1519,7 +1519,7 @@ mod tests {
             fn color_type(&self) -> ColorType {
                 ColorType::L8
             }
-            fn read_image(self, buf: &mut [u8]) -> ImageResult<()> {
+            fn read_image(self, _buf: &mut [u8]) -> ImageResult<()> {
                 unimplemented!()
             }
             fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
@@ -1644,7 +1644,7 @@ mod tests {
             fn color_type(&self) -> ColorType {
                 ColorType::L8
             }
-            fn read_image(self, buf: &mut [u8]) -> ImageResult<()> {
+            fn read_image(self, _buf: &mut [u8]) -> ImageResult<()> {
                 unimplemented!()
             }
             fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
@@ -1886,7 +1886,7 @@ mod tests {
             fn dimensions(&self) -> (u32, u32) {
                 (0xffffffff, 0xffffffff)
             }
-            fn read_image(self, buf: &mut [u8]) -> ImageResult<()> {
+            fn read_image(self, _buf: &mut [u8]) -> ImageResult<()> {
                 unimplemented!()
             }
             fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::{BufRead, BufReader, BufWriter, Seek};
+use std::io::{BufRead, BufWriter, Seek};
 use std::path::Path;
 use std::u32;
 
@@ -17,12 +17,6 @@ use crate::{
     ImageOutputFormat,
 };
 
-pub(crate) fn open_impl(path: &Path) -> ImageResult<DynamicImage> {
-    let buffered_read = BufReader::new(File::open(path).map_err(ImageError::IoError)?);
-
-    load(buffered_read, ImageFormat::from_path(path)?)
-}
-
 /// Create a new image from a Reader.
 ///
 /// Assumes the reader is already buffered. For optimal performance,
@@ -31,110 +25,10 @@ pub(crate) fn open_impl(path: &Path) -> ImageResult<DynamicImage> {
 /// Try [`io::Reader`] for more advanced uses.
 ///
 /// [`io::Reader`]: io/struct.Reader.html
-#[allow(unused_variables)]
-// r is unused if no features are supported.
 pub fn load<R: BufRead + Seek>(r: R, format: ImageFormat) -> ImageResult<DynamicImage> {
-    load_inner(r, super::Limits::default(), format)
-}
-
-pub(crate) trait DecoderVisitor {
-    type Result;
-    fn visit_decoder<'a, D: ImageDecoder<'a>>(self, decoder: D) -> ImageResult<Self::Result>;
-}
-
-pub(crate) fn load_decoder<R: BufRead + Seek, V: DecoderVisitor>(
-    r: R,
-    format: ImageFormat,
-    limits: super::Limits,
-    visitor: V,
-) -> ImageResult<V::Result> {
-    #[allow(unreachable_patterns)]
-    // Default is unreachable if all features are supported.
-    match format {
-        #[cfg(feature = "avif-decoder")]
-        image::ImageFormat::Avif => visitor.visit_decoder(avif::AvifDecoder::new(r)?),
-        #[cfg(feature = "png")]
-        image::ImageFormat::Png => visitor.visit_decoder(png::PngDecoder::with_limits(r, limits)?),
-        #[cfg(feature = "gif")]
-        image::ImageFormat::Gif => visitor.visit_decoder(gif::GifDecoder::new(r)?),
-        #[cfg(feature = "jpeg")]
-        image::ImageFormat::Jpeg => visitor.visit_decoder(jpeg::JpegDecoder::new(r)?),
-        #[cfg(feature = "webp")]
-        image::ImageFormat::WebP => visitor.visit_decoder(webp::WebPDecoder::new(r)?),
-        #[cfg(feature = "tiff")]
-        image::ImageFormat::Tiff => visitor.visit_decoder(tiff::TiffDecoder::new(r)?),
-        #[cfg(feature = "tga")]
-        image::ImageFormat::Tga => visitor.visit_decoder(tga::TgaDecoder::new(r)?),
-        #[cfg(feature = "dds")]
-        image::ImageFormat::Dds => visitor.visit_decoder(dds::DdsDecoder::new(r)?),
-        #[cfg(feature = "bmp")]
-        image::ImageFormat::Bmp => visitor.visit_decoder(bmp::BmpDecoder::new(r)?),
-        #[cfg(feature = "ico")]
-        image::ImageFormat::Ico => visitor.visit_decoder(ico::IcoDecoder::new(r)?),
-        #[cfg(feature = "hdr")]
-        image::ImageFormat::Hdr => visitor.visit_decoder(hdr::HdrAdapter::new(BufReader::new(r))?),
-        #[cfg(feature = "exr")]
-        image::ImageFormat::OpenExr => visitor.visit_decoder(openexr::OpenExrDecoder::new(r)?),
-        #[cfg(feature = "pnm")]
-        image::ImageFormat::Pnm => visitor.visit_decoder(pnm::PnmDecoder::new(r)?),
-        #[cfg(feature = "farbfeld")]
-        image::ImageFormat::Farbfeld => visitor.visit_decoder(farbfeld::FarbfeldDecoder::new(r)?),
-        #[cfg(feature = "qoi")]
-        image::ImageFormat::Qoi => visitor.visit_decoder(qoi::QoiDecoder::new(r)?),
-        _ => Err(ImageError::Unsupported(
-            ImageFormatHint::Exact(format).into(),
-        )),
-    }
-}
-
-pub(crate) fn load_inner<R: BufRead + Seek>(
-    r: R,
-    limits: super::Limits,
-    format: ImageFormat,
-) -> ImageResult<DynamicImage> {
-    struct LoadVisitor(super::Limits);
-
-    impl DecoderVisitor for LoadVisitor {
-        type Result = DynamicImage;
-
-        fn visit_decoder<'a, D: ImageDecoder<'a>>(
-            self,
-            mut decoder: D,
-        ) -> ImageResult<Self::Result> {
-            let mut limits = self.0;
-            // Check that we do not allocate a bigger buffer than we are allowed to
-            // FIXME: should this rather go in `DynamicImage::from_decoder` somehow?
-            limits.reserve(decoder.total_bytes())?;
-            decoder.set_limits(limits)?;
-            DynamicImage::from_decoder(decoder)
-        }
-    }
-
-    load_decoder(r, format, limits.clone(), LoadVisitor(limits))
-}
-
-pub(crate) fn image_dimensions_impl(path: &Path) -> ImageResult<(u32, u32)> {
-    let format = image::ImageFormat::from_path(path)?;
-    let reader = BufReader::new(File::open(path)?);
-    image_dimensions_with_format_impl(reader, format)
-}
-
-#[allow(unused_variables)]
-// fin is unused if no features are supported.
-pub(crate) fn image_dimensions_with_format_impl<R: BufRead + Seek>(
-    buffered_read: R,
-    format: ImageFormat,
-) -> ImageResult<(u32, u32)> {
-    struct DimVisitor;
-
-    impl DecoderVisitor for DimVisitor {
-        type Result = (u32, u32);
-        fn visit_decoder<'a, D: ImageDecoder<'a>>(self, decoder: D) -> ImageResult<Self::Result> {
-            Ok(decoder.dimensions())
-        }
-    }
-
-    load_decoder(buffered_read, format, super::Limits::default(), DimVisitor)
+    let mut reader = crate::io::Reader::new(r);
+    reader.set_format(format);
+    reader.decode()
 }
 
 #[allow(unused_variables)]

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -57,7 +57,8 @@ pub struct Limits {
     pub max_image_height: Option<u32>,
     /// The maximum allowed sum of allocations allocated by the decoder at any one time excluding
     /// allocator overhead. This limit is non-strict by default and some decoders may ignore it.
-    /// The default is 512MiB.
+    /// The bytes required to store the output image count towards this value. The default is
+    /// 512MiB.
     pub max_alloc: Option<u64>,
     _non_exhaustive: (),
 }

--- a/src/io/reader.rs
+++ b/src/io/reader.rs
@@ -185,6 +185,7 @@ impl<'a, R: 'a + Read + Seek> Reader<R> {
         })
     }
 
+    /// Convert the reader into a decoder.
     pub fn into_decoder(mut self) -> ImageResult<impl ImageDecoder + 'a> {
         let mut decoder = Self::make_decoder(self.require_format()?, self.inner, self.limits.clone())?;
         decoder.set_limits(self.limits)?;

--- a/src/io/reader.rs
+++ b/src/io/reader.rs
@@ -187,7 +187,8 @@ impl<'a, R: 'a + Read + Seek> Reader<R> {
 
     /// Convert the reader into a decoder.
     pub fn into_decoder(mut self) -> ImageResult<impl ImageDecoder + 'a> {
-        let mut decoder = Self::make_decoder(self.require_format()?, self.inner, self.limits.clone())?;
+        let mut decoder =
+            Self::make_decoder(self.require_format()?, self.inner, self.limits.clone())?;
         decoder.set_limits(self.limits)?;
         Ok(decoder)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,6 @@ pub use crate::image::{
     ImageOutputFormat,
     // Iterators
     Pixels,
-    Progress,
     SubImage,
 };
 
@@ -255,9 +254,6 @@ pub mod codecs {
     pub mod bmp;
     #[cfg(feature = "dds")]
     pub mod dds;
-    #[cfg(feature = "dxt")]
-    #[deprecated = "DXT support will be removed or reworked in a future version. Prefer the `squish` crate instead. See https://github.com/image-rs/image/issues/1623"]
-    pub mod dxt;
     #[cfg(feature = "farbfeld")]
     pub mod farbfeld;
     #[cfg(feature = "gif")]
@@ -282,6 +278,9 @@ pub mod codecs {
     pub mod tiff;
     #[cfg(feature = "webp")]
     pub mod webp;
+
+    #[cfg(feature = "dds")]
+    mod dxt;
 }
 
 mod animation;

--- a/tests/reference_images.rs
+++ b/tests/reference_images.rs
@@ -223,7 +223,7 @@ fn check_references() {
                     use image::AnimationDecoder;
                     let stream = io::BufReader::new(fs::File::open(&img_path).unwrap());
                     let decoder = match image::codecs::png::PngDecoder::new(stream) {
-                        Ok(decoder) => decoder.apng(),
+                        Ok(decoder) => decoder.apng().unwrap(),
                         Err(image::ImageError::Unsupported(_)) => return,
                         Err(err) => {
                             panic!("decoding of {:?} failed with: {}", img_path, err)


### PR DESCRIPTION
This sketches out possible changes we may want to make to the ImageDecoder trait in the next major release:
* Makes the trait object safe
* ~~Adds a constructor (all non-deprecated implementations had one, but it wasn't part of the trait).~~
* ~~Combines `ImageDecoder` and `ImageDecoderRect`~~
* Removes the `into_reader`, `*_with_progress`, and `scanline_bytes` methods. This is the aspect I'm least sure about, but few backends had meaningful implementations of these and it cuts down on the number of methods on the trait. Some decoders will still be able to support incremental decoding by doing multiple `read_rect` calls 

The object safety change in particular makes our internal usage of the trait much nicer. Instead of having to work with a DecoderVisitor trait, we can rely on dynamic dispatch.

~~For now I've held on updating the various format decoders. That'll be a bunch of work so it makes sense to settle on what the API should be first.~~ 

_**Edit:** scaled back some of these changes and updated all the format decoders._