### PR TITLE
Faster BMP and JPEG decoding with any backend

### DIFF
--- a/src/codecs/bmp/decoder.rs
+++ b/src/codecs/bmp/decoder.rs
@@ -1518,10 +1518,7 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for BmpDecoder<R> {
     }
 
     fn into_reader(mut self) -> ImageResult<Self::Reader> {
-        Ok(BmpReader(
-            Cursor::new(self.get_image_data()?),
-            PhantomData,
-        ))
+        Ok(BmpReader(Cursor::new(self.get_image_data()?), PhantomData))
     }
 
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {

--- a/src/codecs/bmp/decoder.rs
+++ b/src/codecs/bmp/decoder.rs
@@ -1512,9 +1512,11 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for BmpDecoder<R> {
         }
     }
 
-    fn into_reader(self) -> ImageResult<Self::Reader> {
+    fn into_reader(mut self) -> ImageResult<Self::Reader> {
+        let mut buf: Vec<u8> = vec![0; self.total_bytes() as usize];
+        self.read_image_data(&mut buf)?;
         Ok(BmpReader(
-            Cursor::new(image::decoder_to_vec(self)?),
+            Cursor::new(buf),
             PhantomData,
         ))
     }

--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -108,8 +108,10 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for GifDecoder<R> {
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
+        let mut buf = vec![0; self.total_bytes() as usize];
+        self.read_image(&mut buf)?;
         Ok(GifReader(
-            Cursor::new(image::decoder_to_vec(self)?),
+            Cursor::new(buf),
             PhantomData,
         ))
     }

--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -110,10 +110,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for GifDecoder<R> {
     fn into_reader(self) -> ImageResult<Self::Reader> {
         let mut buf = vec![0; self.total_bytes() as usize];
         self.read_image(&mut buf)?;
-        Ok(GifReader(
-            Cursor::new(buf),
-            PhantomData,
-        ))
+        Ok(GifReader(Cursor::new(buf), PhantomData))
     }
 
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {

--- a/src/codecs/hdr/decoder.rs
+++ b/src/codecs/hdr/decoder.rs
@@ -201,10 +201,7 @@ impl<'a, R: 'a + BufRead> ImageDecoder<'a> for HdrAdapter<R> {
     fn into_reader(self) -> ImageResult<Self::Reader> {
         let mut buf = vec![0; self.total_bytes() as usize];
         self.read_image(&mut buf)?;
-        Ok(HdrReader(
-            Cursor::new(buf),
-            PhantomData,
-        ))
+        Ok(HdrReader(Cursor::new(buf), PhantomData))
     }
 
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {

--- a/src/codecs/hdr/decoder.rs
+++ b/src/codecs/hdr/decoder.rs
@@ -199,8 +199,10 @@ impl<'a, R: 'a + BufRead> ImageDecoder<'a> for HdrAdapter<R> {
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
+        let mut buf = vec![0; self.total_bytes() as usize];
+        self.read_image(&mut buf)?;
         Ok(HdrReader(
-            Cursor::new(image::decoder_to_vec(self)?),
+            Cursor::new(buf),
             PhantomData,
         ))
     }

--- a/src/codecs/ico/decoder.rs
+++ b/src/codecs/ico/decoder.rs
@@ -296,10 +296,9 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for IcoDecoder<R> {
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
-        Ok(IcoReader(
-            Cursor::new(image::decoder_to_vec(self)?),
-            PhantomData,
-        ))
+        let mut buf = vec![0; self.total_bytes() as usize];
+        self.read_image(&mut buf)?;
+        Ok(IcoReader(Cursor::new(buf), PhantomData))
     }
 
     fn read_image(self, buf: &mut [u8]) -> ImageResult<()> {

--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -386,8 +386,8 @@ mod test {
 
     use crate::buffer_::{Rgb32FImage, Rgba32FImage};
     use crate::error::{LimitError, LimitErrorKind};
-    use crate::{ImageBuffer, Rgb, Rgba};
     use crate::image::decoder_to_vec;
+    use crate::{ImageBuffer, Rgb, Rgba};
 
     const BASE_PATH: &[&str] = &[".", "tests", "images", "exr"];
 

--- a/src/codecs/pnm/decoder.rs
+++ b/src/codecs/pnm/decoder.rs
@@ -616,10 +616,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for PnmDecoder<R> {
     fn into_reader(self) -> ImageResult<Self::Reader> {
         let mut buf = vec![0; self.total_bytes() as usize];
         self.read_image(&mut buf)?;
-        Ok(PnmReader(
-            Cursor::new(buf),
-            PhantomData,
-        ))
+        Ok(PnmReader(Cursor::new(buf), PhantomData))
     }
 
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {

--- a/src/codecs/pnm/decoder.rs
+++ b/src/codecs/pnm/decoder.rs
@@ -614,8 +614,10 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for PnmDecoder<R> {
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
+        let mut buf = vec![0; self.total_bytes() as usize];
+        self.read_image(&mut buf)?;
         Ok(PnmReader(
-            Cursor::new(image::decoder_to_vec(self)?),
+            Cursor::new(buf),
             PhantomData,
         ))
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -608,9 +608,9 @@ where
     if TypeId::of::<T>() == TypeId::of::<u8>() {
         // It's faster to read u8 without zeroing the buffer first.
         // On top of that, some implementations such as JPEG produce a `Vec<u8>` up front,
-        // so going through the other codepath would cause a memcpy() and double the memory usage.
+        // so going through the other codepath would cause a memcpy().
         // A single large allocation here is actually OK because the memory won't be provisioned until
-        // we actuall write to it, so this doesn't increase actual memory usage
+        // we actually write to it, so this doesn't increase actual memory usage
         let mut buf: Vec<u8> = Vec::with_capacity(total_bytes.unwrap());
         decoder.into_reader()?.read_to_end(&mut buf)?;
         Ok(bytemuck::allocation::cast_vec(buf))

--- a/src/image.rs
+++ b/src/image.rs
@@ -619,7 +619,8 @@ where
         // and an allocation must be freed with the same size and alignment with which it was allocated,
         // so we have to create a Vec<T> up front and initialize it,
         // so that we could slice it and then change the layout of the slice, which is valid.
-        let mut buf = vec![num_traits::Zero::zero(); total_bytes.unwrap() / std::mem::size_of::<T>()];
+        let mut buf =
+            vec![num_traits::Zero::zero(); total_bytes.unwrap() / std::mem::size_of::<T>()];
         decoder.read_image(bytemuck::cast_slice_mut(buf.as_mut_slice()))?;
         Ok(buf)
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -595,7 +595,7 @@ where
 /// Panics if there isn't enough memory to decode the image.
 pub(crate) fn decoder_to_vec<'a, T>(decoder: impl ImageDecoder<'a>) -> ImageResult<Vec<T>>
 where
-    T: crate::traits::Primitive + bytemuck::Pod + std::any::Any,
+    T: crate::traits::Primitive + bytemuck::Pod,
 {
     let total_bytes = usize::try_from(decoder.total_bytes());
     if total_bytes.is_err() || total_bytes.unwrap() > isize::max_value() as usize {


### PR DESCRIPTION
Avoid a `memset()` + `memcpy()` of the entire decompressed image, saving 10%-15% of the time in decoding JPEGs and 25%-30% in decoding BMP, measured on

```rust
ImageReader::open(input)?.with_guessed_format()?.decode()?;
```

-----

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.