### PR TITLE
Fix `pixel_indices` bound check

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -810,7 +810,7 @@ where
 
     #[inline(always)]
     fn pixel_indices(&self, x: u32, y: u32) -> Option<Range<usize>> {
-        if x >= self.width || y >= self.height {
+        if x > self.width || y > self.height {
             return None;
         }
 


### PR DESCRIPTION
Currently the bounds check for `pixel_indices` is:
```rs
if x >= self.width || y >= self.height {
    return None;
}
```

Having this as greater then or equal causes issues if you attempt to get the edge of a image, I noticed my program was crashing when I sent my cursor coordinates to get a pixel color from the edge of my screen. Changing this to be only `>` fixed the issue.