### PR TITLE
Temporarily disable PCX format

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        features: ['', default, rayon, avif, bmp, dds, exr, ff, gif, hdr, ico, jpeg, pcx, png, pnm, qoi, tga, tiff, webp]
+        features: ['', default, rayon, avif, bmp, dds, exr, ff, gif, hdr, ico, jpeg, png, pnm, qoi, tga, tiff, webp]
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ exr = { version = "1.5.0", optional = true }
 gif = { version = "0.13", optional = true }
 image-webp = { version = "0.2.0", optional = true }
 mp4parse = { version = "0.17.0", optional = true }
-pcx = { version = "0.2.3", optional = true }
 png = { version = "0.17.6", optional = true }
 qoi = { version = "0.4", optional = true }
 ravif = { version = "0.11.11", default-features = false, optional = true }
@@ -78,7 +77,6 @@ gif = ["dep:gif", "dep:color_quant"]
 hdr = []
 ico = ["bmp", "png"]
 jpeg = ["dep:zune-core", "dep:zune-jpeg"]
-pcx = ["dep:pcx"] # Note that the PCX dependency uses the WTFPL license
 png = ["dep:png"]
 pnm = []
 qoi = ["dep:qoi"]

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ image format encoders and decoders.
 | ICO      | Yes                                       | Yes                                     |
 | JPEG     | Yes                                       | Yes                                     |
 | EXR      | Yes                                       | Yes                                     |
-| PCX      | Yes                                       | ---                                     |
 | PNG      | Yes                                       | Yes                                     |
 | PNM      | Yes                                       | Yes                                     |
 | QOI      | Yes                                       | Yes                                     |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,6 @@ pub mod flat;
 /// | ICO      | Yes                                       | Yes                                     |
 /// | JPEG     | Yes                                       | Yes                                     |
 /// | EXR      | Yes                                       | Yes                                     |
-/// | PCX      | Yes                                       | ---                                     |
 /// | PNG      | Yes                                       | Yes                                     |
 /// | PNM      | Yes                                       | Yes                                     |
 /// | QOI      | Yes                                       | Yes                                     |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,14 @@
 #![deny(missing_copy_implementations)]
 #![cfg_attr(all(test, feature = "benchmarks"), feature(test))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+// We've temporarily disabled PCX support for 0.25.5 release
+// by removing the corresponding feature.
+// We want to ship bug fixes without committing to PCX support.
+//
+// Cargo shows warnings about code depending on a nonexistent feature
+// even to people using the crate as a dependency,
+// so we have to suppress those warnings.
+#![allow(unexpected_cfgs)]
 
 #[cfg(all(test, feature = "benchmarks"))]
 extern crate test;


### PR DESCRIPTION
As discussed in #2378, temporarily disable PCX support so that we could ship bugfixes without being blocked on decisions about support for an obsolete format.

In my tests, Cargo shows warnings about nonexistent features even to people who use the crate as a dependency, so I had to add `#![allow(unexpected_cfgs)]` as well.

I'll revert this PR once 0.25.5 is released.