### PR TITLE
Fix avif odd width/height handling

### DIFF
--- a/src/codecs/avif/decoder.rs
+++ b/src/codecs/avif/decoder.rs
@@ -149,8 +149,7 @@ impl<'a, R: 'a + Read> ImageDecoder<'a> for AvifDecoder<R> {
                 src_buffers[0].resize(len + strides[0], 0u8);
             }
 
-            let mut tmp_buf: Vec<u8> = Vec::new();
-            tmp_buf.resize(rounded_width as usize * rounded_height as usize * 4, 0u8);
+            let mut tmp_buf = vec![0u8; rounded_width as usize * rounded_height as usize * 4];
             let mut tmp_buf_wrapper = [tmp_buf.as_mut_slice()];
 
             let src_buffers = src_buffers.iter().map(AsRef::as_ref).collect::<Vec<_>>();


### PR DESCRIPTION
I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.

[Related issue](https://github.com/image-rs/image/issues/1647)

This PR fixes the InvalidValue error in dcv_color_primitives when trying to decode odd width/height AVIF files and changes PixelLayout::I422 to todo!() since it's not supported by dcv_color_primitives [(source)](https://docs.rs/dcv-color-primitives/latest/dcv_color_primitives/fn.convert_image.html).

It's a bit hacky but dav1d's output buffer's width/stride seems to always be a multiple of 128 (not too sure about this though) so no need to account for that just increase the width provided to the convert_image  by 1 if it's odd.

And for the height add a padding row of zeros to the source luma buffer.

And at the end copy only the actual width and height parts of the dst buffer while discarding the padding.