### PR TITLE
AvifEncoder: Add with_num_threads()

### DIFF
--- a/src/codecs/avif/encoder.rs
+++ b/src/codecs/avif/encoder.rs
@@ -81,6 +81,13 @@ impl<W: Write> AvifEncoder<W> {
             .with_internal_color_space(color_space.to_ravif());
         self
     }
+
+    /// Configures `rayon` thread pool size.
+    /// The default `None` is to use all threads in the default `rayon` thread pool.
+    pub fn with_num_threads(mut self, num_threads: Option<usize>) -> Self {
+        self.encoder = self.encoder.with_num_threads(num_threads);
+        self
+    }
 }
 
 impl<W: Write> ImageEncoder for AvifEncoder<W> {


### PR DESCRIPTION
Basically to allow some control over used system resources dedicated to encoding images.

---

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.