### PR TITLE
Add WebP roundtrip fuzzing target

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -64,3 +64,7 @@ path = "fuzzers/fuzzer_script_hdr.rs"
 [[bin]]
 name = "fuzzer_script_exr"
 path = "fuzzers/fuzzer_script_exr.rs"
+
+[[bin]]
+name = "roundtrip_webp"
+path = "fuzzers/roundtrip_webp.rs"

--- a/fuzz/fuzzers/roundtrip_webp.rs
+++ b/fuzz/fuzzers/roundtrip_webp.rs
@@ -1,0 +1,40 @@
+//! Verifies that any data encoded with WebP lossless encoder can be decoded,
+//! and is unaltered after the encode-decode roundtrip.
+
+#![no_main]
+
+use std::io::Cursor;
+
+use image::{ImageBuffer, Rgba};
+#[macro_use] extern crate libfuzzer_sys;
+extern crate image;
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() > 3 {
+        let width = data[0] as usize;
+        let height = data[1] as usize;
+        let content = &data[2..];
+
+        if width == 0 || height == 0 {
+            return;
+        }
+
+        let content_len = width * height * 4;
+        if content.len() >= content_len {
+            let content = content[..content_len].to_owned();
+            let image : ImageBuffer<Rgba<u8>, Vec<u8>> = ImageBuffer::from_vec(
+                width as u32, height as u32, 
+                content
+            ).unwrap();
+
+            let encoded: Vec<u8> = Vec::new();
+            let mut cursor = Cursor::new(encoded);
+            image.write_to(&mut cursor, image::ImageFormat::WebP).unwrap();
+            let encoded = cursor.into_inner();
+            // verify that the imade decoded without errors
+            let decoded = image::load_from_memory_with_format(&encoded, image::ImageFormat::WebP).unwrap();
+            // compare contents - the encoding should be lossless and roundtrip bit-perfectly
+            assert_eq!(image.into_vec(), decoded.into_bytes());
+        }
+    }
+});


### PR DESCRIPTION
This will detect issues such as #2171, as well as instances of incorrect encoding or decoding.

It is currently limited to RGBA, since I didn't find an easy way to use RGB format conditionally. The decoding always returns RGBA, which makes comparisons of the data a little tricky.