### PR TITLE
improve JPEG encode_block perf by about 25% with faster integer encoding

### DIFF
--- a/src/codecs/jpeg/encoder.rs
+++ b/src/codecs/jpeg/encoder.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::too_many_arguments)]
 
 use std::borrow::Cow;
-use std::convert::TryFrom;
 use std::io::{self, Write};
 use std::num::NonZeroI32;
 


### PR DESCRIPTION
I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.

Also add benches for tracking performance of JPEG block encoding. 

pre:
`test codecs::jpeg::encoder::tests::bench_encode_block      ... bench:         548 ns/iter (+/- 131) = 135 MB/s`
post:
`test codecs::jpeg::encoder::tests::bench_encode_block      ... bench:         410 ns/iter (+/- 140) = 180 MB/s`