### PR TITLE
Add sampling using [0,1] for `GenericImageView`

### DIFF
--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -16,7 +16,9 @@ pub use self::affine::{
 };
 
 /// Image sampling
-pub use self::sample::{blur, filter3x3, resize, thumbnail, unsharpen};
+pub use self::sample::{
+    blur, filter3x3, interpolate_bilinear, resize, sample_bilinear, thumbnail, unsharpen,
+};
 
 /// Color operations
 pub use self::colorops::{


### PR DESCRIPTION
***WIP***
Not sure whether this should directly go on `GenericImageView`, and where the enums should go.
Also need to add tests but put the general idea up for review.

---


Adds a way to sample images in [0,1], which is a common use case in graphics.

Currently adds non-exhaustive enums based on OpenGL's that allow for simple sampling of nearby coordinates.

Nearest sampling can produce artifacts depending on the sampling resolution of the UV whereas bilinear will smoothly interpolate.

Addresses #1905

<!--
If you are a new contributor, consent to licensing by including this text:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.

Thank you for contributing, you can delete this comment.
-->
