### PR TITLE
Clearer error messages for limit errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -465,8 +465,8 @@ impl Error for DecodingError {
 impl fmt::Display for LimitError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self.kind {
-            LimitErrorKind::InsufficientMemory => write!(fmt, "Insufficient memory"),
-            LimitErrorKind::DimensionError => write!(fmt, "Image is too large"),
+            LimitErrorKind::InsufficientMemory => write!(fmt, "Memory limit exceeded"),
+            LimitErrorKind::DimensionError => write!(fmt, "Image size exceeds limit"),
             LimitErrorKind::Unsupported { .. } => {
                 write!(fmt, "The following strict limits are specified but not supported by the opertation: ")?;
                 Ok(())


### PR DESCRIPTION
Based on the feedback from https://github.com/image-rs/image/issues/2092#issuecomment-1888417160:

> The error message could be improved, since it makes the user think they have a RAM problem. My team ran into this same issue this week.
