### PR TITLE
Only accept .ff as path extension for Farbfeld

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -101,7 +101,7 @@ impl ImageFormat {
                 "hdr" => ImageFormat::Hdr,
                 "exr" => ImageFormat::OpenExr,
                 "pbm" | "pam" | "ppm" | "pgm" => ImageFormat::Pnm,
-                "ff" | "farbfeld" => ImageFormat::Farbfeld,
+                "ff" => ImageFormat::Farbfeld,
                 "qoi" => ImageFormat::Qoi,
                 _ => return None,
             })


### PR DESCRIPTION
Now only accepts .ff as path extension for Farbfeld

This is consistent with ImageFormat::extensions_str, and usage by other image libraries and tools.

<!--
If you are a new contributor, consent to licensing by including this text:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.

Thank you for contributing, you can delete this comment.
-->
