### PR TITLE
refactor: replace byteorder with the equivalent built-in methods

### DIFF
--- a/src/codecs/hdr/decoder.rs
+++ b/src/codecs/hdr/decoder.rs
@@ -998,21 +998,28 @@ fn read_line_u8_test() {
 
 /// Helper function for reading raw 3-channel f32 images
 pub fn read_raw_file<P: AsRef<Path>>(path: P) -> ::std::io::Result<Vec<Rgb<f32>>> {
-    use byteorder::{LittleEndian as LE, ReadBytesExt};
     use std::fs::File;
     use std::io::BufReader;
 
     let mut r = BufReader::new(File::open(path)?);
-    let w = r.read_u32::<LE>()? as usize;
-    let h = r.read_u32::<LE>()? as usize;
-    let c = r.read_u32::<LE>()? as usize;
+    let mut buf = [0; 4];
+    r.read_exact(&mut buf)?;
+    let w = u32::from_le_bytes(buf);
+    r.read_exact(&mut buf)?;
+    let h = u32::from_le_bytes(buf);
+    r.read_exact(&mut buf)?;
+    let c = u32::from_le_bytes(buf);
     assert_eq!(c, 3);
     let cnt = w * h;
-    let mut ret = Vec::with_capacity(cnt);
+    let mut ret = Vec::with_capacity(cnt as usize);
+    let mut buf = [0; 4];
     for _ in 0..cnt {
-        let cr = r.read_f32::<LE>()?;
-        let cg = r.read_f32::<LE>()?;
-        let cb = r.read_f32::<LE>()?;
+        r.read_exact(&mut buf)?;
+        let cr = f32::from_le_bytes(buf);
+        r.read_exact(&mut buf)?;
+        let cg = f32::from_le_bytes(buf);
+        r.read_exact(&mut buf)?;
+        let cb = f32::from_le_bytes(buf);
         ret.push(Rgb([cr, cg, cb]));
     }
     Ok(ret)

--- a/src/codecs/ico/encoder.rs
+++ b/src/codecs/ico/encoder.rs
@@ -1,4 +1,3 @@
-use byteorder::{LittleEndian, WriteBytesExt};
 use std::borrow::Cow;
 use std::io::{self, Write};
 
@@ -164,11 +163,11 @@ impl<W: Write> ImageEncoder for IcoEncoder<W> {
 
 fn write_icondir<W: Write>(w: &mut W, num_images: u16) -> io::Result<()> {
     // Reserved field (must be zero):
-    w.write_u16::<LittleEndian>(0)?;
+    w.write_all(&0u16.to_le_bytes())?;
     // Image type (ICO or CUR):
-    w.write_u16::<LittleEndian>(ICO_IMAGE_TYPE)?;
+    w.write_all(&ICO_IMAGE_TYPE.to_le_bytes())?;
     // Number of images in the file:
-    w.write_u16::<LittleEndian>(num_images)?;
+    w.write_all(&num_images.to_le_bytes())?;
     Ok(())
 }
 
@@ -181,19 +180,20 @@ fn write_direntry<W: Write>(
     data_size: u32,
 ) -> io::Result<()> {
     // Image dimensions:
-    w.write_u8(width)?;
-    w.write_u8(height)?;
+    // w.write_u8(width)?;
+    // w.write_u8(height)?;
+    w.write_all(&[width, height])?;
     // Number of colors in palette (or zero for no palette):
-    w.write_u8(0)?;
+    w.write_all(&[0])?;
     // Reserved field (must be zero):
-    w.write_u8(0)?;
+    w.write_all(&[0])?;
     // Color planes:
-    w.write_u16::<LittleEndian>(0)?;
+    w.write_all(&0u16.to_le_bytes())?;
     // Bits per pixel:
-    w.write_u16::<LittleEndian>(color.bits_per_pixel())?;
+    w.write_all(&color.bits_per_pixel().to_le_bytes())?;
     // Image data size, in bytes:
-    w.write_u32::<LittleEndian>(data_size)?;
+    w.write_all(&data_size.to_le_bytes())?;
     // Image data offset, in bytes:
-    w.write_u32::<LittleEndian>(data_start)?;
+    w.write_all(&data_start.to_le_bytes())?;
     Ok(())
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -92,6 +92,17 @@ where
     }
 }
 
+#[macro_export]
+macro_rules! read_le {
+    ($r:ident, $ty:ty, $buf:ident) => {{
+        if let Err(e) = $r.read_exact(&mut $buf) {
+            Err(e)
+        } else {
+            Ok(<$ty>::from_le_bytes($buf))
+        }
+    }};
+}
+
 #[cfg(test)]
 mod test {
     #[test]


### PR DESCRIPTION
Follow up to #2071, this PR replace the usage of `byteorder` utilities to convert the bytes between the different representations and use the built-in methods.

This PR isn't completely done yet, since that the final aim of this PR is to remove `byteorder` from our deps.

 But after refactoring the `ico` and `hdr` decoder/encoder, I noticed the there is an annoying-repeated pattern to read the needed bytes from the reader and convert them to the representation that we want + there's a potential error if we forget to read before convert the buffer, so I introduced a new utility macro in 8478822d5303079c34a52f3229a8e811f8a48bd6 to take care of those steps. But I have some concerns about the way that this should be done with, like:
* Did we should use `?` inside this macro, or just return an `Result` and leave the error handling to the caller? Which it'll use the `?` operator anyway.
* The syntax
* Should we take the buffer from the caller, or just create an internal one on the call. (from the performance perspective).


<!--
If you are a new contributor, consent to licensing by including this text:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.

Thank you for contributing, you can delete this comment.
-->
