### PR TITLE
Small typo in CHANGES.md

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,7 @@
 New features:
 - Added `{ImageBuffer, DynamicImage}::write_with_encoder` to simplify writing
   images with custom settings.
-- Expose ICC profiles stored in tiff and wepb files.
+- Expose ICC profiles stored in tiff and webp files.
 - Added option to set the background color of animated webp images.
 - New methods for sampling and interpolation of `GenericImageView`s
 


### PR DESCRIPTION
I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.
