### PR TITLE
Use SIMD to speed up clamping

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -92,8 +92,20 @@ where
     }
 }
 
+#[inline]
+pub(crate) fn clamp_simd<N>(mut a: [N; 4], min: N, max: N) -> [N; 4]
+where
+    N: Ord + Copy,
+{
+    a.iter_mut().for_each(|i| *i = max.min(*i));
+    a.iter_mut().for_each(|i| *i = min.max(*i));
+    a
+}
+
 #[cfg(test)]
 mod test {
+    use super::clamp_simd;
+
     #[test]
     fn gray_to_luma8_skip() {
         let check = |bit_depth, w, from, to| {
@@ -124,5 +136,12 @@ mod test {
         );
         // Bit depth 4, skip is half a byte
         check(4, 1, &[0b11110011, 0b00001100], vec![255, 0]);
+    }
+
+    #[test]
+    fn simd_clamp() {
+        let input = [-5, 0, 5, 500];
+        let result = clamp_simd(input, 0, 255);
+        assert_eq!(result, [0, 0, 5, 255]);
     }
 }


### PR DESCRIPTION
Leverage autovectorization to speed up clamping.

Improves end-to-end WebP decoding performance by 2% on x86_64 baseline; should be even better with more recent instructions, and even benefits from AVX-512. 

Not a whole lot of an improvement because Huffman decoding takes up so much time that everything else is trivial by comparison, see #1956; but this will become a significant improvement in the future once Huffman is sped up.

Fixes #2019

I'm opening this to get feedback on the basic direction. If you're OK with the approach I can add it to other parts of the codebase for a few % speedups in other places too.