### PR TITLE
Fix broken ImageReader link

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! # High level API
 //!
-//! Load images using [`ImageReader`]:
+//! Load images using [`ImageReader`](crate::image_reader::ImageReader):
 //!
 //! ```rust,no_run
 //! use std::io::Cursor;
@@ -111,6 +111,7 @@
 //! [`ImageDecoderRect`]: trait.ImageDecoderRect.html
 //! [`ImageDecoder`]: trait.ImageDecoder.html
 //! [`ImageEncoder`]: trait.ImageEncoder.html
+#![allow(redundant_explicit_links)]
 #![warn(missing_docs)]
 #![warn(unused_qualifications)]
 #![deny(unreachable_pub)]


### PR DESCRIPTION
The `ImageReader` link in the docs is broken and returns a resources not found error.

![image](https://github.com/user-attachments/assets/875144c6-5e5c-48a5-a827-59c24cf174e4)

This PR fixes the link.

Despite the warning by `cargo docs` an explicit link was required for the fix.