### PR TITLE
Remove lingering references to ImageOutputFormat

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1044,11 +1044,8 @@ where
 {
     /// Writes the buffer to a writer in the specified format.
     ///
-    /// Assumes the writer is buffered. In most cases,
-    /// you should wrap your writer in a `BufWriter` for best performance.
-    ///
-    /// See [`ImageOutputFormat`](enum.ImageOutputFormat.html) for
-    /// supported types.
+    /// Assumes the writer is buffered. In most cases, you should wrap your writer in a `BufWriter`
+    /// for best performance.
     pub fn write_to<W>(&self, writer: &mut W, format: ImageFormat) -> ImageResult<()>
     where
         W: std::io::Write + std::io::Seek,

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -1148,16 +1148,11 @@ pub fn save_buffer_with_format(
 
 /// Writes the supplied buffer to a writer in the specified format.
 ///
-/// The buffer is assumed to have the correct format according
-/// to the specified color type.
-/// This will lead to corrupted writers if the buffer contains
-/// malformed data.
+/// The buffer is assumed to have the correct format according to the specified color type. This
+/// will lead to corrupted writers if the buffer contains malformed data.
 ///
-/// See [`ImageOutputFormat`](enum.ImageOutputFormat.html) for
-/// supported types.
-///
-/// Assumes the writer is buffered. In most cases,
-/// you should wrap your writer in a `BufWriter` for best performance.
+/// Assumes the writer is buffered. In most cases, you should wrap your writer in a `BufWriter` for
+/// best performance.
 pub fn write_buffer_with_format<W: Write + Seek>(
     buffered_writer: &mut W,
     buf: &[u8],


### PR DESCRIPTION
<!--
If you are a new contributor, consent to licensing by including this text:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.

Thank you for contributing, you can delete this comment.
-->
