### PR TITLE
Fix missing spaces in JpegDecoder error message

### DIFF
--- a/src/codecs/jpeg/decoder.rs
+++ b/src/codecs/jpeg/decoder.rs
@@ -110,8 +110,8 @@ impl<R: BufRead + Seek> ImageDecoder for JpegDecoder<R> {
             return Err(ImageError::Decoding(DecodingError::new(
                 ImageFormat::Jpeg.into(),
                 format!(
-                    "Length of the decoded data {actual_len}\
-                    doesn't match the advertised dimensions of the image\
+                    "Length of the decoded data {actual_len} \
+                    doesn't match the advertised dimensions of the image \
                     that imply length {advertised_len}"
                 ),
             )));


### PR DESCRIPTION
Fixes this: `Format error decoding Jpeg: Length of the decoded data 201283584doesn't match the advertised dimensions of the imagethat imply length 150962688`
