### PR TITLE
Update resize and blurs doc

### DIFF
--- a/src/imageops/fast_blur.rs
+++ b/src/imageops/fast_blur.rs
@@ -5,6 +5,7 @@ use crate::{ImageBuffer, Pixel, Primitive};
 /// Approximation of Gaussian blur after
 /// Kovesi, P.:  Fast Almost-Gaussian Filtering The Australian Pattern
 /// Recognition Society Conference: DICTA 2010. December 2010. Sydney.
+/// This method requires alpha pre-multiplication for images that contain non-constant alpha.
 #[must_use]
 pub fn fast_blur<P: Pixel>(
     image_buffer: &ImageBuffer<P, Vec<P::Subpixel>>,

--- a/src/imageops/fast_blur.rs
+++ b/src/imageops/fast_blur.rs
@@ -5,7 +5,7 @@ use crate::{ImageBuffer, Pixel, Primitive};
 /// Approximation of Gaussian blur after
 /// Kovesi, P.:  Fast Almost-Gaussian Filtering The Australian Pattern
 /// Recognition Society Conference: DICTA 2010. December 2010. Sydney.
-/// This method requires alpha pre-multiplication for images that contain non-constant alpha.
+/// This method assumes alpha pre-multiplication for images that contain non-constant alpha.
 #[must_use]
 pub fn fast_blur<P: Pixel>(
     image_buffer: &ImageBuffer<P, Vec<P::Subpixel>>,

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -930,7 +930,7 @@ where
 /// Resize the supplied image to the specified dimensions.
 /// ```nwidth``` and ```nheight``` are the new dimensions.
 /// ```filter``` is the sampling filter to use.
-/// This method requires alpha pre-multiplication for images that contain non-constant alpha.
+/// This method assumes alpha pre-multiplication for images that contain non-constant alpha.
 pub fn resize<I: GenericImageView>(
     image: &I,
     nwidth: u32,
@@ -990,7 +990,7 @@ where
 /// ```sigma``` is a measure of how much to blur by.
 /// Use [`crate::imageops::fast_blur()`] for a faster but less
 /// accurate version.
-/// This method requires alpha pre-multiplication for images that contain non-constant alpha.
+/// This method assumes alpha pre-multiplication for images that contain non-constant alpha.
 pub fn blur<I: GenericImageView>(
     image: &I,
     sigma: f32,

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -930,6 +930,7 @@ where
 /// Resize the supplied image to the specified dimensions.
 /// ```nwidth``` and ```nheight``` are the new dimensions.
 /// ```filter``` is the sampling filter to use.
+/// This method requires alpha pre-multiplication for images that contain non-constant alpha.
 pub fn resize<I: GenericImageView>(
     image: &I,
     nwidth: u32,
@@ -989,6 +990,7 @@ where
 /// ```sigma``` is a measure of how much to blur by.
 /// Use [`crate::imageops::fast_blur()`] for a faster but less
 /// accurate version.
+/// This method requires alpha pre-multiplication for images that contain non-constant alpha.
 pub fn blur<I: GenericImageView>(
     image: &I,
     sigma: f32,


### PR DESCRIPTION
Updated doc for `blur` and `resize`.
Clippy error seems to be the error in the clippy itself.