### PR TITLE
Fix to prevent blocking file::open that may happen on some file types. Replacing File::Open() with OpenOptions()

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -1097,7 +1097,21 @@ where
     P: AsRef<Path>,
 {
     // thin wrapper function to strip generics before calling open_impl
-    free_functions::open_impl(path.as_ref())
+    free_functions::open_impl_with_custom_flags(path.as_ref(),0)
+}
+/// Open the image located at the path specified with the flags specified.
+/// The image's format is determined from the path's file extension.
+///
+/// Try [`io::Reader`] for more advanced uses, including guessing the format based on the file's
+/// content before its path.
+///
+/// [`io::Reader`]: io/struct.Reader.html
+pub fn open_with_custom_flags<P>(path: P,custom_flags:i32) -> ImageResult<DynamicImage>
+where
+    P: AsRef<Path>,
+{
+    // thin wrapper function to strip generics before calling open_impl
+    free_functions::open_impl_with_custom_flags(path.as_ref(),custom_flags)
 }
 
 /// Read a tuple containing the (width, height) of the image located at the specified path.
@@ -1112,7 +1126,21 @@ where
     P: AsRef<Path>,
 {
     // thin wrapper function to strip generics before calling open_impl
-    free_functions::image_dimensions_impl(path.as_ref())
+    free_functions::image_dimensions_impl_with_custom_flags(path.as_ref(),0)
+}
+/// Read a tuple containing the (width, height) of the image located at the specified path with specified flags.
+/// This is faster than fully loading the image and then getting its dimensions.
+///
+/// Try [`io::Reader`] for more advanced uses, including guessing the format based on the file's
+/// content before its path or manually supplying the format.
+///
+/// [`io::Reader`]: io/struct.Reader.html
+pub fn image_dimensions_with_custom_flags<P>(path: P,custom_flags:i32) -> ImageResult<(u32, u32)>
+where
+    P: AsRef<Path>,
+{
+    // thin wrapper function to strip generics before calling open_impl
+    free_functions::image_dimensions_impl_with_custom_flags(path.as_ref(),custom_flags)
 }
 
 /// Saves the supplied buffer to a file at the path specified.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@ pub use crate::traits::{EncodableLayout, Pixel, PixelWithColorType, Primitive};
 // Opening and loading images
 pub use crate::dynimage::{
     image_dimensions, load_from_memory, load_from_memory_with_format, open, save_buffer,
-    save_buffer_with_format, write_buffer_with_format,
+    save_buffer_with_format, write_buffer_with_format,open_with_custom_flags,image_dimensions_with_custom_flags
 };
 pub use crate::io::free_functions::{guess_format, load};
 


### PR DESCRIPTION
While iterating over a list of files and trying to list dimensions if images. I found that the execution was indefinitely stuck in the part of code that used image crate, I used img::open(), instead of img::image_dimensions(). Upon further lookup found that File::open was the culprit as it can block execution when opening a pipe file since it blocks until there is some data to read. If the pipe is empty or not ready, the program will wait indefinitely.  To prevent this we can pass custom flags to OpenOptions, which is what File::Open is an abstraction of. 
The code changes replace File::open() with OpenOptions(). The changes allow for optionally setting custom flags when opening a file using : 
image::open_with_custom_flags()
image::image_dimensions_with_custom_flags()
reader::open_with_custom_flags()
functions that take a path and customflag as arguments. 
This has been done in a way so as to not introduce any braking changes.

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.