### PR TITLE
Fix error string for unsupported color type

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -361,7 +361,7 @@ impl fmt::Display for UnsupportedError {
             }
             UnsupportedErrorKind::Color(color) => write!(
                 fmt,
-                "The decoder for {} does not support the color type `{:?}`",
+                "The encoder or decoder for {} does not support the color type `{:?}`",
                 self.format, color,
             ),
             UnsupportedErrorKind::GenericFeature(message) => match &self.format {


### PR DESCRIPTION
<!--
If you are a new contributor, consent to licensing by including this text:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.

Thank you for contributing, you can delete this comment.
-->
