### PR TITLE
Bump `webp` version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ dcv-color-primitives = { version = "0.5.4", optional = true }
 color_quant = "1.1"
 exr = { version = "1.5.0", optional = true }
 qoi = { version = "0.4", optional = true }
-libwebp = { package = "webp", version = "0.2.2", default-features = false, optional = true }
+libwebp = { package = "webp", version = "0.2.6", default-features = false, optional = true }
 
 [dev-dependencies]
 crc32fast = "1.2.0"


### PR DESCRIPTION
There is a security advisory for the `libwebp-sys` that `webp` uses. It's suggested to upgrade to `libwebp-sys` 0.9.3, which happens in `webp` 0.2.6


I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.

