### PR TITLE
Bump dcv-color-primitives to 0.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ ravif = { version = "0.11.0", optional = true }
 rgb = { version = "0.8.25", optional = true }
 mp4parse = { version = "0.17.0", optional = true }
 dav1d = { version = "0.9.4", optional = true }
-dcv-color-primitives = { version = "0.5.4", optional = true }
+dcv-color-primitives = { version = "0.6.1", optional = true }
 color_quant = "1.1"
 exr = { version = "1.5.0", optional = true }
 qoi = { version = "0.4", optional = true }

--- a/src/codecs/avif/decoder.rs
+++ b/src/codecs/avif/decoder.rs
@@ -108,8 +108,6 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for AvifDecoder<R> {
     fn read_image(self, buf: &mut [u8]) -> ImageResult<()> {
         assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
 
-        dcp::initialize();
-
         if self.picture.pixel_layout() != PixelLayout::I400 {
             let pixel_format = match self.picture.pixel_layout() {
                 PixelLayout::I400 => todo!(),


### PR DESCRIPTION
Note: `dcp::initialize` no longer needs to be called, as its global state is [initialized automatically when required](https://github.com/aws/dcv-color-primitives/pull/78).