### PR TITLE
Implement ImageEncoder for hdr where color type is Rgba32F

### DIFF
--- a/src/codecs/hdr/encoder.rs
+++ b/src/codecs/hdr/encoder.rs
@@ -22,9 +22,9 @@ impl<W: Write> ImageEncoder for HdrEncoder<W> {
                 self.encode_pixels(rgbe_pixels, width as usize, height as usize)
             },
 
-            _ => return Err(ImageError::Encoding(EncodingError::new(
+            _ => Err(ImageError::Encoding(EncodingError::new(
                 ImageFormatHint::Exact(ImageFormat::Hdr),
-                format!("hdr format currently only supports the `Rgb32F` color type"),
+                "hdr format currently only supports the `Rgb32F` color type".to_string(),
             )))
         }
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -365,6 +365,10 @@ pub enum ImageOutputFormat {
     /// An image in WebP Format.
     WebP,
 
+    #[cfg(feature = "hdr")]
+    /// An image in HDR Format.
+    Hdr,
+
     /// A value for signalling an error: An unsupported format was requested
     // Note: When TryFrom is stabilized, this value should not be needed, and
     // a TryInto<ImageOutputFormat> should be used instead of an Into<ImageOutputFormat>.

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -253,6 +253,10 @@ pub(crate) fn write_buffer_impl<W: std::io::Write + Seek>(
         ImageOutputFormat::WebP => {
             webp::WebPEncoder::new_lossless(buffered_write).write_image(buf, width, height, color)
         }
+        #[cfg(feature = "hdr")]
+        ImageOutputFormat::Hdr => {
+            hdr::HdrEncoder::new(buffered_write).write_image(buf, width, height, color)
+        }
 
         image::ImageOutputFormat::Unsupported(msg) => Err(ImageError::Unsupported(
             UnsupportedError::from_format_and_kind(


### PR DESCRIPTION
- impl encoder for hdr where rgba32f for now
- add new output format 

this unlocks:
- ImageBuffer.write_with_encoder, which unlocks DynamicImage.write_with_encoder
- free_functions::write_buffer_impl, which unlocks all the sweet stuff (DynamicImage.write_to, ImageBuffer.write_to)
