### PR TITLE
fix: repair for rustc rustc 1.71.0-nightly (ce5919fce 2023-05-15)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ png = { version = "0.17.6", optional = true }
 tiff = { version = "0.8.0", optional = true }
 ravif = { version = "0.11.0", optional = true }
 rgb = { version = "0.8.25", optional = true }
-mp4parse = { version = "0.12.0", optional = true }
+mp4parse = { git = "https://github.com/mozilla/mp4parse-rust", rev = "cf8b0e04de9c60f38f7f057f9f29c74d19336d0c", optional = true }
 dav1d = { version = "0.6.0", optional = true }
 dcv-color-primitives = { version = "0.4.0", optional = true }
 color_quant = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ png = { version = "0.17.6", optional = true }
 tiff = { version = "0.8.0", optional = true }
 ravif = { version = "0.11.0", optional = true }
 rgb = { version = "0.8.25", optional = true }
-mp4parse = { git = "https://github.com/mozilla/mp4parse-rust", rev = "cf8b0e04de9c60f38f7f057f9f29c74d19336d0c", optional = true }
+mp4parse = { version = "0.17.0", optional = true }
 dav1d = { version = "0.6.0", optional = true }
 dcv-color-primitives = { version = "0.4.0", optional = true }
 color_quant = "1.1"


### PR DESCRIPTION
<!--
If you are a new contributor, consent to licensing by including this text:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.

Thank you for contributing, you can delete this comment.
-->
```bash
cargo build --release --features avif-decoder
```
with
```bash
$ cargo --version && rustc --version           
cargo 1.71.0-nightly (13413c64f 2023-05-10)
rustc 1.71.0-nightly (ce5919fce 2023-05-15)
```
yields 
```bash
$ cargo build --release --features avif-decoder
    Blocking waiting for file lock on package cache
    Updating crates.io index
    Blocking waiting for file lock on package cache
   Compiling mp4parse v0.12.0
error[E0277]: cannot multiply `u64` by `NonZeroU8`
    --> /home/john/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mp4parse-0.12.0/src/lib.rs:2547:62
     |
2547 |                 static_assertions::const_assert!(<$lhs>::MAX * <$rhs>::MAX <= <$output>::MAX);
     |                                                              ^ no implementation for `u64 * NonZeroU8`
...
2557 | impl_mul!((U8, std::num::NonZeroU8) => (U16, u16));
     | -------------------------------------------------- in this macro invocation
     |
     = help: the trait `Mul<NonZeroU8>` is not implemented for `u64`
     = help: the following other types implement trait `Mul<Rhs>`:
               <&'a u64 as Mul<u64>>
               <&u64 as Mul<&u64>>
               <u64 as Mul<&u64>>
               <u64 as Mul>
     = note: this error originates in the macro `impl_mul` (in Nightly builds, run with -Z macro-backtrace for more info)

note: erroneous constant used
    --> /home/john/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mp4parse-0.12.0/src/lib.rs:2557:1
     |
2557 | impl_mul!((U8, std::num::NonZeroU8) => (U16, u16));
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: this note originates in the macro `static_assertions::const_assert` which comes from the expansion of the macro `impl_mul` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: cannot multiply `u64` by `NonZeroU8`
    --> /home/john/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mp4parse-0.12.0/src/lib.rs:2547:62
     |
2547 |                 static_assertions::const_assert!(<$lhs>::MAX * <$rhs>::MAX <= <$output>::MAX);
     |                                                              ^ no implementation for `u64 * NonZeroU8`
...
2558 | impl_mul!((U32, std::num::NonZeroU8) => (U32MulU8, u64));
     | -------------------------------------------------------- in this macro invocation
     |
     = help: the trait `Mul<NonZeroU8>` is not implemented for `u64`
     = help: the following other types implement trait `Mul<Rhs>`:
               <&'a u64 as Mul<u64>>
               <&u64 as Mul<&u64>>
               <u64 as Mul<&u64>>
               <u64 as Mul>
     = note: this error originates in the macro `impl_mul` (in Nightly builds, run with -Z macro-backtrace for more info)

note: erroneous constant used
    --> /home/john/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mp4parse-0.12.0/src/lib.rs:2558:1
     |
2558 | impl_mul!((U32, std::num::NonZeroU8) => (U32MulU8, u64));
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: this note originates in the macro `static_assertions::const_assert` which comes from the expansion of the macro `impl_mul` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0277`.
error: could not compile `mp4parse` (lib) due to 2 previous errors
```
This is an `mp4parse` which is addressed in https://github.com/mozilla/mp4parse-rust/issues/405 . Applying the fixes described, there, yields a `image-rs/image` issue:
```bash
$ cargo build --release --features avif-decoder
   Compiling image v0.24.6 (/home/john/code/repos/forks/image)
warning: unused imports: `ImageFormatHint`, `UnsupportedErrorKind`, `UnsupportedError`
  --> src/dynimage.rs:20:20
   |
20 | use crate::error::{ImageFormatHint, UnsupportedError, UnsupportedErrorKind};
   |                    ^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

error[E0277]: the trait bound `Option<&[u8]>: AsRef<[u8]>` is not satisfied
  --> src/codecs/avif/decoder.rs:40:24
   |
40 |             .send_data(coded, None, None, None)
   |              --------- ^^^^^ the trait `AsRef<[u8]>` is not implemented for `Option<&[u8]>`
   |              |
   |              required by a bound introduced by this call
   |
note: required by a bound in `dav1d::Decoder::send_data`
  --> /home/john/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dav1d-0.6.1/src/lib.rs:76:25
   |
76 |     pub fn send_data<T: AsRef<[u8]>>(
   |                         ^^^^^^^^^^^ required by this bound in `Decoder::send_data`

error[E0599]: no method named `is_empty` found for enum `Option` in the current scope
  --> src/codecs/avif/decoder.rs:44:44
   |
44 |         let alpha_picture = if !alpha_item.is_empty() {
   |                                            ^^^^^^^^ method not found in `Option<&[u8]>`
   |
note: the method `is_empty` exists on the type `&[u8]`
  --> /rustc/ce5919fcef67103098219e1868f741e56fc90963/library/core/src/slice/mod.rs:156:5
help: consider using `Option::expect` to unwrap the `&[u8]` value, panicking if the value is an `Option::None`
   |
44 |         let alpha_picture = if !alpha_item.expect("REASON").is_empty() {
   |                                           +++++++++++++++++

error[E0277]: the trait bound `Option<&[u8]>: AsRef<[u8]>` is not satisfied
  --> src/codecs/avif/decoder.rs:47:28
   |
47 |                 .send_data(alpha_item, None, None, None)
   |                  --------- ^^^^^^^^^^ the trait `AsRef<[u8]>` is not implemented for `Option<&[u8]>`
   |                  |
   |                  required by a bound introduced by this call
   |
note: required by a bound in `dav1d::Decoder::send_data`
  --> /home/john/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dav1d-0.6.1/src/lib.rs:76:25
   |
76 |     pub fn send_data<T: AsRef<[u8]>>(
   |                         ^^^^^^^^^^^ required by this bound in `Decoder::send_data`

error[E0599]: no method named `ok` found for enum `Option` in the current scope
  --> src/codecs/avif/decoder.rs:53:56
   |
53 |         let icc_profile = ctx.icc_colour_information().ok().map(|x| x.to_vec());
   |                                                        ^^
   |
note: the method `ok` exists on the type `std::result::Result<&[u8], mp4parse::Error>`
  --> /rustc/ce5919fcef67103098219e1868f741e56fc90963/library/core/src/result.rs:631:5
help: consider using `Option::expect` to unwrap the `std::result::Result<&[u8], mp4parse::Error>` value, panicking if the value is an `Option::None`
   |
53 |         let icc_profile = ctx.icc_colour_information().expect("REASON").ok().map(|x| x.to_vec());
   |                                                       +++++++++++++++++
help: there is a method with a similar name
   |
53 |         let icc_profile = ctx.icc_colour_information().or().map(|x| x.to_vec());
   |                                                        ~~

Some errors have detailed explanations: E0277, E0599.
For more information about an error, try `rustc --explain E0277`.
warning: `image` (lib) generated 1 warning
error: could not compile `image` (lib) due to 4 previous errors; 1 warning emitted
```

It seems that `master` (and `0.24.6`) are broken on nightly.