### PR TITLE
Clippy

### DIFF
--- a/src/codecs/pnm/decoder.rs
+++ b/src/codecs/pnm/decoder.rs
@@ -370,6 +370,7 @@ trait HeaderReader: Read {
         let mut bytes = Vec::new();
 
         // pair input bytes with a bool mask to remove comments
+        #[allow(clippy::unbuffered_bytes)]
         let mark_comments = self.bytes().scan(true, |partof, read| {
             let byte = match read {
                 Err(err) => return Some((*partof, Err(err))),
@@ -489,6 +490,7 @@ trait HeaderReader: Read {
             }
         }
 
+        #[allow(clippy::unbuffered_bytes)]
         match self.bytes().next() {
             None => return Err(ImageError::IoError(io::ErrorKind::UnexpectedEof.into())),
             Some(Err(io)) => return Err(ImageError::IoError(io)),
@@ -688,6 +690,7 @@ fn read_separated_ascii<T: TryFrom<u16>>(reader: &mut dyn Read) -> ImageResult<T
     let is_separator = |v: &u8| matches!(*v, b'\t' | b'\n' | b'\x0b' | b'\x0c' | b'\r' | b' ');
 
     let mut v: u16 = 0;
+    #[allow(clippy::unbuffered_bytes)]
     for rc in reader
         .bytes()
         .skip_while(|v| v.as_ref().ok().is_some_and(is_separator))
@@ -763,6 +766,7 @@ impl Sample for PbmBit {
     }
 
     fn from_ascii(reader: &mut dyn Read, output_buf: &mut [u8]) -> ImageResult<()> {
+        #[allow(clippy::unbuffered_bytes)]
         let mut bytes = reader.bytes();
         for b in output_buf {
             loop {


### PR DESCRIPTION
The new version of Clippy started suggesting changing Read to BufRead, but since there is a trait, I believe this suggestion is not applicable.

```rust
warning: calling .bytes() is very inefficient when data is not in memory
   --> src/codecs/pnm/decoder.rs:767:25
    |
767 |         let mut bytes = reader.bytes();
    |                         ^^^^^^^^^^^^^^
    |
    = help: consider using `BufReader`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unbuffered_bytes
```