### PR TITLE
Deprecate incremental decoding

### DIFF
--- a/src/codecs/dds.rs
+++ b/src/codecs/dds.rs
@@ -340,10 +340,12 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for DdsDecoder<R> {
     }
 
     fn scanline_bytes(&self) -> u64 {
+        #[allow(deprecated)]
         self.inner.scanline_bytes()
     }
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
+        #[allow(deprecated)]
         self.inner.into_reader()
     }
 

--- a/src/codecs/dxt.rs
+++ b/src/codecs/dxt.rs
@@ -100,7 +100,13 @@ impl<R: Read> DxtDecoder<R> {
     }
 
     fn read_scanline(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        assert_eq!(u64::try_from(buf.len()), Ok(#[allow(deprecated)] self.scanline_bytes()));
+        assert_eq!(
+            u64::try_from(buf.len()),
+            Ok(
+                #[allow(deprecated)]
+                self.scanline_bytes()
+            )
+        );
 
         let mut src =
             vec![0u8; self.variant.encoded_bytes_per_block() * self.width_blocks as usize];
@@ -134,7 +140,11 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for DxtDecoder<R> {
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
         Ok(DxtReader {
-            buffer: ImageReadBuffer::new(#[allow(deprecated)] self.scanline_bytes(), self.total_bytes()),
+            buffer: ImageReadBuffer::new(
+                #[allow(deprecated)]
+                self.scanline_bytes(),
+                self.total_bytes(),
+            ),
             decoder: self,
         })
     }

--- a/src/codecs/dxt.rs
+++ b/src/codecs/dxt.rs
@@ -100,7 +100,7 @@ impl<R: Read> DxtDecoder<R> {
     }
 
     fn read_scanline(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        assert_eq!(u64::try_from(buf.len()), Ok(self.scanline_bytes()));
+        assert_eq!(u64::try_from(buf.len()), Ok(#[allow(deprecated)] self.scanline_bytes()));
 
         let mut src =
             vec![0u8; self.variant.encoded_bytes_per_block() * self.width_blocks as usize];
@@ -134,7 +134,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for DxtDecoder<R> {
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
         Ok(DxtReader {
-            buffer: ImageReadBuffer::new(self.scanline_bytes(), self.total_bytes()),
+            buffer: ImageReadBuffer::new(#[allow(deprecated)] self.scanline_bytes(), self.total_bytes()),
             decoder: self,
         })
     }
@@ -142,6 +142,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for DxtDecoder<R> {
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
         assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
 
+        #[allow(deprecated)]
         for chunk in buf.chunks_mut(self.scanline_bytes().max(1) as usize) {
             self.read_scanline(chunk)?;
         }

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -740,6 +740,7 @@ mod tests {
             "Image MUST have the Rgb8 format"
         ];
 
+        #[allow(deprecated)]
         let correct_bytes = dec
             .into_reader()
             .expect("Unable to read file")

--- a/src/codecs/tga/decoder.rs
+++ b/src/codecs/tga/decoder.rs
@@ -435,7 +435,7 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for TgaDecoder<R> {
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
         Ok(TGAReader {
-            buffer: ImageReadBuffer::new(self.scanline_bytes(), self.total_bytes()),
+            buffer: ImageReadBuffer::new(#[allow(deprecated)] self.scanline_bytes(), self.total_bytes()),
             decoder: self,
         })
     }

--- a/src/codecs/tga/decoder.rs
+++ b/src/codecs/tga/decoder.rs
@@ -435,7 +435,11 @@ impl<'a, R: 'a + Read + Seek> ImageDecoder<'a> for TgaDecoder<R> {
 
     fn into_reader(self) -> ImageResult<Self::Reader> {
         Ok(TGAReader {
-            buffer: ImageReadBuffer::new(#[allow(deprecated)] self.scanline_bytes(), self.total_bytes()),
+            buffer: ImageReadBuffer::new(
+                #[allow(deprecated)]
+                self.scanline_bytes(),
+                self.total_bytes(),
+            ),
             decoder: self,
         })
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -514,6 +514,7 @@ where
     let dimensions = decoder.dimensions();
     let bytes_per_pixel = u64::from(decoder.color_type().bytes_per_pixel());
     let row_bytes = bytes_per_pixel * u64::from(dimensions.0);
+    #[allow(deprecated)]
     let scanline_bytes = decoder.scanline_bytes();
     let total_bytes = width * height * bytes_per_pixel;
 
@@ -716,6 +717,7 @@ pub trait ImageDecoder<'a>: Sized {
     /// Returns a reader that can be used to obtain the bytes of the image. For the best
     /// performance, always try to read at least `scanline_bytes` from the reader at a time. Reading
     /// fewer bytes will cause the reader to perform internal buffering.
+    #[deprecated = "Planned for removal. See https://github.com/image-rs/image/issues/1989"]
     fn into_reader(self) -> ImageResult<Self::Reader>;
 
     /// Returns the total number of bytes in the decoded image.
@@ -733,6 +735,7 @@ pub trait ImageDecoder<'a>: Sized {
 
     /// Returns the minimum number of bytes that can be efficiently read from this decoder. This may
     /// be as few as 1 or as many as `total_bytes()`.
+    #[deprecated = "Planned for removal. See https://github.com/image-rs/image/issues/1989"]
     fn scanline_bytes(&self) -> u64 {
         self.total_bytes()
     }
@@ -759,11 +762,13 @@ pub trait ImageDecoder<'a>: Sized {
     /// }
     /// ```
     fn read_image(self, buf: &mut [u8]) -> ImageResult<()> {
+        #[allow(deprecated)]
         self.read_image_with_progress(buf, |_| {})
     }
 
     /// Same as `read_image` but periodically calls the provided callback to give updates on loading
     /// progress.
+    #[deprecated = "Use read_image instead. See https://github.com/image-rs/image/issues/1989"]
     fn read_image_with_progress<F: Fn(Progress)>(
         self,
         buf: &mut [u8],
@@ -772,6 +777,7 @@ pub trait ImageDecoder<'a>: Sized {
         assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
 
         let total_bytes = self.total_bytes() as usize;
+        #[allow(deprecated)]
         let scanline_bytes = self.scanline_bytes() as usize;
         let target_read_size = if scanline_bytes < 4096 {
             (4096 / scanline_bytes) * scanline_bytes
@@ -779,6 +785,7 @@ pub trait ImageDecoder<'a>: Sized {
             scanline_bytes
         };
 
+        #[allow(deprecated)]
         let mut reader = self.into_reader()?;
 
         let mut bytes_read = 0;
@@ -828,6 +835,7 @@ pub trait ImageDecoderRect<'a>: ImageDecoder<'a> + Sized {
         height: u32,
         buf: &mut [u8],
     ) -> ImageResult<()> {
+        #[allow(deprecated)]
         self.read_rect_with_progress(x, y, width, height, buf, |_| {})
     }
 
@@ -843,6 +851,7 @@ pub trait ImageDecoderRect<'a>: ImageDecoder<'a> + Sized {
     ///
     /// This function will panic if the output buffer isn't at least
     /// `color_type().bytes_per_pixel() * color_type().channel_count() * width * height` bytes long.
+    #[deprecated = "Use read_image instead. See https://github.com/image-rs/image/issues/1989"]
     fn read_rect_with_progress<F: Fn(Progress)>(
         &mut self,
         x: u32,


### PR DESCRIPTION
In preparation for removal of the methods in https://github.com/image-rs/image/pull/1869.

Associated tracking issue: #1989 