### PR TITLE
Impl Hash for FilterType

### DIFF
--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -78,7 +78,7 @@ use crate::{ImageBuffer, Rgba32FImage};
 ///     <td>1170 ms</td>
 ///   </tr>
 /// </table>
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Hash)]
 pub enum FilterType {
     /// Nearest Neighbor
     Nearest,


### PR DESCRIPTION
I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.

--

I'm not sure if there is a reason it's not implemented but we could use that for Zola.