### PR TITLE
Don't use deprecated `ravif::ColorSpace`

### DIFF
--- a/src/codecs/avif/encoder.rs
+++ b/src/codecs/avif/encoder.rs
@@ -40,10 +40,10 @@ pub enum ColorSpace {
 }
 
 impl ColorSpace {
-    fn to_ravif(self) -> ravif::ColorSpace {
+    fn to_ravif(self) -> ravif::ColorModel {
         match self {
-            Self::Srgb => ravif::ColorSpace::RGB,
-            Self::Bt709 => ravif::ColorSpace::YCbCr,
+            Self::Srgb => ravif::ColorModel::RGB,
+            Self::Bt709 => ravif::ColorModel::YCbCr,
         }
     }
 }


### PR DESCRIPTION
This is a continuation of #2452.

After a good night's sleep, I remembered that seeing commits in `ravif` that deprecated not just `with_internal_color_space` (which was addressed in #2452) but also the `ColorSpace` type itself (now renamed to `ColorModel`). For whatever reason, Rust sometimes silently ignores `#[deprecated]` attributes and doesn't issue any warnings for them. See https://github.com/kornelski/cavif-rs/issues/99 for more details.

This PR removes the use of the deprecated `ColorSpace` name and uses `ColorModel` instead. This should prevent future CI failures when later versions of `ravif` deprecate `ColorSpace` in a way Rust knows how to detect.