### PR TITLE
implement From<DynamicImage> for all image types

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -14,6 +14,7 @@ use crate::image::{GenericImage, GenericImageView, ImageEncoder, ImageFormat, Im
 use crate::math::Rect;
 use crate::traits::{EncodableLayout, Pixel, PixelWithColorType};
 use crate::utils::expand_packed;
+use crate::DynamicImage;
 
 /// Iterate over pixel refs.
 pub struct Pixels<'a, P: Pixel + 'a>
@@ -1426,6 +1427,60 @@ pub type Rgb32FImage = ImageBuffer<Rgb<f32>, Vec<f32>>;
 /// An image buffer for 32-bit float RGBA pixels,
 /// where the backing container is a flattened vector of floats.
 pub type Rgba32FImage = ImageBuffer<Rgba<f32>, Vec<f32>>;
+
+impl From<DynamicImage> for RgbImage {
+    fn from(value: DynamicImage) -> Self {
+        value.into_rgb8()
+    }
+}
+
+impl From<DynamicImage> for RgbaImage {
+    fn from(value: DynamicImage) -> Self {
+        value.into_rgba8()
+    }
+}
+
+impl From<DynamicImage> for GrayImage {
+    fn from(value: DynamicImage) -> Self {
+        value.into_luma8()
+    }
+}
+
+impl From<DynamicImage> for GrayAlphaImage {
+    fn from(value: DynamicImage) -> Self {
+        value.into_luma_alpha8()
+    }
+}
+
+impl From<DynamicImage> for Rgb16Image {
+    fn from(value: DynamicImage) -> Self {
+        value.into_rgb16()
+    }
+}
+
+impl From<DynamicImage> for Rgba16Image {
+    fn from(value: DynamicImage) -> Self {
+        value.into_rgba16()
+    }
+}
+
+impl From<DynamicImage> for Gray16Image {
+    fn from(value: DynamicImage) -> Self {
+        value.into_luma16()
+    }
+}
+
+impl From<DynamicImage> for GrayAlpha16Image {
+    fn from(value: DynamicImage) -> Self {
+        value.into_luma_alpha16()
+    }
+}
+
+impl From<DynamicImage> for Rgba32FImage {
+    fn from(value: DynamicImage) -> Self {
+        value.into_rgba32f()
+    }
+}
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
Allows for generically converting from a dynamicImage. This is something that would be handy to have in another project, and I realized it would be easy to add myself. 

<!--
If you are a new contributor, consent to licensing by including this text:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.

Thank you for contributing, you can delete this comment.
-->
