### PR TITLE
Fix wrong implementation of unsharpen filter

### DIFF
--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -991,9 +991,9 @@ where
                 let ic: i32 = NumCast::from(c).unwrap();
                 let id: i32 = NumCast::from(d).unwrap();
 
-                let diff = (ic - id).abs();
+                let diff = ic - id;
 
-                if diff > threshold {
+                if diff.abs() > threshold {
                     let e = clamp(ic + diff, 0, max); // FIXME what does this do for f32? clamp 0-1 integers??
 
                     NumCast::from(e).unwrap()


### PR DESCRIPTION
This PR fixes the crate's current implementation of the unsharpen filter, which currently does not work in the intended way. Normally, in order to calculate the unsharpen filter, the following steps are taken:
- a blurred version of the image is generated
- that version is subtracted from the original, giving us their difference, that can be either negative or positive.
- the difference is filtered by a minimum `threshold` parameter, so that *absolute* difference values that lie below a certain limit are not used in the filter
- the filtered difference is multiplied by an `amount` parameter, which controls the strength of the filter (this PR does not add that parameter)
- the result of that is added to the original image

The current way this is done doesn't take into account that the difference that has to be added to the original image can be both positive and negative, returning *less* sharp images than the originals. That's what this PR aims to fix.

It should also be noted that:
- The current public API for the `imageops::unsharpen()` function is not great, using a datatype-dependent threshold value, and lacking the very common `amount` or `strength` value that is present in almost all applications that have this filter.
- Neither the current nor this PR's implementation work properly with high dynamic range float-based images.

### Image examples:

Current:
![An image showing the current implementation of the unsharpen filter](https://i.imgur.com/2HEMqUp.png)

This PR:
![An image showing this PR's implementation of the unsharpen filter](https://i.imgur.com/9g8uhRa.png)

Original:
![The original image](https://i.imgur.com/XVCm6bM.png)

Other examples of the desired effect can also be found on the [unsharp masking Wikipedia page](https://en.wikipedia.org/wiki/Unsharp_masking)

I license past and future contributions under the dual MIT/Apache-2.0 license, allowing licensees to choose either at their option.