### PR TITLE
av1 decoder colorspace from dav1d

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ num-traits = { version = "0.2.0" }
 
 # Optional dependencies
 color_quant = { version = "1.1", optional = true }
-dav1d = { version = "0.10.2", optional = true }
+dav1d = { version = "0.10.3", optional = true }
 dcv-color-primitives = { version = "0.6.1", optional = true }
 exr = { version = "1.5.0", optional = true }
 gif = { version = "0.13", optional = true }

--- a/src/codecs/avif/decoder.rs
+++ b/src/codecs/avif/decoder.rs
@@ -109,9 +109,23 @@ impl<R: Read> ImageDecoder for AvifDecoder<R> {
                 PixelLayout::I422 => dcp::PixelFormat::I422,
                 PixelLayout::I444 => dcp::PixelFormat::I444,
             };
+            let src_color_space=match (self.picture.color_primaries(),self.picture.color_range()) {
+                (dav1d::pixel::ColorPrimaries::BT709,dav1d::pixel::YUVRange::Full) => {
+                    dcp::ColorSpace::Bt709FR
+                },
+                (dav1d::pixel::ColorPrimaries::BT709,dav1d::pixel::YUVRange::Limited) => {
+                    dcp::ColorSpace::Bt709
+                },
+                (_,dav1d::pixel::YUVRange::Full)=>{
+                    dcp::ColorSpace::Bt601FR
+                },
+                (_,dav1d::pixel::YUVRange::Limited)=>{
+                    dcp::ColorSpace::Bt601
+                }
+            };
             let src_format = dcp::ImageFormat {
                 pixel_format,
-                color_space: dcp::ColorSpace::Bt601,
+                color_space: src_color_space,
                 num_planes: 3,
             };
             let dst_format = dcp::ImageFormat {

--- a/src/codecs/avif/decoder.rs
+++ b/src/codecs/avif/decoder.rs
@@ -109,19 +109,16 @@ impl<R: Read> ImageDecoder for AvifDecoder<R> {
                 PixelLayout::I422 => dcp::PixelFormat::I422,
                 PixelLayout::I444 => dcp::PixelFormat::I444,
             };
-            let src_color_space=match (self.picture.color_primaries(),self.picture.color_range()) {
-                (dav1d::pixel::ColorPrimaries::BT709,dav1d::pixel::YUVRange::Full) => {
+            let src_color_space = match (self.picture.color_primaries(), self.picture.color_range())
+            {
+                (dav1d::pixel::ColorPrimaries::BT709, dav1d::pixel::YUVRange::Full) => {
                     dcp::ColorSpace::Bt709FR
-                },
-                (dav1d::pixel::ColorPrimaries::BT709,dav1d::pixel::YUVRange::Limited) => {
-                    dcp::ColorSpace::Bt709
-                },
-                (_,dav1d::pixel::YUVRange::Full)=>{
-                    dcp::ColorSpace::Bt601FR
-                },
-                (_,dav1d::pixel::YUVRange::Limited)=>{
-                    dcp::ColorSpace::Bt601
                 }
+                (dav1d::pixel::ColorPrimaries::BT709, dav1d::pixel::YUVRange::Limited) => {
+                    dcp::ColorSpace::Bt709
+                }
+                (_, dav1d::pixel::YUVRange::Full) => dcp::ColorSpace::Bt601FR,
+                (_, dav1d::pixel::YUVRange::Limited) => dcp::ColorSpace::Bt601,
             };
             let src_format = dcp::ImageFormat {
                 pixel_format,


### PR DESCRIPTION
Read color spaces other than Bt601Limited (preferably)

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.
