### PR TITLE
Add PngDecoder::gamma_value method

### DIFF
--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -193,6 +193,27 @@ impl<R: Read> PngDecoder<R> {
         Ok(PngDecoder { color_type, reader })
     }
 
+    /// Returns the gamma value of the image or None if no gamma value is indicated.
+    ///
+    /// If an sRGB chunk is present this method returns a gamma value of 0.45455 and ignores the
+    /// value in the gAMA chunk. This is the recommended behavior according to the PNG standard:
+    ///
+    /// > When the sRGB chunk is present, [...] decoders that recognize the sRGB chunk but are not
+    /// > capable of colour management are recommended to ignore the gAMA and cHRM chunks, and use
+    /// > the values given above as if they had appeared in gAMA and cHRM chunks.
+    pub fn gamma_value(&self) -> ImageResult<Option<f64>> {
+        let gamma = if self.reader.info().srgb.is_some() {
+            Some(0.45455)
+        } else {
+            self.reader
+                .info()
+                .gama_chunk
+                .map(|x| x.into_scaled() as f64 / 100000.0)
+        };
+
+        Ok(gamma)
+    }
+
     /// Turn this into an iterator over the animation frames.
     ///
     /// Reading the complete animation requires more memory than reading the data from the IDAT

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -202,16 +202,11 @@ impl<R: Read> PngDecoder<R> {
     /// > capable of colour management are recommended to ignore the gAMA and cHRM chunks, and use
     /// > the values given above as if they had appeared in gAMA and cHRM chunks.
     pub fn gamma_value(&self) -> ImageResult<Option<f64>> {
-        let gamma = if self.reader.info().srgb.is_some() {
-            Some(0.45455)
-        } else {
-            self.reader
-                .info()
-                .gama_chunk
-                .map(|x| x.into_scaled() as f64 / 100000.0)
-        };
-
-        Ok(gamma)
+        Ok(self
+            .reader
+            .info()
+            .source_gamma
+            .map(|x| x.into_scaled() as f64 / 100000.0))
     }
 
     /// Turn this into an iterator over the animation frames.


### PR DESCRIPTION
The `Result` return type was chosen so that the method can return I/O errors once the PNG decoder no longer reads all metadata in the `new()` method. And an `f64` was used so that all gamma values can be exactly represented (PNG encodes the value as a fixed precision decimal stored as a u32 which doesn't directly map to a f32).

cc: @anforowicz 

Fixes #2001