### PR TITLE
Detect image/vnd.microsoft.icon mime types as ImageFormat::Ico

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -177,7 +177,7 @@ impl ImageFormat {
             "image/x-targa" | "image/x-tga" => Some(ImageFormat::Tga),
             "image/vnd-ms.dds" => Some(ImageFormat::Dds),
             "image/bmp" => Some(ImageFormat::Bmp),
-            "image/x-icon" => Some(ImageFormat::Ico),
+            "image/x-icon" | "image/vnd.microsoft.icon" => Some(ImageFormat::Ico),
             "image/vnd.radiance" => Some(ImageFormat::Hdr),
             "image/x-exr" => Some(ImageFormat::OpenExr),
             "image/x-portable-bitmap"


### PR DESCRIPTION
I just added 'image/vnd.microsoft.icon' as mime for the ImageFormat::Ico format. I think it's a valid mime for this image type ([iana](https://www.iana.org/assignments/media-types/image/vnd.microsoft.icon))

Returning 'icon/x-icon' seems valid during the opposite operation (retrieving a mime from the [ImageFormat](https://github.com/image-rs/image/blob/85f2412d552ddd2f576e16d023fd352589f4c605/src/image.rs#L228)), no change needed here IMO

Context:

I'm using egui_extra to load a bunch of favicons in a UI, there is a loader that forwards image loading to this crate, using the ImageFormat to detect which format to use. Some favicons weren't loading since the mime was 'image/vnd.microsoft.icon'. For the full chain to work properly, a change is also needed in egui_extra though ([PR](https://github.com/emilk/egui/pull/5769))