### PR TITLE
webp: Allow unknown chunks at the end of the file

### DIFF
--- a/src/codecs/webp/decoder.rs
+++ b/src/codecs/webp/decoder.rs
@@ -265,11 +265,11 @@ where
         }
     }
 
-    let chunk = WebPRiffChunk::from_fourcc(chunk_fourcc)?;
+    let chunk = WebPRiffChunk::from_fourcc(chunk_fourcc);
 
     let cursor = read_len_cursor(r)?;
 
-    Ok(Some((cursor, chunk)))
+    Ok(Some((cursor, chunk?)))
 }
 
 /// Wrapper struct around a `Cursor<Vec<u8>>`


### PR DESCRIPTION
Issue #1873 shows a number of real-world WebP images fail during decoding. For almost all of these, this is because they contain ["unknown chunks"](https://developers.google.com/speed/webp/docs/riff_container#unknown_chunks) at the end of the file. Those unknown chunks were reported as errors, while the specification says they should be ignored at the end of the file. This PR changes the decoder's behavior accordingly.

One of the images provided in #1873 still fails to decode after this PR. This is an animation file, so it might be related to that the standard also specifies that unknown chunks should be ignored at the end of animation "ANMF" chunks, which I don't think is currently implemented. However, running `webpmux -info` on this file resulted in `Failed to create mux object from file chunk_header_invalid/Ataturk-Bayrak.webp.`, so it may also just be a malformed file.

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.
