### PR TITLE
Faster JPEG decoding with `jpeg_decoder`

### DIFF
--- a/src/codecs/jpeg/decoder.rs
+++ b/src/codecs/jpeg/decoder.rs
@@ -118,6 +118,10 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for JpegDecoder<R> {
         Ok(())
     }
 
+    // `jpeg_decoder` crate always returns a `Vec<u8>`
+    // and provides no option to read into a pre-allocated buffer.
+    // So we specialize this method to simply return the Vec whenever possible
+    // for a 10% to 15% reduction in decoding time.
     fn read_to_vec<T>(self) -> ImageResult<Vec<T>>
     where
         T: crate::traits::Primitive + bytemuck::Pod,

--- a/src/codecs/jpeg/decoder.rs
+++ b/src/codecs/jpeg/decoder.rs
@@ -5,7 +5,8 @@ use std::mem;
 
 use crate::color::ColorType;
 use crate::error::{
-    DecodingError, ImageError, ImageResult, UnsupportedError, UnsupportedErrorKind, LimitError, LimitErrorKind,
+    DecodingError, ImageError, ImageResult, LimitError, LimitErrorKind, UnsupportedError,
+    UnsupportedErrorKind,
 };
 use crate::image::{ImageDecoder, ImageFormat};
 
@@ -136,11 +137,12 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for JpegDecoder<R> {
                 // and the old Vec<u8> is actually laid out in memory in such a way
                 // that it's insufficiently aligned for casting to T.
                 // So we have to perform a copying conversion to T.
-                let mut new_vec = vec![num_traits::Zero::zero(); total_bytes.unwrap() / std::mem::size_of::<T>()];
+                let mut new_vec =
+                    vec![num_traits::Zero::zero(); total_bytes.unwrap() / std::mem::size_of::<T>()];
                 let destination: &mut [u8] = bytemuck::cast_slice_mut(new_vec.as_mut_slice());
                 destination.copy_from_slice(&old_vec);
                 Ok(new_vec)
-            },
+            }
         }
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -756,7 +756,8 @@ pub trait ImageDecoder<'a>: Sized {
             )));
         }
 
-        let mut buf = vec![num_traits::Zero::zero(); total_bytes.unwrap() / std::mem::size_of::<T>()];
+        let mut buf =
+            vec![num_traits::Zero::zero(); total_bytes.unwrap() / std::mem::size_of::<T>()];
         self.read_image(bytemuck::cast_slice_mut(buf.as_mut_slice()))?;
         Ok(buf)
     }


### PR DESCRIPTION
Avoid a `memset()` + `memcpy()` of the entire decompressed image, saving 10%-15% of the time in decoding JPEGs as measured on

```rust
ImageReader::open(input)?.with_guessed_format()?.decode()?;
```

----

Supersedes #1878 but only implements JPEG, not BMP. I'll file issues for BMP and HDR.

----

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to choose either at their option.