### PR TITLE
Update dav1d and dcv-color-primitives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,8 @@ tiff = { version = "0.8.0", optional = true }
 ravif = { version = "0.11.0", optional = true }
 rgb = { version = "0.8.25", optional = true }
 mp4parse = { version = "0.12.0", optional = true }
-dav1d = { version = "0.6.0", optional = true }
-dcv-color-primitives = { version = "0.4.0", optional = true }
+dav1d = { version = "0.9.3", optional = true }
+dcv-color-primitives = { version = "0.5.2", optional = true }
 color_quant = "1.1"
 exr = { version = "1.5.0", optional = true }
 qoi = { version = "0.4", optional = true }


### PR DESCRIPTION
I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.