### PR TITLE
Make color_quant optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ rgb = { version = "0.8.25", optional = true }
 mp4parse = { version = "0.17.0", optional = true }
 dav1d = { version = "0.10.2", optional = true }
 dcv-color-primitives = { version = "0.6.1", optional = true }
-color_quant = "1.1"
+color_quant = { version = "1.1", optional = true }
 exr = { version = "1.5.0", optional = true }
 qoi = { version = "0.4", optional = true }
 libwebp = { package = "webp", version = "0.2.2", default-features = false, optional = true }
@@ -73,6 +73,7 @@ dds = []
 farbfeld = []
 openexr = ["exr"]
 qoi = ["dep:qoi"]
+gif = ["dep:gif", "dep:color_quant"]
 
 # Enables WebP decoder support.
 webp = []

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -3,7 +3,7 @@
 use num_traits::NumCast;
 use std::f64::consts::PI;
 
-use crate::color::{FromColor, IntoColor, Luma, LumaA, Rgba};
+use crate::color::{FromColor, IntoColor, Luma, LumaA};
 use crate::image::{GenericImage, GenericImageView};
 use crate::traits::{Pixel, Primitive};
 use crate::utils::clamp;
@@ -435,11 +435,12 @@ impl ColorMap for BiLevel {
     }
 }
 
+#[cfg(feature = "color_quant")]
 impl ColorMap for color_quant::NeuQuant {
-    type Color = Rgba<u8>;
+    type Color = crate::color::Rgba<u8>;
 
     #[inline(always)]
-    fn index_of(&self, color: &Rgba<u8>) -> usize {
+    fn index_of(&self, color: &Self::Color) -> usize {
         self.index_of(color.channels())
     }
 
@@ -454,7 +455,7 @@ impl ColorMap for color_quant::NeuQuant {
     }
 
     #[inline(always)]
-    fn map_color(&self, color: &mut Rgba<u8>) {
+    fn map_color(&self, color: &mut Self::Color) {
         self.map_pixel(color.channels_mut())
     }
 }


### PR DESCRIPTION
This eliminates one dependency when running with `default-features = false`. It is unlikely to have much impact on most users, but is technically a breaking change.