### PR TITLE
Use `chunks_exact_mut` in PNG decoder

### DIFF
--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -676,7 +676,7 @@ impl<W: Write> ImageEncoder for PngEncoder<W> {
                 // yet take Write/Read traits, create a temporary buffer for
                 // big endian reordering.
                 let mut reordered = vec![0; buf.len()];
-                buf.chunks(2)
+                buf.chunks_exact(2)
                     .zip(reordered.chunks_exact_mut(2))
                     .for_each(|(b, r)| BigEndian::write_u16(r, NativeEndian::read_u16(b)));
                 self.encode_inner(&reordered, width, height, color_type)

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -274,7 +274,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for PngDecoder<R> {
 
         match bpc {
             1 => (), // No reodering necessary for u8
-            2 => buf.chunks_mut(2).for_each(|c| {
+            2 => buf.chunks_exact_mut(2).for_each(|c| {
                 let v = BigEndian::read_u16(c);
                 NativeEndian::write_u16(c, v)
             }),
@@ -677,7 +677,7 @@ impl<W: Write> ImageEncoder for PngEncoder<W> {
                 // big endian reordering.
                 let mut reordered = vec![0; buf.len()];
                 buf.chunks(2)
-                    .zip(reordered.chunks_mut(2))
+                    .zip(reordered.chunks_exact_mut(2))
                     .for_each(|(b, r)| BigEndian::write_u16(r, NativeEndian::read_u16(b)));
                 self.encode_inner(&reordered, width, height, color_type)
             }


### PR DESCRIPTION
`chunks_mut` can return chunks with sizes 1 or 2, while `chunks_exact_mut` always returns chunks of size 2. This should result in better codegen.

This certainly could be vectorized further, but this codepath is only taken for 16-bit images which are uncommon, so I'm not going to invest a lot of my time into optimizing it.

In the current code a chunk of size 1 being returned would result in a panic, so this should not break anything.