### PR TITLE
Update WebPDecoder doc comments

### DIFF
--- a/src/codecs/dxt.rs
+++ b/src/codecs/dxt.rs
@@ -153,7 +153,6 @@ impl<R: Read> ImageDecoder for DxtDecoder<R> {
 /**
  * Actual encoding/decoding logic below.
  */
-
 type Rgb = [u8; 3];
 
 /// decodes a 5-bit R, 6-bit G, 5-bit B 16-bit packed color value into 8-bit RGB

--- a/src/codecs/webp/decoder.rs
+++ b/src/codecs/webp/decoder.rs
@@ -5,14 +5,15 @@ use crate::error::{DecodingError, ImageError, ImageResult};
 use crate::image::{ImageDecoder, ImageFormat};
 use crate::{AnimationDecoder, ColorType, Delay, Frame, Frames, RgbImage, Rgba, RgbaImage};
 
-/// WebP Image format decoder. Currently only supports lossy RGB images or lossless RGBA images.
+/// WebP Image format decoder.
+///
+/// Supports both lossless and lossy WebP images.
 pub struct WebPDecoder<R> {
     inner: image_webp::WebPDecoder<R>,
 }
 
 impl<R: BufRead + Seek> WebPDecoder<R> {
-    /// Create a new `WebPDecoder` from the Reader ```r```.
-    /// This function takes ownership of the Reader.
+    /// Create a new `WebPDecoder` from the Reader `r`.
     pub fn new(r: R) -> ImageResult<Self> {
         Ok(Self {
             inner: image_webp::WebPDecoder::new(r).map_err(ImageError::from_webp_decode)?,


### PR DESCRIPTION
We've had full WebP decoding support for a while. Update the docs to reflect that...

(There may still be bugs. If you find any WebP images that don't decode properly, please file a bug against the `image-webp` repository!)