### PR TITLE
Upgrade image-webp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ dav1d = { version = "0.10.3", optional = true }
 dcv-color-primitives = { version = "0.6.1", optional = true }
 exr = { version = "1.5.0", optional = true }
 gif = { version = "0.13", optional = true }
-image-webp = { version = "0.1.0", optional = true }
+image-webp = { version = "0.2.0", optional = true }
 mp4parse = { version = "0.17.0", optional = true }
 png = { version = "0.17.6", optional = true }
 qoi = { version = "0.4", optional = true }

--- a/src/codecs/webp/decoder.rs
+++ b/src/codecs/webp/decoder.rs
@@ -92,13 +92,13 @@ impl<R: BufRead + Seek> ImageDecoder for WebPDecoder<R> {
     }
 }
 
-impl<'a, R: 'a + Read + Seek> AnimationDecoder<'a> for WebPDecoder<R> {
+impl<'a, R: 'a + BufRead + Seek> AnimationDecoder<'a> for WebPDecoder<R> {
     fn into_frames(self) -> Frames<'a> {
         struct FramesInner<R: Read + Seek> {
             decoder: WebPDecoder<R>,
             current: u32,
         }
-        impl<R: Read + Seek> Iterator for FramesInner<R> {
+        impl<R: BufRead + Seek> Iterator for FramesInner<R> {
             type Item = ImageResult<Frame>;
 
             fn next(&mut self) -> Option<Self::Item> {


### PR DESCRIPTION
The `BufRead` trait bound changes should be non-breaking because it isn't possible to construct a `AnimationDecoder` without first calling `WebPDecoder::new` which already requires `BufRead`.