### PR TITLE
Improve panic messages when providing invalid buffer sizes to `ImageEncoder`s

### DIFF
--- a/src/codecs/avif/encoder.rs
+++ b/src/codecs/avif/encoder.rs
@@ -105,9 +105,16 @@ impl<W: Write> ImageEncoder for AvifEncoder<W> {
         height: u32,
         color: ColorType,
     ) -> ImageResult<()> {
+        let expected_buffer_len =
+            (width as u64 * height as u64).saturating_mul(color.bytes_per_pixel() as u64);
         assert_eq!(
-            (width as u64 * height as u64).saturating_mul(color.bytes_per_pixel() as u64),
-            data.len() as u64
+            expected_buffer_len,
+            data.len() as u64,
+            "Invalid buffer length: expected {} got {} for image dimensions ({}, {})",
+            expected_buffer_len,
+            data.len(),
+            width,
+            height,
         );
 
         self.set_color(color);

--- a/src/codecs/avif/encoder.rs
+++ b/src/codecs/avif/encoder.rs
@@ -98,6 +98,7 @@ impl<W: Write> ImageEncoder for AvifEncoder<W> {
     /// The encoder currently requires all data to be RGBA8, it will be converted internally if
     /// necessary. When data is suitably aligned, i.e. u16 channels to two bytes, then the
     /// conversion may be more efficient.
+    #[track_caller]
     fn write_image(
         mut self,
         data: &[u8],

--- a/src/codecs/avif/encoder.rs
+++ b/src/codecs/avif/encoder.rs
@@ -111,11 +111,8 @@ impl<W: Write> ImageEncoder for AvifEncoder<W> {
         assert_eq!(
             expected_buffer_len,
             data.len() as u64,
-            "Invalid buffer length: expected {} got {} for image dimensions ({}, {})",
-            expected_buffer_len,
+            "Invalid buffer length: expected {expected_buffer_len} got {} for {width}x{height} image",
             data.len(),
-            width,
-            height,
         );
 
         self.set_color(color);

--- a/src/codecs/bmp/encoder.rs
+++ b/src/codecs/bmp/encoder.rs
@@ -68,11 +68,8 @@ impl<'a, W: Write + 'a> BmpEncoder<'a, W> {
         assert_eq!(
             expected_buffer_len,
             image.len() as u64,
-            "Invalid buffer length: expected {} got {} for image dimensions ({}, {})",
-            expected_buffer_len,
+            "Invalid buffer length: expected {expected_buffer_len} got {} for {width}x{height} image",
             image.len(),
-            width,
-            height,
         );
 
         let bmp_header_size = BITMAPFILEHEADER_SIZE;

--- a/src/codecs/bmp/encoder.rs
+++ b/src/codecs/bmp/encoder.rs
@@ -27,6 +27,7 @@ impl<'a, W: Write + 'a> BmpEncoder<'a, W> {
     /// # Panics
     ///
     /// Panics if `width * height * c.bytes_per_pixel() != image.len()`.
+    #[track_caller]
     pub fn encode(
         &mut self,
         image: &[u8],
@@ -43,6 +44,7 @@ impl<'a, W: Write + 'a> BmpEncoder<'a, W> {
     /// # Panics
     ///
     /// Panics if `width * height * c.bytes_per_pixel() != image.len()`.
+    #[track_caller]
     pub fn encode_with_palette(
         &mut self,
         image: &[u8],
@@ -269,6 +271,7 @@ impl<'a, W: Write + 'a> BmpEncoder<'a, W> {
 }
 
 impl<'a, W: Write> ImageEncoder for BmpEncoder<'a, W> {
+    #[track_caller]
     fn write_image(
         mut self,
         buf: &[u8],

--- a/src/codecs/bmp/encoder.rs
+++ b/src/codecs/bmp/encoder.rs
@@ -61,9 +61,16 @@ impl<'a, W: Write + 'a> BmpEncoder<'a, W> {
             )));
         }
 
+        let expected_buffer_len =
+            (width as u64 * height as u64).saturating_mul(c.bytes_per_pixel() as u64);
         assert_eq!(
-            (width as u64 * height as u64).saturating_mul(c.bytes_per_pixel() as u64),
-            image.len() as u64
+            expected_buffer_len,
+            image.len() as u64,
+            "Invalid buffer length: expected {} got {} for image dimensions ({}, {})",
+            expected_buffer_len,
+            image.len(),
+            width,
+            height,
         );
 
         let bmp_header_size = BITMAPFILEHEADER_SIZE;

--- a/src/codecs/farbfeld.rs
+++ b/src/codecs/farbfeld.rs
@@ -261,6 +261,7 @@ impl<W: Write> FarbfeldEncoder<W> {
     /// # Panics
     ///
     /// Panics if `width * height * 8 != data.len()`.
+    #[track_caller]
     pub fn encode(self, data: &[u8], width: u32, height: u32) -> ImageResult<()> {
         let expected_buffer_len = (width as u64 * height as u64).saturating_mul(8);
         assert_eq!(
@@ -292,6 +293,7 @@ impl<W: Write> FarbfeldEncoder<W> {
 }
 
 impl<W: Write> ImageEncoder for FarbfeldEncoder<W> {
+    #[track_caller]
     fn write_image(
         self,
         buf: &[u8],

--- a/src/codecs/farbfeld.rs
+++ b/src/codecs/farbfeld.rs
@@ -267,11 +267,8 @@ impl<W: Write> FarbfeldEncoder<W> {
         assert_eq!(
             expected_buffer_len,
             data.len() as u64,
-            "Invalid buffer length: expected {} got {} for image dimensions ({}, {})",
-            expected_buffer_len,
+            "Invalid buffer length: expected {expected_buffer_len} got {} for {width}x{height} image",
             data.len(),
-            width,
-            height,
         );
         self.encode_impl(data, width, height)?;
         Ok(())

--- a/src/codecs/farbfeld.rs
+++ b/src/codecs/farbfeld.rs
@@ -262,9 +262,15 @@ impl<W: Write> FarbfeldEncoder<W> {
     ///
     /// Panics if `width * height * 8 != data.len()`.
     pub fn encode(self, data: &[u8], width: u32, height: u32) -> ImageResult<()> {
+        let expected_buffer_len = (width as u64 * height as u64).saturating_mul(8);
         assert_eq!(
-            (width as u64 * height as u64).saturating_mul(8),
-            data.len() as u64
+            expected_buffer_len,
+            data.len() as u64,
+            "Invalid buffer length: expected {} got {} for image dimensions ({}, {})",
+            expected_buffer_len,
+            data.len(),
+            width,
+            height,
         );
         self.encode_impl(data, width, height)?;
         Ok(())

--- a/src/codecs/ico/encoder.rs
+++ b/src/codecs/ico/encoder.rs
@@ -145,6 +145,7 @@ impl<W: Write> ImageEncoder for IcoEncoder<W> {
     /// native endian.
     ///
     /// WARNING: In image 0.23.14 and earlier this method erroneously expected buf to be in big endian.
+    #[track_caller]
     fn write_image(
         self,
         buf: &[u8],

--- a/src/codecs/ico/encoder.rs
+++ b/src/codecs/ico/encoder.rs
@@ -152,9 +152,16 @@ impl<W: Write> ImageEncoder for IcoEncoder<W> {
         height: u32,
         color_type: ColorType,
     ) -> ImageResult<()> {
+        let expected_buffer_len =
+            (width as u64 * height as u64).saturating_mul(color_type.bytes_per_pixel() as u64);
         assert_eq!(
-            (width as u64 * height as u64).saturating_mul(color_type.bytes_per_pixel() as u64),
-            buf.len() as u64
+            expected_buffer_len,
+            buf.len() as u64,
+            "Invalid buffer length: expected {} got {} for image dimensions ({}, {})",
+            expected_buffer_len,
+            buf.len(),
+            width,
+            height,
         );
 
         let image = IcoFrame::as_png(buf, width, height, color_type)?;

--- a/src/codecs/ico/encoder.rs
+++ b/src/codecs/ico/encoder.rs
@@ -158,11 +158,8 @@ impl<W: Write> ImageEncoder for IcoEncoder<W> {
         assert_eq!(
             expected_buffer_len,
             buf.len() as u64,
-            "Invalid buffer length: expected {} got {} for image dimensions ({}, {})",
-            expected_buffer_len,
+            "Invalid buffer length: expected {expected_buffer_len} got {} for {width}x{height} image",
             buf.len(),
-            width,
-            height,
         );
 
         let image = IcoFrame::as_png(buf, width, height, color_type)?;

--- a/src/codecs/jpeg/encoder.rs
+++ b/src/codecs/jpeg/encoder.rs
@@ -447,9 +447,16 @@ impl<W: Write> JpegEncoder<W> {
         height: u32,
         color_type: ColorType,
     ) -> ImageResult<()> {
+        let expected_buffer_len =
+            (width as u64 * height as u64).saturating_mul(color_type.bytes_per_pixel() as u64);
         assert_eq!(
-            (width as u64 * height as u64).saturating_mul(color_type.bytes_per_pixel() as u64),
-            image.len() as u64
+            expected_buffer_len,
+            image.len() as u64,
+            "Invalid buffer length: expected {} got {} for image dimensions ({}, {})",
+            expected_buffer_len,
+            image.len(),
+            width,
+            height,
         );
 
         match color_type {

--- a/src/codecs/jpeg/encoder.rs
+++ b/src/codecs/jpeg/encoder.rs
@@ -453,11 +453,8 @@ impl<W: Write> JpegEncoder<W> {
         assert_eq!(
             expected_buffer_len,
             image.len() as u64,
-            "Invalid buffer length: expected {} got {} for image dimensions ({}, {})",
-            expected_buffer_len,
+            "Invalid buffer length: expected {expected_buffer_len} got {} for {width}x{height} image",
             image.len(),
-            width,
-            height,
         );
 
         match color_type {

--- a/src/codecs/jpeg/encoder.rs
+++ b/src/codecs/jpeg/encoder.rs
@@ -440,6 +440,7 @@ impl<W: Write> JpegEncoder<W> {
     /// # Panics
     ///
     /// Panics if `width * height * color_type.bytes_per_pixel() != image.len()`.
+    #[track_caller]
     pub fn encode(
         &mut self,
         image: &[u8],
@@ -670,6 +671,7 @@ impl<W: Write> JpegEncoder<W> {
 }
 
 impl<W: Write> ImageEncoder for JpegEncoder<W> {
+    #[track_caller]
     fn write_image(
         mut self,
         buf: &[u8],

--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -365,11 +365,8 @@ where
         assert_eq!(
             expected_buffer_len,
             buf.len() as u64,
-            "Invalid buffer length: expected {} got {} for image dimensions ({}, {})",
-            expected_buffer_len,
+            "Invalid buffer length: expected {expected_buffer_len} got {} for {width}x{height} image",
             buf.len(),
-            width,
-            height,
         );
 
         write_buffer(self.0, buf, width, height, color_type)

--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -359,9 +359,16 @@ where
         height: u32,
         color_type: ColorType,
     ) -> ImageResult<()> {
+        let expected_buffer_len =
+            (width as u64 * height as u64).saturating_mul(color_type.bytes_per_pixel() as u64);
         assert_eq!(
-            (width as u64 * height as u64).saturating_mul(color_type.bytes_per_pixel() as u64),
-            buf.len() as u64
+            expected_buffer_len,
+            buf.len() as u64,
+            "Invalid buffer length: expected {} got {} for image dimensions ({}, {})",
+            expected_buffer_len,
+            buf.len(),
+            width,
+            height,
         );
 
         write_buffer(self.0, buf, width, height, color_type)

--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -352,6 +352,7 @@ where
     ///
     /// Assumes the writer is buffered. In most cases, you should wrap your writer in a `BufWriter`
     /// for best performance.
+    #[track_caller]
     fn write_image(
         self,
         buf: &[u8],

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -709,10 +709,14 @@ impl<W: Write> ImageEncoder for PngEncoder<W> {
         use byteorder::{BigEndian, ByteOrder, NativeEndian};
         use ColorType::*;
 
-        assert_eq!(
-            (width as u64 * height as u64).saturating_mul(color_type.bytes_per_pixel() as u64),
-            buf.len() as u64
-        );
+        let expected_bufffer_len =
+            (width as u64 * height as u64).saturating_mul(color_type.bytes_per_pixel() as u64);
+        if expected_bufffer_len != buf.len() as u64 {
+            panic!(
+                "length missmatch writing PNG buffer: expected a buffer of len {} (got {}) for image with dimensions ({}, {})",
+                expected_bufffer_len, buf.len(), width, height
+            );
+        }
 
         // PNG images are big endian. For 16 bit per channel and larger types,
         // the buffer may need to be reordered to big endian per the

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -711,12 +711,15 @@ impl<W: Write> ImageEncoder for PngEncoder<W> {
 
         let expected_bufffer_len =
             (width as u64 * height as u64).saturating_mul(color_type.bytes_per_pixel() as u64);
-        if expected_bufffer_len != buf.len() as u64 {
-            panic!(
-                "length missmatch writing PNG buffer: expected a buffer of len {} (got {}) for image with dimensions ({}, {})",
-                expected_bufffer_len, buf.len(), width, height
-            );
-        }
+        assert_eq!(
+            expected_bufffer_len,
+            buf.len() as u64,
+            "Invalid buffer length: expected {} got {} for image dimensions ({}, {})",
+            expected_bufffer_len,
+            buf.len(),
+            width,
+            height,
+        );
 
         // PNG images are big endian. For 16 bit per channel and larger types,
         // the buffer may need to be reordered to big endian per the

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -699,6 +699,7 @@ impl<W: Write> ImageEncoder for PngEncoder<W> {
     /// For color types with 16-bit per channel or larger, the contents of `buf` should be in
     /// native endian. PngEncoder will automatically convert to big endian as required by the
     /// underlying PNG format.
+    #[track_caller]
     fn write_image(
         self,
         buf: &[u8],

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -715,11 +715,8 @@ impl<W: Write> ImageEncoder for PngEncoder<W> {
         assert_eq!(
             expected_bufffer_len,
             buf.len() as u64,
-            "Invalid buffer length: expected {} got {} for image dimensions ({}, {})",
-            expected_bufffer_len,
+            "Invalid buffer length: expected {expected_bufffer_len} got {} for {width}x{height} image",
             buf.len(),
-            width,
-            height,
         );
 
         // PNG images are big endian. For 16 bit per channel and larger types,

--- a/src/codecs/pnm/encoder.rs
+++ b/src/codecs/pnm/encoder.rs
@@ -302,11 +302,8 @@ impl<W: Write> ImageEncoder for PnmEncoder<W> {
         assert_eq!(
             expected_buffer_len,
             buf.len() as u64,
-            "Invalid buffer length: expected {} got {} for image dimensions ({}, {})",
-            expected_buffer_len,
+            "Invalid buffer length: expected {expected_buffer_len} got {} for {width}x{height} image",
             buf.len(),
-            width,
-            height,
         );
 
         self.encode(buf, width, height, color_type)

--- a/src/codecs/pnm/encoder.rs
+++ b/src/codecs/pnm/encoder.rs
@@ -296,9 +296,16 @@ impl<W: Write> ImageEncoder for PnmEncoder<W> {
         height: u32,
         color_type: ColorType,
     ) -> ImageResult<()> {
+        let expected_buffer_len =
+            (width as u64 * height as u64).saturating_mul(color_type.bytes_per_pixel() as u64);
         assert_eq!(
-            (width as u64 * height as u64).saturating_mul(color_type.bytes_per_pixel() as u64),
-            buf.len() as u64
+            expected_buffer_len,
+            buf.len() as u64,
+            "Invalid buffer length: expected {} got {} for image dimensions ({}, {})",
+            expected_buffer_len,
+            buf.len(),
+            width,
+            height,
         );
 
         self.encode(buf, width, height, color_type)

--- a/src/codecs/pnm/encoder.rs
+++ b/src/codecs/pnm/encoder.rs
@@ -289,6 +289,7 @@ impl<W: Write> PnmEncoder<W> {
 }
 
 impl<W: Write> ImageEncoder for PnmEncoder<W> {
+    #[track_caller]
     fn write_image(
         mut self,
         buf: &[u8],

--- a/src/codecs/qoi.rs
+++ b/src/codecs/qoi.rs
@@ -83,11 +83,8 @@ impl<W: Write> ImageEncoder for QoiEncoder<W> {
         assert_eq!(
             expected_buffer_len,
             buf.len() as u64,
-            "Invalid buffer length: expected {} got {} for image dimensions ({}, {})",
-            expected_buffer_len,
+            "Invalid buffer length: expected {expected_buffer_len} got {} for {width}x{height} image",
             buf.len(),
-            width,
-            height,
         );
 
         // Encode data in QOI

--- a/src/codecs/qoi.rs
+++ b/src/codecs/qoi.rs
@@ -77,9 +77,16 @@ impl<W: Write> ImageEncoder for QoiEncoder<W> {
             )));
         }
 
+        let expected_buffer_len =
+            (width as u64 * height as u64).saturating_mul(color_type.bytes_per_pixel() as u64);
         assert_eq!(
-            (width as u64 * height as u64).saturating_mul(color_type.bytes_per_pixel() as u64),
-            buf.len() as u64
+            expected_buffer_len,
+            buf.len() as u64,
+            "Invalid buffer length: expected {} got {} for image dimensions ({}, {})",
+            expected_buffer_len,
+            buf.len(),
+            width,
+            height,
         );
 
         // Encode data in QOI

--- a/src/codecs/qoi.rs
+++ b/src/codecs/qoi.rs
@@ -63,6 +63,7 @@ impl<W: Write> QoiEncoder<W> {
 }
 
 impl<W: Write> ImageEncoder for QoiEncoder<W> {
+    #[track_caller]
     fn write_image(
         mut self,
         buf: &[u8],

--- a/src/codecs/tga/encoder.rs
+++ b/src/codecs/tga/encoder.rs
@@ -163,9 +163,16 @@ impl<W: Write> TgaEncoder<W> {
         height: u32,
         color_type: ColorType,
     ) -> ImageResult<()> {
+        let expected_buffer_len =
+            (width as u64 * height as u64).saturating_mul(color_type.bytes_per_pixel() as u64);
         assert_eq!(
-            (width as u64 * height as u64).saturating_mul(color_type.bytes_per_pixel() as u64),
-            buf.len() as u64
+            expected_buffer_len,
+            buf.len() as u64,
+            "Invalid buffer length: expected {} got {} for image dimensions ({}, {})",
+            expected_buffer_len,
+            buf.len(),
+            width,
+            height,
         );
 
         // Validate dimensions.

--- a/src/codecs/tga/encoder.rs
+++ b/src/codecs/tga/encoder.rs
@@ -156,6 +156,7 @@ impl<W: Write> TgaEncoder<W> {
     /// # Panics
     ///
     /// Panics if `width * height * color_type.bytes_per_pixel() != data.len()`.
+    #[track_caller]
     pub fn encode(
         mut self,
         buf: &[u8],
@@ -233,6 +234,7 @@ impl<W: Write> TgaEncoder<W> {
 }
 
 impl<W: Write> ImageEncoder for TgaEncoder<W> {
+    #[track_caller]
     fn write_image(
         self,
         buf: &[u8],

--- a/src/codecs/tga/encoder.rs
+++ b/src/codecs/tga/encoder.rs
@@ -169,11 +169,8 @@ impl<W: Write> TgaEncoder<W> {
         assert_eq!(
             expected_buffer_len,
             buf.len() as u64,
-            "Invalid buffer length: expected {} got {} for image dimensions ({}, {})",
-            expected_buffer_len,
+            "Invalid buffer length: expected {expected_buffer_len} got {} for {width}x{height} image",
             buf.len(),
-            width,
-            height,
         );
 
         // Validate dimensions.

--- a/src/codecs/tiff.rs
+++ b/src/codecs/tiff.rs
@@ -346,9 +346,16 @@ impl<W: Write + Seek> TiffEncoder<W> {
     ///
     /// Panics if `width * height * color_type.bytes_per_pixel() != data.len()`.
     pub fn encode(self, data: &[u8], width: u32, height: u32, color: ColorType) -> ImageResult<()> {
+        let expected_buffer_len =
+            (width as u64 * height as u64).saturating_mul(color.bytes_per_pixel() as u64);
         assert_eq!(
-            (width as u64 * height as u64).saturating_mul(color.bytes_per_pixel() as u64),
-            data.len() as u64
+            expected_buffer_len,
+            data.len() as u64,
+            "Invalid buffer length: expected {} got {} for image dimensions ({}, {})",
+            expected_buffer_len,
+            data.len(),
+            width,
+            height,
         );
 
         let mut encoder =

--- a/src/codecs/tiff.rs
+++ b/src/codecs/tiff.rs
@@ -352,11 +352,8 @@ impl<W: Write + Seek> TiffEncoder<W> {
         assert_eq!(
             expected_buffer_len,
             data.len() as u64,
-            "Invalid buffer length: expected {} got {} for image dimensions ({}, {})",
-            expected_buffer_len,
+            "Invalid buffer length: expected {expected_buffer_len} got {} for {width}x{height} image",
             data.len(),
-            width,
-            height,
         );
 
         let mut encoder =

--- a/src/codecs/tiff.rs
+++ b/src/codecs/tiff.rs
@@ -345,6 +345,7 @@ impl<W: Write + Seek> TiffEncoder<W> {
     /// # Panics
     ///
     /// Panics if `width * height * color_type.bytes_per_pixel() != data.len()`.
+    #[track_caller]
     pub fn encode(self, data: &[u8], width: u32, height: u32, color: ColorType) -> ImageResult<()> {
         let expected_buffer_len =
             (width as u64 * height as u64).saturating_mul(color.bytes_per_pixel() as u64);
@@ -401,6 +402,7 @@ impl<W: Write + Seek> TiffEncoder<W> {
 }
 
 impl<W: Write + Seek> ImageEncoder for TiffEncoder<W> {
+    #[track_caller]
     fn write_image(
         self,
         buf: &[u8],

--- a/src/codecs/webp/encoder.rs
+++ b/src/codecs/webp/encoder.rs
@@ -705,9 +705,16 @@ impl<W: Write> WebPEncoder<W> {
     ///
     /// Panics if `width * height * color.bytes_per_pixel() != data.len()`.
     pub fn encode(self, data: &[u8], width: u32, height: u32, color: ColorType) -> ImageResult<()> {
+        let expected_buffer_len =
+            (width as u64 * height as u64).saturating_mul(color.bytes_per_pixel() as u64);
         assert_eq!(
-            (width as u64 * height as u64).saturating_mul(color.bytes_per_pixel() as u64),
-            data.len() as u64
+            expected_buffer_len,
+            data.len() as u64,
+            "Invalid buffer length: expected {} got {} for image dimensions ({}, {})",
+            expected_buffer_len,
+            data.len(),
+            width,
+            height,
         );
 
         if let WebPQuality(Quality::Lossless) = self.quality {

--- a/src/codecs/webp/encoder.rs
+++ b/src/codecs/webp/encoder.rs
@@ -704,6 +704,7 @@ impl<W: Write> WebPEncoder<W> {
     /// # Panics
     ///
     /// Panics if `width * height * color.bytes_per_pixel() != data.len()`.
+    #[track_caller]
     pub fn encode(self, data: &[u8], width: u32, height: u32, color: ColorType) -> ImageResult<()> {
         let expected_buffer_len =
             (width as u64 * height as u64).saturating_mul(color.bytes_per_pixel() as u64);
@@ -729,6 +730,7 @@ impl<W: Write> WebPEncoder<W> {
 }
 
 impl<W: Write> ImageEncoder for WebPEncoder<W> {
+    #[track_caller]
     fn write_image(
         self,
         buf: &[u8],

--- a/src/codecs/webp/encoder.rs
+++ b/src/codecs/webp/encoder.rs
@@ -711,11 +711,8 @@ impl<W: Write> WebPEncoder<W> {
         assert_eq!(
             expected_buffer_len,
             data.len() as u64,
-            "Invalid buffer length: expected {} got {} for image dimensions ({}, {})",
-            expected_buffer_len,
+            "Invalid buffer length: expected {expected_buffer_len} got {} for {width}x{height} image",
             data.len(),
-            width,
-            height,
         );
 
         if let WebPQuality(Quality::Lossless) = self.quality {


### PR DESCRIPTION
Replaces the cryptic `assertion failed` into a more useful panic message when writing a PNG image with invalid buffer/dimensions.