### PR TITLE
WebP's `into_frames` iterator returns `None` upon encountering `DecodingError::NoMoreFrames`

### DIFF
--- a/src/codecs/webp/decoder.rs
+++ b/src/codecs/webp/decoder.rs
@@ -84,12 +84,14 @@ impl<'a, R: 'a + Read + Seek> AnimationDecoder<'a> for WebPDecoder<R> {
                     let mut img = RgbaImage::new(width, height);
                     match self.decoder.inner.read_frame(&mut img) {
                         Ok(delay) => (img, delay),
+                        Err(image_webp::DecodingError::NoMoreFrames) => return None,
                         Err(e) => return Some(Err(ImageError::from_webp_decode(e))),
                     }
                 } else {
                     let mut img = RgbImage::new(width, height);
                     match self.decoder.inner.read_frame(&mut img) {
                         Ok(delay) => (img.convert(), delay),
+                        Err(image_webp::DecodingError::NoMoreFrames) => return None,
                         Err(e) => return Some(Err(ImageError::from_webp_decode(e))),
                     }
                 };


### PR DESCRIPTION
There's one problem: the original regression test swallowed errors because it just counted results without checking for `Ok`. I fixed that, but the WebP decoding fails on 

> Error decoding "tests/images/webp/extended_images/advertises_rgba_but_frames_are_rgb.webp" frame 3: IoError(Error { kind: UnexpectedEof, message: "failed to fill whole buffer" })  

---

Closes #2263 

---

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.
