### PR TITLE
Webp encode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ qoi = ["dep:qoi"]
 # Enables WebP decoder support.
 webp = []
 # Non-default, not included in `webp`. Requires native dependency libwebp.
-webp-encoder = ["libwebp"]
+webp-encoder = ["libwebp", "webp"]
 
 # Enables multi-threading.
 # Requires latest stable Rust.

--- a/src/codecs/webp/encoder.rs
+++ b/src/codecs/webp/encoder.rs
@@ -482,8 +482,7 @@ impl<W: Write> ImageEncoder for WebPEncoder<W> {
 
 #[cfg(test)]
 mod tests {
-    use crate::codecs::webp::{WebPEncoder, WebPQuality};
-    use crate::{ColorType, ImageEncoder};
+    use crate::ImageEncoder;
 
     #[test]
     fn write_webp() {
@@ -510,6 +509,13 @@ mod tests {
 
         assert_eq!(img, img2);
     }
+}
+
+#[cfg(test)]
+#[cfg(feature = "webp-encoder")]
+mod native_tests {
+    use crate::codecs::webp::{WebPEncoder, WebPQuality};
+    use crate::{ColorType, ImageEncoder};
 
     #[derive(Debug, Clone)]
     struct MockImage {

--- a/src/codecs/webp/encoder.rs
+++ b/src/codecs/webp/encoder.rs
@@ -252,7 +252,7 @@ impl<W: Write> WebPEncoder<W> {
                 current[i] = current[i].wrapping_sub(prev[i]);
             }
         }
-        for i in (channels..row_bytes as usize).rev() {
+        for i in (channels..row_bytes).rev() {
             pixels[i] = pixels[i].wrapping_sub(pixels[i - channels]);
         }
         if is_alpha {
@@ -304,9 +304,9 @@ impl<W: Write> WebPEncoder<W> {
             vec![0u16; 256],
             vec![0u16; 256],
         ];
-        for i in 0..4 {
-            for j in 0..256 {
-                codes[i][j] = (j as u8).reverse_bits() as u16;
+        for code in codes.iter_mut() {
+            for i in 0..256 {
+                code[i] = (i as u8).reverse_bits() as u16;
             }
         }
 
@@ -450,7 +450,7 @@ impl<W: Write> WebPEncoder<W> {
         }
 
         self.writer.write_all(&encoded)?;
-        return Ok(());
+        Ok(())
     }
 
     /// Encode image data with the indicated color type.

--- a/src/codecs/webp/encoder.rs
+++ b/src/codecs/webp/encoder.rs
@@ -483,8 +483,8 @@ impl<W: Write> WebPEncoder<W> {
                     let len0 = lengths[1][pixel[0] as usize];
                     let len3 = lengths[3][pixel[1] as usize];
 
-                    let code = codes[1][pixel[0] as usize] as u64 |
-                        (codes[3][pixel[1] as usize] as u64) << len0;
+                    let code = codes[1][pixel[0] as usize] as u64
+                        | (codes[3][pixel[1] as usize] as u64) << len0;
 
                     self.write_bits(code, len0 + len3)?;
                 }
@@ -495,9 +495,9 @@ impl<W: Write> WebPEncoder<W> {
                     let len0 = lengths[0][pixel[0] as usize];
                     let len2 = lengths[2][pixel[2] as usize];
 
-                    let code = codes[1][pixel[1] as usize] as u64 |
-                        (codes[0][pixel[0] as usize] as u64) << len1 |
-                        (codes[2][pixel[2] as usize] as u64) << (len1 + len0);
+                    let code = codes[1][pixel[1] as usize] as u64
+                        | (codes[0][pixel[0] as usize] as u64) << len1
+                        | (codes[2][pixel[2] as usize] as u64) << (len1 + len0);
 
                     self.write_bits(code, len1 + len0 + len2)?;
                 }
@@ -509,10 +509,10 @@ impl<W: Write> WebPEncoder<W> {
                     let len2 = lengths[2][pixel[2] as usize];
                     let len3 = lengths[3][pixel[3] as usize];
 
-                    let code = codes[1][pixel[1] as usize] as u64 |
-                        (codes[0][pixel[0] as usize] as u64) << len1 |
-                        (codes[2][pixel[2] as usize] as u64) << (len1 + len0) |
-                        (codes[3][pixel[3] as usize] as u64) << (len1 + len0 + len2);
+                    let code = codes[1][pixel[1] as usize] as u64
+                        | (codes[0][pixel[0] as usize] as u64) << len1
+                        | (codes[2][pixel[2] as usize] as u64) << (len1 + len0)
+                        | (codes[3][pixel[3] as usize] as u64) << (len1 + len0 + len2);
 
                     self.write_bits(code, len1 + len0 + len2 + len3)?;
                 }

--- a/src/codecs/webp/encoder.rs
+++ b/src/codecs/webp/encoder.rs
@@ -337,7 +337,7 @@ impl<W: Write> WebPEncoder<W> {
 
     fn length_to_symbol(len: u16) -> (u16, u8) {
         let len = len - 1;
-        let highest_bit = len.ilog2() as u16;
+        let highest_bit = 15 - len.leading_zeros() as u16; // TODO: use ilog2 once MSRV >= 1.67
         let second_highest_bit = (len >> (highest_bit - 1)) & 1;
         let extra_bits = highest_bit - 1;
         let symbol = 2 * highest_bit + second_highest_bit;

--- a/src/codecs/webp/encoder.rs
+++ b/src/codecs/webp/encoder.rs
@@ -681,6 +681,7 @@ impl<W: Write> WebPEncoder<W> {
         let encoder = Encoder::new(data, layout, width, height);
         let encoded: WebPMemory = match self.quality.0 {
             Quality::Lossless => encoder.encode_lossless(),
+            #[allow(deprecated)]
             Quality::Lossy(quality) => encoder.encode(quality as f32),
         };
 
@@ -788,7 +789,7 @@ mod native_tests {
         fn fuzz_webp_valid_image(image: MockImage, quality: u8) -> bool {
             // Check valid images do not panic.
             let mut buffer = Vec::<u8>::new();
-            for webp_quality in [WebPQuality::lossless(), WebPQuality::lossy(quality)] {
+            for webp_quality in [WebPQuality::lossless(), #[allow(deprecated)] WebPQuality::lossy(quality)] {
                 buffer.clear();
                 #[allow(deprecated)]
                 let encoder = WebPEncoder::new_with_quality(&mut buffer, webp_quality);
@@ -805,7 +806,7 @@ mod native_tests {
             // Check random (usually invalid) parameters do not panic.
             let mut buffer = Vec::<u8>::new();
             for color in [ColorType::Rgb8, ColorType::Rgba8] {
-                for webp_quality in [WebPQuality::lossless(), WebPQuality::lossy(quality)] {
+                for webp_quality in [WebPQuality::lossless(), #[allow(deprecated)] WebPQuality::lossy(quality)] {
                     buffer.clear();
                     #[allow(deprecated)]
                     let encoder = WebPEncoder::new_with_quality(&mut buffer, webp_quality);

--- a/src/codecs/webp/encoder.rs
+++ b/src/codecs/webp/encoder.rs
@@ -482,16 +482,11 @@ impl<W: Write> ImageEncoder for WebPEncoder<W> {
 
 #[cfg(test)]
 mod tests {
-    use crate::ImageEncoder;
+    use crate::{ImageEncoder, RgbaImage};
 
     #[test]
     fn write_webp() {
-        let img = crate::load_from_memory_with_format(
-            include_bytes!("../../../tests/images/png/transparency/tbwn3p08.png"),
-            crate::ImageFormat::Png,
-        )
-        .unwrap()
-        .to_rgba8();
+        let img = RgbaImage::from_raw(10, 6, (0..240).collect()).unwrap();
 
         let mut output = Vec::new();
         super::WebPEncoder::new_lossless(&mut output)

--- a/src/codecs/webp/encoder.rs
+++ b/src/codecs/webp/encoder.rs
@@ -304,9 +304,9 @@ impl<W: Write> WebPEncoder<W> {
             vec![0u16; 256],
             vec![0u16; 256],
         ];
-        for code in codes.iter_mut() {
-            for i in 0..256 {
-                code[i] = (i as u8).reverse_bits() as u16;
+        for code_group in codes.iter_mut() {
+            for (i, code) in code_group.iter_mut().enumerate() {
+                *code = (i as u8).reverse_bits() as u16;
             }
         }
 

--- a/src/codecs/webp/encoder.rs
+++ b/src/codecs/webp/encoder.rs
@@ -32,6 +32,7 @@ pub struct WebPQuality(Quality);
 #[derive(Debug, Copy, Clone)]
 enum Quality {
     Lossless,
+    #[deprecated = "Lossy encoding will be removed in a future version. See: https://github.com/image-rs/image/issues/1984"]
     Lossy(u8),
 }
 
@@ -51,13 +52,16 @@ impl WebPQuality {
     /// Lossy encoding. 0 = low quality, small size; 100 = high quality, large size.
     ///
     /// Values are clamped from 0 to 100.
+    #[deprecated = "Lossy encoding will be removed in a future version. See: https://github.com/image-rs/image/issues/1984"]
     pub fn lossy(quality: u8) -> Self {
+        #[allow(deprecated)]
         Self(Quality::Lossy(quality.clamp(Self::MIN, Self::MAX)))
     }
 }
 
 impl Default for WebPQuality {
     fn default() -> Self {
+        #[allow(deprecated)]
         Self::lossy(WebPQuality::DEFAULT)
     }
 }
@@ -66,7 +70,7 @@ impl<W: Write> WebPEncoder<W> {
     /// Create a new encoder that writes its output to `w`.
     ///
     /// Defaults to lossy encoding, see [`WebPQuality::DEFAULT`].
-    #[deprecated = "Use `new_lossless` instead. Lossy encoding will be removed in a future version. See: github.com/image-rs/image/issues/XXXX"]
+    #[deprecated = "Use `new_lossless` instead. Lossy encoding will be removed in a future version. See: https://github.com/image-rs/image/issues/1984"]
     #[cfg(feature = "webp-encoder")]
     pub fn new(w: W) -> Self {
         #[allow(deprecated)]
@@ -74,7 +78,7 @@ impl<W: Write> WebPEncoder<W> {
     }
 
     /// Create a new encoder with the specified quality, that writes its output to `w`.
-    #[deprecated = "Use `new_lossless` instead. Lossy encoding will be removed in a future version. See: github.com/image-rs/image/issues/XXXX"]
+    #[deprecated = "Use `new_lossless` instead. Lossy encoding will be removed in a future version. See: https://github.com/image-rs/image/issues/1984"]
     #[cfg(feature = "webp-encoder")]
     pub fn new_with_quality(w: W, quality: WebPQuality) -> Self {
         Self {

--- a/src/codecs/webp/mod.rs
+++ b/src/codecs/webp/mod.rs
@@ -1,9 +1,9 @@
 //! Decoding and Encoding of WebP Images
 
-#[cfg(feature = "webp-encoder")]
+#[cfg(feature = "webp")]
 pub use self::encoder::{WebPEncoder, WebPQuality};
 
-#[cfg(feature = "webp-encoder")]
+#[cfg(feature = "webp")]
 mod encoder;
 
 #[cfg(feature = "webp")]

--- a/src/image.rs
+++ b/src/image.rs
@@ -361,7 +361,7 @@ pub enum ImageOutputFormat {
     /// An image in QOI Format
     Qoi,
 
-    #[cfg(any(feature = "webp-encoder", feature = "webp"))]
+    #[cfg(feature = "webp")]
     /// An image in WebP Format.
     WebP,
 
@@ -397,7 +397,7 @@ impl From<ImageFormat> for ImageOutputFormat {
 
             #[cfg(feature = "avif-encoder")]
             ImageFormat::Avif => ImageOutputFormat::Avif,
-            #[cfg(feature = "webp-encoder")]
+            #[cfg(feature = "webp")]
             ImageFormat::WebP => ImageOutputFormat::WebP,
 
             #[cfg(feature = "qoi")]

--- a/src/image.rs
+++ b/src/image.rs
@@ -361,7 +361,7 @@ pub enum ImageOutputFormat {
     /// An image in QOI Format
     Qoi,
 
-    #[cfg(feature = "webp-encoder")]
+    #[cfg(any(feature = "webp-encoder", feature = "webp"))]
     /// An image in WebP Format.
     WebP,
 

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -249,9 +249,9 @@ pub(crate) fn write_buffer_impl<W: std::io::Write + Seek>(
         ImageOutputFormat::Qoi => {
             qoi::QoiEncoder::new(buffered_write).write_image(buf, width, height, color)
         }
-        #[cfg(feature = "webp-encoder")]
+        #[cfg(feature = "webp")]
         ImageOutputFormat::WebP => {
-            webp::WebPEncoder::new(buffered_write).write_image(buf, width, height, color)
+            webp::WebPEncoder::new_lossless(buffered_write).write_image(buf, width, height, color)
         }
 
         image::ImageOutputFormat::Unsupported(msg) => Err(ImageError::Unsupported(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,7 +277,7 @@ pub mod codecs {
     pub mod tga;
     #[cfg(feature = "tiff")]
     pub mod tiff;
-    #[cfg(any(feature = "webp", feature = "webp-encoder"))]
+    #[cfg(feature = "webp")]
     pub mod webp;
 }
 


### PR DESCRIPTION
The goal of this PR is to have "good enough" pure-Rust webp encoding to enable it by default and remove our dependency on libwebp.

My plan is to completely ignore lossy webp encoding (we already have pure-Rust lossy jpeg and avif encoders) and only focus on lossless mode. ~~Right now, the code is able to produce valid lossless webp's, but they're completely uncompressed. Actually compressing the input will require building huffman trees based on symbol frequency.~~

I have however implemented hard-coded "subtract green" and "predictor" transforms which should make the data at least somewhat compressible. That's in contrast to libwebp which tries a whole bunch of different transform configurations to see what produces the best compression. Nonetheless, it might be enough to get compression ratios on par with PNG

*Update: Huffman compression is implemented.* 