### PR TITLE
Add `zune-jpeg` as an alternative backend for JPEG decoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ color_quant = "1.1"
 exr = { version = "1.5.0", optional = true }
 qoi = { version = "0.4", optional = true }
 libwebp = { package = "webp", version = "0.2.2", default-features = false, optional = true }
-zune-jpeg = { version = "0.3.12", path = "../zune-image/zune-jpeg" }
-zune-core = { version = "0.2.1", path = "../zune-image/zune-core" }
+zune-jpeg = { version = "0.3.13" }
+zune-core = { version = "0.2.1" }
 
 [dev-dependencies]
 crc32fast = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ exr = { version = "1.5.0", optional = true }
 qoi = { version = "0.4", optional = true }
 libwebp = { package = "webp", version = "0.2.2", default-features = false, optional = true }
 zune-jpeg = { version = "0.3.12", path = "../zune-image/zune-jpeg" }
-zune-core = "0.2.1"
+zune-core = { version = "0.2.1", path = "../zune-image/zune-core" }
 
 [dev-dependencies]
 crc32fast = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,8 @@ color_quant = "1.1"
 exr = { version = "1.5.0", optional = true }
 qoi = { version = "0.4", optional = true }
 libwebp = { package = "webp", version = "0.2.2", default-features = false, optional = true }
+zune-jpeg = { version = "0.3.12", path = "../zune-image/zune-jpeg" }
+zune-core = "0.2.1"
 
 [dev-dependencies]
 crc32fast = "1.2.0"

--- a/src/codecs/jpeg/decoder_zune.rs
+++ b/src/codecs/jpeg/decoder_zune.rs
@@ -99,8 +99,8 @@ impl ColorType {
         let colorspace = to_supported_color_space(colorspace);
         use zune_core::colorspace::ColorSpace::*;
         match colorspace {
-            // TODO: are these always 8-bit? I've asked at
-            // https://github.com/etemesi254/zune-image/discussions/99
+            // As of zune-jpeg 0.3.13 the output is always 8-bit,
+            // but support for 16-bit JPEG might be added in the future.
             RGB => ColorType::Rgb8,
             RGBA => ColorType::Rgba8,
             Luma => ColorType::L8,

--- a/src/codecs/jpeg/decoder_zune.rs
+++ b/src/codecs/jpeg/decoder_zune.rs
@@ -88,8 +88,7 @@ impl<'a> ImageDecoder<'a> for ZuneJpegDecoder {
         }
 
         let mut decoder = new_zune_decoder(&self.input, self.orig_color_space);
-        let data = decoder.decode().map_err(ImageError::from_zune_jpeg)?;
-        buf.copy_from_slice(&data);
+        decoder.decode_into(buf).map_err(ImageError::from_zune_jpeg)?;
         Ok(())
     }
 }

--- a/src/codecs/jpeg/decoder_zune.rs
+++ b/src/codecs/jpeg/decoder_zune.rs
@@ -1,0 +1,49 @@
+use crate::{ImageError, ColorType, error::{DecodingError, UnsupportedErrorKind, UnsupportedError, LimitError}, ImageFormat, color};
+
+type ZuneColorSpace = zune_core::colorspace::ColorSpace;
+
+pub struct ZuneJpegDecoder<R> {
+    decoder: jpeg::Decoder<R>,
+    metadata: jpeg::ImageInfo,
+}
+
+impl ColorType {
+    fn from_zune_jpeg(colorspace: ZuneColorSpace) -> ColorType {
+        let colorspace = to_supported_color_space(colorspace);
+        use zune_core::colorspace::ColorSpace::*;
+        match colorspace {
+            // TODO: are these always 8-bit? I've asked at
+            // https://github.com/etemesi254/zune-image/discussions/99
+            RGB => ColorType::Rgb8,
+            RGBA => ColorType::Rgba8,
+            Luma => ColorType::L8,
+            LumaA => ColorType::La8,
+            _ => unreachable!(),
+        }
+    }
+}
+
+fn to_supported_color_space(orig: ZuneColorSpace) -> ZuneColorSpace {
+    use zune_core::colorspace::ColorSpace::*;
+    match orig {
+        RGB | RGBA | Luma | LumaA => orig,
+        // the rest is not supported by `image` so it will be converted to RGB during decoding
+        _ => RGB,
+    }
+}
+
+impl ImageError {
+    fn from_zune_jpeg(err: zune_jpeg::errors::DecodeErrors) -> ImageError {
+        use zune_jpeg::errors::DecodeErrors::*;
+        match err {
+            Unsupported(desc) => ImageError::Unsupported(UnsupportedError::from_format_and_kind(
+                ImageFormat::Jpeg.into(),
+                UnsupportedErrorKind::GenericFeature(format!("{:?}", desc)),
+            )),
+            LargeDimensions(_) => ImageError::Limits(LimitError::from_kind(crate::error::LimitErrorKind::DimensionError)),
+            err => {
+                ImageError::Decoding(DecodingError::new(ImageFormat::Jpeg.into(), err))
+            }
+        }
+    }
+}

--- a/src/codecs/jpeg/decoder_zune.rs
+++ b/src/codecs/jpeg/decoder_zune.rs
@@ -88,7 +88,9 @@ impl<'a> ImageDecoder<'a> for ZuneJpegDecoder {
         }
 
         let mut decoder = new_zune_decoder(&self.input, self.orig_color_space);
-        decoder.decode_into(buf).map_err(ImageError::from_zune_jpeg)?;
+        decoder
+            .decode_into(buf)
+            .map_err(ImageError::from_zune_jpeg)?;
         Ok(())
     }
 }

--- a/src/codecs/jpeg/decoder_zune.rs
+++ b/src/codecs/jpeg/decoder_zune.rs
@@ -1,4 +1,3 @@
-use std::convert::TryFrom;
 use std::io::{self, Cursor, Read};
 
 use crate::{

--- a/src/codecs/jpeg/decoder_zune.rs
+++ b/src/codecs/jpeg/decoder_zune.rs
@@ -106,6 +106,7 @@ impl ColorType {
             RGBA => ColorType::Rgba8,
             Luma => ColorType::L8,
             LumaA => ColorType::La8,
+            // to_supported_color_space() doesn't return any of the other variants
             _ => unreachable!(),
         }
     }

--- a/src/codecs/jpeg/mod.rs
+++ b/src/codecs/jpeg/mod.rs
@@ -8,9 +8,11 @@
 //!
 
 pub use self::decoder::JpegDecoder;
+pub use self::decoder_zune::ZuneJpegDecoder;
 pub use self::encoder::{JpegEncoder, PixelDensity, PixelDensityUnit};
 
 mod decoder;
+mod decoder_zune;
 mod encoder;
 mod entropy;
 mod transform;


### PR DESCRIPTION
This is an initial implementation to get the ball rolling. I've implemented a decoder but it's not yet wired up to decoder selection based on format, or any other machinery. Haven't tested it either.

Right now this buffers the entire input in memory, but this requirement [may be relaxed soon.](https://github.com/etemesi254/zune-image/pull/98#issuecomment-1462742148).

It also parses headers twice, because `zune_jpeg::JpegDecoder` accepts a lifetime parameter and putting it into the same struct as the input data would create a self-referential struct. This should not be a big deal because it is offset by the efficiency gains over `jpeg-decoder`.

Fixes #1845 once complete

----

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to choose either at their option.