### PR TITLE
Support limits in PNG animation decoding

### DIFF
--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -402,7 +402,7 @@ impl<R: Read> ApngDecoder<R> {
 
         self.animatable_color_type()?;
 
-        // We've initialized them earlier
+        // We've initialized them earlier in this function
         let previous = self.previous.as_mut().unwrap();
         let current = self.current.as_mut().unwrap();
 

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -338,9 +338,8 @@ impl<R: Read> ApngDecoder<R> {
         let has_thumbnail = info.frame_control.is_none();
         ApngDecoder {
             inner,
-            // TODO: should we delay this allocation? At least if we support limits we should.
-            current: None,  //  RgbaImage::new(width, height),
-            previous: None, // RgbaImage::new(width, height),
+            current: None,
+            previous: None,
             dispose: DisposeOp::Background,
             remaining,
             has_thumbnail,

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -118,7 +118,7 @@ pub struct PngDecoder<R: Read> {
 impl<R: Read> PngDecoder<R> {
     /// Creates a new decoder that decodes from the stream ```r```
     pub fn new(r: R) -> ImageResult<PngDecoder<R>> {
-        Self::with_limits(r, Limits::default())
+        Self::with_limits(r, Limits::no_limits())
     }
 
     /// Creates a new decoder that decodes from the stream ```r``` with the given limits.

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -292,6 +292,16 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for PngDecoder<R> {
         let width = self.reader.info().width;
         self.reader.output_line_size(width) as u64
     }
+
+    fn set_limits(&mut self, limits: Limits) -> ImageResult<()> {
+        limits.check_support(&crate::io::LimitSupport::default())?;
+        let info = self.reader.info();
+        limits.check_dimensions(info.width, info.height)?;
+        self.limits = limits;
+        // TODO: add `png::Reader::change_limits()` and call it here
+        // to also constrain the internal buffer allocations in the PNG crate
+        Ok(())
+    }
 }
 
 /// An [`AnimationDecoder`] adapter of [`PngDecoder`].

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -327,7 +327,6 @@ pub struct ApngDecoder<R: Read> {
 
 impl<R: Read> ApngDecoder<R> {
     fn new(inner: PngDecoder<R>) -> Self {
-        let (width, height) = inner.dimensions();
         let info = inner.reader.info();
         let remaining = match info.animation_control() {
             // The expected number of fcTL in the remaining image.

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -402,16 +402,16 @@ impl<R: Read> ApngDecoder<R> {
         // Dispose of the previous frame.
         match self.dispose {
             DisposeOp::None => {
-                previous.clone_from(&current);
+                previous.clone_from(current);
             }
             DisposeOp::Background => {
-                previous.clone_from(&current);
+                previous.clone_from(current);
                 current
                     .pixels_mut()
                     .for_each(|pixel| *pixel = Rgba([0, 0, 0, 0]));
             }
             DisposeOp::Previous => {
-                current.clone_from(&previous);
+                current.clone_from(previous);
             }
         }
 
@@ -494,7 +494,7 @@ impl<R: Read> ApngDecoder<R> {
         // Ok, we can proceed with actually remaining images.
         self.remaining = remaining;
         // Return composited output buffer.
-        Ok(Some(&self.current.as_ref().unwrap()))
+        Ok(Some(self.current.as_ref().unwrap()))
     }
 
     fn animatable_color_type(&self) -> Result<(), ImageError> {

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -112,6 +112,7 @@ impl<R: Read> Read for PngReader<R> {
 pub struct PngDecoder<R: Read> {
     color_type: ColorType,
     reader: png::Reader<R>,
+    limits: Limits,
 }
 
 impl<R: Read> PngDecoder<R> {
@@ -191,7 +192,11 @@ impl<R: Read> PngDecoder<R> {
             }
         };
 
-        Ok(PngDecoder { color_type, reader })
+        Ok(PngDecoder {
+            color_type,
+            reader,
+            limits,
+        })
     }
 
     /// Returns the gamma value of the image or None if no gamma value is indicated.

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -391,7 +391,7 @@ impl<R: Read> ApngDecoder<R> {
         if self.has_thumbnail {
             // Clone the limits so that our one-off allocation that's destroyed after this scope doesn't persist
             let mut limits = self.inner.limits.clone();
-            limits_reserve_buffer(&mut limits, width, height)?;
+            limits.reserve_usize(self.inner.reader.output_buffer_size())?;
             let mut buffer = vec![0; self.inner.reader.output_buffer_size()];
             self.inner
                 .reader

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -2,7 +2,7 @@
 
 use std::convert::TryFrom;
 
-use crate::{error, ImageError, ImageResult};
+use crate::{error, ColorType, ImageError, ImageResult};
 
 pub(crate) mod free_functions;
 mod reader;
@@ -139,6 +139,22 @@ impl Limits {
                 Ok(())
             }
         }
+    }
+
+    /// This function acts identically to [`reserve`], but accepts the width, height and color type
+    /// used to create an [`ImageBuffer`] and does all the math for you.
+    pub fn reserve_buffer(
+        &mut self,
+        width: u32,
+        height: u32,
+        color_type: ColorType,
+    ) -> ImageResult<()> {
+        self.check_dimensions(width, height)?;
+        let in_memory_size = (width as u64)
+            .saturating_mul(height as u64)
+            .saturating_mul(color_type.bytes_per_pixel().into());
+        self.reserve(in_memory_size)?;
+        Ok(())
     }
 
     /// This function increases the `max_alloc` limit with amount. Should only be used


### PR DESCRIPTION
Implements memory limit for animation decoding and dimensions limits for individual animation frames, similar to how 
it's done for GIF.

Notable changes:

- Added a helper function `reserve_buffer` on `Limits` to be reused in PNG and GIF animation decoders
- Implemented allocation tracking in `ApngDecoder`
- Changed the PNG decoder's `new()` to default to no limits (consistently with other decoders) now that the limits are actually enforced

Out of scope of this PR:

 - Passing through the limits to the `png` crate for it to limit its own allocations in animation decoding because the required APIs for that are missing from `png`
 - `png` crate actually enforcing the limits it's passed: https://github.com/image-rs/image-png/issues/286 (rendering the previous bullet point moot)
 - #1748 still isn't fixed (I think?). A proper fix would require an API break so that `is_apng` is allowed to return an error (unless we're OK with it just returning `false` on an error or something?), see #2084

Open questions:

 - Does defaulting to no limits make #1748 worse / easier to trigger? It would if `png` crate allocates large amounts of memory when reading just the headers, but I don't know if it does.
 - Should #2111 be fixed in this PR or separately?