### PR TITLE
Override `clone_from` implementations for a few types

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -33,7 +33,6 @@ impl<'a> Iterator for Frames<'a> {
 }
 
 /// A single animation frame
-#[derive(Clone)]
 pub struct Frame {
     /// Delay between the frames in milliseconds
     delay: Delay,
@@ -42,6 +41,24 @@ pub struct Frame {
     /// y offset
     top: u32,
     buffer: RgbaImage,
+}
+
+impl Clone for Frame {
+    fn clone(&self) -> Self {
+        Self {
+            delay: self.delay,
+            left: self.left,
+            top: self.top,
+            buffer: self.buffer.clone(),
+        }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.delay = source.delay;
+        self.left = source.left;
+        self.top = source.top;
+        self.buffer.clone_from(&source.buffer);
+    }
 }
 
 /// The delay of a frame relative to the previous one.

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1157,6 +1157,12 @@ where
             _phantom: PhantomData,
         }
     }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.data.clone_from(&source.data);
+        self.width = source.width;
+        self.height = source.height;
+    }
 }
 
 impl<P, Container> GenericImageView for ImageBuffer<P, Container>

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -44,7 +44,7 @@ use crate::{Rgb32FImage, Rgba32FImage};
 /// would hardly be feasible as a simple enum, due to the sheer number of combinations of channel
 /// kinds, channel order, and bit depth. Rather, this type provides an opinionated selection with
 /// normalized channel order which can store common pixel values without loss.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug, PartialEq)]
 #[non_exhaustive]
 pub enum DynamicImage {
     /// Each pixel in this image is 8-bit Luma
@@ -110,6 +110,28 @@ macro_rules! dynamic_map(
             }
         );
 );
+
+impl Clone for DynamicImage {
+    fn clone(&self) -> Self {
+        dynamic_map!(*self, ref p, DynamicImage::from(p.clone()))
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        match (self, source) {
+            (Self::ImageLuma8(p1), Self::ImageLuma8(p2)) => p1.clone_from(p2),
+            (Self::ImageLumaA8(p1), Self::ImageLumaA8(p2)) => p1.clone_from(p2),
+            (Self::ImageRgb8(p1), Self::ImageRgb8(p2)) => p1.clone_from(p2),
+            (Self::ImageRgba8(p1), Self::ImageRgba8(p2)) => p1.clone_from(p2),
+            (Self::ImageLuma16(p1), Self::ImageLuma16(p2)) => p1.clone_from(p2),
+            (Self::ImageLumaA16(p1), Self::ImageLumaA16(p2)) => p1.clone_from(p2),
+            (Self::ImageRgb16(p1), Self::ImageRgb16(p2)) => p1.clone_from(p2),
+            (Self::ImageRgba16(p1), Self::ImageRgba16(p2)) => p1.clone_from(p2),
+            (Self::ImageRgb32F(p1), Self::ImageRgb32F(p2)) => p1.clone_from(p2),
+            (Self::ImageRgba32F(p1), Self::ImageRgba32F(p2)) => p1.clone_from(p2),
+            (this, source) => *this = source.clone(),
+        }
+    }
+}
 
 impl DynamicImage {
     /// Creates a dynamic image backed by a buffer depending on


### PR DESCRIPTION
I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.

