### PR TITLE
Fixes potential panic on out-of-bounds if a frame is larger than a canvas

### DIFF
--- a/src/codecs/webp/extended.rs
+++ b/src/codecs/webp/extended.rs
@@ -261,9 +261,19 @@ impl ExtendedImage {
         let has_alpha = anim_image.image.has_alpha();
         let pixel_len: u32 = anim_image.image.color_type().bytes_per_pixel().into();
 
+        'x:
         for x in 0..anim_image.width {
             for y in 0..anim_image.height {
                 let canvas_index: (u32, u32) = (x + anim_image.offset_x, y + anim_image.offset_y);
+                // Negative offsets are not possible due to unsigned ints
+                // If we go out of bounds by height, still continue by x
+                if canvas_index.1 >= canvas.height() {
+                    continue 'x;
+                }
+                // If we go out of bounds by width, it doesn't make sense to continue at all
+                if canvas_index.0 >= canvas.width() {
+                    break 'x;
+                }
                 let index: usize = ((y * anim_image.width + x) * pixel_len).try_into().unwrap();
                 canvas[canvas_index] = if anim_image.use_alpha_blending && has_alpha {
                     let buffer: [u8; 4] = buffer[index..][..4].try_into().unwrap();

--- a/src/codecs/webp/extended.rs
+++ b/src/codecs/webp/extended.rs
@@ -261,8 +261,7 @@ impl ExtendedImage {
         let has_alpha = anim_image.image.has_alpha();
         let pixel_len: u32 = anim_image.image.color_type().bytes_per_pixel().into();
 
-        'x:
-        for x in 0..anim_image.width {
+        'x: for x in 0..anim_image.width {
             for y in 0..anim_image.height {
                 let canvas_index: (u32, u32) = (x + anim_image.offset_x, y + anim_image.offset_y);
                 // Negative offsets are not possible due to unsigned ints


### PR DESCRIPTION
If the frame's width or height are larger than the canvas size, or even if they are smaller, but they have an x or y offset + width/height, that gets larger than the canvas width/height, than the code will panic on [extended.rs#268](https://github.com/image-rs/image/blob/master/src/codecs/webp/extended.rs#L268), because of how Index is implemented for ImageBuffer.

The fix for #1960. The logic basically crops a frame which is beyond a canvas.

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.
