### PR TITLE
Add option to set the background color of animated webp images

### DIFF
--- a/src/codecs/webp/decoder.rs
+++ b/src/codecs/webp/decoder.rs
@@ -4,9 +4,9 @@ use std::io::{self, Cursor, Error, Read};
 use std::marker::PhantomData;
 use std::{error, fmt, mem};
 
-use crate::error::{DecodingError, ImageError, ImageResult};
+use crate::error::{DecodingError, ImageError, ImageResult, ParameterError, ParameterErrorKind};
 use crate::image::{ImageDecoder, ImageFormat};
-use crate::{color, AnimationDecoder, Frames};
+use crate::{color, AnimationDecoder, Frames, Rgba};
 
 use super::lossless::{LosslessDecoder, LosslessFrame};
 use super::vp8::{Frame as VP8Frame, Vp8Decoder};
@@ -203,6 +203,18 @@ impl<R: Read> WebPDecoder<R> {
             WebPImage::Lossy(_) => false,
             WebPImage::Lossless(_) => false,
             WebPImage::Extended(extended) => extended.has_animation(),
+        }
+    }
+
+    /// Sets the background color if the image is an extended and animated webp.
+    pub fn set_background_color(&mut self, color: Rgba<u8>) -> ImageResult<()> {
+        match &mut self.image {
+            WebPImage::Extended(image) => image.set_background_color(color),
+            _ => Err(ImageError::Parameter(ParameterError::from_kind(
+                ParameterErrorKind::Generic(
+                    "Background color can only be set on animated webp".to_owned(),
+                ),
+            ))),
         }
     }
 }

--- a/src/codecs/webp/extended.rs
+++ b/src/codecs/webp/extended.rs
@@ -5,7 +5,7 @@ use std::{error, fmt};
 use super::decoder::{read_chunk, DecoderError::ChunkHeaderInvalid, WebPRiffChunk};
 use super::lossless::{LosslessDecoder, LosslessFrame};
 use super::vp8::{Frame as VP8Frame, Vp8Decoder};
-use crate::error::DecodingError;
+use crate::error::{DecodingError, ParameterError, ParameterErrorKind};
 use crate::image::ImageFormat;
 use crate::{
     ColorType, Delay, Frame, Frames, ImageError, ImageResult, Rgb, RgbImage, Rgba, RgbaImage,
@@ -328,6 +328,20 @@ impl ExtendedImage {
             ExtendedImageData::Static(image) => image,
         }
         .get_buf_size()
+    }
+
+    pub(crate) fn set_background_color(&mut self, color: Rgba<u8>) -> ImageResult<()> {
+        match &mut self.image {
+            ExtendedImageData::Animation { anim_info, .. } => {
+                anim_info.background_color = color;
+                Ok(())
+            }
+            _ => Err(ImageError::Parameter(ParameterError::from_kind(
+                ParameterErrorKind::Generic(
+                    "Background color can only be set on animated webp".to_owned(),
+                ),
+            ))),
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #1906.

I'm not sure I chose the right error type, tell me if there's one that suits this type of error better, maybe `UnsuportedError` ?

---

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.