### PR TITLE
Implement writing ICC profiles for JPEG and PNG images.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,10 +43,10 @@ num-traits = { version = "0.2.0" }
 color_quant = { version = "1.1", optional = true }
 dav1d = { version = "0.10.3", optional = true }
 exr = { version = "1.5.0", optional = true }
-gif = { version = "0.13", optional = true }
+gif = { version = "0.13.1", optional = true }
 image-webp = { version = "0.2.0", optional = true }
 mp4parse = { version = "0.17.0", optional = true }
-png = { version = "0.17.6", optional = true }
+png = { version = "0.17.11", optional = true }
 qoi = { version = "0.4", optional = true }
 ravif = { version = "0.11.11", default-features = false, optional = true }
 rayon = { version = "1.7.0", optional = true }


### PR DESCRIPTION
Notes:
- `png` crate doesn't actually write ICC profiles at all in latest published version as of writing (0.17.14), however it seems that 0.17.15 will be released soon: <https://github.com/image-rs/image-png/commit/10644dbff4d5b5614199cbc81145838abdafd98c>