### PR TITLE
pnm: Scale samples according to specified maximum

### DIFF
--- a/src/codecs/pnm/decoder.rs
+++ b/src/codecs/pnm/decoder.rs
@@ -60,6 +60,8 @@ enum DecoderError {
     UnexpectedByteInRaster(u8),
     /// Specified sample was out of bounds (e.g. >1 in B&W)
     SampleOutOfBounds(u8),
+    /// The image's maxval is zero
+    MaxvalZero,
     /// The image's maxval exceeds 0xFFFF
     MaxvalTooBig(u32),
 
@@ -133,6 +135,7 @@ impl Display for DecoderError {
             DecoderError::SampleOutOfBounds(val) => {
                 f.write_fmt(format_args!("Sample value {} outside of bounds", val))
             }
+            DecoderError::MaxvalZero => f.write_str("Image MAXVAL is zero"),
             DecoderError::MaxvalTooBig(maxval) => {
                 f.write_fmt(format_args!("Image MAXVAL exceeds {}: {}", 0xFFFF, maxval))
             }
@@ -232,7 +235,15 @@ enum TupleType {
 }
 
 trait Sample {
-    fn bytelen(width: u32, height: u32, samples: u32) -> ImageResult<usize>;
+    type Representation;
+
+    /// Representation size in bytes
+    fn sample_size() -> u32 {
+        std::mem::size_of::<Self::Representation>() as u32
+    }
+    fn bytelen(width: u32, height: u32, samples: u32) -> ImageResult<usize> {
+        Ok((width * height * samples * Self::sample_size()) as usize)
+    }
     fn from_bytes(bytes: &[u8], row_size: usize, output_buf: &mut [u8]) -> ImageResult<()>;
     fn from_ascii(reader: &mut dyn Read, output_buf: &mut [u8]) -> ImageResult<()>;
 }
@@ -659,10 +670,33 @@ impl<R: Read> PnmDecoder<R> {
                     .checked_mul(components)
                     .ok_or(DecoderError::Overflow)?;
 
-                S::from_bytes(&bytes, row_size, buf)
+                S::from_bytes(&bytes, row_size, buf)?;
             }
-            SampleEncoding::Ascii => self.read_ascii::<S>(buf),
+            SampleEncoding::Ascii => {
+                self.read_ascii::<S>(buf)?;
+            }
+        };
+
+        // Scale samples if 8bit or 16bit is not saturated
+        let current_sample_max = self.header.maximal_sample();
+        let target_sample_max = 256_u32.pow(S::sample_size()) - 1;
+
+        if current_sample_max != target_sample_max {
+            let factor = target_sample_max as f32 / current_sample_max as f32;
+
+            if S::sample_size() == 1 {
+                buf.iter_mut().for_each(|v| {
+                    *v = (*v as f32 * factor).round() as u8;
+                })
+            } else if S::sample_size() == 2 {
+                for chunk in buf.chunks_exact_mut(2) {
+                    let v = NativeEndian::read_u16(chunk);
+                    NativeEndian::write_u16(chunk, (v as f32 * factor).round() as u16);
+                }
+            }
         }
+
+        Ok(())
     }
 
     fn read_ascii<Basic: Sample>(&mut self, output_buf: &mut [u8]) -> ImageResult<()> {
@@ -701,9 +735,7 @@ where
 }
 
 impl Sample for U8 {
-    fn bytelen(width: u32, height: u32, samples: u32) -> ImageResult<usize> {
-        Ok((width * height * samples) as usize)
-    }
+    type Representation = u8;
 
     fn from_bytes(bytes: &[u8], _row_size: usize, output_buf: &mut [u8]) -> ImageResult<()> {
         output_buf.copy_from_slice(bytes);
@@ -719,9 +751,7 @@ impl Sample for U8 {
 }
 
 impl Sample for U16 {
-    fn bytelen(width: u32, height: u32, samples: u32) -> ImageResult<usize> {
-        Ok((width * height * samples * 2) as usize)
-    }
+    type Representation = u16;
 
     fn from_bytes(bytes: &[u8], _row_size: usize, output_buf: &mut [u8]) -> ImageResult<()> {
         output_buf.copy_from_slice(bytes);
@@ -745,6 +775,8 @@ impl Sample for U16 {
 // be ignored. Also, contrary to rgb, black pixels are encoded as a 1 while white is 0. This will
 // need to be reversed for the grayscale output.
 impl Sample for PbmBit {
+    type Representation = u8;
+
     fn bytelen(width: u32, height: u32, samples: u32) -> ImageResult<usize> {
         let count = width * samples;
         let linelen = (count / 8) + ((count % 8) != 0) as u32;
@@ -783,9 +815,7 @@ impl Sample for PbmBit {
 
 // Encoded just like a normal U8 but we check the values.
 impl Sample for BWBit {
-    fn bytelen(width: u32, height: u32, samples: u32) -> ImageResult<usize> {
-        U8::bytelen(width, height, samples)
-    }
+    type Representation = u8;
 
     fn from_bytes(bytes: &[u8], row_size: usize, output_buf: &mut [u8]) -> ImageResult<()> {
         U8::from_bytes(bytes, row_size, output_buf)?;
@@ -809,6 +839,7 @@ impl DecodableImageHeader for BitmapHeader {
 impl DecodableImageHeader for GraymapHeader {
     fn tuple_type(&self) -> ImageResult<TupleType> {
         match self.maxwhite {
+            0 => Err(DecoderError::MaxvalZero.into()),
             v if v <= 0xFF => Ok(TupleType::GrayU8),
             v if v <= 0xFFFF => Ok(TupleType::GrayU16),
             _ => Err(DecoderError::MaxvalTooBig(self.maxwhite).into()),
@@ -819,6 +850,7 @@ impl DecodableImageHeader for GraymapHeader {
 impl DecodableImageHeader for PixmapHeader {
     fn tuple_type(&self) -> ImageResult<TupleType> {
         match self.maxval {
+            0 => Err(DecoderError::MaxvalZero.into()),
             v if v <= 0xFF => Ok(TupleType::RGBU8),
             v if v <= 0xFFFF => Ok(TupleType::RGBU16),
             _ => Err(DecoderError::MaxvalTooBig(self.maxval).into()),
@@ -829,6 +861,7 @@ impl DecodableImageHeader for PixmapHeader {
 impl DecodableImageHeader for ArbitraryHeader {
     fn tuple_type(&self) -> ImageResult<TupleType> {
         match self.tupltype {
+            _ if self.maxval == 0 => Err(DecoderError::MaxvalZero.into()),
             None if self.depth == 1 => Ok(TupleType::GrayU8),
             None if self.depth == 2 => Err(ImageError::Unsupported(
                 UnsupportedError::from_format_and_kind(
@@ -937,8 +970,8 @@ ENDHDR
         assert_eq!(
             image,
             vec![
-                0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x01, 0x00,
-                0x00, 0x01
+                0xFF, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0xFF, 0xFF, 0x00,
+                0x00, 0xFF
             ]
         );
         match PnmDecoder::new(&pamdata[..]).unwrap().into_inner() {
@@ -1236,6 +1269,25 @@ ENDHDR
             ) => (),
             _ => panic!("Decoded header is incorrect"),
         }
+    }
+
+    #[test]
+    fn ppm_ascii() {
+        let ascii = b"P3 1 1 2000\n0 1000 2000";
+        let decoder = PnmDecoder::new(&ascii[..]).unwrap();
+        let mut image = vec![0; decoder.total_bytes() as usize];
+        decoder.read_image(&mut image).unwrap();
+        assert_eq!(
+            image,
+            [
+                0_u16.to_ne_bytes(),
+                (u16::MAX / 2 + 1).to_ne_bytes(),
+                u16::MAX.to_ne_bytes()
+            ]
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Some formats allow to specify a maximum value for samples. Before, samples were not scaled respective to this white point, decoding some images incorrectly dimmed.

### PAM (P7)

I think the tests were wrong before. But I'm not 100% confident since I haven't found something to test this format in practice.

### Example

Comparison of `image-rs` and correct rendering.

![Screenshot from 2023-11-17 23-32-57](https://github.com/image-rs/image/assets/3466497/2b8c8e32-e4a7-45c2-b537-d37a111e1b81) ![Screenshot from 2023-11-17 23-33-06](https://github.com/image-rs/image/assets/3466497/5493bcb3-45cd-41db-8ca7-adc5aa5f5d26)

```
P3 3 3 20
20 0 0
0 20 0
0 0 20
20 20 0
0 20 20
20 0 20
20 20 20
0 0 0
0 0 0
```