### PR TITLE
pnm: Decode PAM format variants which have alpha

### DIFF
--- a/src/codecs/pnm/decoder.rs
+++ b/src/codecs/pnm/decoder.rs
@@ -221,10 +221,15 @@ impl Display for ErrorDataSource {
 enum TupleType {
     PbmBit,
     BWBit,
+    BWAlphaBit,
     GrayU8,
+    GrayAlphaU8,
     GrayU16,
+    GrayAlphaU16,
     RGBU8,
+    RGBAlphaU8,
     RGBU16,
+    RGBAlphaU16,
 }
 
 trait Sample {
@@ -584,10 +589,15 @@ impl<R: Read> ImageDecoder for PnmDecoder<R> {
         match self.tuple {
             TupleType::PbmBit => ColorType::L8,
             TupleType::BWBit => ColorType::L8,
+            TupleType::BWAlphaBit => ColorType::La8,
             TupleType::GrayU8 => ColorType::L8,
+            TupleType::GrayAlphaU8 => ColorType::La8,
             TupleType::GrayU16 => ColorType::L16,
+            TupleType::GrayAlphaU16 => ColorType::La16,
             TupleType::RGBU8 => ColorType::Rgb8,
+            TupleType::RGBAlphaU8 => ColorType::Rgba8,
             TupleType::RGBU16 => ColorType::Rgb16,
+            TupleType::RGBAlphaU16 => ColorType::Rgba16,
         }
     }
 
@@ -595,10 +605,15 @@ impl<R: Read> ImageDecoder for PnmDecoder<R> {
         match self.tuple {
             TupleType::PbmBit => ExtendedColorType::L1,
             TupleType::BWBit => ExtendedColorType::L1,
+            TupleType::BWAlphaBit => ExtendedColorType::La1,
             TupleType::GrayU8 => ExtendedColorType::L8,
+            TupleType::GrayAlphaU8 => ExtendedColorType::La8,
             TupleType::GrayU16 => ExtendedColorType::L16,
+            TupleType::GrayAlphaU16 => ExtendedColorType::La16,
             TupleType::RGBU8 => ExtendedColorType::Rgb8,
+            TupleType::RGBAlphaU8 => ExtendedColorType::Rgba8,
             TupleType::RGBU16 => ExtendedColorType::Rgb16,
+            TupleType::RGBAlphaU16 => ExtendedColorType::Rgba16,
         }
     }
 
@@ -607,10 +622,15 @@ impl<R: Read> ImageDecoder for PnmDecoder<R> {
         match self.tuple {
             TupleType::PbmBit => self.read_samples::<PbmBit>(1, buf),
             TupleType::BWBit => self.read_samples::<BWBit>(1, buf),
+            TupleType::BWAlphaBit => self.read_samples::<BWBit>(2, buf),
             TupleType::RGBU8 => self.read_samples::<U8>(3, buf),
+            TupleType::RGBAlphaU8 => self.read_samples::<U8>(4, buf),
             TupleType::RGBU16 => self.read_samples::<U16>(3, buf),
+            TupleType::RGBAlphaU16 => self.read_samples::<U16>(4, buf),
             TupleType::GrayU8 => self.read_samples::<U8>(1, buf),
+            TupleType::GrayAlphaU8 => self.read_samples::<U8>(2, buf),
             TupleType::GrayU16 => self.read_samples::<U16>(1, buf),
+            TupleType::GrayAlphaU16 => self.read_samples::<U16>(2, buf),
         }
     }
 
@@ -833,19 +853,9 @@ impl DecodableImageHeader for ArbitraryHeader {
         match self.tupltype {
             _ if self.maxval == 0 => Err(DecoderError::MaxvalZero.into()),
             None if self.depth == 1 => Ok(TupleType::GrayU8),
-            None if self.depth == 2 => Err(ImageError::Unsupported(
-                UnsupportedError::from_format_and_kind(
-                    ImageFormat::Pnm.into(),
-                    UnsupportedErrorKind::Color(ExtendedColorType::La8),
-                ),
-            )),
+            None if self.depth == 2 => Ok(TupleType::GrayAlphaU8),
             None if self.depth == 3 => Ok(TupleType::RGBU8),
-            None if self.depth == 4 => Err(ImageError::Unsupported(
-                UnsupportedError::from_format_and_kind(
-                    ImageFormat::Pnm.into(),
-                    UnsupportedErrorKind::Color(ExtendedColorType::Rgba8),
-                ),
-            )),
+            None if self.depth == 4 => Ok(TupleType::RGBAlphaU8),
 
             Some(ArbitraryTuplType::BlackAndWhite) if self.maxval == 1 && self.depth == 1 => {
                 Ok(TupleType::BWBit)
@@ -882,27 +892,42 @@ impl DecodableImageHeader for ArbitraryHeader {
             }
             .into()),
 
-            Some(ArbitraryTuplType::BlackAndWhiteAlpha) => Err(ImageError::Unsupported(
-                UnsupportedError::from_format_and_kind(
-                    ImageFormat::Pnm.into(),
-                    UnsupportedErrorKind::GenericFeature(format!(
-                        "Color type {}",
-                        ArbitraryTuplType::BlackAndWhiteAlpha.name()
-                    )),
-                ),
-            )),
-            Some(ArbitraryTuplType::GrayscaleAlpha) => Err(ImageError::Unsupported(
-                UnsupportedError::from_format_and_kind(
-                    ImageFormat::Pnm.into(),
-                    UnsupportedErrorKind::Color(ExtendedColorType::La8),
-                ),
-            )),
-            Some(ArbitraryTuplType::RGBAlpha) => Err(ImageError::Unsupported(
-                UnsupportedError::from_format_and_kind(
-                    ImageFormat::Pnm.into(),
-                    UnsupportedErrorKind::Color(ExtendedColorType::Rgba8),
-                ),
-            )),
+            Some(ArbitraryTuplType::BlackAndWhiteAlpha) if self.depth == 2 && self.maxval == 1 => {
+                Ok(TupleType::BWAlphaBit)
+            }
+            Some(ArbitraryTuplType::BlackAndWhiteAlpha) => {
+                Err(DecoderError::InvalidDepthOrMaxval {
+                    tuple_type: ArbitraryTuplType::BlackAndWhiteAlpha,
+                    maxval: self.maxval,
+                    depth: self.depth,
+                }
+                .into())
+            }
+
+            Some(ArbitraryTuplType::GrayscaleAlpha) if self.depth == 2 && self.maxval <= 0xFF => {
+                Ok(TupleType::GrayAlphaU8)
+            }
+            Some(ArbitraryTuplType::GrayscaleAlpha) if self.depth == 2 && self.maxval <= 0xFFFF => {
+                Ok(TupleType::GrayAlphaU16)
+            }
+            Some(ArbitraryTuplType::GrayscaleAlpha) => Err(DecoderError::InvalidDepth {
+                tuple_type: ArbitraryTuplType::GrayscaleAlpha,
+                depth: self.depth,
+            }
+            .into()),
+
+            Some(ArbitraryTuplType::RGBAlpha) if self.depth == 4 && self.maxval <= 0xFF => {
+                Ok(TupleType::RGBAlphaU8)
+            }
+            Some(ArbitraryTuplType::RGBAlpha) if self.depth == 4 && self.maxval <= 0xFFFF => {
+                Ok(TupleType::RGBAlphaU16)
+            }
+            Some(ArbitraryTuplType::RGBAlpha) => Err(DecoderError::InvalidDepth {
+                tuple_type: ArbitraryTuplType::RGBAlpha,
+                depth: self.depth,
+            }
+            .into()),
+
             Some(ArbitraryTuplType::Custom(ref custom)) => Err(ImageError::Unsupported(
                 UnsupportedError::from_format_and_kind(
                     ImageFormat::Pnm.into(),
@@ -963,6 +988,46 @@ ENDHDR
         }
     }
 
+    /// Tests reading of a valid blackandwhite_alpha pam
+    #[test]
+    fn pam_blackandwhite_alpha() {
+        let pamdata = b"P7
+WIDTH 2
+HEIGHT 2
+DEPTH 2
+MAXVAL 1
+TUPLTYPE BLACKANDWHITE_ALPHA
+# Comment line
+ENDHDR
+\x01\x00\x00\x01\x01\x00\x00\x01";
+        let decoder = PnmDecoder::new(&pamdata[..]).unwrap();
+        assert_eq!(decoder.color_type(), ColorType::La8);
+        assert_eq!(decoder.original_color_type(), ExtendedColorType::La1);
+        assert_eq!(decoder.dimensions(), (2, 2));
+        assert_eq!(decoder.subtype(), PnmSubtype::ArbitraryMap);
+
+        let mut image = vec![0; decoder.total_bytes() as usize];
+        decoder.read_image(&mut image).unwrap();
+        assert_eq!(image, vec![0xFF, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0xFF,]);
+        match PnmDecoder::new(&pamdata[..]).unwrap().into_inner() {
+            (
+                _,
+                PnmHeader {
+                    decoded:
+                        HeaderRecord::Arbitrary(ArbitraryHeader {
+                            width: 2,
+                            height: 2,
+                            maxval: 1,
+                            depth: 2,
+                            tupltype: Some(ArbitraryTuplType::BlackAndWhiteAlpha),
+                        }),
+                    encoded: _,
+                },
+            ) => (),
+            _ => panic!("Decoded header is incorrect"),
+        }
+    }
+
     /// Tests reading of a valid grayscale pam
     #[test]
     fn pam_grayscale() {
@@ -1008,6 +1073,55 @@ ENDHDR
         }
     }
 
+    /// Tests reading of a valid grayscale_alpha pam
+    #[test]
+    fn pam_grayscale_alpha() {
+        let pamdata = b"P7
+HEIGHT 1
+WIDTH 2
+MAXVAL 65535
+DEPTH 2
+TUPLTYPE GRAYSCALE_ALPHA
+# Comment line
+ENDHDR
+\xdc\xba\x32\x10\xdc\xba\x32\x10";
+        let decoder = PnmDecoder::new(&pamdata[..]).unwrap();
+        assert_eq!(decoder.color_type(), ColorType::La16);
+        assert_eq!(decoder.original_color_type(), ExtendedColorType::La16);
+        assert_eq!(decoder.dimensions(), (2, 1));
+        assert_eq!(decoder.subtype(), PnmSubtype::ArbitraryMap);
+
+        let mut image = vec![0; decoder.total_bytes() as usize];
+        decoder.read_image(&mut image).unwrap();
+        assert_eq!(
+            image,
+            [
+                u16::to_ne_bytes(0xdcba),
+                u16::to_ne_bytes(0x3210),
+                u16::to_ne_bytes(0xdcba),
+                u16::to_ne_bytes(0x3210)
+            ]
+            .concat()
+        );
+        match PnmDecoder::new(&pamdata[..]).unwrap().into_inner() {
+            (
+                _,
+                PnmHeader {
+                    decoded:
+                        HeaderRecord::Arbitrary(ArbitraryHeader {
+                            width: 2,
+                            height: 1,
+                            maxval: 65535,
+                            depth: 2,
+                            tupltype: Some(ArbitraryTuplType::GrayscaleAlpha),
+                        }),
+                    encoded: _,
+                },
+            ) => (),
+            _ => panic!("Decoded header is incorrect"),
+        }
+    }
+
     /// Tests reading of a valid rgb pam
     #[test]
     fn pam_rgb() {
@@ -1042,6 +1156,46 @@ ENDHDR
                             depth: 3,
                             width: 2,
                             height: 2,
+                        }),
+                    encoded: _,
+                },
+            ) => (),
+            _ => panic!("Decoded header is incorrect"),
+        }
+    }
+
+    /// Tests reading of a valid rgb_alpha pam
+    #[test]
+    fn pam_rgb_alpha() {
+        let pamdata = b"P7
+WIDTH 1
+HEIGHT 3
+DEPTH 4
+MAXVAL 15
+TUPLTYPE RGB_ALPHA
+# Comment line
+ENDHDR
+\x00\x01\x02\x03\x0a\x0b\x0c\x0d\x05\x06\x07\x08";
+        let decoder = PnmDecoder::new(&pamdata[..]).unwrap();
+        assert_eq!(decoder.color_type(), ColorType::Rgba8);
+        assert_eq!(decoder.original_color_type(), ExtendedColorType::Rgba8);
+        assert_eq!(decoder.dimensions(), (1, 3));
+        assert_eq!(decoder.subtype(), PnmSubtype::ArbitraryMap);
+
+        let mut image = vec![0; decoder.total_bytes() as usize];
+        decoder.read_image(&mut image).unwrap();
+        assert_eq!(image, b"\x00\x11\x22\x33\xaa\xbb\xcc\xdd\x55\x66\x77\x88",);
+        match PnmDecoder::new(&pamdata[..]).unwrap().into_inner() {
+            (
+                _,
+                PnmHeader {
+                    decoded:
+                        HeaderRecord::Arbitrary(ArbitraryHeader {
+                            width: 1,
+                            height: 3,
+                            maxval: 15,
+                            depth: 4,
+                            tupltype: Some(ArbitraryTuplType::RGBAlpha),
                         }),
                     encoded: _,
                 },

--- a/src/codecs/pnm/mod.rs
+++ b/src/codecs/pnm/mod.rs
@@ -1,8 +1,9 @@
 //! Decoding of netpbm image formats (pbm, pgm, ppm and pam).
 //!
-//! The formats pbm, pgm and ppm are fully supported. The pam decoder recognizes the tuple types
-//! `BLACKANDWHITE`, `GRAYSCALE` and `RGB` and explicitly recognizes but rejects their `_ALPHA`
-//! variants for now as alpha color types are unsupported.
+//! The formats pbm, pgm and ppm are fully supported. Only the official subformats
+//! (`BLACKANDWHITE`, `GRAYSCALE`, `RGB`, `BLACKANDWHITE_ALPHA`, `GRAYSCALE_ALPHA`,
+//! and `RGB_ALPHA`) of pam are supported; custom tuple types have no clear
+//! interpretation as an image and will be rejected.
 use self::autobreak::AutoBreak;
 pub use self::decoder::PnmDecoder;
 pub use self::encoder::PnmEncoder;


### PR DESCRIPTION
This implements the transparent tupltypes listed in the PAM spec, at https://netpbm.sourceforge.net/doc/pam.html.

* I am submitting this PR to a) complete PAM format support so that image viewers based on `image` can read all
  reasonably constructable PAM images b) ensure that the `image` crate itself can read all the PAM tuple types that it
  writes. The format technically allows non-RGBA tuple types and depths > 4, but these should be rejected as they
  have no clear interpretation as an image.

* I've only added simple tests in-file for PAM, extending the existing ones, but if desired I can make regression test images.

* Other than by using `image` itself, PAM images with alpha channels can be produced by NetPBM and ImageMagick.
For example:
```
pngtopam -alphapam rgb_alpha.png > pam_rgb_alpha.pam
pngtopam -alphapam gray_alpha.png > pam_grayscale_alpha.pam
convert rgb_alpha.png pam_rgb_alpha.pam
convert gray_alpha.png pam_grayscale_alpha.pam
convert blackandwhite_alpha.png -depth 1 pam_blackandwhite_alpha.pam
```
![rgb_alpha](https://github.com/user-attachments/assets/05bbdce0-07e2-40b9-be10-6a8adf9eedf4)![gray_alpha](https://github.com/user-attachments/assets/f0de9069-c3a2-45dc-bc3d-30b36ec3f274)![blackandwhite_alpha](https://github.com/user-attachments/assets/b6f3b3d0-ab34-47d0-bc08-fa5173a02564)

(Note: `pngtopam` does not produce BLACKANDWHITE_ALPHA; `pamthreshold` can, but isn't general and appears to have bugs; so
ImageMagick's `convert` is the only standard converter which works. On the other hand, going from PAM to PNG,
ImageMagick's `convert` incorrectly flips the alpha channel, while `pamtopng` works correctly.)

* I wasn't able to find detailed documentation on the ColorType memory layout, but assume, based on how the other encoders and decoders handle alpha, that pixel types like `ColorType::Rgba16` are stored unpremultiplied, with native-endian channels in R,G,B,A memory order, and a linear alpha channel. 

