### PR TITLE
Fix `<flat::View(Mut) as GenericImageView>::bounds` implementations

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1169,10 +1169,6 @@ where
 {
     type Pixel = P;
 
-    fn dimensions(&self) -> (u32, u32) {
-        self.dimensions()
-    }
-
     fn bounds(&self) -> (u32, u32, u32, u32) {
         (0, 0, self.width, self.height)
     }

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -1386,13 +1386,8 @@ where
 {
     type Pixel = P;
 
-    fn dimensions(&self) -> (u32, u32) {
-        (self.inner.layout.width, self.inner.layout.height)
-    }
-
     fn bounds(&self) -> (u32, u32, u32, u32) {
-        let (w, h) = self.dimensions();
-        (0, 0, w, h)
+        (0, 0, self.inner.layout.width, self.inner.layout.height)
     }
 
     fn in_bounds(&self, x: u32, y: u32) -> bool {
@@ -1429,13 +1424,8 @@ where
 {
     type Pixel = P;
 
-    fn dimensions(&self) -> (u32, u32) {
-        (self.inner.layout.width, self.inner.layout.height)
-    }
-
     fn bounds(&self) -> (u32, u32, u32, u32) {
-        let (w, h) = self.dimensions();
-        (0, 0, w, h)
+        (0, 0, self.inner.layout.width, self.inner.layout.height)
     }
 
     fn in_bounds(&self, x: u32, y: u32) -> bool {

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -1392,7 +1392,7 @@ where
 
     fn bounds(&self) -> (u32, u32, u32, u32) {
         let (w, h) = self.dimensions();
-        (0, w, 0, h)
+        (0, 0, w, h)
     }
 
     fn in_bounds(&self, x: u32, y: u32) -> bool {
@@ -1435,7 +1435,7 @@ where
 
     fn bounds(&self) -> (u32, u32, u32, u32) {
         let (w, h) = self.dimensions();
-        (0, w, 0, h)
+        (0, 0, w, h)
     }
 
     fn in_bounds(&self, x: u32, y: u32) -> bool {

--- a/src/image.rs
+++ b/src/image.rs
@@ -959,7 +959,7 @@ pub trait GenericImageView {
         h
     }
 
-    /// The bounding rectangle of this image.
+    /// The bounding rectangle (x, y, w, h) of this image.
     fn bounds(&self) -> (u32, u32, u32, u32);
 
     /// Returns true if this x, y coordinate is contained inside the image.

--- a/src/image.rs
+++ b/src/image.rs
@@ -945,7 +945,10 @@ pub trait GenericImageView {
     type Pixel: Pixel;
 
     /// The width and height of this image.
-    fn dimensions(&self) -> (u32, u32);
+    fn dimensions(&self) -> (u32, u32) {
+        let (_, _, w, h) = self.bounds();
+        (w, h)
+    }
 
     /// The width of this image.
     fn width(&self) -> u32 {


### PR DESCRIPTION
`flat::View(Mut)` have incorrect implementations of `GenericImageView::bounds`, given that it should return `(x, y, w, h)`, which i inferred from `GenericImageView::view`'s parameters.