### PR TITLE
refactor: replace the (dublicated) impl blocks with the equivalent macros

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -130,17 +130,20 @@ pub trait Lerp: Bounded + NumCast {
     }
 }
 
-impl Lerp for u8 {
-    type Ratio = f32;
+macro_rules! impl_lerp {
+    ($base:ty: $rt:ty) => {
+        impl Lerp for $base {
+            type Ratio = $rt;
+        }
+    };
+    ($($b:ty: $r:ty,)*) => {
+        $(
+            impl_lerp!($b: $r);
+        )*
+    }
 }
 
-impl Lerp for u16 {
-    type Ratio = f32;
-}
-
-impl Lerp for u32 {
-    type Ratio = f64;
-}
+impl_lerp!(u8: f32, u16: f32, u32: f64,);
 
 impl Lerp for f32 {
     type Ratio = f32;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -87,44 +87,28 @@ pub trait Enlargeable: Sized + Bounded + NumCast {
     }
 }
 
-impl Enlargeable for u8 {
-    type Larger = u32;
+macro_rules! impl_enlargeable {
+    ($base:ty: $larger:ty) => {
+        impl Enlargeable for $base {
+            type Larger = $larger;
+        }
+    };
+    ($($b:ty: $l:ty,)*) => {
+        $(
+            impl_enlargeable!($b: $l);
+        )*
+    }
 }
-impl Enlargeable for u16 {
-    type Larger = u32;
-}
-impl Enlargeable for u32 {
-    type Larger = u64;
-}
-impl Enlargeable for u64 {
-    type Larger = u128;
-}
-impl Enlargeable for usize {
-    // Note: On 32-bit architectures, u64 should be enough here.
-    type Larger = u128;
-}
-impl Enlargeable for i8 {
-    type Larger = i32;
-}
-impl Enlargeable for i16 {
-    type Larger = i32;
-}
-impl Enlargeable for i32 {
-    type Larger = i64;
-}
-impl Enlargeable for i64 {
-    type Larger = i128;
-}
-impl Enlargeable for isize {
-    // Note: On 32-bit architectures, i64 should be enough here.
-    type Larger = i128;
-}
-impl Enlargeable for f32 {
-    type Larger = f64;
-}
-impl Enlargeable for f64 {
-    type Larger = f64;
-}
+
+impl_enlargeable!(u8: u32, u16: u32, u32: u64, u64: u128,);
+// NOTE: On 32-bit architectures, u64 should be enough here.
+impl_enlargeable!(usize: u128);
+
+impl_enlargeable!(i8: i32, i16: i32, i32: i64, i64: i128,);
+// NOTE: On 32-bit architectures, i64 should be enough here.
+impl_enlargeable!(isize: i128);
+
+impl_enlargeable!(f32: f64, f64: f64,);
 
 /// Linear interpolation without involving floating numbers.
 pub trait Lerp: Bounded + NumCast {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -163,38 +163,30 @@ pub trait PixelWithColorType: Pixel + self::private::SealedPixelWithColorType {
     const COLOR_TYPE: ColorType;
 }
 
-impl PixelWithColorType for Rgb<u8> {
-    const COLOR_TYPE: ColorType = ColorType::Rgb8;
-}
-impl PixelWithColorType for Rgb<u16> {
-    const COLOR_TYPE: ColorType = ColorType::Rgb16;
-}
-impl PixelWithColorType for Rgb<f32> {
-    const COLOR_TYPE: ColorType = ColorType::Rgb32F;
+macro_rules! impl_pixel_with_color_ty {
+    ($base:ty: $ct:expr) => {
+        impl PixelWithColorType for $base {
+            const COLOR_TYPE: ColorType = $ct;
+        }
+    };
+    (rgb; $($base:ty: $ct:expr,)*) => {
+        $(impl_pixel_with_color_ty!(Rgb<$base>: $ct);)*
+    };
+    (rgba; $($base:ty: $ct:expr,)*) => {
+        $(impl_pixel_with_color_ty!(Rgba<$base>: $ct);)*
+    };
+    (luma; $($base:ty: $ct:expr,)*) => {
+        $(impl_pixel_with_color_ty!(Luma<$base>: $ct);)*
+    };
+    (lumaA; $($base:ty: $ct:expr,)*) => {
+        $(impl_pixel_with_color_ty!(LumaA<$base>: $ct);)*
+    };
 }
 
-impl PixelWithColorType for Rgba<u8> {
-    const COLOR_TYPE: ColorType = ColorType::Rgba8;
-}
-impl PixelWithColorType for Rgba<u16> {
-    const COLOR_TYPE: ColorType = ColorType::Rgba16;
-}
-impl PixelWithColorType for Rgba<f32> {
-    const COLOR_TYPE: ColorType = ColorType::Rgba32F;
-}
-
-impl PixelWithColorType for Luma<u8> {
-    const COLOR_TYPE: ColorType = ColorType::L8;
-}
-impl PixelWithColorType for Luma<u16> {
-    const COLOR_TYPE: ColorType = ColorType::L16;
-}
-impl PixelWithColorType for LumaA<u8> {
-    const COLOR_TYPE: ColorType = ColorType::La8;
-}
-impl PixelWithColorType for LumaA<u16> {
-    const COLOR_TYPE: ColorType = ColorType::La16;
-}
+impl_pixel_with_color_ty!(rgb; u8: ColorType::Rgb8, u16: ColorType::Rgb16, f32: ColorType::Rgb32F,);
+impl_pixel_with_color_ty!(rgba; u8: ColorType::Rgba8, u16: ColorType::Rgba16, f32: ColorType::Rgba32F,);
+impl_pixel_with_color_ty!(luma; u8: ColorType::L8, u16: ColorType::L16,);
+impl_pixel_with_color_ty!(lumaA; u8: ColorType::La8, u16: ColorType::La16,);
 
 /// Prevents down-stream users from implementing the `Primitive` trait
 mod private {


### PR DESCRIPTION
Apply DRY (Don't Repeat Yourself) rule and replace the (simirer) impl blocks with equivalent macros


I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.
