### PR TITLE
chg: update webp dependency (MEMORYLEAK)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ dcv-color-primitives = { version = "0.5.4", optional = true }
 color_quant = "1.1"
 exr = { version = "1.5.0", optional = true }
 qoi = { version = "0.4", optional = true }
-libwebp = { package = "webp", version = "0.2.2", default-features = false, optional = true }
+libwebp = { package = "webp", version = "0.2.6", default-features = false, optional = true }
 
 [dev-dependencies]
 crc32fast = "1.2.0"


### PR DESCRIPTION
This update of the webp dependency fixes a memory leak when saving images as ".webp".

The memory leak can be easily simulated with the following code:

```rust
use image::io::Reader as ImageReader;

const IMAGE: &str = "input.png";
const OUTPATH: &str = "out.webp";

fn main() {
    println!("Hello, world!");


    // do this 1 M times
    for i in 0..1_000_000 {
        println!("{}", i);
        let img = ImageReader::open(IMAGE).unwrap().decode().unwrap();

        // save image as webp
        img.save(OUTPATH).unwrap();
    }
}
```


I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.

