### PR TITLE
Update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
 <!--
-If you are a new contributor, consent to licensing by including this text:
+We welcome performance optimizations, bug fixes, and documentation improvements.
 
-I license past and future contributions under the dual MIT/Apache-2.0 license,
-allowing licensees to choose either at their option.
+Feature additions are also welcome, but we encourage you to open an issue first
+to discuss whether it is something we want to add.
 
 Thank you for contributing, you can delete this comment.
 -->


### PR DESCRIPTION
Now that this repository is dual licensed under MIT and Apache 2.0, we can rely on the [inbound=outbound statement from the GitHub terms of service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license).

Additionally, add a specific encouragement to discuss feature additions in issues before creating a PR. 