### PR TITLE
webp frames iterator is now ending iteration if no more frames are decodable

### DIFF
--- a/src/codecs/webp/decoder.rs
+++ b/src/codecs/webp/decoder.rs
@@ -79,12 +79,14 @@ impl<'a, R: 'a + Read + Seek> AnimationDecoder<'a> for WebPDecoder<R> {
                     let mut img = RgbaImage::new(width, height);
                     match self.decoder.inner.read_frame(&mut img) {
                         Ok(delay) => (img, delay),
+                        Err(image_webp::DecodingError::NoMoreFrames) => return None,
                         Err(e) => return Some(Err(ImageError::from_webp_decode(e))),
                     }
                 } else {
                     let mut img = RgbImage::new(width, height);
                     match self.decoder.inner.read_frame(&mut img) {
                         Ok(delay) => (img.convert(), delay),
+                        Err(image_webp::DecodingError::NoMoreFrames) => return None,
                         Err(e) => return Some(Err(ImageError::from_webp_decode(e))),
                     }
                 };

--- a/src/codecs/webp/decoder.rs
+++ b/src/codecs/webp/decoder.rs
@@ -68,25 +68,28 @@ impl<'a, R: 'a + Read + Seek> AnimationDecoder<'a> for WebPDecoder<R> {
     fn into_frames(self) -> Frames<'a> {
         struct FramesInner<R: Read + Seek> {
             decoder: WebPDecoder<R>,
+            current: u32,
         }
         impl<R: Read + Seek> Iterator for FramesInner<R> {
             type Item = ImageResult<Frame>;
 
             fn next(&mut self) -> Option<Self::Item> {
+                if self.current == self.decoder.inner.num_frames() {
+                    return None;
+                }
+                self.current += 1;
                 let (width, height) = self.decoder.inner.dimensions();
 
                 let (img, delay) = if self.decoder.inner.has_alpha() {
                     let mut img = RgbaImage::new(width, height);
                     match self.decoder.inner.read_frame(&mut img) {
                         Ok(delay) => (img, delay),
-                        Err(image_webp::DecodingError::NoMoreFrames) => return None,
                         Err(e) => return Some(Err(ImageError::from_webp_decode(e))),
                     }
                 } else {
                     let mut img = RgbImage::new(width, height);
                     match self.decoder.inner.read_frame(&mut img) {
                         Ok(delay) => (img.convert(), delay),
-                        Err(image_webp::DecodingError::NoMoreFrames) => return None,
                         Err(e) => return Some(Err(ImageError::from_webp_decode(e))),
                     }
                 };
@@ -100,7 +103,10 @@ impl<'a, R: 'a + Read + Seek> AnimationDecoder<'a> for WebPDecoder<R> {
             }
         }
 
-        Frames::new(Box::new(FramesInner { decoder: self }))
+        Frames::new(Box::new(FramesInner {
+            decoder: self,
+            current: 0,
+        }))
     }
 }
 

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1,4 +1,10 @@
-use std::{fs::File, io::BufReader, path::PathBuf};
+use std::{
+    fs::{self, File},
+    io::{BufReader, Cursor},
+    path::PathBuf,
+};
+
+use image::{codecs::webp::WebPDecoder, AnimationDecoder};
 
 const BASE_PATH: [&str; 2] = [".", "tests"];
 const IMAGE_DIR: &str = "images";
@@ -36,6 +42,29 @@ fn check_regressions() {
     process_images(REGRESSION_DIR, None, |path| {
         let _ = image::open(path);
     })
+}
+/// Check that the WEBP frames iterator returns the right amount of frames.
+#[test]
+fn check_webp_frames_regressions() {
+    let path: PathBuf = BASE_PATH
+        .iter()
+        .collect::<PathBuf>()
+        .join(IMAGE_DIR)
+        .join("webp/extended_images")
+        .join("*.webp");
+    let pattern = &*format!("{}", path.display());
+    for path in glob::glob(pattern).unwrap().filter_map(Result::ok) {
+        let bytes = fs::read(path).unwrap();
+        let cursor = Cursor::new(&bytes);
+        let frame_count = image_webp::WebPDecoder::new(cursor.clone())
+            .unwrap()
+            .num_frames() as usize;
+        let decoder = WebPDecoder::new(cursor).unwrap();
+        // The `take` guards against a potentially infinitely running iterator.
+        // Since we take `frame_count + 1`, we can assume that the last iteration already returns `None`.
+        let actual_frame_count = decoder.into_frames().take(frame_count + 1).count();
+        assert_eq!(actual_frame_count, frame_count);
+    }
 }
 
 /// Check that BMP files with large values could cause OOM issues are rejected.

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -4,6 +4,7 @@ use std::{
     path::PathBuf,
 };
 
+#[cfg(feature = "webp")]
 use image::{codecs::webp::WebPDecoder, AnimationDecoder};
 
 const BASE_PATH: [&str; 2] = [".", "tests"];
@@ -45,6 +46,7 @@ fn check_regressions() {
 }
 /// Check that the WEBP frames iterator returns the right amount of frames.
 #[test]
+#[cfg(feature = "webp")]
 fn check_webp_frames_regressions() {
     let path: PathBuf = BASE_PATH
         .iter()


### PR DESCRIPTION
Fixes #2226 

The iterator returns `None` as soon as a `DecodingError::NoMoreFrames` is found.

## Debatable
The current implementation returns every `Frame` only once regardless of the specified `LoopCount`. I believe this is what most people would expect, especially since `LoopCount::Forever` is the most used variant.

It would be a bit more performant to return the iterator at the start since the allocation of one `RgbaImage`/`RgbImage` can be saved. 
(Thank you for this awesome project btw :))