### PR TITLE
Adjust two doc comments

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -60,10 +60,10 @@ pub enum ImageFormat {
     /// An Image in farbfeld Format
     Farbfeld,
 
-    /// An Image in AVIF format.
+    /// An Image in AVIF Format
     Avif,
 
-    /// An Image in QOI format.
+    /// An Image in QOI Format
     Qoi,
 }
 


### PR DESCRIPTION
Adjust two doc comments on ImageFormat in order to unite the format.
