### PR TITLE
Fix incorrect documentation of AvifEncoder::new_with_speed_quality

### DIFF
--- a/src/codecs/avif/encoder.rs
+++ b/src/codecs/avif/encoder.rs
@@ -58,9 +58,10 @@ impl<W: Write> AvifEncoder<W> {
         AvifEncoder::new_with_speed_quality(w, 4, 80) // `cavif` uses these defaults
     }
 
-    /// Create a new encoder with specified speed and quality, that writes its output to `w`.
-    /// `speed` accepts a value in the range 0-10, where 0 is the slowest and 10 is the fastest.
-    /// `quality` accepts a value in the range 0-100, where 0 is the worst and 100 is the best.
+    /// Create a new encoder with a specified speed and quality that writes its output to `w`.
+    /// `speed` accepts a value in the range 1-10, where 1 is the slowest and 10 is the fastest.
+    /// Slower speeds generally yield better compression results.
+    /// `quality` accepts a value in the range 1-100, where 1 is the worst and 100 is the best.
     pub fn new_with_speed_quality(w: W, speed: u8, quality: u8) -> Self {
         // Clamp quality and speed to range
         let quality = min(quality, 100);


### PR DESCRIPTION
Fixes #2105.

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.
