### PR TITLE
Bump `exr` minor version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ mp4parse = { version = "0.12.0", optional = true }
 dav1d = { version = "0.6.0", optional = true }
 dcv-color-primitives = { version = "0.4.0", optional = true }
 color_quant = "1.1"
-exr = { version = "1.5.0", optional = true }
+exr = { version = "1.6.0", optional = true }
 qoi = { version = "0.4", optional = true }
 libwebp = { package = "webp", version = "0.2.2", default-features = false, optional = true }
 


### PR DESCRIPTION
Running `cargo audit` in a project of mine prints the following:

```
Crate:     spin
Version:   0.9.5
Warning:   yanked
Dependency tree:
spin 0.9.5
└── flume 0.10.14
    └── exr 1.5.3
        └── image 0.24.5
            └── ...
```

The [`exr`](https://crates.io/crates/exr) crate is currently in `1.6.3`. I can't find a changelog on the crate but [it seems like `1.5` focused on performance upgrades](https://github.com/johannesvollmer/exrs/releases) so I can only assume the same holds for `1.6`

My warning did get fixed with a `cargo update` but I thought I'd make the PR regardless.

I'm somewhat new to Rust so if this PR doesn't make sense or there's reasons against upgrading, let me know :)