### PR TITLE
feat: add sccache to the build pipeline

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: '5 16 * * 6'
 
+env:
+  CARGO_INCREMENTAL: 0
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+
 jobs:
   test_features:
     runs-on: ubuntu-latest
@@ -19,9 +24,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
     - name: Cache Cargo Dependencies
-      uses: Swatinem/rust-cache@v2
-      with:
-        cache-on-failure: true
+      uses: mozilla-actions/sccache-action@v0.0.5
     - name: build
       run: cargo build -v --no-default-features --features "$FEATURES"
       env:
@@ -52,9 +55,7 @@ jobs:
       with:
         toolchain: ${{ matrix.rust }}
     - name: Cache Cargo Dependencies
-      uses: Swatinem/rust-cache@v2
-      with:
-        cache-on-failure: true
+      uses: mozilla-actions/sccache-action@v0.0.5
     - name: build
       run: cargo build -v
     - name: test
@@ -78,10 +79,7 @@ jobs:
         with:
           crate: cross
       - name: Cache Cargo Dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          key: ${{ matrix.arch }}
+        uses: mozilla-actions/sccache-action@v0.0.5
       - name: Start Docker (required for cross-rs)
         run: sudo systemctl start docker
       - name: Cross-Run Tests using QEMU
@@ -94,6 +92,8 @@ jobs:
       run: sudo apt update && sudo apt install ninja-build meson nasm
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable
+    - name: Cache Cargo Dependencies
+      uses: mozilla-actions/sccache-action@v0.0.5    
     - name: build
       run: cargo build -v --no-default-features --features="avif,avif-native"
       env:
@@ -108,6 +108,8 @@ jobs:
     - uses: dtolnay/rust-toolchain@nightly
       with:
         components: clippy
+    - name: Cache Cargo Dependencies
+      uses: mozilla-actions/sccache-action@v0.0.5        
     - run: cargo clippy --all-features --all-targets -- -D warnings
       env:
         SYSTEM_DEPS_DAV1D_BUILD_INTERNAL: always
@@ -120,12 +122,8 @@ jobs:
     - uses: dtolnay/rust-toolchain@nightly
     - name: install-deps
       run: sudo apt-get -y install clang llvm
-    - name: Cache Cargo Registry
-      uses: Swatinem/rust-cache@v2
-      with:
-        cache-targets: false
-        cache-all-crates: true
-        cache-on-failure: true
+    - name: Cache Cargo Dependencies
+      uses: mozilla-actions/sccache-action@v0.0.5        
     - name: Install cargo-afl
       run: cargo install --locked -f cargo-afl
     - name: build
@@ -144,6 +142,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
+    - name: Cache Cargo Dependencies
+      uses: mozilla-actions/sccache-action@v0.0.5      
     - name: Install cargo-fuzz
       uses: baptiste0928/cargo-install@v3
       with:
@@ -158,6 +158,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
+    - name: Cache Cargo Dependencies
+      uses: mozilla-actions/sccache-action@v0.0.5  
     - name: build
       run: |
         echo "#![deny(exported_private_dependencies)]" | cat - src/lib.rs > src/lib.rs.0
@@ -171,6 +173,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
+    - name: Cache Cargo Dependencies
+      uses: mozilla-actions/sccache-action@v0.0.5  
     - name: build
       run: cargo build -v --benches --features=benchmarks
 
@@ -181,6 +185,8 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: rustfmt
+    - name: Cache Cargo Dependencies
+      uses: mozilla-actions/sccache-action@v0.0.5  
     - name: Run rustfmt check
       run: cargo fmt -- --check
 
@@ -195,9 +201,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Cache Cargo Dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
+        uses: mozilla-actions/sccache-action@v0.0.5  
       - uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           feature-group: default-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -192,6 +192,10 @@ jobs:
 
   cargo-deny:
     runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: 0
+      SCCACHE_GHA_ENABLED: "false"
+      RUSTC_WRAPPER: "rustc"
     steps:
       - uses: actions/checkout@v4
       - name: Cache Cargo Dependencies

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -194,6 +194,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Cache Cargo Dependencies
+        uses: mozilla-actions/sccache-action@v0.0.5  
       - uses: EmbarkStudios/cargo-deny-action@v1
 
   cargo-semver-checks:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,6 +68,10 @@ jobs:
     # an emulated mips system. NOTE: you can also use this approach to test for
     # big endian locally.
     runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: 0
+      SCCACHE_GHA_ENABLED: "false"
+      RUSTC_WRAPPER: ""  
     strategy:
       fail-fast: false
       matrix:
@@ -78,8 +82,6 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: cross
-      - name: Cache Cargo Dependencies
-        uses: mozilla-actions/sccache-action@v0.0.5
       - name: Start Docker (required for cross-rs)
         run: sudo systemctl start docker
       - name: Cross-Run Tests using QEMU

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -195,7 +195,7 @@ jobs:
     env:
       CARGO_INCREMENTAL: 0
       SCCACHE_GHA_ENABLED: "false"
-      RUSTC_WRAPPER: "rustc"
+      RUSTC_WRAPPER: ""
     steps:
       - uses: actions/checkout@v4
       - name: Cache Cargo Dependencies


### PR DESCRIPTION
This PR builds all on CI with the sccache from Mozilla. It should in theory speed up builds by a significant amount of time.

But let's see.

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.