### PR TITLE
Update free_functions.rs

### DIFF
--- a/src/image_reader/free_functions.rs
+++ b/src/image_reader/free_functions.rs
@@ -124,7 +124,7 @@ pub(crate) fn write_buffer_impl<W: std::io::Write + Seek>(
     }
 }
 
-static MAGIC_BYTES: [(&[u8], ImageFormat); 25] = [
+static MAGIC_BYTES: [(&[u8], ImageFormat); 26] = [
     (b"\x89PNG\r\n\x1a\n", ImageFormat::Png),
     (&[0xff, 0xd8, 0xff], ImageFormat::Jpeg),
     (b"GIF89a", ImageFormat::Gif),

--- a/src/image_reader/free_functions.rs
+++ b/src/image_reader/free_functions.rs
@@ -146,6 +146,7 @@ static MAGIC_BYTES: [(&[u8], ImageFormat); 25] = [
     (b"farbfeld", ImageFormat::Farbfeld),
     (b"\0\0\0 ftypavif", ImageFormat::Avif),
     (b"\0\0\0\x1cftypavif", ImageFormat::Avif),
+    (b"\0\0\0\x18ftypavif", ImageFormat::Avif),
     (&[0x76, 0x2f, 0x31, 0x01], ImageFormat::OpenExr), // = &exr::meta::magic_number::BYTES
     (b"qoif", ImageFormat::Qoi),
     (&[0x0a, 0x02], ImageFormat::Pcx),


### PR DESCRIPTION
Support guessing AVIF image generated by this library (with native avif)

Exemple of image generated by this library with the magic bytes not yet recognized:
[image.zip](https://github.com/user-attachments/files/18562280/image.zip)
