### PR TITLE
Minor improvements to documentation

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -691,7 +691,7 @@ pub trait ImageDecoder {
     ///
     /// # Examples
     ///
-    /// ```rust,no_build
+    /// ```ignore
     /// use zerocopy::IntoBytes;
     /// fn read_16bit_image(decoder: impl ImageDecoder) -> Vec<u16> {
     ///     let mut buf: Vec<u16> = vec![0; decoder.total_bytes() / 2];
@@ -726,10 +726,10 @@ pub trait ImageDecoder {
     ///
     /// Note to implementors: This method should be implemented by calling `read_image` on
     /// the boxed decoder...
-    /// ```rust,no_build
-    ///     fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
-    ///        (*self).read_image(buf)
-    ///    }
+    /// ```ignore
+    /// fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
+    ///     (*self).read_image(buf)
+    /// }
     /// ```
     fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()>;
 }

--- a/src/image.rs
+++ b/src/image.rs
@@ -680,9 +680,10 @@ pub trait ImageDecoder {
     /// Returns all the bytes in the image.
     ///
     /// This function takes a slice of bytes and writes the pixel data of the image into it.
-    /// Although not required, for certain color types callers may want to pass buffers which are
-    /// aligned to 2 or 4 byte boundaries to the slice can be cast to a [u16] or [u32]. To accommodate
-    /// such casts, the returned contents will always be in native endian.
+    /// While no specific alignment is required for `buf`, for certain color types callers
+    /// may want to pass buffers which are aligned to 2 or 4 byte boundaries so the slice can
+    /// be cast to `[u16]` or `[u32]` for improved performance. To accommodate such casts,
+    /// the returned contents will always be in native endian.
     ///
     /// # Panics
     ///
@@ -690,11 +691,11 @@ pub trait ImageDecoder {
     ///
     /// # Examples
     ///
-    /// ```no_build
-    /// use zerocopy::{AsBytes, FromBytes};
-    /// fn read_16bit_image(decoder: impl ImageDecoder) -> Vec<16> {
-    ///     let mut buf: Vec<u16> = vec![0; decoder.total_bytes()/2];
-    ///     decoder.read_image(buf.as_bytes());
+    /// ```rust,no_build
+    /// use zerocopy::IntoBytes;
+    /// fn read_16bit_image(decoder: impl ImageDecoder) -> Vec<u16> {
+    ///     let mut buf: Vec<u16> = vec![0; decoder.total_bytes() / 2];
+    ///     decoder.read_image(buf.as_mut_bytes());
     ///     buf
     /// }
     /// ```
@@ -725,7 +726,7 @@ pub trait ImageDecoder {
     ///
     /// Note to implementors: This method should be implemented by calling `read_image` on
     /// the boxed decoder...
-    /// ```no_build
+    /// ```rust,no_build
     ///     fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
     ///        (*self).read_image(buf)
     ///    }
@@ -797,13 +798,9 @@ pub trait ImageEncoder {
     /// Writes all the bytes in an image to the encoder.
     ///
     /// This function takes a slice of bytes of the pixel data of the image
-    /// and encodes them. Unlike particular format encoders inherent impl encode
-    /// methods where endianness is not specified, here image data bytes should
-    /// always be in native endian. The implementor will reorder the endianness
-    /// as necessary for the target encoding format.
-    ///
-    /// See also `ImageDecoder::read_image` which reads byte buffers into
-    /// native endian.
+    /// and encodes them. Just like for [`ImageDecoder::read_image`], no particular
+    /// alignment is required and data is expected to be in native endian.
+    /// The implementor will reorder the endianness as necessary for the target encoding format.
     ///
     /// # Panics
     ///

--- a/src/image.rs
+++ b/src/image.rs
@@ -800,7 +800,7 @@ pub trait ImageEncoder {
     /// This function takes a slice of bytes of the pixel data of the image
     /// and encodes them. Just like for [`ImageDecoder::read_image`], no particular
     /// alignment is required and data is expected to be in native endian.
-    /// The implementor will reorder the endianness as necessary for the target encoding format.
+    /// The implementation will reorder the endianness as necessary for the target encoding format.
     ///
     /// # Panics
     ///

--- a/src/image.rs
+++ b/src/image.rs
@@ -691,11 +691,11 @@ pub trait ImageDecoder {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// use zerocopy::IntoBytes;
+    /// ```
+    /// # use image::ImageDecoder;
     /// fn read_16bit_image(decoder: impl ImageDecoder) -> Vec<u16> {
-    ///     let mut buf: Vec<u16> = vec![0; decoder.total_bytes() / 2];
-    ///     decoder.read_image(buf.as_mut_bytes());
+    ///     let mut buf: Vec<u16> = vec![0; (decoder.total_bytes() / 2) as usize];
+    ///     decoder.read_image(bytemuck::cast_slice_mut(&mut buf));
     ///     buf
     /// }
     /// ```

--- a/src/image.rs
+++ b/src/image.rs
@@ -680,10 +680,12 @@ pub trait ImageDecoder {
     /// Returns all the bytes in the image.
     ///
     /// This function takes a slice of bytes and writes the pixel data of the image into it.
-    /// While no specific alignment is required for `buf`, for certain color types callers
-    /// may want to pass buffers which are aligned to 2 or 4 byte boundaries so the slice can
-    /// be cast to `[u16]` or `[u32]` for improved performance. To accommodate such casts,
-    /// the returned contents will always be in native endian.
+    /// `buf` does not need to be aligned to any byte boundaries. However,
+    /// alignment to 2 or 4 byte boundaries may result in small performance
+    /// improvements for certain decoder implementations.
+    ///
+    /// The returned pixel data will always be in native endian. This allows
+    /// `[u16]` and `[f32]` slices to be cast to `[u8]` and used for this method.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
Changes:

- I rephrased certain sections to make it a bit clearer that there are no alignment requirements for `buf`.
- Example code now gets syntax highlighting.
- I fixed the example for `ImageDecoder::read_image`. It now actually works. (It might be worth taking zerocopy as a dev dependency just to run doc tests for example like this. Thoughts?)