### PR TITLE
Improve format detection

### DIFF
--- a/src/image_reader/free_functions.rs
+++ b/src/image_reader/free_functions.rs
@@ -173,15 +173,12 @@ pub(crate) fn guess_format_impl(buffer: &[u8]) -> Option<ImageFormat> {
             if buffer.starts_with(signature) {
                 return Some(format);
             }
-        } else if buffer.len() >= signature.len() {
-            if buffer
+        } else if buffer.len() >= signature.len() && buffer
                 .iter()
                 .zip(signature.iter())
                 .zip(mask.iter().chain(iter::repeat(&0xFF)))
-                .all(|((&byte, &sig), &mask)| byte & mask == sig)
-            {
-                return Some(format);
-            }
+                .all(|((&byte, &sig), &mask)| byte & mask == sig) {
+            return Some(format);
         }
     }
 

--- a/src/image_reader/free_functions.rs
+++ b/src/image_reader/free_functions.rs
@@ -173,11 +173,13 @@ pub(crate) fn guess_format_impl(buffer: &[u8]) -> Option<ImageFormat> {
             if buffer.starts_with(signature) {
                 return Some(format);
             }
-        } else if buffer.len() >= signature.len() && buffer
+        } else if buffer.len() >= signature.len()
+            && buffer
                 .iter()
                 .zip(signature.iter())
                 .zip(mask.iter().chain(iter::repeat(&0xFF)))
-                .all(|((&byte, &sig), &mask)| byte & mask == sig) {
+                .all(|((&byte, &sig), &mask)| byte & mask == sig)
+        {
             return Some(format);
         }
     }


### PR DESCRIPTION
Allows formats to specify a mask of which bytes to compare against the signature. Particularly useful for WebP and AVIF which place size fields prior to their signatures.

Fixes #2409