### PR TITLE
test(fuzz): cover other image types

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -67,5 +67,17 @@ name = "fuzzer_script_exr"
 path = "fuzzers/fuzzer_script_exr.rs"
 
 [[bin]]
+name = "fuzzer_script_qoi"
+path = "fuzzers/fuzzer_script_qoi.rs"
+
+[[bin]]
+name = "fuzzer_script_openexr"
+path = "fuzzers/fuzzer_script_openexr.rs"
+
+[[bin]]
+name = "fuzzer_script_farbfeld"
+path = "fuzzers/fuzzer_script_farbfeld.rs"
+
+[[bin]]
 name = "roundtrip_webp"
 path = "fuzzers/roundtrip_webp.rs"

--- a/fuzz/fuzzers/fuzzer_script_farbfeld.rs
+++ b/fuzz/fuzzers/fuzzer_script_farbfeld.rs
@@ -1,0 +1,7 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate image;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = image::load_from_memory_with_format(data, image::ImageFormat::Farbfeld);
+});

--- a/fuzz/fuzzers/fuzzer_script_openexr.rs
+++ b/fuzz/fuzzers/fuzzer_script_openexr.rs
@@ -1,0 +1,7 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate image;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = image::load_from_memory_with_format(data, image::ImageFormat::OpenExr);
+});

--- a/fuzz/fuzzers/fuzzer_script_qoi.rs
+++ b/fuzz/fuzzers/fuzzer_script_qoi.rs
@@ -1,0 +1,7 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate image;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = image::load_from_memory_with_format(data, image::ImageFormat::Qoi);
+});


### PR DESCRIPTION
I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.

Adds fuzz targets for the QOI, OpenEXR, and Farbfeld image formats