### PR TITLE
Add nasm to optionally enable faster AVIF encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ webp = ["dep:image-webp"]
 
 # Other features
 rayon = ["dep:rayon"] # Enables multi-threading
+nasm = ["ravif?/asm"] # Enables use of nasm by rav1e (requires nasm to be installed)
 avif-native = ["dep:mp4parse", "dep:dcv-color-primitives", "dep:dav1d"] # Enable native dependency libdav1d
 benchmarks = [] # Build some inline benchmarks. Useful only during development (requires nightly Rust)
 


### PR DESCRIPTION
<!--
If you are a new contributor, consent to licensing by including this text:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.

Thank you for contributing, you can delete this comment.
-->
