### PR TITLE
Add optional serde feature for image::ImageFormat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ rgb = { version = "0.8.48", default-features = false, optional = true }
 tiff = { version = "0.9.0", optional = true }
 zune-core = { version = "0.4.12", default-features = false, optional = true }
 zune-jpeg = { version = "0.4.13", optional = true }
+serde = { version = "1.0.214", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 crc32fast = "1.2.0"
@@ -92,6 +93,7 @@ nasm = ["ravif?/asm"] # Enables use of nasm by rav1e (requires nasm to be instal
 color_quant = ["dep:color_quant"] # Enables color quantization
 avif-native = ["dep:mp4parse", "dep:dcv-color-primitives", "dep:dav1d"] # Enable native dependency libdav1d
 benchmarks = [] # Build some inline benchmarks. Useful only during development (requires nightly Rust)
+serde = ["dep:serde"]
 
 [[bench]]
 path = "benches/decode.rs"

--- a/src/image.rs
+++ b/src/image.rs
@@ -5,6 +5,9 @@ use std::mem::size_of;
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::color::{ColorType, ExtendedColorType};
 use crate::error::{
     ImageError, ImageFormatHint, ImageResult, LimitError, LimitErrorKind, ParameterError,
@@ -20,6 +23,7 @@ use crate::animation::Frames;
 /// An enumeration of supported image formats.
 /// Not all formats support both encoding and decoding.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[non_exhaustive]
 pub enum ImageFormat {
     /// An Image in PNG Format


### PR DESCRIPTION
This change fixes #2254 by adding the non-default `serde` feature to `image::ImageForamt`.

Fixes #2254