### PR TITLE
Fix panic on empty dxt

### DIFF
--- a/src/codecs/dxt.rs
+++ b/src/codecs/dxt.rs
@@ -142,7 +142,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for DxtDecoder<R> {
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
         assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
 
-        for chunk in buf.chunks_mut(self.scanline_bytes() as usize) {
+        for chunk in buf.chunks_mut(self.scanline_bytes().max(1) as usize) {
             self.read_scanline(chunk)?;
         }
         Ok(())


### PR DESCRIPTION
Should fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=56032&q=label%3AProj-image-rs
