### PR TITLE
Add `track_caller` attribute on `get_pixel`, `get_pixel_mut`, `put_pixel`

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -764,6 +764,7 @@ where
     ///
     /// Panics if `(x, y)` is out of the bounds `(width, height)`.
     #[inline]
+    #[track_caller]
     pub fn get_pixel(&self, x: u32, y: u32) -> &P {
         match self.pixel_indices(x, y) {
             None => panic!(
@@ -941,6 +942,7 @@ where
     ///
     /// Panics if `(x, y)` is out of the bounds `(width, height)`.
     #[inline]
+    #[track_caller]
     pub fn get_pixel_mut(&mut self, x: u32, y: u32) -> &mut P {
         match self.pixel_indices(x, y) {
             None => panic!(
@@ -975,6 +977,7 @@ where
     ///
     /// Panics if `(x, y)` is out of the bounds `(width, height)`.
     #[inline]
+    #[track_caller]
     pub fn put_pixel(&mut self, x: u32, y: u32, pixel: P) {
         *self.get_pixel_mut(x, y) = pixel
     }


### PR DESCRIPTION
The `track_caller` attribute allows tracking the panic location of the caller, instead of location where the panic was invoked, giving more useful panic information.


I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.
