### PR TITLE
Remove remaining unsafe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ include = [
 ]
 
 [dependencies]
-bytemuck = { version = "1.7.0", features = ["extern_crate_alloc"] } # includes cast_vec
+bytemuck = { version = "1.7.0", features = ["extern_crate_alloc", "derive"] } # includes cast_vec
 byteorder = "1.3.2"
 num-traits = "0.2.0"
 gif = { version = "0.12", optional = true }

--- a/Cargo.toml.public-private-dependencies
+++ b/Cargo.toml.public-private-dependencies
@@ -29,7 +29,7 @@ name = "image"
 path = "./src/lib.rs"
 
 [dependencies]
-bytemuck = { version = "1.7.0", features = ["extern_crate_alloc"] } # includes cast_vec
+bytemuck = { version = "1.7.0", features = ["extern_crate_alloc", "derive"] } # includes cast_vec
 byteorder = "1.3.2"
 num-iter = "0.1.32"
 num-rational = { version = "0.4", default-features = false }

--- a/Cargo.toml.public-private-dependencies
+++ b/Cargo.toml.public-private-dependencies
@@ -3,7 +3,7 @@ cargo-features = ["public-dependency"]
 [package]
 name = "image"
 version = "0.24.0-alpha"
-edition = "2018"
+edition = "2021"
 rust-version = "1.56"
 
 license = "MIT"

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1180,13 +1180,6 @@ where
     fn get_pixel(&self, x: u32, y: u32) -> P {
         *self.get_pixel(x, y)
     }
-
-    /// Returns the pixel located at (x, y), ignoring bounds checking.
-    #[inline(always)]
-    unsafe fn unsafe_get_pixel(&self, x: u32, y: u32) -> P {
-        let indices = self.pixel_indices_unchecked(x, y);
-        *<P as Pixel>::from_slice(self.data.get_unchecked(indices))
-    }
 }
 
 impl<P, Container> GenericImage for ImageBuffer<P, Container>
@@ -1200,14 +1193,6 @@ where
 
     fn put_pixel(&mut self, x: u32, y: u32, pixel: P) {
         *self.get_pixel_mut(x, y) = pixel
-    }
-
-    /// Puts a pixel at location (x, y), ignoring bounds checking.
-    #[inline(always)]
-    unsafe fn unsafe_put_pixel(&mut self, x: u32, y: u32, pixel: P) {
-        let indices = self.pixel_indices_unchecked(x, y);
-        let p = <P as Pixel>::from_slice_mut(self.data.get_unchecked_mut(indices));
-        *p = pixel
     }
 
     /// Put a pixel at location (x, y), taking into account alpha channels

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,7 +1,7 @@
 use std::ops::{Index, IndexMut};
 
-use num_traits::{NumCast, ToPrimitive, Zero};
 use bytemuck::TransparentWrapper;
+use num_traits::{NumCast, ToPrimitive, Zero};
 
 use crate::traits::{Enlargeable, Pixel, Primitive};
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,6 +1,7 @@
 use std::ops::{Index, IndexMut};
 
 use num_traits::{NumCast, ToPrimitive, Zero};
+use bytemuck::TransparentWrapper;
 
 use crate::traits::{Enlargeable, Pixel, Primitive};
 
@@ -211,8 +212,8 @@ macro_rules! define_colors {
 $( // START Structure definitions
 
 $(#[$doc])*
-#[derive(PartialEq, Eq, Clone, Debug, Copy, Hash)]
-#[repr(C)]
+#[derive(PartialEq, Eq, Clone, Debug, Copy, Hash, TransparentWrapper)]
+#[repr(transparent)]
 #[allow(missing_docs)]
 pub struct $ident<T> (pub [T; $channels]);
 
@@ -246,12 +247,10 @@ impl<T: $($bound+)*> Pixel for $ident<T> {
     }
 
     fn from_slice(slice: &[T]) -> &$ident<T> {
-        assert_eq!(slice.len(), $channels);
-        unsafe { &*(slice.as_ptr() as *const $ident<T>) }
+        Self::wrap_ref(slice.try_into().unwrap())
     }
     fn from_slice_mut(slice: &mut [T]) -> &mut $ident<T> {
-        assert_eq!(slice.len(), $channels);
-        unsafe { &mut *(slice.as_mut_ptr() as *mut $ident<T>) }
+        Self::wrap_mut(slice.try_into().unwrap())
     }
 
     fn to_rgb(&self) -> Rgb<T> {

--- a/src/image.rs
+++ b/src/image.rs
@@ -962,18 +962,6 @@ pub trait GenericImageView {
     /// Panics if `(x, y)` is out of bounds.
     fn get_pixel(&self, x: u32, y: u32) -> Self::Pixel;
 
-    /// Returns the pixel located at (x, y). Indexed from top left.
-    ///
-    /// This function can be implemented in a way that ignores bounds checking.
-    /// # Safety
-    ///
-    /// The coordinates must be [`in_bounds`] of the image.
-    ///
-    /// [`in_bounds`]: #method.in_bounds
-    unsafe fn unsafe_get_pixel(&self, x: u32, y: u32) -> Self::Pixel {
-        self.get_pixel(x, y)
-    }
-
     /// Returns an Iterator over the pixels of this image.
     /// The iterator yields the coordinates of each pixel
     /// along with their value
@@ -1036,18 +1024,6 @@ pub trait GenericImage: GenericImageView {
     ///
     /// Panics if `(x, y)` is out of bounds.
     fn put_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel);
-
-    /// Puts a pixel at location (x, y). Indexed from top left.
-    ///
-    /// This function can be implemented in a way that ignores bounds checking.
-    /// # Safety
-    ///
-    /// The coordinates must be [`in_bounds`] of the image.
-    ///
-    /// [`in_bounds`]: traits.GenericImageView.html#method.in_bounds
-    unsafe fn unsafe_put_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel) {
-        self.put_pixel(x, y, pixel);
-    }
 
     /// Put a pixel at location (x, y), taking into account alpha channels
     #[deprecated(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,7 @@
 #![allow(clippy::many_single_char_names)]
 // it's a backwards compatibility break
 #![allow(clippy::wrong_self_convention, clippy::enum_variant_names)]
+#![forbid(unsafe_code)]
 
 #[cfg(all(test, feature = "benchmarks"))]
 extern crate test;


### PR DESCRIPTION
This PR removes all remaining instances of unsafe code from this crate and lets us set the `#![forbid(unsafe_code)]` annotation. Unfortunately, it involves a few breaking changes and enables bytemuck's "derive" feature which has several proc-macro dependencies, so it may or may not be worth doing.