### PR TITLE
Fix cargo deny warnings and errors

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,5 +1,6 @@
 # https://embarkstudios.github.io/cargo-deny/
 
+[graph]
 targets = [
     { triple = "aarch64-apple-darwin" },
     { triple = "aarch64-linux-android" },
@@ -10,9 +11,21 @@ targets = [
 ]
 
 
+[licenses]
+confidence-threshold = 0.93
+allow = [
+    "Apache-2.0 WITH LLVM-exception",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "MIT",
+    "MIT-0",
+    "MPL-2.0",
+    "Unicode-DFS-2016",
+]
+
+
 [advisories]
-vulnerability = "deny"
-unmaintained = "warn"
 yanked = "deny"
 ignore = []
 
@@ -22,17 +35,7 @@ multiple-versions = "deny"
 wildcards = "allow" # at least until https://github.com/EmbarkStudios/cargo-deny/issues/241 is fixed
 deny = []
 skip = [
-    { name = "num-derive" } # ravif transatively depends on 0.3 and 0.4.
+    { name = "bitflags" },   # Some deps depend on 1.3.2 while others on 2.6.0
+    { name = "hashbrown" },  # Some deps depend on 0.13.2 while others on 0.14.5
+    { name = "miniz_oxide" } # Some deps depend on 0.7.4 while others on 0.8.0
 ]
-skip-tree = [
-    { name = "criterion" },  # dev-dependency
-    { name = "quickcheck" }, # dev-dependency
-    { name = "dav1d" }, # TODO: needs upgrade
-    { name = "clap" },
-]
-
-
-[licenses]
-unlicensed = "allow"
-allow-osi-fsf-free = "either"
-copyleft = "allow"


### PR DESCRIPTION
The CI has been failing since [20 August 2024](https://github.com/image-rs/image/pull/2302). Since it's been failing, I suspect commits following that PR have added things that have broken the `cargo deny check` command even more. This PR should make the CI green again.

This PR fixes the errors. Things this PR addresses:

- Add `targets` property under [`[graph]` field](https://embarkstudios.github.io/cargo-deny/checks/cfg.html?highlight=graph#the-graph-field-optional)
- Remove `vulnerability` and `unmaintained` properties since they've been removed from `cargo-deny` and now [emit errors](https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html#the-version-field-optional).
- Remove unnecessary `deny.toml` properties like `skip-tree`. Maybe this was needed at some point, but it's not anymore.
- Remove `num-derive` from `skip` list since it doesn't emit errors anymore.
- Add `miniz_oxide` to `skip` list since some deps depend on `0.7.4` while others on `0.8.0`. I've created a ex-rs PR on to bump the dep to `0.8.0` https://github.com/johannesvollmer/exrs/pull/240

## Current error/warning logs

The PR solves these erorr/warnings:

```
❯ cargo deny check
warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
   ┌─ /home/user/projects/image/deny.toml:14:1
   │
14 │ vulnerability = "deny"
   │ ^^^^^^^^^^^^^

warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
   ┌─ /home/user/projects/image/deny.toml:15:1
   │
15 │ unmaintained = "warn"
   │ ^^^^^^^^^^^^

warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
   ┌─ /home/user/projects/image/deny.toml:36:1
   │
36 │ unlicensed = "allow"
   │ ^^^^^^^^^^

warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
   ┌─ /home/suer/projects/image/deny.toml:37:1
   │
37 │ allow-osi-fsf-free = "either"
   │ ^^^^^^^^^^^^^^^^^^

warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
   ┌─ /home/user/projects/image/deny.toml:38:1
   │
38 │ copyleft = "allow"
   │ ^^^^^^^^

warning[deprecated]: this key has been moved to [graph]
  ┌─ /home/user/projects/image/deny.toml:3:1
  │
3 │ targets = [
  │ ^^^^^^^

warning[unmatched-skip-root]: skip tree root was not found in the dependency graph
   ┌─ /home/user/projects/image/deny.toml:30:15
   │
30 │     { name = "dav1d" }, # TODO: needs upgrade
   │               ^^^^^ no crate matched these criteria

error[duplicate]: found 2 duplicate entries for crate 'miniz_oxide'
   ┌─ /home/user/projects/image/Cargo.lock:61:1
   │
61 │ ╭ miniz_oxide 0.7.4 registry+https://github.com/rust-lang/crates.io-index
62 │ │ miniz_oxide 0.8.0 registry+https://github.com/rust-lang/crates.io-index
   │ ╰───────────────────────────────────────────────────────────────────────^ lock entries
   │
   = miniz_oxide v0.7.4
     ├── exr v1.72.0
     │   └── image v0.25.2
     └── png v0.17.13
         └── image v0.25.2 (*)
   = miniz_oxide v0.8.0
     └── flate2 v1.0.33
         ├── png v0.17.13
         │   └── image v0.25.2
         └── tiff v0.9.1
             └── image v0.25.2 (*)

advisories ok, bans FAILED, licenses ok, sources ok
```

<!--
If you are a new contributor, consent to licensing by including this text:

I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.

Thank you for contributing, you can delete this comment.
-->
