### PR TITLE
change invert() and add invert_in_place()

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -736,9 +736,15 @@ impl DynamicImage {
     }
 
     /// Invert the colors of this image.
+    /// use [DynamicImage::invert_in_place()] for an in-place version.
+    pub fn invert(&mut self) -> DynamicImage {
+        dynamic_map!(*self, ref p =>  imageops::invert(p))
+    }
+
+    /// Invert the colors of this image.
     /// This method operates inplace.
-    pub fn invert(&mut self) {
-        dynamic_map!(*self, ref mut p, imageops::invert(p));
+    pub fn invert_in_place(&mut self) {
+        dynamic_map!(*self, ref mut p, imageops::invert_in_place(p));
     }
 
     /// Resize this image using the specified filter algorithm.

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -24,7 +24,8 @@ pub use self::sample::{
 /// Color operations
 pub use self::colorops::{
     brighten, contrast, dither, grayscale, grayscale_alpha, grayscale_with_type,
-    grayscale_with_type_alpha, huerotate, index_colors, invert, BiLevel, ColorMap,
+    grayscale_with_type_alpha, huerotate, index_colors, invert, invert_in, invert_in_place,
+    BiLevel, ColorMap,
 };
 
 mod affine;


### PR DESCRIPTION
<!--
We welcome performance optimizations, bug fixes, and documentation improvements.

Feature additions are also welcome, but we encourage you to open an issue first
to discuss whether it is something we want to add.

Thank you for contributing, you can delete this comment.
-->

This PR copy the design of `flip_horizontal` for `invert()`

Invert is the only inplace function

