### PR TITLE
reduce low-level byte fiddling in openexr encoder

### DIFF
--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -28,7 +28,6 @@ use crate::{
     ColorType, ExtendedColorType, ImageDecoder, ImageEncoder, ImageError, ImageFormat, ImageResult,
     Progress,
 };
-use std::convert::TryInto;
 use std::io::{Cursor, Read, Seek, Write};
 
 /// An OpenEXR decoder. Immediately reads the meta data from the file.

--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -272,14 +272,7 @@ fn write_buffer(
         }
     }
 
-    // bytes might be unaligned so we cannot cast the whole thing, instead lookup each f32 individually
-    let lookup_f32 = move |f32_index: usize| {
-        let unaligned_f32_bytes_slice = &unaligned_bytes[f32_index * 4..(f32_index + 1) * 4];
-        let f32_bytes_array = unaligned_f32_bytes_slice
-            .try_into()
-            .expect("indexing error");
-        f32::from_ne_bytes(f32_bytes_array)
-    };
+    let bytes_per_pixel = color_type.bytes_per_pixel() as usize;
 
     match color_type {
         ColorType::Rgb32F => {
@@ -287,12 +280,14 @@ fn write_buffer(
                 ::from_channels(
                 (width, height),
                 SpecificChannels::rgb(|pixel: Vec2<usize>| {
-                    let pixel_index = 3 * pixel.flat_index_for_size(Vec2(width, height));
-                    (
-                        lookup_f32(pixel_index),
-                        lookup_f32(pixel_index + 1),
-                        lookup_f32(pixel_index + 2),
-                    )
+                    let pixel_index = pixel.flat_index_for_size(Vec2(width, height));
+                    let start_byte = pixel_index * bytes_per_pixel;
+
+                    let [r,g,b]: [f32; 3] = bytemuck::pod_read_unaligned(&unaligned_bytes[
+                        start_byte .. start_byte + bytes_per_pixel
+                    ]);
+
+                    (r,g,b)
                 }),
             )
             .write()
@@ -306,13 +301,14 @@ fn write_buffer(
                 ::from_channels(
                 (width, height),
                 SpecificChannels::rgba(|pixel: Vec2<usize>| {
-                    let pixel_index = 4 * pixel.flat_index_for_size(Vec2(width, height));
-                    (
-                        lookup_f32(pixel_index),
-                        lookup_f32(pixel_index + 1),
-                        lookup_f32(pixel_index + 2),
-                        lookup_f32(pixel_index + 3),
-                    )
+                    let pixel_index = pixel.flat_index_for_size(Vec2(width, height));
+                    let start_byte = pixel_index * bytes_per_pixel;
+
+                    let [r,g,b, a]: [f32; 4] = bytemuck::pod_read_unaligned(&unaligned_bytes[
+                        start_byte .. start_byte + bytes_per_pixel
+                    ]);
+
+                    (r,g,b,a)
                 }),
             )
             .write()

--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -283,11 +283,11 @@ fn write_buffer(
                     let pixel_index = pixel.flat_index_for_size(Vec2(width, height));
                     let start_byte = pixel_index * bytes_per_pixel;
 
-                    let [r,g,b]: [f32; 3] = bytemuck::pod_read_unaligned(&unaligned_bytes[
-                        start_byte .. start_byte + bytes_per_pixel
-                    ]);
+                    let [r, g, b]: [f32; 3] = bytemuck::pod_read_unaligned(
+                        &unaligned_bytes[start_byte..start_byte + bytes_per_pixel],
+                    );
 
-                    (r,g,b)
+                    (r, g, b)
                 }),
             )
             .write()
@@ -304,11 +304,11 @@ fn write_buffer(
                     let pixel_index = pixel.flat_index_for_size(Vec2(width, height));
                     let start_byte = pixel_index * bytes_per_pixel;
 
-                    let [r,g,b, a]: [f32; 4] = bytemuck::pod_read_unaligned(&unaligned_bytes[
-                        start_byte .. start_byte + bytes_per_pixel
-                    ]);
+                    let [r, g, b, a]: [f32; 4] = bytemuck::pod_read_unaligned(
+                        &unaligned_bytes[start_byte..start_byte + bytes_per_pixel],
+                    );
 
-                    (r,g,b,a)
+                    (r, g, b, a)
                 }),
             )
             .write()


### PR DESCRIPTION
use more high-level function `pod_read_unaligned` to read [f32;3] array instead of manually constructing it component by component

should be completely backwards compatible