### PR TITLE
Expose `enlargeable` trait

### DIFF
--- a/src/codecs/avif/encoder.rs
+++ b/src/codecs/avif/encoder.rs
@@ -18,7 +18,7 @@ use crate::{ImageError, ImageResult};
 
 use bytemuck::{try_cast_slice, try_cast_slice_mut, Pod, PodCastError};
 use num_traits::Zero;
-use ravif::{Encoder, Img, RGB8, RGBA8};
+use ravif::{BitDepth, Encoder, Img, RGB8, RGBA8};
 use rgb::AsPixels;
 
 /// AVIF Encoder.
@@ -72,7 +72,7 @@ impl<W: Write> AvifEncoder<W> {
             .with_quality(f32::from(quality))
             .with_alpha_quality(f32::from(quality))
             .with_speed(speed)
-            .with_depth(Some(8));
+            .with_bit_depth(BitDepth::Eight);
 
         AvifEncoder { inner: w, encoder }
     }
@@ -81,7 +81,7 @@ impl<W: Write> AvifEncoder<W> {
     pub fn with_colorspace(mut self, color_space: ColorSpace) -> Self {
         self.encoder = self
             .encoder
-            .with_internal_color_space(color_space.to_ravif());
+            .with_internal_color_model(color_space.to_ravif());
         self
     }
 

--- a/src/codecs/avif/encoder.rs
+++ b/src/codecs/avif/encoder.rs
@@ -18,7 +18,7 @@ use crate::{ImageError, ImageResult};
 
 use bytemuck::{try_cast_slice, try_cast_slice_mut, Pod, PodCastError};
 use num_traits::Zero;
-use ravif::{BitDepth, Encoder, Img, RGB8, RGBA8};
+use ravif::{Encoder, Img, RGB8, RGBA8};
 use rgb::AsPixels;
 
 /// AVIF Encoder.
@@ -72,7 +72,7 @@ impl<W: Write> AvifEncoder<W> {
             .with_quality(f32::from(quality))
             .with_alpha_quality(f32::from(quality))
             .with_speed(speed)
-            .with_bit_depth(BitDepth::Eight);
+            .with_depth(Some(8));
 
         AvifEncoder { inner: w, encoder }
     }
@@ -81,7 +81,7 @@ impl<W: Write> AvifEncoder<W> {
     pub fn with_colorspace(mut self, color_space: ColorSpace) -> Self {
         self.encoder = self
             .encoder
-            .with_internal_color_model(color_space.to_ravif());
+            .with_internal_color_space(color_space.to_ravif());
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@ pub use crate::buffer_::{
 pub use crate::flat::FlatSamples;
 
 // Traits
-pub use crate::traits::{EncodableLayout, Pixel, PixelWithColorType, Primitive};
+pub use crate::traits::{EncodableLayout, Enlargeable, Pixel, PixelWithColorType, Primitive};
 
 // Opening and loading images
 pub use crate::dynimage::{

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -76,7 +76,7 @@ pub trait Enlargeable: Sized + Bounded + NumCast {
     type Larger: Copy + NumCast + Num + PartialOrd<Self::Larger> + Clone + Bounded + AddAssign;
 
     /// Convert `Larger` type  to `Self` type.
-    /// Clamp values exeed the max value and min value of `Self` type.
+    /// Clamp value that exceeds the max value and min value of `Self` type.
     fn clamp_from(n: Self::Larger) -> Self {
         if n > Self::max_value().to_larger() {
             Self::max_value()

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -71,8 +71,12 @@ declare_primitive!(f64: (0.0)..1.0);
 /// An `Enlargable::Larger` value should be enough to calculate
 /// the sum (average) of a few hundred or thousand Enlargeable values.
 pub trait Enlargeable: Sized + Bounded + NumCast {
+    /// A type with larger capacity to calculate
+    /// the sum (average) of a few hundred or thousand Enlargeable values.
     type Larger: Copy + NumCast + Num + PartialOrd<Self::Larger> + Clone + Bounded + AddAssign;
 
+    /// Convert `Larger` type  to `Self` type.
+    /// Clamp values exeed the max value and min value of `Self` type.
     fn clamp_from(n: Self::Larger) -> Self {
         if n > Self::max_value().to_larger() {
             Self::max_value()
@@ -83,6 +87,7 @@ pub trait Enlargeable: Sized + Bounded + NumCast {
         }
     }
 
+    /// Convert `Self` type to `Larger` type.
     fn to_larger(self) -> Self::Larger {
         NumCast::from(self).unwrap()
     }


### PR DESCRIPTION
This trait will allow user to restrict type or extend the `T` in `Rgb<T: Primitive Enlargeable>` and `Rgba<T: Primitive Enlargeable>`.

## example1

A simple example for allowing restrict type.

```rust
pub trait  MyPrimitive:
    image::Primitive + image::Enlargeable
{}
impl MyPrimitivefor u8 {}
impl MyPrimitivefor u16 {}
// This function only allow 8bit or 16bit image as input.
pub fn process<T>(src: &image::ImageBuffer<image::Rgb<T>, Vec<T>>)
{
    todo!();
}
```

## example2

This is what I used in camera raw image processing with `libraw`. `libraw` gives a pointer that could convert to u16 rgba (representing R,G,B,G2 pixel in sensor) imagebuffer after `raw2image()` and `subtract_black()`. But in custom raw image post processing for those camera with standard bayer sensor, knowing CFA pattern and a grayscale bayer image is satisfied and could reduce the memory usage.

```rust
pub trait  BayerPrimitive :
    image::Primitive + image::Enlargeable + std::marker::Send + std::marker::Sync
{}
impl BayerPrimitive for u16 {}
impl BayerPrimitive for f32 {}
// This function only allow 16bit or f32 image as output.
// 16bit for general photographic workflow.
// 32bit for calibration and analysis purpose.
// Other types like i32 which have negative values are not prctical for photographic workflow.
pub fn extract_bayer<T>(src: &image::ImageBuffer<image::Rgba<u16>, Vec<u16>>)
->&image::ImageBuffer<image::Rgb<T>, Vec<T>>
{
    let dst = ImageBuffer::from_par_fn(raw_img.width(), raw_img.height(), |x, y| {
            let pixel = raw_img.get_pixel(x, y);
            // Extract the max value in pixel and convert it to `T` type.
            // `T::from()` require the `T` impl `Send` and `Sync` trait.
            let value = T::from(pixel[0].max(pixel[1]).max(pixel[2]).max(pixel[3])).unwrap();
            image::Luma::<T>([value])
        });
    dst
}
```

