### PR TITLE
Overhaul Pixel methods on `ImageBuffer` and `GenericImage`/`GenericImageView` traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ let (width, height) = img.dimensions();
 let pixel = img[(100, 100)];
 
 // Or use the `get_pixel` method from the `GenericImage` trait.
-let pixel = *img.get_pixel(100, 100);
+let pixel = img.get_pixel(100, 100);
 
 // Put a pixel at coordinate (100, 100).
 img.put_pixel(100, 100, pixel);
@@ -218,7 +218,7 @@ fn main() {
                 i += 1;
             }
 
-            let pixel = imgbuf.get_pixel_mut(x, y);
+            let pixel = &mut imgbuf[(x, y)];
             let image::Rgb(data) = *pixel;
             *pixel = image::Rgb([data[0], i as u8, data[2]]);
         }

--- a/examples/fractal.rs
+++ b/examples/fractal.rs
@@ -2,6 +2,8 @@
 extern crate image;
 extern crate num_complex;
 
+use image::{GenericImage, ImageBuffer, Rgb};
+
 fn main() {
     let imgx = 800;
     let imgy = 800;
@@ -10,13 +12,13 @@ fn main() {
     let scaley = 3.0 / imgy as f32;
 
     // Create a new ImgBuf with width: imgx and height: imgy
-    let mut imgbuf = image::ImageBuffer::new(imgx, imgy);
+    let mut imgbuf = ImageBuffer::new(imgx, imgy);
 
     // Iterate over the coordinates and pixels of the image
     for (x, y, pixel) in imgbuf.enumerate_pixels_mut() {
         let r = (0.3 * x as f32) as u8;
         let b = (0.3 * y as f32) as u8;
-        *pixel = image::Rgb([r, 0, b]);
+        *pixel = Rgb([r, 0, b]);
     }
 
     // A redundant loop to demonstrate reading image data
@@ -33,10 +35,7 @@ fn main() {
                 z = z * z + c;
                 i += 1;
             }
-
-            let pixel = imgbuf.get_pixel_mut(x, y);
-            let data = (*pixel as image::Rgb<u8>).0;
-            *pixel = image::Rgb([data[0], i as u8, data[2]]);
+            imgbuf.pixel_mut(x, y).map(|pixel| pixel.0[1] = i as u8);
         }
     }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1653,7 +1653,7 @@ mod test {
 #[cfg(feature = "benchmarks")]
 mod benchmarks {
     use super::{ConvertBuffer, GrayImage, ImageBuffer, Pixel, RgbImage};
-    use crate::GenericImage;
+    use crate::GenericImageView;
     use test;
 
     #[bench]

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -614,7 +614,7 @@ where
 /// Create a simple canvas and paint a small cross.
 ///
 /// ```
-/// use image::{RgbImage, Rgb};
+/// use image::{GenericImage, RgbImage, Rgb};
 ///
 /// let mut img = RgbImage::new(32, 32);
 ///
@@ -1414,6 +1414,26 @@ mod test {
 
         assert_eq!(a.pixel(1, 0), Some(&WHITE));
         assert_eq!(*a.pixel(1, 0).unwrap(), a[(1, 0)]);
+    }
+
+    #[test]
+    fn pixel_i64() {
+        use crate::{GenericImage, GenericImageView};
+
+        let mut image = RgbImage::from_raw(3, 3, vec![255; 27]).unwrap();
+        assert!(image.pixel_i64(0, 3).is_none());
+        assert!(image.pixel_i64(3, 0).is_none());
+        assert!(image.pixel_i64(-1, 0).is_none());
+        assert!(image.pixel_i64(0, -1).is_none());
+        assert!(image.pixel_i64(-32, -32).is_none());
+        assert!(image.pixel_mut_i64(0, 3).is_none());
+        assert!(image.pixel_mut_i64(3, 0).is_none());
+        assert!(image.pixel_mut_i64(-1, 0).is_none());
+        assert!(image.pixel_mut_i64(0, -1).is_none());
+        assert!(image.pixel_mut_i64(-32, -32).is_none());
+        assert_eq!(image.pixel_i64(0, 2).unwrap(), &Rgb([255; 3]));
+        *image.pixel_mut_i64(0, 2).unwrap() = Rgb([0; 3]);
+        assert_eq!(image.pixel_i64(0, 2).unwrap(), &Rgb([0; 3]));
     }
 
     #[test]

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1162,6 +1162,16 @@ where
         let indices = self.pixel_indices_unchecked(x, y);
         *<P as Pixel>::from_slice(self.data.get_unchecked(indices))
     }
+
+    fn pixel(&self, x: u32, y: u32) -> Option<&P> {
+        self.get_pixel_checked(x, y)
+    }
+
+    #[inline(always)]
+    unsafe fn pixel_unchecked(&self, x: u32, y: u32) -> &P {
+        let indices = self.pixel_indices_unchecked(x, y);
+        <P as Pixel>::from_slice(self.data.get_unchecked(indices))
+    }
 }
 
 impl<P, Container> GenericImage for ImageBuffer<P, Container>
@@ -1169,10 +1179,6 @@ where
     P: Pixel,
     Container: Deref<Target = [P::Subpixel]> + DerefMut,
 {
-    fn get_pixel_mut(&mut self, x: u32, y: u32) -> &mut P {
-        self.get_pixel_mut(x, y)
-    }
-
     fn put_pixel(&mut self, x: u32, y: u32, pixel: P) {
         *self.get_pixel_mut(x, y) = pixel
     }
@@ -1185,11 +1191,14 @@ where
         *p = pixel
     }
 
-    /// Put a pixel at location (x, y), taking into account alpha channels
-    ///
-    /// DEPRECATED: This method will be removed. Blend the pixel directly instead.
-    fn blend_pixel(&mut self, x: u32, y: u32, p: P) {
-        self.get_pixel_mut(x, y).blend(&p)
+    fn pixel_mut(&mut self, x: u32, y: u32) -> Option<&mut P> {
+        self.get_pixel_mut_checked(x, y)
+    }
+
+    #[inline(always)]
+    unsafe fn pixel_mut_unchecked(&mut self, x: u32, y: u32) -> &mut P {
+        let indices = self.pixel_indices_unchecked(x, y);
+        <P as Pixel>::from_slice_mut(self.data.get_unchecked_mut(indices))
     }
 
     fn copy_within(&mut self, source: Rect, x: u32, y: u32) -> bool {

--- a/src/codecs/jpeg/encoder.rs
+++ b/src/codecs/jpeg/encoder.rs
@@ -795,9 +795,11 @@ fn rgb_to_ycbcr<P: Pixel>(pixel: P) -> (u8, u8, u8) {
 #[inline]
 fn pixel_at_or_near<I: GenericImageView>(source: &I, x: u32, y: u32) -> I::Pixel {
     if source.in_bounds(x, y) {
-        source.get_pixel(x, y)
+        *source.pixel(x, y).unwrap()
     } else {
-        source.get_pixel(x.min(source.width() - 1), y.min(source.height() - 1))
+        *source
+            .pixel(x.min(source.width() - 1), y.min(source.height() - 1))
+            .unwrap()
     }
 }
 

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -418,7 +418,7 @@ impl<R: Read> ApngDecoder<R> {
             BlendOp::Over => {
                 // TODO: investigate speed, speed-ups, and bounds-checks.
                 for (x, y, p) in source.enumerate_pixels() {
-                    self.current.get_pixel_mut(x + px, y + py).blend(p);
+                    self.current.pixel_mut(x + px, y + py).map(|c| c.blend(p));
                 }
             }
         }

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -966,6 +966,16 @@ impl GenericImageView for DynamicImage {
     fn get_pixel(&self, x: u32, y: u32) -> color::Rgba<u8> {
         dynamic_map!(*self, |ref p| p.get_pixel(x, y).to_rgba().into_color())
     }
+
+    /// Do not use. This function is unimplemented.
+    fn pixel(&self, _: u32, _: u32) -> Option<&Self::Pixel> {
+        unimplemented!()
+    }
+
+    /// Do not use. This function is unimplemented.
+    unsafe fn pixel_unchecked(&self, _: u32, _: u32) -> &Self::Pixel {
+        unimplemented!()
+    }
 }
 
 #[allow(deprecated)]
@@ -987,29 +997,13 @@ impl GenericImage for DynamicImage {
         }
     }
 
-    fn blend_pixel(&mut self, x: u32, y: u32, pixel: color::Rgba<u8>) {
-        match *self {
-            DynamicImage::ImageLuma8(ref mut p) => p.blend_pixel(x, y, pixel.to_luma()),
-            DynamicImage::ImageLumaA8(ref mut p) => p.blend_pixel(x, y, pixel.to_luma_alpha()),
-            DynamicImage::ImageRgb8(ref mut p) => p.blend_pixel(x, y, pixel.to_rgb()),
-            DynamicImage::ImageRgba8(ref mut p) => p.blend_pixel(x, y, pixel),
-            DynamicImage::ImageLuma16(ref mut p) => {
-                p.blend_pixel(x, y, pixel.to_luma().into_color())
-            }
-            DynamicImage::ImageLumaA16(ref mut p) => {
-                p.blend_pixel(x, y, pixel.to_luma_alpha().into_color())
-            }
-            DynamicImage::ImageRgb16(ref mut p) => p.blend_pixel(x, y, pixel.to_rgb().into_color()),
-            DynamicImage::ImageRgba16(ref mut p) => p.blend_pixel(x, y, pixel.into_color()),
-            DynamicImage::ImageRgb32F(ref mut p) => {
-                p.blend_pixel(x, y, pixel.to_rgb().into_color())
-            }
-            DynamicImage::ImageRgba32F(ref mut p) => p.blend_pixel(x, y, pixel.into_color()),
-        }
+    /// Do not use. This function is unimplemented.
+    fn pixel_mut(&mut self, _: u32, _: u32) -> Option<&mut Self::Pixel> {
+        unimplemented!()
     }
 
-    /// Do not use is function: It is unimplemented!
-    fn get_pixel_mut(&mut self, _: u32, _: u32) -> &mut color::Rgba<u8> {
+    /// Do not use. This function is unimplemented.
+    unsafe fn pixel_mut_unchecked(&mut self, _: u32, _: u32) -> &mut Self::Pixel {
         unimplemented!()
     }
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -1405,7 +1405,7 @@ mod tests {
             *sub2.pixel_mut(0, 0).unwrap() = Rgba([0, 0, 0, 0]);
         }
 
-        assert_eq!(*source.get_pixel(1, 1), Rgba([0, 0, 0, 0]));
+        assert_eq!(source[(1, 1)], Rgba([0, 0, 0, 0]));
 
         let view1 = source.view(0, 0, 2, 2);
         assert_eq!(source[(1, 1)], *view1.pixel(1, 1).unwrap());

--- a/src/image.rs
+++ b/src/image.rs
@@ -932,6 +932,14 @@ pub trait GenericImageView {
     /// Returns a reference to the pixel located at (x, y). Indexed from top left.
     fn pixel(&self, x: u32, y: u32) -> Option<&Self::Pixel>;
 
+    /// Returns a reference to the pixel located at (x, y) using signed integer
+    /// coordinates. Indexed from top left.
+    fn pixel_i64(&self, x: i64, y: i64) -> Option<&Self::Pixel> {
+        let x = u32::try_from(x).ok()?;
+        let y = u32::try_from(y).ok()?;
+        self.pixel(x, y)
+    }
+
     /// Returns a reference to the pixel located at (x, y). Indexed from top left.
     ///
     /// This function can be implemented in a way that ignores bounds checking.
@@ -997,6 +1005,14 @@ pub trait GenericImage: GenericImageView {
 
     /// Returns a mutable reference to the pixel at location (x, y). Indexed from top left.
     fn pixel_mut(&mut self, x: u32, y: u32) -> Option<&mut Self::Pixel>;
+
+    /// Returns a mutable reference to the pixel at location (x, y) using signed integer
+    /// coordinates. Indexed from top left.
+    fn pixel_mut_i64(&mut self, x: i64, y: i64) -> Option<&mut Self::Pixel> {
+        let x = u32::try_from(x).ok()?;
+        let y = u32::try_from(y).ok()?;
+        self.pixel_mut(x, y)
+    }
 
     /// Returns a mutable reference to the pixel at location (x, y). Indexed from top left.
     ///

--- a/src/imageops/affine.rs
+++ b/src/imageops/affine.rs
@@ -63,8 +63,7 @@ where
 
     for y in 0..h0 {
         for x in 0..w0 {
-            let p = image.get_pixel(x, y);
-            destination.put_pixel(h0 - y - 1, x, p);
+            image.pixel(x, y).map(|p| destination[(h0 - y - 1, x)] = *p);
         }
     }
     Ok(())
@@ -89,8 +88,9 @@ where
 
     for y in 0..h0 {
         for x in 0..w0 {
-            let p = image.get_pixel(x, y);
-            destination.put_pixel(w0 - x - 1, h0 - y - 1, p);
+            image
+                .pixel(x, y)
+                .map(|p| destination[(w0 - x - 1, h0 - y - 1)] = *p);
         }
     }
     Ok(())
@@ -115,8 +115,7 @@ where
 
     for y in 0..h0 {
         for x in 0..w0 {
-            let p = image.get_pixel(x, y);
-            destination.put_pixel(y, w0 - x - 1, p);
+            image.pixel(x, y).map(|p| destination[(y, w0 - x - 1)] = *p);
         }
     }
     Ok(())
@@ -167,8 +166,7 @@ where
 
     for y in 0..h0 {
         for x in 0..w0 {
-            let p = image.get_pixel(x, y);
-            destination.put_pixel(w0 - x - 1, y, p);
+            image.pixel(x, y).map(|p| destination[(w0 - x - 1, y)] = *p);
         }
     }
     Ok(())
@@ -193,8 +191,7 @@ where
 
     for y in 0..h0 {
         for x in 0..w0 {
-            let p = image.get_pixel(x, y);
-            destination.put_pixel(x, h0 - 1 - y, p);
+            image.pixel(x, y).map(|p| destination[(x, h0 - 1 - y)] = *p);
         }
     }
     Ok(())
@@ -206,14 +203,14 @@ pub fn rotate180_in_place<I: GenericImage>(image: &mut I) {
 
     for y in 0..height / 2 {
         for x in 0..width {
-            let p = image.get_pixel(x, y);
-
             let x2 = width - x - 1;
             let y2 = height - y - 1;
 
-            let p2 = image.get_pixel(x2, y2);
-            image.put_pixel(x, y, p2);
-            image.put_pixel(x2, y2, p);
+            // TODO: A `swap` function could be useful here and below
+            let p = *image.pixel(x, y).unwrap();
+            let p2 = *image.pixel(x2, y2).unwrap();
+            image.pixel_mut(x, y).map(|p| *p = p2);
+            image.pixel_mut(x2, y2).map(|p2| *p2 = p);
         }
     }
 
@@ -221,12 +218,12 @@ pub fn rotate180_in_place<I: GenericImage>(image: &mut I) {
         let middle = height / 2;
 
         for x in 0..width / 2 {
-            let p = image.get_pixel(x, middle);
             let x2 = width - x - 1;
 
-            let p2 = image.get_pixel(x2, middle);
-            image.put_pixel(x, middle, p2);
-            image.put_pixel(x2, middle, p);
+            let p = *image.pixel(x, middle).unwrap();
+            let p2 = *image.pixel(x2, middle).unwrap();
+            image.pixel_mut(x, middle).map(|p| *p = p2);
+            image.pixel_mut(x2, middle).map(|p2| *p2 = p);
         }
     }
 }
@@ -238,10 +235,11 @@ pub fn flip_horizontal_in_place<I: GenericImage>(image: &mut I) {
     for y in 0..height {
         for x in 0..width / 2 {
             let x2 = width - x - 1;
-            let p2 = image.get_pixel(x2, y);
-            let p = image.get_pixel(x, y);
-            image.put_pixel(x2, y, p);
-            image.put_pixel(x, y, p2);
+
+            let p2 = *image.pixel(x2, y).unwrap();
+            let p = *image.pixel(x, y).unwrap();
+            image.pixel_mut(x2, y).map(|p2| *p2 = p);
+            image.pixel_mut(x, y).map(|p| *p = p2);
         }
     }
 }
@@ -253,10 +251,11 @@ pub fn flip_vertical_in_place<I: GenericImage>(image: &mut I) {
     for y in 0..height / 2 {
         for x in 0..width {
             let y2 = height - y - 1;
-            let p2 = image.get_pixel(x, y2);
-            let p = image.get_pixel(x, y);
-            image.put_pixel(x, y2, p);
-            image.put_pixel(x, y, p2);
+
+            let p2 = *image.pixel(x, y2).unwrap();
+            let p = *image.pixel(x, y).unwrap();
+            image.pixel_mut(x, y2).map(|p2| *p2 = p);
+            image.pixel_mut(x, y).map(|p| *p = p2);
         }
     }
 }

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -368,7 +368,7 @@ pub trait ColorMap {
 /// # Examples
 /// ```
 /// use image::imageops::colorops::{index_colors, BiLevel, ColorMap};
-/// use image::{ImageBuffer, Luma};
+/// use image::{GenericImageView, ImageBuffer, Luma};
 ///
 /// let (w, h) = (16, 16);
 /// // Create an image with a smooth horizontal gradient from black (0) to white (255).

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -469,7 +469,7 @@ macro_rules! do_dithering(
     ($map:expr, $image:expr, $err:expr, $x:expr, $y:expr) => (
         {
             let old_pixel = $image[($x, $y)];
-            let new_pixel = $image.get_pixel_mut($x, $y);
+            let new_pixel = &mut $image[($x, $y)];
             $map.map_color(new_pixel);
             for ((e, &old), &new) in $err.iter_mut()
                                         .zip(old_pixel.channels().iter())
@@ -493,28 +493,28 @@ where
     for y in 0..height - 1 {
         let x = 0;
         do_dithering!(color_map, image, err, x, y);
-        diffuse_err(image.get_pixel_mut(x + 1, y), err, 7);
-        diffuse_err(image.get_pixel_mut(x, y + 1), err, 5);
-        diffuse_err(image.get_pixel_mut(x + 1, y + 1), err, 1);
+        diffuse_err(&mut image[(x + 1, y)], err, 7);
+        diffuse_err(&mut image[(x, y + 1)], err, 5);
+        diffuse_err(&mut image[(x + 1, y + 1)], err, 1);
         for x in 1..width - 1 {
             do_dithering!(color_map, image, err, x, y);
-            diffuse_err(image.get_pixel_mut(x + 1, y), err, 7);
-            diffuse_err(image.get_pixel_mut(x - 1, y + 1), err, 3);
-            diffuse_err(image.get_pixel_mut(x, y + 1), err, 5);
-            diffuse_err(image.get_pixel_mut(x + 1, y + 1), err, 1);
+            diffuse_err(&mut image[(x + 1, y)], err, 7);
+            diffuse_err(&mut image[(x - 1, y + 1)], err, 3);
+            diffuse_err(&mut image[(x, y + 1)], err, 5);
+            diffuse_err(&mut image[(x + 1, y + 1)], err, 1);
         }
         let x = width - 1;
         do_dithering!(color_map, image, err, x, y);
-        diffuse_err(image.get_pixel_mut(x - 1, y + 1), err, 3);
-        diffuse_err(image.get_pixel_mut(x, y + 1), err, 5);
+        diffuse_err(&mut image[(x - 1, y + 1)], err, 3);
+        diffuse_err(&mut image[(x, y + 1)], err, 5);
     }
     let y = height - 1;
     let x = 0;
     do_dithering!(color_map, image, err, x, y);
-    diffuse_err(image.get_pixel_mut(x + 1, y), err, 7);
+    diffuse_err(&mut image[(x + 1, y)], err, 7);
     for x in 1..width - 1 {
         do_dithering!(color_map, image, err, x, y);
-        diffuse_err(image.get_pixel_mut(x + 1, y), err, 7);
+        diffuse_err(&mut image[(x + 1, y)], err, 7);
     }
     let x = width - 1;
     do_dithering!(color_map, image, err, x, y);

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -73,10 +73,7 @@ pub fn invert<I: GenericImage>(image: &mut I) {
 
     for y in 0..height {
         for x in 0..width {
-            let mut p = image.get_pixel(x, y);
-            p.invert();
-
-            image.put_pixel(x, y, p);
+            image.pixel_mut(x, y).map(|p| p.invert());
         }
     }
 }
@@ -134,16 +131,15 @@ where
     // TODO find a way to use pixels?
     for y in 0..height {
         for x in 0..width {
-            let f = image.get_pixel(x, y).map(|b| {
-                let c: f32 = NumCast::from(b).unwrap();
+            if let Some(p) = image.pixel_mut(x, y) {
+                *p = p.map(|b| {
+                    let c: f32 = NumCast::from(b).unwrap();
+                    let d = ((c / max - 0.5) * percent + 0.5) * max;
+                    let e = clamp(d, 0.0, max);
 
-                let d = ((c / max - 0.5) * percent + 0.5) * max;
-                let e = clamp(d, 0.0, max);
-
-                NumCast::from(e).unwrap()
-            });
-
-            image.put_pixel(x, y, f);
+                    NumCast::from(e).unwrap()
+                });
+            }
         }
     }
 }
@@ -198,17 +194,17 @@ where
     // TODO find a way to use pixels?
     for y in 0..height {
         for x in 0..width {
-            let e = image.get_pixel(x, y).map_with_alpha(
-                |b| {
-                    let c: i32 = NumCast::from(b).unwrap();
-                    let d = clamp(c + value, 0, max);
+            if let Some(p) = image.pixel_mut(x, y) {
+                *p = p.map_with_alpha(
+                    |b| {
+                        let c: i32 = NumCast::from(b).unwrap();
+                        let d = clamp(c + value, 0, max);
 
-                    NumCast::from(d).unwrap()
-                },
-                |alpha| alpha,
-            );
-
-            image.put_pixel(x, y, e);
+                        NumCast::from(d).unwrap()
+                    },
+                    |alpha| alpha,
+                );
+            }
         }
     }
 }
@@ -247,7 +243,7 @@ where
         0.072 + cosv * 0.928 + sinv * 0.072,
     ];
     for (x, y, pixel) in out.enumerate_pixels_mut() {
-        let p = image.get_pixel(x, y);
+        let p = image.pixel(x, y).unwrap();
 
         #[allow(deprecated)]
         let (k1, k2, k3, k4) = p.channels4();
@@ -313,8 +309,7 @@ where
     // TODO find a way to use pixels?
     for y in 0..height {
         for x in 0..width {
-            let pixel = image.get_pixel(x, y);
-
+            let pixel = image.pixel_mut(x, y).unwrap();
             #[allow(deprecated)]
             let (k1, k2, k3, k4) = pixel.channels4();
 
@@ -342,7 +337,7 @@ where
                 NumCast::from(clamp(vec.3, 0.0, max)).unwrap(),
             );
 
-            image.put_pixel(x, y, outpixel);
+            *pixel = outpixel;
         }
     }
 }

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -226,11 +226,11 @@ where
 
     for y in 0..range_height {
         for x in 0..range_width {
-            let p = top.get_pixel(origin_top_x + x, origin_top_y + y);
-            let mut bottom_pixel = bottom.get_pixel(origin_bottom_x + x, origin_bottom_y + y);
-            bottom_pixel.blend(&p);
-
-            bottom.put_pixel(origin_bottom_x + x, origin_bottom_y + y, bottom_pixel);
+            if let Some(p) = top.pixel(origin_top_x + x, origin_top_y + y) {
+                bottom
+                    .pixel_mut(origin_bottom_x + x, origin_bottom_y + y)
+                    .map(|bottom_pixel| bottom_pixel.blend(&p));
+            }
         }
     }
 }
@@ -287,7 +287,7 @@ where
         });
 
         for x in 0..img.width() {
-            img.put_pixel(x, y, pixel);
+            img.pixel_mut(x, y).map(|p| *p = pixel);
         }
     }
 }
@@ -320,7 +320,7 @@ where
         });
 
         for y in 0..img.height() {
-            img.put_pixel(x, y, pixel);
+            img.pixel_mut(x, y).map(|p| *p = pixel);
         }
     }
 }
@@ -340,8 +340,11 @@ where
 
     for y in 0..range_height {
         for x in 0..range_width {
-            let p = top.get_pixel(origin_top_x + x, origin_top_y + y);
-            bottom.put_pixel(origin_bottom_x + x, origin_bottom_y + y, p);
+            if let Some(p) = top.pixel(origin_top_x + x, origin_top_y + y) {
+                bottom
+                    .pixel_mut(origin_bottom_x + x, origin_bottom_y + y)
+                    .map(|bot| *bot = *p);
+            }
         }
     }
 }

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -399,11 +399,11 @@ mod tests {
         let mut target = ImageBuffer::new(32, 32);
         let source = ImageBuffer::from_pixel(16, 16, Rgb([255u8, 0, 0]));
         overlay(&mut target, &source, 0, 0);
-        assert!(*target.get_pixel(0, 0) == Rgb([255u8, 0, 0]));
-        assert!(*target.get_pixel(15, 0) == Rgb([255u8, 0, 0]));
-        assert!(*target.get_pixel(16, 0) == Rgb([0u8, 0, 0]));
-        assert!(*target.get_pixel(0, 15) == Rgb([255u8, 0, 0]));
-        assert!(*target.get_pixel(0, 16) == Rgb([0u8, 0, 0]));
+        assert!(target[(0, 0)] == Rgb([255u8, 0, 0]));
+        assert!(target[(15, 0)] == Rgb([255u8, 0, 0]));
+        assert!(target[(16, 0)] == Rgb([0u8, 0, 0]));
+        assert!(target[(0, 15)] == Rgb([255u8, 0, 0]));
+        assert!(target[(0, 16)] == Rgb([0u8, 0, 0]));
     }
 
     #[test]
@@ -412,9 +412,9 @@ mod tests {
         let mut target = ImageBuffer::new(32, 32);
         let source = ImageBuffer::from_pixel(32, 32, Rgb([255u8, 0, 0]));
         overlay(&mut target, &source, 1, 1);
-        assert!(*target.get_pixel(0, 0) == Rgb([0, 0, 0]));
-        assert!(*target.get_pixel(1, 1) == Rgb([255u8, 0, 0]));
-        assert!(*target.get_pixel(31, 31) == Rgb([255u8, 0, 0]));
+        assert!(target[(0, 0)] == Rgb([0, 0, 0]));
+        assert!(target[(1, 1)] == Rgb([255u8, 0, 0]));
+        assert!(target[(31, 31)] == Rgb([255u8, 0, 0]));
     }
 
     #[test]
@@ -424,9 +424,9 @@ mod tests {
         let mut target = ImageBuffer::new(32, 32);
         let source = ImageBuffer::from_pixel(32, 32, Rgb([255u8, 0, 0]));
         overlay(&mut target, &source, 33, 33);
-        assert!(*target.get_pixel(0, 0) == Rgb([0, 0, 0]));
-        assert!(*target.get_pixel(1, 1) == Rgb([0, 0, 0]));
-        assert!(*target.get_pixel(31, 31) == Rgb([0, 0, 0]));
+        assert!(target[(0, 0)] == Rgb([0, 0, 0]));
+        assert!(target[(1, 1)] == Rgb([0, 0, 0]));
+        assert!(target[(31, 31)] == Rgb([0, 0, 0]));
     }
 
     #[test]
@@ -441,9 +441,9 @@ mod tests {
             i64::from(u32::max_value() - 31),
             i64::from(u32::max_value() - 31),
         );
-        assert!(*target.get_pixel(0, 0) == Rgb([0, 0, 0]));
-        assert!(*target.get_pixel(1, 1) == Rgb([0, 0, 0]));
-        assert!(*target.get_pixel(15, 15) == Rgb([0, 0, 0]));
+        assert!(target[(0, 0)] == Rgb([0, 0, 0]));
+        assert!(target[(1, 1)] == Rgb([0, 0, 0]));
+        assert!(target[(15, 15)] == Rgb([0, 0, 0]));
     }
 
     use super::{horizontal_gradient, vertical_gradient};
@@ -458,8 +458,8 @@ mod tests {
 
         horizontal_gradient(&mut img, &start, &end);
 
-        assert_eq!(img.get_pixel(0, 0), &start);
-        assert_eq!(img.get_pixel(img.width() - 1, 0), &end);
+        assert_eq!(img[(0, 0)], start);
+        assert_eq!(img[(img.width() - 1, 0)], end);
     }
 
     #[test]
@@ -472,8 +472,8 @@ mod tests {
 
         vertical_gradient(&mut img, &start, &end);
 
-        assert_eq!(img.get_pixel(0, 0), &start);
-        assert_eq!(img.get_pixel(0, img.height() - 1), &end);
+        assert_eq!(img[(0, 0)], start);
+        assert_eq!(img[(0, img.height() - 1)], end);
     }
 
     #[test]

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -829,7 +829,7 @@ where
     for y in 0..height {
         for x in 0..width {
             let a = image.pixel(x, y).unwrap();
-            let b = tmp.get_pixel_mut(x, y);
+            let b = tmp.pixel_mut(x, y).unwrap();
 
             let p = a.map2(b, |c, d| {
                 let ic: i32 = NumCast::from(c).unwrap();


### PR DESCRIPTION
_#1853 for background_

Best viewed commit by commit. Most of the changes are in the first commit.

This PR adds `Option`-returning methods to the main image traits. Duplicate methods that `ImageBuffer` implemented were removed.

I migrated functions that used the old methods like `get_pixel` internally to the newer `Option` methods where applicable so they could eventually be phased out. Where possible, I kept the old behavior by using `Index` access on `ImageBuffer`s. Since this is a breaking change, I also removed the deprecated functions from the traits.

- Add `pixel[_unchecked]` to GenericImageView
- Add `pixel_mut[_unchecked]` to GenericImage
- Remove `get_pixel_mut`, `blend_pixel` from GenericImage
- Remove `get_pixel[_checked]`, `get_pixel_mut[_checked]` from ImageBuffer
- Move the inner implementation of `get_pixel[_mut]` to Index, IndexMut
- Add `pixel_i64` to GenericImageView, `pixel_mut_i64` to GenericImage
