### PR TITLE
JXL: initial support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ dcv-color-primitives = { version = "0.4.0", optional = true }
 color_quant = "1.1"
 exr = { version = "1.5.0", optional = true }
 qoi = { version = "0.4", optional = true }
-jxl-oxide = { version = "0.2.0", optional = true }
+jxl-oxide = { version = "0.3.0", optional = true }
 libwebp = { package = "webp", version = "0.2.2", default-features = false, optional = true }
 
 [dev-dependencies]
@@ -61,7 +61,7 @@ jpeg = { package = "jpeg-decoder", version = "0.3.0", default-features = false, 
 
 [features]
 # TODO: Add "avif" to this list while preparing for 0.24.0
-default = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "dds", "farbfeld", "jpeg_rayon", "openexr", "qoi", "jxl"]
+default = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "dds", "farbfeld", "jpeg_rayon", "openexr", "qoi"]
 
 ico = ["bmp", "png"]
 pnm = []
@@ -72,7 +72,6 @@ dxt = []
 dds = ["dxt"]
 farbfeld = []
 openexr = ["exr"]
-jxl = ["jxl-oxide"] 
 qoi = ["dep:qoi"]
 
 # Enables WebP decoder support.
@@ -90,6 +89,8 @@ avif = ["avif-encoder"]
 avif-encoder = ["ravif", "rgb"]
 # Non-default, even in `avif`. Requires stable Rust and native dependency libdav1d.
 avif-decoder = ["mp4parse", "dcv-color-primitives", "dav1d"]
+# Enables jxl support.
+jxl-decoder = ["jxl-oxide"] 
 
 # Build some inline benchmarks. Useful only during development.
 # Requires rustc nightly for feature test.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ dcv-color-primitives = { version = "0.4.0", optional = true }
 color_quant = "1.1"
 exr = { version = "1.5.0", optional = true }
 qoi = { version = "0.4", optional = true }
-jxl = { package = "jxl-oxide", path = "/home/vert/rpmbuild/SOURCES/jxl-oxide/crates/jxl-oxide", version = "0.2.0", optional = true }
+jxl-oxide = { version = "0.2.0", optional = true }
 libwebp = { package = "webp", version = "0.2.2", default-features = false, optional = true }
 
 [dev-dependencies]
@@ -72,8 +72,8 @@ dxt = []
 dds = ["dxt"]
 farbfeld = []
 openexr = ["exr"]
+jxl = ["jxl-oxide"] 
 qoi = ["dep:qoi"]
-jxl = ["dep:jxl"]
 
 # Enables WebP decoder support.
 webp = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ dcv-color-primitives = { version = "0.4.0", optional = true }
 color_quant = "1.1"
 exr = { version = "1.5.0", optional = true }
 qoi = { version = "0.4", optional = true }
+jxl = { package = "jxl-oxide", path = "/home/vert/rpmbuild/SOURCES/jxl-oxide/crates/jxl-oxide", version = "0.2.0", optional = true }
 libwebp = { package = "webp", version = "0.2.2", default-features = false, optional = true }
 
 [dev-dependencies]
@@ -60,7 +61,7 @@ jpeg = { package = "jpeg-decoder", version = "0.3.0", default-features = false, 
 
 [features]
 # TODO: Add "avif" to this list while preparing for 0.24.0
-default = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "dds", "farbfeld", "jpeg_rayon", "openexr", "qoi"]
+default = ["gif", "jpeg", "ico", "png", "pnm", "tga", "tiff", "webp", "bmp", "hdr", "dxt", "dds", "farbfeld", "jpeg_rayon", "openexr", "qoi", "jxl"]
 
 ico = ["bmp", "png"]
 pnm = []
@@ -72,6 +73,7 @@ dds = ["dxt"]
 farbfeld = []
 openexr = ["exr"]
 qoi = ["dep:qoi"]
+jxl = ["dep:jxl"]
 
 # Enables WebP decoder support.
 webp = []

--- a/src/codecs/jxl.rs
+++ b/src/codecs/jxl.rs
@@ -1,0 +1,159 @@
+//! Decoding of JPEG XL images
+//!
+//! TODO: animation handling, CMYK [ColorType]
+
+use crate::{
+    error::{DecodingError, UnsupportedError, UnsupportedErrorKind},
+    image::decoder_to_vec,
+    ColorType, ExtendedColorType, ImageDecoder, ImageError, ImageFormat, ImageResult,
+};
+use std::io::{Cursor, Read};
+
+use jxl::{JxlImage, PixelFormat, Render};
+
+/// JPEG XL decoder
+pub struct JxlDecoder<R> {
+    image: JxlImage<R>,
+    bitdepth: BitDepth,
+    colortype: ColorType,
+    keyframes: Vec<Render>,
+}
+
+impl<R: Read> JxlDecoder<R> {
+    /// Creates a new decoder that decodes from the stream ```r```
+    pub fn new(r: R) -> ImageResult<JxlDecoder<R>> {
+        let mut image = JxlImage::from_reader(r).map_err(|_| {
+            ImageError::Decoding(DecodingError::new(
+                ImageFormat::Jxl.into(),
+                "Failsed to parse image",
+            ))
+        })?;
+        let mut keyframes = Vec::new();
+        let mut renderer = image.renderer();
+        loop {
+            let result = renderer.render_next_frame().map_err(|e| {
+                ImageError::Decoding(DecodingError::new(ImageFormat::Jxl.into(), e))
+            })?;
+            match result {
+                jxl::RenderResult::Done(frame) => keyframes.push(frame),
+                jxl::RenderResult::NeedMoreData => {
+                    return Err(ImageError::Decoding(DecodingError::new(
+                        ImageFormat::Jxl.into(),
+                        "Unexpected end of file",
+                    )))
+                }
+                jxl::RenderResult::NoMoreFrames => break,
+            }
+        }
+        let pixfmt = renderer.pixel_format();
+        let metadata = &image.image_header().metadata;
+        let bits_per_sample = metadata.bit_depth.bits_per_sample();
+        let bitdepth = BitDepth::new(bits_per_sample);
+
+        let colortype = match (pixfmt, bitdepth) {
+            (PixelFormat::Gray, BitDepth::Eight) => ColorType::L8,
+            (PixelFormat::Gray, BitDepth::Sixteen) => ColorType::L16,
+            //
+            (PixelFormat::Graya, BitDepth::Eight) => ColorType::La8,
+            (PixelFormat::Graya, BitDepth::Sixteen) => ColorType::La16,
+            //
+            (PixelFormat::Rgb, BitDepth::Eight) => ColorType::Rgb8,
+            (PixelFormat::Rgb, BitDepth::Sixteen) => ColorType::Rgb16,
+            (PixelFormat::Rgb, BitDepth::ThirtyTwo) => ColorType::Rgb32F,
+            //
+            (PixelFormat::Rgba, BitDepth::Eight) => ColorType::Rgba8,
+            (PixelFormat::Rgba, BitDepth::Sixteen) => ColorType::Rgba16,
+            (PixelFormat::Rgba, BitDepth::ThirtyTwo) => ColorType::Rgba32F,
+            //
+            _ => {
+                return Err(unsupported_color(ExtendedColorType::Unknown(
+                    bits_per_sample as u8,
+                )))
+            }
+        };
+
+        Ok(Self {
+            image,
+            bitdepth: BitDepth::new(bits_per_sample),
+            colortype,
+            keyframes,
+        })
+    }
+}
+
+fn unsupported_color(ect: ExtendedColorType) -> ImageError {
+    ImageError::Unsupported(UnsupportedError::from_format_and_kind(
+        ImageFormat::Jxl.into(),
+        UnsupportedErrorKind::Color(ect),
+    ))
+}
+
+impl<'a, R: 'a + Read> ImageDecoder<'a> for JxlDecoder<R> {
+    type Reader = Cursor<Vec<u8>>;
+
+    fn dimensions(&self) -> (u32, u32) {
+        let size = &self.image.image_header().size;
+        (size.width, size.height)
+    }
+
+    fn color_type(&self) -> ColorType {
+        self.colortype
+    }
+
+    fn into_reader(self) -> ImageResult<Self::Reader> {
+        Ok(Cursor::new(decoder_to_vec(self)?))
+    }
+
+    fn icc_profile(&mut self) -> Option<Vec<u8>> {
+        self.image.embedded_icc().map(Vec::from)
+    }
+
+    fn read_image(self, buf: &mut [u8]) -> ImageResult<()> {
+        let fb = self
+            .keyframes
+            .get(0)
+            .ok_or_else(|| {
+                ImageError::Decoding(DecodingError::new(
+                    ImageFormat::Jxl.into(),
+                    "No keyframes found",
+                ))
+            })?
+            .image();
+        match self.bitdepth {
+            BitDepth::Eight => {
+                for (b, s) in buf.iter_mut().zip(fb.buf()) {
+                    *b = (*s * 255.0 + 0.5).clamp(0.0, 255.0) as u8;
+                }
+            }
+            BitDepth::Sixteen => {
+                for (b, s) in buf.chunks_exact_mut(2).zip(fb.buf()) {
+                    let w = (*s * 65535.0 + 0.5).clamp(0.0, 65535.0) as u16;
+                    let [b0, b1] = w.to_ne_bytes();
+                    b[0] = b0;
+                    b[1] = b1;
+                }
+            }
+            BitDepth::ThirtyTwo => {
+                buf.clone_from_slice(bytemuck::cast_slice(fb.buf()));
+            }
+        };
+        Ok(())
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum BitDepth {
+    Eight,
+    Sixteen,
+    ThirtyTwo,
+}
+
+impl BitDepth {
+    fn new(bits_per_sample: u32) -> Self {
+        match bits_per_sample {
+            17.. => Self::ThirtyTwo,
+            9.. => Self::Sixteen,
+            _ => Self::Eight,
+        }
+    }
+}

--- a/src/codecs/jxl/mod.rs
+++ b/src/codecs/jxl/mod.rs
@@ -1,5 +1,6 @@
 //! Encoding of JXL images.
 ///
 
+#[cfg(feature = "jxl-decoder")]
 pub use self::decoder::JxlDecoder;
 mod decoder;

--- a/src/codecs/jxl/mod.rs
+++ b/src/codecs/jxl/mod.rs
@@ -1,0 +1,5 @@
+//! Encoding of JXL images.
+///
+
+pub use self::decoder::JxlDecoder;
+mod decoder;

--- a/src/image.rs
+++ b/src/image.rs
@@ -70,6 +70,9 @@ pub enum ImageFormat {
 
     /// An Image in QOI format.
     Qoi,
+
+    /// An Image in JPEG XL format.
+    Jxl,
 }
 
 impl ImageFormat {
@@ -108,6 +111,7 @@ impl ImageFormat {
                 "pbm" | "pam" | "ppm" | "pgm" => ImageFormat::Pnm,
                 "ff" | "farbfeld" => ImageFormat::Farbfeld,
                 "qoi" => ImageFormat::Qoi,
+                "jxl" => ImageFormat::Jxl,
                 _ => return None,
             })
         }
@@ -183,6 +187,7 @@ impl ImageFormat {
             // Qoi's MIME type is being worked on.
             // See: https://github.com/phoboslab/qoi/issues/167
             "image/x-qoi" => Some(ImageFormat::Qoi),
+            "image/jxl" => Some(ImageFormat::Jxl),
             _ => None,
         }
     }
@@ -211,6 +216,7 @@ impl ImageFormat {
         match self {
             ImageFormat::Avif => "image/avif",
             ImageFormat::Jpeg => "image/jpeg",
+            ImageFormat::Jxl => "image/jxl",
             ImageFormat::Png => "image/png",
             ImageFormat::Gif => "image/gif",
             ImageFormat::WebP => "image/webp",
@@ -252,6 +258,7 @@ impl ImageFormat {
             ImageFormat::Farbfeld => true,
             ImageFormat::Avif => true,
             ImageFormat::Qoi => true,
+            ImageFormat::Jxl => true,
         }
     }
 
@@ -275,6 +282,7 @@ impl ImageFormat {
             ImageFormat::OpenExr => true,
             ImageFormat::Dds => false,
             ImageFormat::Qoi => true,
+            ImageFormat::Jxl => false,
         }
     }
 
@@ -305,6 +313,7 @@ impl ImageFormat {
             // According to: https://aomediacodec.github.io/av1-avif/#mime-registration
             ImageFormat::Avif => &["avif"],
             ImageFormat::Qoi => &["qoi"],
+            ImageFormat::Jxl => &["jxl"],
         }
     }
 }
@@ -708,7 +717,7 @@ pub trait ImageDecoder<'a>: Sized {
     /// Returns the ICC color profile embedded in the image
     ///
     /// For formats that don't support embedded profiles this function will always return `None`.
-    /// This feature is currently only supported for the JPEG, PNG, and AVIF formats.
+    /// This feature is currently only supported for the JPEG, PNG, AVIF and JXL formats.
     fn icc_profile(&mut self) -> Option<Vec<u8>> {
         None
     }
@@ -1878,7 +1887,7 @@ mod tests {
     fn image_formats_are_recognized() {
         use ImageFormat::*;
         const ALL_FORMATS: &'static [ImageFormat] = &[
-            Avif, Png, Jpeg, Gif, WebP, Pnm, Tiff, Tga, Dds, Bmp, Ico, Hdr, Farbfeld, OpenExr,
+            Avif, Png, Jpeg, Jxl, Gif, WebP, Pnm, Tiff, Tga, Dds, Bmp, Ico, Hdr, Farbfeld, OpenExr,
         ];
         for &format in ALL_FORMATS {
             let mut file = Path::new("file.nothing").to_owned();

--- a/src/image.rs
+++ b/src/image.rs
@@ -1716,6 +1716,7 @@ mod tests {
         assert_eq!(from_path("./a.Ppm").unwrap(), ImageFormat::Pnm);
         assert_eq!(from_path("./a.pgm").unwrap(), ImageFormat::Pnm);
         assert_eq!(from_path("./a.AViF").unwrap(), ImageFormat::Avif);
+        //TODO: add jxl
         assert!(from_path("./a.txt").is_err());
         assert!(from_path("./a").is_err());
     }

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -81,6 +81,8 @@ pub(crate) fn load_decoder<R: BufRead + Seek, V: DecoderVisitor>(
         image::ImageFormat::Farbfeld => visitor.visit_decoder(farbfeld::FarbfeldDecoder::new(r)?),
         #[cfg(feature = "qoi")]
         image::ImageFormat::Qoi => visitor.visit_decoder(qoi::QoiDecoder::new(r)?),
+        #[cfg(feature = "jxl")]
+        image::ImageFormat::Jxl => visitor.visit_decoder(jxl::JxlDecoder::new(r)?),
         _ => Err(ImageError::Unsupported(
             ImageFormatHint::Exact(format).into(),
         )),
@@ -263,7 +265,8 @@ pub(crate) fn write_buffer_impl<W: std::io::Write + Seek>(
     }
 }
 
-static MAGIC_BYTES: [(&[u8], ImageFormat); 23] = [
+#[rustfmt::skip]
+static MAGIC_BYTES: [(&[u8], ImageFormat); 25] = [
     (b"\x89PNG\r\n\x1a\n", ImageFormat::Png),
     (&[0xff, 0xd8, 0xff], ImageFormat::Jpeg),
     (b"GIF89a", ImageFormat::Gif),
@@ -287,6 +290,8 @@ static MAGIC_BYTES: [(&[u8], ImageFormat); 23] = [
     (b"\0\0\0\x1cftypavif", ImageFormat::Avif),
     (&[0x76, 0x2f, 0x31, 0x01], ImageFormat::OpenExr), // = &exr::meta::magic_number::BYTES
     (b"qoif", ImageFormat::Qoi),
+    (&[0xff, 0x0a], ImageFormat::Jxl),
+    (&[0x00, 0x00, 0x00, 0x0C, 0x4A, 0x58, 0x4C, 0x20, 0x0D, 0x0A, 0x87, 0x0A], ImageFormat::Jxl),
 ];
 
 /// Guess image format from memory block

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -81,7 +81,7 @@ pub(crate) fn load_decoder<R: BufRead + Seek, V: DecoderVisitor>(
         image::ImageFormat::Farbfeld => visitor.visit_decoder(farbfeld::FarbfeldDecoder::new(r)?),
         #[cfg(feature = "qoi")]
         image::ImageFormat::Qoi => visitor.visit_decoder(qoi::QoiDecoder::new(r)?),
-        #[cfg(feature = "jxl")]
+        #[cfg(feature = "jxl-decoder")]
         image::ImageFormat::Jxl => visitor.visit_decoder(jxl::JxlDecoder::new(r)?),
         _ => Err(ImageError::Unsupported(
             ImageFormatHint::Exact(format).into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,13 +187,12 @@ pub mod flat;
 /// | TIFF   | Baseline(no fax support) + LZW + PackBits | Rgb8, Rgba8, Gray8 |
 /// | WebP   | Yes | Rgb8, Rgba8 |
 /// | AVIF   | Only 8-bit | Lossy |
-/// | JXL    | Rgb, Rgba | No |
 /// | PNM    | PBM, PGM, PPM, standard PAM | Yes |
 /// | DDS    | DXT1, DXT3, DXT5 | No |
 /// | TGA    | Yes | Rgb8, Rgba8, Bgr8, Bgra8, Gray8, GrayA8 |
 /// | OpenEXR  | Rgb32F, Rgba32F (no dwa compression) | Rgb32F, Rgba32F (no dwa compression) |
 /// | farbfeld | Yes | Yes |
-/// | JPEG XL  | Yes | No |
+/// | JPEG XL  | Rgb, Rgba, Gray, Graya | No |
 ///
 /// ## A note on format specific features
 ///
@@ -236,7 +235,7 @@ pub mod codecs {
     pub mod ico;
     #[cfg(feature = "jpeg")]
     pub mod jpeg;
-    #[cfg(feature = "jxl")]
+    #[cfg(feature = "jxl-decoder")]
     pub mod jxl;
     #[cfg(feature = "exr")]
     pub mod openexr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,7 @@ pub mod flat;
 /// | TGA    | Yes | Rgb8, Rgba8, Bgr8, Bgra8, Gray8, GrayA8 |
 /// | OpenEXR  | Rgb32F, Rgba32F (no dwa compression) | Rgb32F, Rgba32F (no dwa compression) |
 /// | farbfeld | Yes | Yes |
+/// | JPEG XL  | Yes | No |
 ///
 /// ## A note on format specific features
 ///
@@ -234,6 +235,8 @@ pub mod codecs {
     pub mod ico;
     #[cfg(feature = "jpeg")]
     pub mod jpeg;
+    #[cfg(feature = "jxl")]
+    pub mod jxl;
     #[cfg(feature = "exr")]
     pub mod openexr;
     #[cfg(feature = "png")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,6 +187,7 @@ pub mod flat;
 /// | TIFF   | Baseline(no fax support) + LZW + PackBits | Rgb8, Rgba8, Gray8 |
 /// | WebP   | Yes | Rgb8, Rgba8 |
 /// | AVIF   | Only 8-bit | Lossy |
+/// | JXL    | Rgb, Rgba | No |
 /// | PNM    | PBM, PGM, PPM, standard PAM | Yes |
 /// | DDS    | DXT1, DXT3, DXT5 | No |
 /// | TGA    | Yes | Rgb8, Rgba8, Bgr8, Bgra8, Gray8, GrayA8 |


### PR DESCRIPTION
The work done here was entirely @EugeneVert, I just cleaned it up a bit and intend to implement missing features at some point, this is a draft because it needs cleaned up and is missing a few features 

- [ ] Animation
- [ ] CMYK (this may be handled internally by jxl-oxide in the future)

jxl-oxide also has some issues decoding large image's often running into OOM issues if the image is large enough. 

currently it's usable enough for a good chunk of images out there. decided to post it both to get comments on the current state as well since I'm using it in it's current state, it may as well be in the open



I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.