### PR TITLE
Add webp has_animation predicate

### DIFF
--- a/src/codecs/webp/decoder.rs
+++ b/src/codecs/webp/decoder.rs
@@ -196,6 +196,15 @@ impl<R: Read> WebPDecoder<R> {
 
         Ok(())
     }
+
+    /// Returns true if the image as described by the bitstream is animated.
+    pub fn has_animation(&self) -> bool {
+        match &self.image {
+            WebPImage::Lossy(_) => false,
+            WebPImage::Lossless(_) => false,
+            WebPImage::Extended(extended) => extended.has_animation(),
+        }
+    }
 }
 
 pub(crate) fn read_len_cursor<R>(r: &mut R) -> ImageResult<Cursor<Vec<u8>>>

--- a/src/codecs/webp/extended.rs
+++ b/src/codecs/webp/extended.rs
@@ -82,6 +82,10 @@ impl ExtendedImage {
         (self.info.canvas_width, self.info.canvas_height)
     }
 
+    pub(crate) fn has_animation(&self) -> bool {
+        self.info._animation
+    }
+
     pub(crate) fn color_type(&self) -> ColorType {
         match &self.image {
             ExtendedImageData::Animation { frames, .. } => &frames[0].image,


### PR DESCRIPTION
I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.