### PR TITLE
Add sample/interpolate nearest

### DIFF
--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -17,7 +17,8 @@ pub use self::affine::{
 
 /// Image sampling
 pub use self::sample::{
-    blur, filter3x3, interpolate_bilinear, resize, sample_bilinear, thumbnail, unsharpen,
+    blur, filter3x3, interpolate_bilinear, interpolate_nearest, resize, sample_bilinear,
+    sample_nearest, thumbnail, unsharpen,
 };
 
 /// Color operations


### PR DESCRIPTION
This looks very similar to the prior PR, but I'm not sure if the two sample modes should be merged into one?
That was originally why I had included an enum to indicate which to perform, but it's fine to keep them separate as well.