### PR TITLE
No generic image impl

### DIFF
--- a/examples/concat/main.rs
+++ b/examples/concat/main.rs
@@ -8,9 +8,15 @@ use image::{GenericImage, GenericImageView, ImageBuffer, Pixel, Primitive};
 /// cargo run --release --example concat
 fn main() {
     h_concat(&[
-        image::open("examples/concat/200x300.png").unwrap(),
-        image::open("examples/concat/300x300.png").unwrap(),
-        image::open("examples/concat/400x300.png").unwrap(),
+        image::open("examples/concat/200x300.png")
+            .unwrap()
+            .to_rgba8(),
+        image::open("examples/concat/300x300.png")
+            .unwrap()
+            .to_rgba8(),
+        image::open("examples/concat/400x300.png")
+            .unwrap()
+            .to_rgba8(),
     ])
     .save("examples/concat/concatenated_900x300.png")
     .unwrap();

--- a/examples/opening.rs
+++ b/examples/opening.rs
@@ -5,7 +5,7 @@ use std::env;
 use std::fs::File;
 use std::path::Path;
 
-use image::{GenericImageView, ImageFormat};
+use image::ImageFormat;
 
 fn main() {
     let file = if env::args().count() == 2 {

--- a/examples/tile/main.rs
+++ b/examples/tile/main.rs
@@ -2,7 +2,9 @@ use image::RgbaImage;
 
 fn main() {
     let mut img = RgbaImage::new(1920, 1080);
-    let tile = image::open("examples/scaleup/tinycross.png").unwrap();
+    let tile = image::open("examples/scaleup/tinycross.png")
+        .unwrap()
+        .to_rgba8();
 
     image::imageops::tile(&mut img, &tile);
     img.save("tiled_wallpaper.png").unwrap();

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1193,10 +1193,6 @@ where
     P: Pixel,
     Container: Deref<Target = [P::Subpixel]> + DerefMut,
 {
-    fn get_pixel_mut(&mut self, x: u32, y: u32) -> &mut P {
-        self.get_pixel_mut(x, y)
-    }
-
     fn put_pixel(&mut self, x: u32, y: u32, pixel: P) {
         *self.get_pixel_mut(x, y) = pixel;
     }

--- a/src/image.rs
+++ b/src/image.rs
@@ -943,29 +943,6 @@ pub trait GenericImageView {
 
 /// A trait for manipulating images.
 pub trait GenericImage: GenericImageView {
-    /// Gets a reference to the mutable pixel at location `(x, y)`. Indexed from top left.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `(x, y)` is out of bounds.
-    ///
-    /// Panics for dynamic images (this method is deprecated and will be removed).
-    ///
-    /// ## Known issues
-    ///
-    /// This requires the buffer to contain a unique set of continuous channels in the exact order
-    /// and byte representation that the pixel type requires. This is somewhat restrictive.
-    ///
-    /// TODO: Maybe use some kind of entry API? this would allow pixel type conversion on the fly
-    /// while still doing only one array lookup:
-    ///
-    /// ```ignore
-    /// let px = image.pixel_entry_at(x,y);
-    /// px.set_from_rgba(rgba)
-    /// ```
-    #[deprecated(since = "0.24.0", note = "Use `get_pixel` and `put_pixel` instead.")]
-    fn get_pixel_mut(&mut self, x: u32, y: u32) -> &mut Self::Pixel;
-
     /// Put a pixel at location (x, y). Indexed from top left.
     ///
     /// # Panics
@@ -1290,10 +1267,6 @@ where
     I: DerefMut,
     I::Target: GenericImage + Sized,
 {
-    fn get_pixel_mut(&mut self, x: u32, y: u32) -> &mut Self::Pixel {
-        self.image.get_pixel_mut(x + self.xoffset, y + self.yoffset)
-    }
-
     fn put_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel) {
         self.image
             .put_pixel(x + self.xoffset, y + self.yoffset, pixel);

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -249,7 +249,7 @@ where
 /// use image::{RgbaImage};
 ///
 /// let mut img = RgbaImage::new(1920, 1080);
-/// let tile = image::open("tile.png").unwrap();
+/// let tile = image::open("tile.png").unwrap().to_rgba8();
 ///
 /// image::imageops::tile(&mut img, &tile);
 /// img.save("tiled_wallpaper.png").unwrap();

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -1060,7 +1060,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::{resize, sample_bilinear, sample_nearest, FilterType};
-    use crate::{GenericImageView, ImageBuffer, RgbImage};
+    use crate::{ImageBuffer, RgbImage};
     #[cfg(feature = "benchmarks")]
     use test;
 
@@ -1079,8 +1079,10 @@ mod tests {
     #[cfg(feature = "png")]
     fn test_resize_same_size() {
         use std::path::Path;
-        let img = crate::open(Path::new("./examples/fractal.png")).unwrap();
-        let resize = img.resize(img.width(), img.height(), FilterType::Triangle);
+        let img = crate::open(Path::new("./examples/fractal.png"))
+            .unwrap()
+            .to_rgba8();
+        let resize = resize(&img, img.width(), img.height(), FilterType::Triangle);
         assert!(img.pixels().eq(resize.pixels()))
     }
 
@@ -1088,7 +1090,9 @@ mod tests {
     #[cfg(feature = "png")]
     fn test_sample_bilinear() {
         use std::path::Path;
-        let img = crate::open(Path::new("./examples/fractal.png")).unwrap();
+        let img = crate::open(Path::new("./examples/fractal.png"))
+            .unwrap()
+            .to_rgb8();
         assert!(sample_bilinear(&img, 0., 0.).is_some());
         assert!(sample_bilinear(&img, 1., 0.).is_some());
         assert!(sample_bilinear(&img, 0., 1.).is_some());
@@ -1107,7 +1111,9 @@ mod tests {
     #[cfg(feature = "png")]
     fn test_sample_nearest() {
         use std::path::Path;
-        let img = crate::open(Path::new("./examples/fractal.png")).unwrap();
+        let img = crate::open(Path::new("./examples/fractal.png"))
+            .unwrap()
+            .to_rgba8();
         assert!(sample_nearest(&img, 0., 0.).is_some());
         assert!(sample_nearest(&img, 1., 0.).is_some());
         assert!(sample_nearest(&img, 0., 1.).is_some());


### PR DESCRIPTION
This sketches how to fully removes the deprecated `GenericImage::get_pixel_mut`, complementary to #2344 . This allows writing a rather well-defined _view_ type for a `GenericImage` in which the caller choose the concrete pixel _type_ on demand.

@fintelia Would such a type resolve or at least mitigate some of your concerns about downstream code effects?