### PR TITLE
Remove `num-rational`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ path = "./src/lib.rs"
 [dependencies]
 bytemuck = { version = "1.7.0", features = ["extern_crate_alloc"] } # includes cast_vec
 byteorder = "1.3.2"
-num-rational = { version = "0.4", default-features = false }
 num-traits = "0.2.0"
 gif = { version = "0.12", optional = true }
 jpeg = { package = "jpeg-decoder", version = "0.3.0", default-features = false, optional = true }

--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -34,9 +34,8 @@ use std::mem;
 
 use gif::ColorOutput;
 use gif::{DisposalMethod, Frame};
-use num_rational::Ratio;
 
-use crate::animation;
+use crate::animation::{self, Ratio};
 use crate::color::{ColorType, Rgba};
 use crate::error::{
     DecodingError, EncodingError, ImageError, ImageResult, ParameterError, ParameterErrorKind,

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -10,10 +10,9 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::io::{self, Read, Write};
 
-use num_rational::Ratio;
 use png::{BlendOp, DisposeOp};
 
-use crate::animation::{Delay, Frame, Frames};
+use crate::animation::{Delay, Frame, Frames, Ratio};
 use crate::color::{Blend, ColorType, ExtendedColorType};
 use crate::error::{
     DecodingError, EncodingError, ImageError, ImageResult, LimitError, LimitErrorKind,


### PR DESCRIPTION
This removes `num-rational` as a dependency. As it turns out, `num-rational`, based on which features are active, can very easily end up on the critical path during compilation, meaning that it is the crate that determines how long it takes to compile the `image` crate. This is because `cargo` can parallelize compilation of many crates, but crates with a long dependency chains (rather than wide), are the ones that in the end determine the compilation speed. This is one of the learnings of the `serde` drama, where it has been noticed that allowing `serde` and `serde_derive` to compile in parallel reduces its long dependency chain, resulting in faster compile times. This introduces the same kind of optimization here, where for all the following features, `num-rational` turns out to be the longest dependency chain:

`png,jpeg,gif,bmp,ico,pnm,tga,tiff,webp,hdr,dxt,dds,farbfeld,qoi`

The critical path is the following:

`autocfg` → `num-traits` compile build.rs → `num-traits` run build.rs → `num-traits` → `num-integer` → `num-rational` → `image`

As it turns out, the only thing really used in `num-rational` is `Ratio`, which can be easily replicated.

This cuts out both `num-integer` and `num-rational` cutting compile times by around 0.5 seconds on a debug build.

![image](https://github.com/image-rs/image/assets/1451630/ebe9230d-5211-4f2b-a4bc-3092b5a9a2f1)
