### PR TITLE
Fix .hdr decoding

### DIFF
--- a/src/codecs/hdr/decoder.rs
+++ b/src/codecs/hdr/decoder.rs
@@ -157,9 +157,9 @@ impl<R: BufRead> HdrAdapter<R> {
         assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
         match self.inner.take() {
             Some(decoder) => {
-                let img: Vec<Rgb<u8>> = decoder.read_image_ldr()?;
+                let img: Vec<Rgb<f32>> = decoder.read_image_hdr()?;
                 for (i, Rgb(data)) in img.into_iter().enumerate() {
-                    buf[(i * 3)..][..3].copy_from_slice(&data);
+                    buf[(i * 12)..][..12].copy_from_slice(bytemuck::cast_slice(&data));
                 }
 
                 Ok(())
@@ -195,7 +195,7 @@ impl<'a, R: 'a + BufRead> ImageDecoder<'a> for HdrAdapter<R> {
     }
 
     fn color_type(&self) -> ColorType {
-        ColorType::Rgb8
+        ColorType::Rgb32F
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {


### PR DESCRIPTION
Fixes https://github.com/image-rs/image/issues/1936. First time contributor, so unsure if this is the right way to fix, but in my testing it seemed to work and causes .exr and .hdr image files to have the same behavior when decoding.

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.
