### PR TITLE
Fix `GifDecoder::with_limits` to raise an error when limits are exceeded

### DIFF
--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -69,10 +69,16 @@ impl<R: Read> GifDecoder<R> {
         let mut decoder = gif::DecodeOptions::new();
         decoder.set_color_output(ColorOutput::RGBA);
 
-        Ok(GifDecoder {
+        let mut img_decoder = GifDecoder {
             reader: decoder.read_info(r).map_err(ImageError::from_decoding)?,
-            limits,
-        })
+            limits: Limits::default(),
+        };
+
+        // call `.set_limits()` instead of just setting the field directly
+        // so that we raise an error in case they are exceeded
+        img_decoder.set_limits(limits)?;
+
+        Ok(img_decoder)
     }
 }
 

--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -66,19 +66,11 @@ impl<R: Read> GifDecoder<R> {
 
     /// Creates a new decoder that decodes the input steam `r`, using limits `limits`
     pub fn with_limits(r: R, limits: Limits) -> ImageResult<GifDecoder<R>> {
-        let mut decoder = gif::DecodeOptions::new();
-        decoder.set_color_output(ColorOutput::RGBA);
-
-        let mut img_decoder = GifDecoder {
-            reader: decoder.read_info(r).map_err(ImageError::from_decoding)?,
-            limits: Limits::default(),
-        };
-
+        let mut decoder = Self::new(r)?;
         // call `.set_limits()` instead of just setting the field directly
         // so that we raise an error in case they are exceeded
-        img_decoder.set_limits(limits)?;
-
-        Ok(img_decoder)
+        decoder.set_limits(limits)?;
+        Ok(decoder)
     }
 }
 

--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -65,7 +65,7 @@ impl<R: Read> GifDecoder<R> {
     }
 
     /// Creates a new decoder that decodes the input steam `r`, using limits `limits`
-    #[deprecated(since="0.24.8", note="Use `new` followed by `set_limits` instead")]
+    #[deprecated(since = "0.24.8", note = "Use `new` followed by `set_limits` instead")]
     pub fn with_limits(r: R, limits: Limits) -> ImageResult<GifDecoder<R>> {
         let mut decoder = Self::new(r)?;
         // call `.set_limits()` instead of just setting the field directly

--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -65,6 +65,7 @@ impl<R: Read> GifDecoder<R> {
     }
 
     /// Creates a new decoder that decodes the input steam `r`, using limits `limits`
+    #[deprecated(since="0.24.8", note="Use `new` followed by `set_limits` instead")]
     pub fn with_limits(r: R, limits: Limits) -> ImageResult<GifDecoder<R>> {
         let mut decoder = Self::new(r)?;
         // call `.set_limits()` instead of just setting the field directly


### PR DESCRIPTION
Partly addresses #1052