### PR TITLE
Bump zune-jpeg to 0.4.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,8 @@ ravif = { version = "0.11.2", default-features = false, optional = true }
 rayon = { version = "1.7.0", optional = true }
 rgb = { version = "0.8.25", optional = true }
 tiff = { version = "0.9.0", optional = true }
-zune-core = { version = "0.4.11", default-features = false, optional = true }
-zune-jpeg = { version = "0.4.11", optional = true }
+zune-core = { version = "0.4.12", default-features = false, optional = true }
+zune-jpeg = { version = "0.4.13", optional = true }
 
 [dev-dependencies]
 crc32fast = "1.2.0"


### PR DESCRIPTION
v0.4.13 is a bugfix release. It fixes the panics that people kept complaining about. 

More info: https://github.com/etemesi254/zune-image/issues/215

This PR makes Cargo.toml require it, to make it impossible to use the older version that on 0.1% of images.