### PR TITLE
Recognize '.jfif' extension as JPEG file

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -90,7 +90,7 @@ impl ImageFormat {
 
             Some(match ext.as_str() {
                 "avif" => ImageFormat::Avif,
-                "jpg" | "jpeg" => ImageFormat::Jpeg,
+                "jpg" | "jpeg" | "jfif" => ImageFormat::Jpeg,
                 "png" | "apng" => ImageFormat::Png,
                 "gif" => ImageFormat::Gif,
                 "webp" => ImageFormat::WebP,


### PR DESCRIPTION
Closes #2361.

*I license past and future contributions under the dual MIT/Apache-2.0 license,
allowing licensees to choose either at their option.*