### PR TITLE
Error if we don't actually see any data in read_separated_ascii

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,7 +12,7 @@ cargo-fuzz = true
 [dependencies.image]
 path = ".."
 [dependencies.libfuzzer-sys]
-version = "0.3"
+version = "0.4"
 
 # Prevent this from interfering with workspaces
 [workspace]


### PR DESCRIPTION
Without this, trying to parse a claimed-large image will just fill it with zeros, but not actually *fail*.

I guess this is *technically* a compat break in the sense that truncated images won't parse now, but I don't think that's really a problem.