### PR TITLE
Map `.apng` files to `ImageFormat::Png`

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -89,7 +89,7 @@ impl ImageFormat {
             Some(match ext.as_str() {
                 "avif" => ImageFormat::Avif,
                 "jpg" | "jpeg" => ImageFormat::Jpeg,
-                "png" => ImageFormat::Png,
+                "png" | "apng" => ImageFormat::Png,
                 "gif" => ImageFormat::Gif,
                 "webp" => ImageFormat::WebP,
                 "tif" | "tiff" => ImageFormat::Tiff,


### PR DESCRIPTION
> I license past and future contributions under the dual MIT/Apache-2.0 license,
> allowing licensees to choose either at their option.

`.apng` is a common file extension used for animated PNGs.