### PR TITLE
Propose wording for republishing as 0.25.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 ## Changes
 
-### Version 0.25.3
+### Version 0.25.4
 
 Features:
  - Much faster decoding of lossless WebP due to a variety of optimizations. Our benchmarks show 2x to 2.5x improvement.
@@ -20,6 +20,12 @@ Features:
 Bug fixes:
  - Fixed some APNG images being decoded incorrectly
  - Fixed the iterator over animated WebP frames to return `None` instead of an error when the end of the animation is reached
+
+### Version 0.25.3
+
+Yanked! This version accidentally missed a commit that should have been
+included with the release. The `Orientation` struct should be in the
+appropriate module instead of the top-level. This release won't be supported.
 
 ### Version 0.25.2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "image"
-version = "0.25.3"
+version = "0.25.4"
 edition = "2021"
 resolver = "2"
 


### PR DESCRIPTION
Closes: #2353 

I've re-written the change to essentially transfer `0.25.3` to `0.25.4`.

The proposed publishing action, in sequence since this is an unusual circumstance:

1. Wait for CI to clear everything apart from the SemVer checks
2. Verify that the Orientation interface is the only linted error in CI
3. Approve the PR
4. Checkout the commit to-be-published
5. Verify the PR is based on the current main branch (otherwise, go back to 1.)
6. Yank the version `0.25.3`: `cargo yank --version 0.25.3`
7. Publish: `cargo publish`

Please review both the changelog and the list.