### PR TITLE
Expose zune-jpeg's Exif chunk extraction

### DIFF
--- a/src/codecs/jpeg/decoder.rs
+++ b/src/codecs/jpeg/decoder.rs
@@ -55,7 +55,7 @@ impl<R: BufRead + Seek> JpegDecoder<R> {
 
     /// Returns the raw [Exif](https://en.wikipedia.org/wiki/Exif) chunk, if it is present.
     /// A third-party crate such as [`kamadak-exif`](https://docs.rs/kamadak-exif/) is required to actually parse it.
-    pub fn exif(&mut self) -> ImageResult<Option<Vec<u8>>> {
+    pub fn exif_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {
         let mut decoder = zune_jpeg::JpegDecoder::new(&self.input);
         decoder.decode_headers().map_err(ImageError::from_jpeg)?;
         Ok(decoder.exif().cloned())

--- a/src/codecs/jpeg/decoder.rs
+++ b/src/codecs/jpeg/decoder.rs
@@ -69,6 +69,12 @@ impl<R: BufRead + Seek> ImageDecoder for JpegDecoder<R> {
         Ok(decoder.icc_profile())
     }
 
+    fn exif_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {
+        let mut decoder = zune_jpeg::JpegDecoder::new(&self.input);
+        decoder.decode_headers().map_err(ImageError::from_jpeg)?;
+        Ok(decoder.exif().cloned())
+    }
+
     fn read_image(self, buf: &mut [u8]) -> ImageResult<()> {
         let advertised_len = self.total_bytes();
         let actual_len = buf.len() as u64;
@@ -99,12 +105,6 @@ impl<R: BufRead + Seek> ImageDecoder for JpegDecoder<R> {
 
     fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
         (*self).read_image(buf)
-    }
-
-    fn exif_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {
-        let mut decoder = zune_jpeg::JpegDecoder::new(&self.input);
-        decoder.decode_headers().map_err(ImageError::from_jpeg)?;
-        Ok(decoder.exif().cloned())
     }
 }
 

--- a/src/codecs/jpeg/decoder.rs
+++ b/src/codecs/jpeg/decoder.rs
@@ -52,6 +52,14 @@ impl<R: BufRead + Seek> JpegDecoder<R> {
             phantom: PhantomData,
         })
     }
+
+    /// Returns the raw [Exif](https://en.wikipedia.org/wiki/Exif) chunk, if it is present.
+    /// A third-party crate such as [`kamadak-exif`](https://docs.rs/kamadak-exif/) is required to actually parse it.
+    pub fn exif(&mut self) -> ImageResult<Option<Vec<u8>>> {
+        let mut decoder = zune_jpeg::JpegDecoder::new(&self.input);
+        decoder.decode_headers().map_err(ImageError::from_jpeg)?;
+        Ok(decoder.exif().cloned())
+    }
 }
 
 impl<R: BufRead + Seek> ImageDecoder for JpegDecoder<R> {

--- a/src/codecs/jpeg/decoder.rs
+++ b/src/codecs/jpeg/decoder.rs
@@ -52,14 +52,6 @@ impl<R: BufRead + Seek> JpegDecoder<R> {
             phantom: PhantomData,
         })
     }
-
-    /// Returns the raw [Exif](https://en.wikipedia.org/wiki/Exif) chunk, if it is present.
-    /// A third-party crate such as [`kamadak-exif`](https://docs.rs/kamadak-exif/) is required to actually parse it.
-    pub fn exif_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {
-        let mut decoder = zune_jpeg::JpegDecoder::new(&self.input);
-        decoder.decode_headers().map_err(ImageError::from_jpeg)?;
-        Ok(decoder.exif().cloned())
-    }
 }
 
 impl<R: BufRead + Seek> ImageDecoder for JpegDecoder<R> {
@@ -107,6 +99,12 @@ impl<R: BufRead + Seek> ImageDecoder for JpegDecoder<R> {
 
     fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
         (*self).read_image(buf)
+    }
+
+    fn exif_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {
+        let mut decoder = zune_jpeg::JpegDecoder::new(&self.input);
+        decoder.decode_headers().map_err(ImageError::from_jpeg)?;
+        Ok(decoder.exif().cloned())
     }
 }
 

--- a/src/image.rs
+++ b/src/image.rs
@@ -718,6 +718,9 @@ impl<T: ?Sized + ImageDecoder> ImageDecoder for Box<T> {
     fn icc_profile(&mut self) -> ImageResult<Option<Vec<u8>>> {
         (**self).icc_profile()
     }
+    fn exif_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {
+        (**self).exif_metadata()
+    }
     fn total_bytes(&self) -> u64 {
         (**self).total_bytes()
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -628,6 +628,14 @@ pub trait ImageDecoder {
         Ok(None)
     }
 
+    /// Returns the raw [Exif](https://en.wikipedia.org/wiki/Exif) chunk, if it is present.
+    /// A third-party crate such as [`kamadak-exif`](https://docs.rs/kamadak-exif/) is required to actually parse it.
+    ///
+    /// For formats that don't support embedded profiles this function should always return `Ok(None)`.
+    fn exif_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {
+        Ok(None)
+    }
+
     /// Returns the total number of bytes in the decoded image.
     ///
     /// This is the size of the buffer that must be passed to `read_image` or


### PR DESCRIPTION
Carbon copy of the ICC chunk handling, but for Exif.

Required for [`wondermagick`](https://github.com/Shnatsel/wondermagick) so that we could rotate the JPEGs correctly based on metadata.

In the long term we probably want to integrate `kamadak-exif`, since it doesn't have any unsafe code and seems to be in quite a good shape. But this PR seems like a simple and uncontroversial start.