### PR TITLE
Add PrimitiveExt trait

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -2,7 +2,7 @@ use std::ops::{Index, IndexMut};
 
 use num_traits::{NumCast, ToPrimitive, Zero};
 
-use crate::traits::{Enlargeable, Pixel, Primitive};
+use crate::traits::{Pixel, Primitive, PrimitiveExt};
 
 /// An enumeration over supported color types and bit depths
 #[derive(Copy, PartialEq, Eq, Debug, Clone, Hash)]
@@ -411,11 +411,11 @@ define_colors! {
     ///
     /// For the purpose of color conversion, as well as blending, the implementation of `Pixel`
     /// assumes an `sRGB` color space of its data.
-    pub struct Rgb<T: Primitive Enlargeable>([T; 3, 0]) = "RGB";
+    pub struct Rgb<T: PrimitiveExt>([T; 3, 0]) = "RGB";
     /// Grayscale colors.
     pub struct Luma<T: Primitive>([T; 1, 0]) = "Y";
     /// RGB colors + alpha channel
-    pub struct Rgba<T: Primitive Enlargeable>([T; 4, 1]) = "RGBA";
+    pub struct Rgba<T: PrimitiveExt>([T; 4, 1]) = "RGBA";
     /// Grayscale colors + alpha channel
     pub struct LumaA<T: Primitive>([T; 2, 1]) = "YA";
 }
@@ -532,7 +532,7 @@ const SRGB_LUMA: [u32; 3] = [2126, 7152, 722];
 const SRGB_LUMA_DIV: u32 = 10000;
 
 #[inline]
-fn rgb_to_luma<T: Primitive + Enlargeable>(rgb: &[T]) -> T {
+fn rgb_to_luma<T: PrimitiveExt>(rgb: &[T]) -> T {
     let l = <T::Larger as NumCast>::from(SRGB_LUMA[0]).unwrap() * rgb[0].to_larger()
         + <T::Larger as NumCast>::from(SRGB_LUMA[1]).unwrap() * rgb[1].to_larger()
         + <T::Larger as NumCast>::from(SRGB_LUMA[2]).unwrap() * rgb[2].to_larger();
@@ -560,7 +560,7 @@ where
     }
 }
 
-impl<S: Primitive + Enlargeable, T: Primitive> FromColor<Rgb<S>> for Luma<T>
+impl<S: PrimitiveExt, T: Primitive> FromColor<Rgb<S>> for Luma<T>
 where
     T: FromPrimitive<S>,
 {
@@ -571,7 +571,7 @@ where
     }
 }
 
-impl<S: Primitive + Enlargeable, T: Primitive> FromColor<Rgba<S>> for Luma<T>
+impl<S: PrimitiveExt, T: Primitive> FromColor<Rgba<S>> for Luma<T>
 where
     T: FromPrimitive<S>,
 {
@@ -597,7 +597,7 @@ where
     }
 }
 
-impl<S: Primitive + Enlargeable, T: Primitive> FromColor<Rgb<S>> for LumaA<T>
+impl<S: PrimitiveExt, T: Primitive> FromColor<Rgb<S>> for LumaA<T>
 where
     T: FromPrimitive<S>,
 {
@@ -609,7 +609,7 @@ where
     }
 }
 
-impl<S: Primitive + Enlargeable, T: Primitive> FromColor<Rgba<S>> for LumaA<T>
+impl<S: Primitive + PrimitiveExt, T: Primitive> FromColor<Rgba<S>> for LumaA<T>
 where
     T: FromPrimitive<S>,
 {

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -10,7 +10,7 @@ use num_traits::{NumCast, ToPrimitive, Zero};
 use serde::{Deserialize, Serialize};
 
 use crate::image::{GenericImage, GenericImageView};
-use crate::traits::{Enlargeable, Pixel, Primitive};
+use crate::traits::{Pixel, Primitive, PrimitiveExt};
 use crate::utils::clamp;
 use crate::{ImageBuffer, Rgba32FImage};
 
@@ -559,9 +559,9 @@ where
 }
 
 /// Local struct for keeping track of pixel sums for fast thumbnail averaging
-struct ThumbnailSum<S: Primitive + Enlargeable>(S::Larger, S::Larger, S::Larger, S::Larger);
+struct ThumbnailSum<S: PrimitiveExt>(S::Larger, S::Larger, S::Larger, S::Larger);
 
-impl<S: Primitive + Enlargeable> ThumbnailSum<S> {
+impl<S: PrimitiveExt> ThumbnailSum<S> {
     fn zeroed() -> Self {
         ThumbnailSum(
             S::Larger::zero(),
@@ -601,7 +601,7 @@ pub fn thumbnail<I, P, S>(image: &I, new_width: u32, new_height: u32) -> ImageBu
 where
     I: GenericImageView<Pixel = P>,
     P: Pixel<Subpixel = S> + 'static,
-    S: Primitive + Enlargeable + 'static,
+    S: PrimitiveExt + 'static,
 {
     let (width, height) = image.dimensions();
     let mut out = ImageBuffer::new(new_width, new_height);
@@ -690,7 +690,7 @@ fn thumbnail_sample_block<I, P, S>(
 where
     I: GenericImageView<Pixel = P>,
     P: Pixel<Subpixel = S>,
-    S: Primitive + Enlargeable,
+    S: PrimitiveExt,
 {
     let mut sum = ThumbnailSum::zeroed();
 
@@ -722,7 +722,7 @@ fn thumbnail_sample_fraction_horizontal<I, P, S>(
 where
     I: GenericImageView<Pixel = P>,
     P: Pixel<Subpixel = S>,
-    S: Primitive + Enlargeable,
+    S: PrimitiveExt,
 {
     let fract = fraction_horizontal;
 
@@ -766,7 +766,7 @@ fn thumbnail_sample_fraction_vertical<I, P, S>(
 where
     I: GenericImageView<Pixel = P>,
     P: Pixel<Subpixel = S>,
-    S: Primitive + Enlargeable,
+    S: PrimitiveExt,
 {
     let fract = fraction_vertical;
 
@@ -808,7 +808,7 @@ fn thumbnail_sample_fraction_both<I, P, S>(
 where
     I: GenericImageView<Pixel = P>,
     P: Pixel<Subpixel = S>,
-    S: Primitive + Enlargeable,
+    S: PrimitiveExt,
 {
     #[allow(deprecated)]
     let k_bl = image.get_pixel(left, bottom).channels4();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@ pub use crate::buffer_::{
 pub use crate::flat::FlatSamples;
 
 // Traits
-pub use crate::traits::{EncodableLayout, Pixel, PixelWithColorType, Primitive};
+pub use crate::traits::{EncodableLayout, Pixel, PixelWithColorType, Primitive, PrimitiveExt};
 
 // Opening and loading images
 pub use crate::dynimage::{

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -51,6 +51,7 @@ macro_rules! declare_primitive {
             const DEFAULT_MAX_VALUE: Self = $to;
             const DEFAULT_MIN_VALUE: Self = $from;
         }
+        impl PrimitiveExt for $base {}
     };
 }
 
@@ -67,6 +68,12 @@ declare_primitive!(i32: (Self::MIN)..Self::MAX);
 declare_primitive!(i64: (Self::MIN)..Self::MAX);
 declare_primitive!(f32: (0.0)..1.0);
 declare_primitive!(f64: (0.0)..1.0);
+
+/// A sealed version of the `Primitive` trait.
+///
+/// In a future version, this trait will likely removed and the `Primitive` trait itself switched to
+/// being sealed.
+pub trait PrimitiveExt: Primitive + Enlargeable {}
 
 /// An `Enlargable::Larger` value should be enough to calculate
 /// the sum (average) of a few hundred or thousand Enlargeable values.


### PR DESCRIPTION
Users cannot currently write their own generic methods that call methods bounded by the (not publicly exported) `Enlargeable` trait. Rather than making that trait public and thus exposing its methods and associated type to users as #2451 proposed, this PR experiments with adding a new sealed trait `PrimitiveExt` that extends `Enlargeable` but has no methods of its own.

This is a intended as stopgap measure since we cannot make `Primitive` a sealed trait until doing another breaking release. 