### PR TITLE
Make pixel types repr(transparent) rather than repr(C)

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -256,7 +256,7 @@ $( // START Structure definitions
 
 $(#[$doc])*
 #[derive(PartialEq, Eq, Clone, Debug, Copy, Hash)]
-#[repr(C)]
+#[repr(transparent)]
 #[allow(missing_docs)]
 pub struct $ident<T> (pub [T; $channels]);
 


### PR DESCRIPTION
<!--
If you are a new contributor, consent to licensing by including this text:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.

Thank you for contributing, you can delete this comment.
-->
