### PR TITLE
Update `ravif` to v0.11.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ image-webp = { version = "0.2.0", optional = true }
 mp4parse = { version = "0.17.0", optional = true }
 png = { version = "0.17.11", optional = true }
 qoi = { version = "0.4", optional = true }
-ravif = { version = "0.11.11", default-features = false, optional = true }
+ravif = { version = "0.11.12", default-features = false, optional = true }
 rayon = { version = "1.7.0", optional = true }
 rgb = { version = "0.8.48", default-features = false, optional = true }
 tiff = { version = "0.9.0", optional = true }

--- a/src/codecs/avif/encoder.rs
+++ b/src/codecs/avif/encoder.rs
@@ -18,7 +18,7 @@ use crate::{ImageError, ImageResult};
 
 use bytemuck::{try_cast_slice, try_cast_slice_mut, Pod, PodCastError};
 use num_traits::Zero;
-use ravif::{Encoder, Img, RGB8, RGBA8};
+use ravif::{BitDepth, Encoder, Img, RGB8, RGBA8};
 use rgb::AsPixels;
 
 /// AVIF Encoder.
@@ -72,7 +72,7 @@ impl<W: Write> AvifEncoder<W> {
             .with_quality(f32::from(quality))
             .with_alpha_quality(f32::from(quality))
             .with_speed(speed)
-            .with_depth(Some(8));
+            .with_bit_depth(BitDepth::Eight);
 
         AvifEncoder { inner: w, encoder }
     }
@@ -81,7 +81,7 @@ impl<W: Write> AvifEncoder<W> {
     pub fn with_colorspace(mut self, color_space: ColorSpace) -> Self {
         self.encoder = self
             .encoder
-            .with_internal_color_space(color_space.to_ravif());
+            .with_internal_color_model(color_space.to_ravif());
         self
     }
 


### PR DESCRIPTION
The latest version of `ravif` was published 2 days ago, and it deprecated certain APIs. Since `image` uses `#![deny(deprecated)]`, this causes CI to fail, as can be seen in recent PRs.

This PR fixes this by updating `ravif` to the latest version and using the new APIs.

---

If updating `ravif` is **not** wanted, I can also make a PR that just `#[allow]`s the now deprecated APIs to pass CI.