### PR TITLE
Add BufRead + Seek bound on many decoders

### DIFF
--- a/fuzz/fuzzers/fuzzer_script_exr.rs
+++ b/fuzz/fuzzers/fuzzer_script_exr.rs
@@ -9,17 +9,13 @@ use image::ExtendedColorType;
 use image::ImageDecoder;
 use image::ImageEncoder;
 use image::ImageResult;
-use std::convert::TryFrom;
-use std::io::Cursor;
-use std::io::Read;
-use std::io::Seek;
-use std::io::Write;
+use std::io::{BufRead, Cursor, Seek, Write};
 
 // "just dont panic"
 fn roundtrip(bytes: &[u8]) -> ImageResult<()> {
     /// Read the file from the specified path into an `Rgba32FImage`.
     // TODO this method should probably already exist in the main image crate
-    fn read_as_rgba_byte_image(read: impl Read + Seek) -> ImageResult<(u32, u32, Vec<u8>)> {
+    fn read_as_rgba_byte_image(read: impl BufRead + Seek) -> ImageResult<(u32, u32, Vec<u8>)> {
         let mut decoder = OpenExrDecoder::with_alpha_preference(read, Some(true))?;
         match usize::try_from(decoder.total_bytes()) {
             Ok(decoded_size) if decoded_size <= 256 * 1024 * 1024 => {
@@ -45,7 +41,12 @@ fn roundtrip(bytes: &[u8]) -> ImageResult<()> {
         write: impl Write + Seek,
         (width, height, data): &(u32, u32, Vec<u8>),
     ) -> ImageResult<()> {
-        OpenExrEncoder::new(write).write_image(data.as_slice(), *width, *height, ExtendedColorType::Rgba32F)
+        OpenExrEncoder::new(write).write_image(
+            data.as_slice(),
+            *width,
+            *height,
+            ExtendedColorType::Rgba32F,
+        )
     }
 
     let decoded_image = read_as_rgba_byte_image(Cursor::new(bytes))?;

--- a/src/codecs/bmp/decoder.rs
+++ b/src/codecs/bmp/decoder.rs
@@ -1,5 +1,5 @@
 use std::cmp::{self, Ordering};
-use std::io::{self, Read, Seek, SeekFrom};
+use std::io::{self, BufRead, Seek, SeekFrom};
 use std::iter::{repeat, Rev};
 use std::slice::ChunksMut;
 use std::{error, fmt};
@@ -502,7 +502,7 @@ enum RLEInsn {
     PixelRun(u8, u8),
 }
 
-impl<R: Read + Seek> BmpDecoder<R> {
+impl<R: BufRead + Seek> BmpDecoder<R> {
     fn new_decoder(reader: R) -> BmpDecoder<R> {
         BmpDecoder {
             reader,
@@ -1329,7 +1329,7 @@ impl<R: Read + Seek> BmpDecoder<R> {
     }
 }
 
-impl<R: Read + Seek> ImageDecoder for BmpDecoder<R> {
+impl<R: BufRead + Seek> ImageDecoder for BmpDecoder<R> {
     fn dimensions(&self) -> (u32, u32) {
         (self.width as u32, self.height as u32)
     }
@@ -1354,7 +1354,7 @@ impl<R: Read + Seek> ImageDecoder for BmpDecoder<R> {
     }
 }
 
-impl<R: Read + Seek> ImageDecoderRect for BmpDecoder<R> {
+impl<R: BufRead + Seek> ImageDecoderRect for BmpDecoder<R> {
     fn read_rect(
         &mut self,
         x: u32,
@@ -1384,7 +1384,7 @@ impl<R: Read + Seek> ImageDecoderRect for BmpDecoder<R> {
 
 #[cfg(test)]
 mod test {
-    use std::io::Cursor;
+    use std::io::{BufReader, Cursor};
 
     use super::*;
 
@@ -1405,7 +1405,8 @@ mod test {
 
     #[test]
     fn read_rect() {
-        let f = std::fs::File::open("tests/images/bmp/images/Core_8_Bit.bmp").unwrap();
+        let f =
+            BufReader::new(std::fs::File::open("tests/images/bmp/images/Core_8_Bit.bmp").unwrap());
         let mut decoder = super::BmpDecoder::new(f).unwrap();
 
         let mut buf: Vec<u8> = vec![0; 8 * 8 * 3];

--- a/src/codecs/jpeg/decoder.rs
+++ b/src/codecs/jpeg/decoder.rs
@@ -1,4 +1,4 @@
-use std::io::Read;
+use std::io::{BufRead, Seek};
 use std::marker::PhantomData;
 
 use crate::color::ColorType;
@@ -22,7 +22,7 @@ pub struct JpegDecoder<R> {
     phantom: PhantomData<R>,
 }
 
-impl<R: Read> JpegDecoder<R> {
+impl<R: BufRead + Seek> JpegDecoder<R> {
     /// Create a new decoder that decodes from the stream ```r```
     pub fn new(r: R) -> ImageResult<JpegDecoder<R>> {
         let mut input = Vec::new();
@@ -50,7 +50,7 @@ impl<R: Read> JpegDecoder<R> {
     }
 }
 
-impl<R: Read> ImageDecoder for JpegDecoder<R> {
+impl<R: BufRead + Seek> ImageDecoder for JpegDecoder<R> {
     fn dimensions(&self) -> (u32, u32) {
         (u32::from(self.width), u32::from(self.height))
     }

--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -27,7 +27,7 @@ use crate::{
     ColorType, ExtendedColorType, ImageDecoder, ImageEncoder, ImageError, ImageFormat, ImageResult,
 };
 
-use std::io::{Read, Seek, Write};
+use std::io::{BufRead, Seek, Write};
 
 /// An OpenEXR decoder. Immediately reads the meta data from the file.
 #[derive(Debug)]
@@ -45,7 +45,7 @@ pub struct OpenExrDecoder<R> {
     alpha_present_in_file: bool,
 }
 
-impl<R: Read + Seek> OpenExrDecoder<R> {
+impl<R: BufRead + Seek> OpenExrDecoder<R> {
     /// Create a decoder. Consumes the first few bytes of the source to extract image dimensions.
     /// Assumes the reader is buffered. In most cases,
     /// you should wrap your reader in a `BufReader` for best performance.
@@ -104,7 +104,7 @@ impl<R: Read + Seek> OpenExrDecoder<R> {
     }
 }
 
-impl<R: Read + Seek> ImageDecoder for OpenExrDecoder<R> {
+impl<R: BufRead + Seek> ImageDecoder for OpenExrDecoder<R> {
     fn dimensions(&self) -> (u32, u32) {
         let size = self
             .selected_exr_header()
@@ -382,7 +382,7 @@ mod test {
     }
 
     /// Read the file from the specified path into an `Rgb32FImage`.
-    fn read_as_rgb_image(read: impl Read + Seek) -> ImageResult<Rgb32FImage> {
+    fn read_as_rgb_image(read: impl BufRead + Seek) -> ImageResult<Rgb32FImage> {
         let decoder = OpenExrDecoder::with_alpha_preference(read, Some(false))?;
         let (width, height) = decoder.dimensions();
         let buffer: Vec<f32> = crate::image::decoder_to_vec(decoder)?;
@@ -396,7 +396,7 @@ mod test {
     }
 
     /// Read the file from the specified path into an `Rgba32FImage`.
-    fn read_as_rgba_image(read: impl Read + Seek) -> ImageResult<Rgba32FImage> {
+    fn read_as_rgba_image(read: impl BufRead + Seek) -> ImageResult<Rgba32FImage> {
         let decoder = OpenExrDecoder::with_alpha_preference(read, Some(true))?;
         let (width, height) = decoder.dimensions();
         let buffer: Vec<f32> = crate::image::decoder_to_vec(decoder)?;

--- a/src/codecs/tga/decoder.rs
+++ b/src/codecs/tga/decoder.rs
@@ -7,7 +7,7 @@ use crate::{
     image::{ImageDecoder, ImageFormat},
 };
 use byteorder::ReadBytesExt;
-use std::io::{self, Read, Seek};
+use std::io::{self, Read};
 
 struct ColorMap {
     /// sizes in bytes
@@ -59,7 +59,7 @@ pub struct TgaDecoder<R> {
     color_map: Option<ColorMap>,
 }
 
-impl<R: Read + Seek> TgaDecoder<R> {
+impl<R: Read> TgaDecoder<R> {
     /// Create a new decoder that decodes from the stream `r`
     pub fn new(r: R) -> ImageResult<TgaDecoder<R>> {
         let mut decoder = TgaDecoder {
@@ -172,7 +172,7 @@ impl<R: Read + Seek> TgaDecoder<R> {
     /// is present
     fn read_image_id(&mut self) -> ImageResult<()> {
         self.r
-            .seek(io::SeekFrom::Current(i64::from(self.header.id_length)))?;
+            .read_exact(&mut vec![0; self.header.id_length as usize])?;
         Ok(())
     }
 
@@ -336,7 +336,7 @@ impl<R: Read + Seek> TgaDecoder<R> {
     }
 }
 
-impl<R: Read + Seek> ImageDecoder for TgaDecoder<R> {
+impl<R: Read> ImageDecoder for TgaDecoder<R> {
     fn dimensions(&self) -> (u32, u32) {
         (self.width as u32, self.height as u32)
     }

--- a/src/codecs/tiff.rs
+++ b/src/codecs/tiff.rs
@@ -8,7 +8,7 @@
 
 extern crate tiff;
 
-use std::io::{self, Cursor, Read, Seek, Write};
+use std::io::{self, BufRead, Cursor, Read, Seek, Write};
 use std::marker::PhantomData;
 use std::mem;
 
@@ -22,7 +22,7 @@ use crate::image::{ImageDecoder, ImageEncoder, ImageFormat};
 /// Decoder for TIFF images.
 pub struct TiffDecoder<R>
 where
-    R: Read + Seek,
+    R: BufRead + Seek,
 {
     dimensions: (u32, u32),
     color_type: ColorType,
@@ -34,7 +34,7 @@ where
 
 impl<R> TiffDecoder<R>
 where
-    R: Read + Seek,
+    R: BufRead + Seek,
 {
     /// Create a new TiffDecoder.
     pub fn new(r: R) -> Result<TiffDecoder<R>, ImageError> {
@@ -183,7 +183,7 @@ impl<R> Read for TiffReader<R> {
     }
 }
 
-impl<R: Read + Seek> ImageDecoder for TiffDecoder<R> {
+impl<R: BufRead + Seek> ImageDecoder for TiffDecoder<R> {
     fn dimensions(&self) -> (u32, u32) {
         self.dimensions
     }

--- a/src/codecs/webp/decoder.rs
+++ b/src/codecs/webp/decoder.rs
@@ -1,4 +1,4 @@
-use std::io::{Read, Seek};
+use std::io::{BufRead, Read, Seek};
 
 use crate::buffer::ConvertBuffer;
 use crate::error::{DecodingError, ImageError, ImageResult};
@@ -10,7 +10,7 @@ pub struct WebPDecoder<R> {
     inner: image_webp::WebPDecoder<R>,
 }
 
-impl<R: Read + Seek> WebPDecoder<R> {
+impl<R: BufRead + Seek> WebPDecoder<R> {
     /// Create a new WebPDecoder from the Reader ```r```.
     /// This function takes ownership of the Reader.
     pub fn new(r: R) -> ImageResult<Self> {
@@ -32,7 +32,7 @@ impl<R: Read + Seek> WebPDecoder<R> {
     }
 }
 
-impl<R: Read + Seek> ImageDecoder for WebPDecoder<R> {
+impl<R: BufRead + Seek> ImageDecoder for WebPDecoder<R> {
     fn dimensions(&self) -> (u32, u32) {
         self.inner.dimensions()
     }

--- a/src/io/reader.rs
+++ b/src/io/reader.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::{self, BufReader, Cursor, Read, Seek, SeekFrom};
+use std::io::{self, BufRead, BufReader, Cursor, Read, Seek, SeekFrom};
 use std::path::Path;
 
 use crate::dynimage::DynamicImage;
@@ -67,7 +67,7 @@ pub struct Reader<R: Read + Seek> {
     limits: super::Limits,
 }
 
-impl<'a, R: 'a + Read + Seek> Reader<R> {
+impl<'a, R: 'a + BufRead + Seek> Reader<R> {
     /// Create a new image reader without a preset format.
     ///
     /// Assumes the reader is already buffered. For optimal performance,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,14 +91,14 @@
 //! While [`ImageDecoder`] and [`ImageDecoderRect`] give access to more advanced decoding options:
 //!
 //! ```rust,no_run
-//! # use std::io::Read;
+//! # use std::io::{BufReader, Cursor};
 //! # use image::DynamicImage;
 //! # use image::ImageDecoder;
 //! # #[cfg(feature = "png")]
 //! # fn main() -> Result<(), image::ImageError> {
 //! # use image::codecs::png::PngDecoder;
 //! # let img: DynamicImage = unimplemented!();
-//! # let reader: Box<dyn Read> = unimplemented!();
+//! # let reader: BufReader<Cursor<&[u8]>> = unimplemented!();
 //! let decoder = PngDecoder::new(&mut reader)?;
 //! let icc = decoder.icc_profile();
 //! let img = DynamicImage::from_decoder(decoder)?;

--- a/tests/limits_anim.rs
+++ b/tests/limits_anim.rs
@@ -7,7 +7,9 @@ use image::codecs::gif::GifDecoder;
 
 #[cfg(feature = "gif")]
 fn gif_decode(data: &[u8], limits: Limits) -> ImageResult<()> {
-    let mut decoder = GifDecoder::new(data).unwrap();
+    use std::io::Cursor;
+
+    let mut decoder = GifDecoder::new(Cursor::new(data)).unwrap();
     decoder.set_limits(limits)?;
     {
         let frames = decoder.into_frames();


### PR DESCRIPTION
The purpose of this change is to allow future decoder improvements:

* [Experiments with the PNG crate](https://github.com/image-rs/image-png/pull/427) have shown that working with a `BufRead` implementation rather than just a `Read` implementation can be faster.
* The `Seek` bound is useful for decreasing the memory usage of the decoder. Instead of storing all image metadata as it is seen, a decoder can record the location in the file of specific chunks and then seek to them if/when they are queried.

At the same time, not all decoders are likely to need either of these and having looser trait bounds is nicer for users. Thus I left the existing `Read` bound for some decoders (and actually _removed_ the `Seek` bound on TGA). After this change, the trait bounds are:

![image](https://github.com/image-rs/image/assets/4943209/b4b8308d-e604-43f2-8e1e-7a70dc2485bc)

