### PR TITLE
Use doc_cfg to show which items require the 'rayon' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,10 @@ avif-decoder = ["mp4parse", "dcv-color-primitives", "dav1d"]
 # Requires rustc nightly for feature test.
 benchmarks = []
 
+[package.metadata.docs.rs]
+features = ["rayon"]
+rustdoc-args = ["--cfg", "doc_cfg"]
+
 [[bench]]
 path = "benches/decode.rs"
 name = "decode"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,9 +116,12 @@
 #![deny(unreachable_pub)]
 #![deny(deprecated)]
 #![deny(missing_copy_implementations)]
-#![cfg_attr(all(test, feature = "benchmarks"), feature(test))]
+
 // it's a backwards compatibility break
 #![allow(clippy::wrong_self_convention, clippy::enum_variant_names)]
+
+#![cfg_attr(all(test, feature = "benchmarks"), feature(test))]
+#![cfg_attr(doc_cfg, feature(doc_cfg))]
 
 #[cfg(all(test, feature = "benchmarks"))]
 extern crate test;
@@ -187,6 +190,7 @@ pub mod buffer {
     };
 
     #[cfg(feature = "rayon")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
     pub use crate::buffer_par::*;
 }
 
@@ -286,6 +290,7 @@ mod animation;
 #[path = "buffer.rs"]
 mod buffer_;
 #[cfg(feature = "rayon")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "rayon")))]
 mod buffer_par;
 mod color;
 mod dynimage;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,17 +111,15 @@
 //! [`ImageDecoderRect`]: trait.ImageDecoderRect.html
 //! [`ImageDecoder`]: trait.ImageDecoder.html
 //! [`ImageEncoder`]: trait.ImageEncoder.html
+#![cfg_attr(all(test, feature = "benchmarks"), feature(test))]
+#![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![warn(missing_docs)]
 #![warn(unused_qualifications)]
 #![deny(unreachable_pub)]
 #![deny(deprecated)]
 #![deny(missing_copy_implementations)]
-
 // it's a backwards compatibility break
 #![allow(clippy::wrong_self_convention, clippy::enum_variant_names)]
-
-#![cfg_attr(all(test, feature = "benchmarks"), feature(test))]
-#![cfg_attr(doc_cfg, feature(doc_cfg))]
 
 #[cfg(all(test, feature = "benchmarks"))]
 extern crate test;


### PR DESCRIPTION
This PR enables nicer doc output that highlights the items requiring the 'rayon' feature. You can generate this output locally via:

```bash
cargo rustdoc --features rayon --open -- --cfg doc_cfg
```

---

![image](https://github.com/image-rs/image/assets/4943209/dc634581-0de2-4fb8-abf1-7c5aee1ca8a3)



