### PR TITLE
chore: fix link to README.md

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! This crate provides native rust implementations of image encoding and decoding as well as some
 //! basic image manipulation functions. Additional documentation can currently also be found in the
 //! [README.md file which is most easily viewed on
-//! github](https://github.com/image-rs/image/blob/master/README.md).
+//! github](https://github.com/image-rs/image/blob/main/README.md).
 //!
 //! There are two core problems for which this library provides solutions: a unified interface for image
 //! encodings and simple generic buffers for their content. It's possible to use either feature


### PR DESCRIPTION
The docs link to README.md still linked to the master branch, which leads to a warning by GitHub about the branch being renamed to main when opening it.

---

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.

