### PR TITLE
Add `no_std` Support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -207,3 +207,15 @@ jobs:
         with:
           feature-group: default-features
           release-type: minor
+
+  clippy_no_std:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy
+        targets: "wasm32v1-none"
+    - run: cargo clippy --no-default-features --target wasm32v1-none --features serde -- -D warnings
+      env:
+        SYSTEM_DEPS_DAV1D_BUILD_INTERNAL: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,14 +38,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: ["1.70.0", nightly, beta]
+        rust: ["1.81.0", nightly, beta]
     steps:
     - uses: actions/checkout@v4
 
     - uses: dtolnay/rust-toolchain@nightly
-      if: ${{ matrix.rust == '1.70.0' }}
+      if: ${{ matrix.rust == '1.81.0' }}
     - name: Generate Cargo.lock with minimal-version dependencies
-      if: ${{ matrix.rust == '1.70.0' }}
+      if: ${{ matrix.rust == '1.81.0' }}
       run: cargo -Zminimal-versions generate-lockfile
 
     - uses: dtolnay/rust-toolchain@v1
@@ -58,7 +58,7 @@ jobs:
     - name: build
       run: cargo build -v
     - name: test
-      if: ${{ matrix.rust != '1.70.0' }}
+      if: ${{ matrix.rust != '1.81.0' }}
       run: cargo test -v && cargo doc -v
 
   test_other_archs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 resolver = "2"
 
 # note: when changed, also update test runner in `.github/workflows/rust.yml`
-rust-version = "1.70.0"
+rust-version = "1.81.0"
 
 license = "MIT OR Apache-2.0"
 description = "Imaging library. Provides basic image processing and encoders/decoders for common image formats."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ avif-native = ["dep:mp4parse", "dep:dav1d", "std"] # Enable native dependency li
 benchmarks = ["std"] # Build some inline benchmarks. Useful only during development (requires nightly Rust)
 serde = ["dep:serde"]
 std = ["byteorder-lite/std", "num-traits/std"]
+libm = ["num-traits/libm"]
 
 [[bench]]
 path = "benches/decode.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 bytemuck = { version = "1.8.0", features = ["extern_crate_alloc"] } # includes cast_vec
-byteorder-lite = "0.1.0"
-num-traits = { version = "0.2.0" }
+byteorder-lite = { version = "0.1.0", default-features = false }
+num-traits = { version = "0.2.0", default-features = false }
 
 # Optional dependencies
 color_quant = { version = "1.1", optional = true }
@@ -54,7 +54,7 @@ rgb = { version = "0.8.48", default-features = false, optional = true }
 tiff = { version = "0.9.0", optional = true }
 zune-core = { version = "0.4.12", default-features = false, optional = true }
 zune-jpeg = { version = "0.4.13", optional = true }
-serde = { version = "1.0.214", optional = true, features = ["derive"] }
+serde = { version = "1.0.214", default-features = false, optional = true, features = ["derive"] }
 
 [dev-dependencies]
 crc32fast = "1.2.0"
@@ -64,33 +64,34 @@ quickcheck = "1"
 criterion = "0.5.0"
 
 [features]
-default = ["rayon", "default-formats"]
+default = ["std", "rayon", "default-formats"]
 
 # Format features
 default-formats = ["avif", "bmp", "dds", "exr", "ff", "gif", "hdr", "ico", "jpeg", "png", "pnm", "qoi", "tga", "tiff", "webp"]
-avif = ["dep:ravif", "dep:rgb"]
-bmp = []
-dds = []
-exr = ["dep:exr"]
-ff = [] # Farbfeld image format
-gif = ["dep:gif", "dep:color_quant"]
-hdr = []
-ico = ["bmp", "png"]
-jpeg = ["dep:zune-core", "dep:zune-jpeg"]
-png = ["dep:png"]
-pnm = []
-qoi = ["dep:qoi"]
-tga = []
-tiff = ["dep:tiff"]
-webp = ["dep:image-webp"]
+avif = ["dep:ravif", "dep:rgb", "std"]
+bmp = ["std"]
+dds = ["std"]
+exr = ["dep:exr", "std"]
+ff = ["std"] # Farbfeld image format
+gif = ["dep:gif", "dep:color_quant", "std"]
+hdr = ["std"]
+ico = ["bmp", "png", "std"]
+jpeg = ["dep:zune-core", "dep:zune-jpeg", "std"]
+png = ["dep:png", "std"]
+pnm = ["std"]
+qoi = ["dep:qoi", "std"]
+tga = ["std"]
+tiff = ["dep:tiff", "std"]
+webp = ["dep:image-webp", "std"]
 
 # Other features
-rayon = ["dep:rayon", "ravif?/threading"] # Enables multi-threading
-nasm = ["ravif?/asm"] # Enables use of nasm by rav1e (requires nasm to be installed)
-color_quant = ["dep:color_quant"] # Enables color quantization
-avif-native = ["dep:mp4parse", "dep:dav1d"] # Enable native dependency libdav1d
-benchmarks = [] # Build some inline benchmarks. Useful only during development (requires nightly Rust)
+rayon = ["dep:rayon", "ravif?/threading", "std"] # Enables multi-threading
+nasm = ["ravif?/asm", "std"] # Enables use of nasm by rav1e (requires nasm to be installed)
+color_quant = ["dep:color_quant", "std"] # Enables color quantization
+avif-native = ["dep:mp4parse", "dep:dav1d", "std"] # Enable native dependency libdav1d
+benchmarks = ["std"] # Build some inline benchmarks. Useful only during development (requires nightly Rust)
 serde = ["dep:serde"]
+std = ["byteorder-lite/std", "num-traits/std"]
 
 [[bench]]
 path = "benches/decode.rs"

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -1,5 +1,7 @@
-use std::cmp::Ordering;
-use std::time::Duration;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+use core::time::Duration;
 
 use crate::error::ImageResult;
 use crate::RgbaImage;
@@ -152,7 +154,7 @@ impl Delay {
     /// # Examples
     ///
     /// ```
-    /// use std::time::Duration;
+    /// use core::time::Duration;
     /// use image::Delay;
     ///
     /// let duration = Duration::from_millis(20);
@@ -206,7 +208,7 @@ impl Delay {
     /// Note that `denom_bound` bounds nominator and denominator of all intermediate
     /// approximations and the end result.
     fn closest_bounded_fraction(denom_bound: u32, nom: u32, denom: u32) -> (u32, u32) {
-        use std::cmp::Ordering::*;
+        use core::cmp::Ordering::*;
         assert!(0 < denom);
         assert!(0 < denom_bound);
         assert!(nom < denom);

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -10,6 +10,7 @@ use num_traits::Zero;
 use crate::color::{FromColor, Luma, LumaA, Rgb, Rgba};
 use crate::error::ImageResult;
 use crate::flat::{FlatSamples, SampleLayout};
+#[cfg_attr(not(feature = "std"), expect(unused_imports))]
 use crate::image::ImageFormat;
 use crate::image::{GenericImage, GenericImageView, ImageEncoder};
 use crate::math::Rect;

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,20 +1,26 @@
 //! Contains the generic `ImageBuffer` struct.
+use alloc::vec;
+use alloc::vec::Vec;
+use core::fmt;
+use core::marker::PhantomData;
+use core::ops::{Deref, DerefMut, Index, IndexMut, Range};
+use core::slice::{ChunksExact, ChunksExactMut};
 use num_traits::Zero;
-use std::fmt;
-use std::marker::PhantomData;
-use std::ops::{Deref, DerefMut, Index, IndexMut, Range};
-use std::path::Path;
-use std::slice::{ChunksExact, ChunksExactMut};
 
 use crate::color::{FromColor, Luma, LumaA, Rgb, Rgba};
-use crate::dynimage::{save_buffer, save_buffer_with_format, write_buffer_with_format};
 use crate::error::ImageResult;
 use crate::flat::{FlatSamples, SampleLayout};
-use crate::image::{GenericImage, GenericImageView, ImageEncoder, ImageFormat};
+use crate::image::ImageFormat;
+use crate::image::{GenericImage, GenericImageView, ImageEncoder};
 use crate::math::Rect;
 use crate::traits::{EncodableLayout, Pixel, PixelWithColorType};
 use crate::utils::expand_packed;
 use crate::DynamicImage;
+
+#[cfg(feature = "std")]
+use crate::dynimage::{save_buffer, save_buffer_with_format, write_buffer_with_format};
+#[cfg(feature = "std")]
+use std::path::Path;
 
 /// Iterate over pixel refs.
 pub struct Pixels<'a, P: Pixel + 'a>
@@ -993,6 +999,7 @@ where
     /// Saves the buffer to a file at the path specified.
     ///
     /// The image format is derived from the file extension.
+    #[cfg(feature = "std")]
     pub fn save<Q>(&self, path: Q) -> ImageResult<()>
     where
         Q: AsRef<Path>,
@@ -1019,6 +1026,7 @@ where
     ///
     /// See [`save_buffer_with_format`](fn.save_buffer_with_format.html) for
     /// supported types.
+    #[cfg(feature = "std")]
     pub fn save_with_format<Q>(&self, path: Q, format: ImageFormat) -> ImageResult<()>
     where
         Q: AsRef<Path>,
@@ -1046,6 +1054,7 @@ where
     ///
     /// Assumes the writer is buffered. In most cases, you should wrap your writer in a `BufWriter`
     /// for best performance.
+    #[cfg(feature = "std")]
     pub fn write_to<W>(&self, writer: &mut W, format: ImageFormat) -> ImageResult<()>
     where
         W: std::io::Write + std::io::Seek,
@@ -1715,7 +1724,7 @@ mod test {
 
     #[test]
     fn exact_size_iter_size_hint() {
-        // The docs for `std::iter::ExactSizeIterator` requires that the implementation of
+        // The docs for `core::iter::ExactSizeIterator` requires that the implementation of
         // `size_hint` on the iterator returns the same value as the `len` implementation.
 
         // This test should work for any size image.

--- a/src/buffer_par.rs
+++ b/src/buffer_par.rs
@@ -1,8 +1,9 @@
+use alloc::vec::Vec;
+use core::fmt;
+use core::ops::{Deref, DerefMut};
 use rayon::iter::plumbing::*;
 use rayon::iter::{IndexedParallelIterator, ParallelIterator};
 use rayon::slice::{ChunksExact, ChunksExactMut, ParallelSlice, ParallelSliceMut};
-use std::fmt;
-use std::ops::{Deref, DerefMut};
 
 use crate::traits::Pixel;
 use crate::ImageBuffer;
@@ -430,7 +431,7 @@ mod test {
     #[test]
     fn iter_parity() {
         let mut image1 = RgbImage::from_fn(17, 29, |x, y| {
-            Rgb(std::array::from_fn(|i| {
+            Rgb(core::array::from_fn(|i| {
                 ((x + y * 98 + i as u32 * 27) % 255) as u8
             }))
         });
@@ -487,9 +488,9 @@ mod benchmarks {
     }
 
     fn pixel_func() -> Rgb<u8> {
+        use core::hash::{BuildHasher, Hasher};
         use std::collections::hash_map::RandomState;
-        use std::hash::{BuildHasher, Hasher};
-        Rgb(std::array::from_fn(|_| {
+        Rgb(core::array::from_fn(|_| {
             RandomState::new().build_hasher().finish() as u8
         }))
     }

--- a/src/codecs/avif/decoder.rs
+++ b/src/codecs/avif/decoder.rs
@@ -8,10 +8,10 @@ use crate::{ColorType, ImageDecoder, ImageError, ImageFormat, ImageResult};
 /// The [AVIF] specification defines an image derivative of the AV1 bitstream, an open video codec.
 ///
 /// [AVIF]: https://aomediacodec.github.io/av1-avif/
-use std::error::Error;
-use std::fmt::{Display, Formatter};
+use core::error::Error;
+use core::fmt::{Display, Formatter};
+use core::marker::PhantomData;
 use std::io::Read;
-use std::marker::PhantomData;
 
 use crate::codecs::avif::yuv::*;
 use dav1d::{PixelLayout, PlanarImageComponent};
@@ -38,7 +38,7 @@ enum AvifDecoderError {
 }
 
 impl Display for AvifDecoderError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             AvifDecoderError::AlphaPlaneFormat(pixel_layout) => match pixel_layout {
                 PixelLayout::I400 => unreachable!("This option must be handled correctly"),
@@ -127,14 +127,14 @@ fn reshape_plane(source: &[u8], stride: usize, width: usize, height: usize) -> V
 }
 
 struct Plane16View<'a> {
-    data: std::borrow::Cow<'a, [u16]>,
+    data: alloc::borrow::Cow<'a, [u16]>,
     stride: usize,
 }
 
 impl Default for Plane16View<'_> {
     fn default() -> Self {
         Plane16View {
-            data: std::borrow::Cow::Owned(vec![]),
+            data: alloc::borrow::Cow::Owned(vec![]),
             stride: 0,
         }
     }
@@ -160,13 +160,13 @@ fn transmute_y_plane16(
     if stride & 1 == 0 {
         match bytemuck::try_cast_slice(plane_ref) {
             Ok(slice) => Plane16View {
-                data: std::borrow::Cow::Borrowed(slice),
+                data: alloc::borrow::Cow::Borrowed(slice),
                 stride: y_plane_stride,
             },
             Err(_) => {
                 shape_y_plane();
                 Plane16View {
-                    data: std::borrow::Cow::Owned(bind_y),
+                    data: alloc::borrow::Cow::Owned(bind_y),
                     stride: y_plane_stride,
                 }
             }
@@ -174,7 +174,7 @@ fn transmute_y_plane16(
     } else {
         shape_y_plane();
         Plane16View {
-            data: std::borrow::Cow::Owned(bind_y),
+            data: alloc::borrow::Cow::Owned(bind_y),
             stride: y_plane_stride,
         }
     }
@@ -209,13 +209,13 @@ fn transmute_chroma_plane16(
     if stride & 1 == 0 {
         match bytemuck::try_cast_slice(plane_ref) {
             Ok(slice) => Plane16View {
-                data: std::borrow::Cow::Borrowed(slice),
+                data: alloc::borrow::Cow::Borrowed(slice),
                 stride: chroma_plane_stride,
             },
             Err(_) => {
                 shape_chroma_plane();
                 Plane16View {
-                    data: std::borrow::Cow::Owned(bind_chroma),
+                    data: alloc::borrow::Cow::Owned(bind_chroma),
                     stride: chroma_plane_stride,
                 }
             }
@@ -223,7 +223,7 @@ fn transmute_chroma_plane16(
     } else {
         shape_chroma_plane();
         Plane16View {
-            data: std::borrow::Cow::Owned(bind_chroma),
+            data: alloc::borrow::Cow::Owned(bind_chroma),
             stride: chroma_plane_stride,
         }
     }

--- a/src/codecs/avif/encoder.rs
+++ b/src/codecs/avif/encoder.rs
@@ -3,10 +3,12 @@
 /// The [AVIF] specification defines an image derivative of the AV1 bitstream, an open video codec.
 ///
 /// [AVIF]: https://aomediacodec.github.io/av1-avif/
-use std::borrow::Cow;
-use std::cmp::min;
+use alloc::borrow::Cow;
+use alloc::vec::Vec;
+use alloc::{format, vec};
+use core::cmp::min;
+use core::mem::size_of;
 use std::io::Write;
-use std::mem::size_of;
 
 use crate::buffer::ConvertBuffer;
 use crate::color::{FromColor, Luma, LumaA, Rgb, Rgba};

--- a/src/codecs/avif/yuv.rs
+++ b/src/codecs/avif/yuv.rs
@@ -1,8 +1,8 @@
 use crate::error::DecodingError;
 use crate::{ImageError, ImageFormat};
+use core::fmt::{Display, Formatter};
+use core::mem::size_of;
 use num_traits::AsPrimitive;
-use std::fmt::{Display, Formatter};
-use std::mem::size_of;
 
 #[derive(Debug, Copy, Clone)]
 /// Representation of inversion matrix
@@ -46,7 +46,7 @@ enum PlaneDefinition {
 }
 
 impl Display for PlaneDefinition {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
         match self {
             PlaneDefinition::Y => f.write_str("Luma"),
             PlaneDefinition::U => f.write_str("U chroma"),
@@ -62,7 +62,7 @@ enum YuvConversionError {
 }
 
 impl Display for YuvConversionError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             YuvConversionError::YuvPlaneSizeMismatch(plane, error_size) => {
                 f.write_fmt(format_args!(
@@ -80,7 +80,7 @@ impl Display for YuvConversionError {
     }
 }
 
-impl std::error::Error for YuvConversionError {}
+impl core::error::Error for YuvConversionError {}
 
 #[inline]
 fn check_yuv_plane_preconditions<V>(

--- a/src/codecs/bmp/decoder.rs
+++ b/src/codecs/bmp/decoder.rs
@@ -1170,7 +1170,7 @@ impl<R: BufRead + Seek> BmpDecoder<R> {
                                 _ => {
                                     let mut length = op as usize;
                                     if self.image_type == ImageType::RLE4 {
-                                        length = (length + 1) / 2;
+                                        length = length.div_ceil(2);
                                     }
                                     length += length & 1;
                                     let mut buffer = vec![0; length];

--- a/src/codecs/bmp/decoder.rs
+++ b/src/codecs/bmp/decoder.rs
@@ -1,8 +1,12 @@
-use std::cmp::{self, Ordering};
+use alloc::borrow::ToOwned;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use alloc::{format, vec};
+use core::cmp::{self, Ordering};
+use core::iter::{repeat, Rev};
+use core::slice::ChunksMut;
+use core::{error, fmt};
 use std::io::{self, BufRead, Seek, SeekFrom};
-use std::iter::{repeat, Rev};
-use std::slice::ChunksMut;
-use std::{error, fmt};
 
 use byteorder_lite::{LittleEndian, ReadBytesExt};
 

--- a/src/codecs/bmp/encoder.rs
+++ b/src/codecs/bmp/encoder.rs
@@ -1,3 +1,5 @@
+use alloc::format;
+use alloc::string::String;
 use byteorder_lite::{LittleEndian, WriteBytesExt};
 use std::io::{self, Write};
 

--- a/src/codecs/dds.rs
+++ b/src/codecs/dds.rs
@@ -13,7 +13,6 @@ use std::io::Read;
 
 use byteorder_lite::{LittleEndian, ReadBytesExt};
 
-#[allow(deprecated)]
 use crate::codecs::dxt::{DxtDecoder, DxtVariant};
 use crate::color::ColorType;
 use crate::error::{
@@ -23,7 +22,7 @@ use crate::image::{ImageDecoder, ImageFormat};
 
 /// Errors that can occur during decoding and parsing a DDS image
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[allow(clippy::enum_variant_names)]
+#[expect(clippy::enum_variant_names)]
 enum DecoderError {
     /// Wrong DDS channel width
     PixelFormatSizeInvalid(u32),
@@ -244,7 +243,6 @@ impl DX10Header {
 
 /// The representation of a DDS decoder
 pub struct DdsDecoder<R: Read> {
-    #[allow(deprecated)]
     inner: DxtDecoder<R>,
 }
 
@@ -260,7 +258,6 @@ impl<R: Read> DdsDecoder<R> {
         let header = Header::from_reader(&mut r)?;
 
         if header.pixel_format.flags & 0x4 != 0 {
-            #[allow(deprecated)]
             let variant = match &header.pixel_format.fourcc {
                 b"DXT1" => DxtVariant::DXT1,
                 b"DXT3" => DxtVariant::DXT3,
@@ -297,7 +294,6 @@ impl<R: Read> DdsDecoder<R> {
                 }
             };
 
-            #[allow(deprecated)]
             let bytes_per_pixel = variant.color_type().bytes_per_pixel();
 
             if crate::utils::check_dimension_overflow(header.width, header.height, bytes_per_pixel)
@@ -313,7 +309,6 @@ impl<R: Read> DdsDecoder<R> {
                 ));
             }
 
-            #[allow(deprecated)]
             let inner = DxtDecoder::new(r, header.width, header.height, variant)?;
             Ok(Self { inner })
         } else {

--- a/src/codecs/dds.rs
+++ b/src/codecs/dds.rs
@@ -5,8 +5,11 @@
 //!  # Related Links
 //!  * <https://docs.microsoft.com/en-us/windows/win32/direct3ddds/dx-graphics-dds-pguide> - Description of the DDS format.
 
+use alloc::boxed::Box;
+use alloc::format;
+use alloc::string::ToString;
+use core::{error, fmt};
 use std::io::Read;
-use std::{error, fmt};
 
 use byteorder_lite::{LittleEndian, ReadBytesExt};
 

--- a/src/codecs/dxt.rs
+++ b/src/codecs/dxt.rs
@@ -7,6 +7,8 @@
 //!
 //!  Note: this module only implements bare DXT encoding/decoding, it does not parse formats that can contain DXT files like .dds
 
+use alloc::boxed::Box;
+use alloc::vec;
 use std::io::{self, Read};
 
 use crate::color::ColorType;

--- a/src/codecs/dxt.rs
+++ b/src/codecs/dxt.rs
@@ -108,7 +108,6 @@ impl<R: Read> DxtDecoder<R> {
         assert_eq!(
             u64::try_from(buf.len()),
             Ok(
-                #[allow(deprecated)]
                 self.scanline_bytes()
             )
         );
@@ -140,7 +139,6 @@ impl<R: Read> ImageDecoder for DxtDecoder<R> {
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
         assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
 
-        #[allow(deprecated)]
         for chunk in buf.chunks_mut(self.scanline_bytes().max(1) as usize) {
             self.read_scanline(chunk)?;
         }
@@ -226,7 +224,7 @@ fn decode_dxt_colors(source: &[u8], dest: &mut [u8], is_dxt1: bool) {
     } else {
         // linearly interpolate one other entry, keep the other at 0
         for i in 0..3 {
-            colors[2][i] = ((u16::from(colors[0][i]) + u16::from(colors[1][i]) + 1) / 2) as u8;
+            colors[2][i] = (u16::from(colors[0][i]) + u16::from(colors[1][i])).div_ceil(2) as u8;
         }
     }
 

--- a/src/codecs/farbfeld.rs
+++ b/src/codecs/farbfeld.rs
@@ -16,6 +16,8 @@
 //! # Related Links
 //! * <https://tools.suckless.org/farbfeld/> - the farbfeld specification
 
+use alloc::boxed::Box;
+use alloc::format;
 use std::io::{self, Read, Seek, SeekFrom, Write};
 
 use crate::color::ExtendedColorType;

--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -27,9 +27,13 @@
 //! ```
 #![allow(clippy::while_let_loop)]
 
+use alloc::borrow::ToOwned;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use alloc::{format, vec};
+use core::marker::PhantomData;
+use core::mem;
 use std::io::{self, BufRead, Cursor, Read, Seek, Write};
-use std::marker::PhantomData;
-use std::mem;
 
 use gif::ColorOutput;
 use gif::{DisposalMethod, Frame};

--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -25,7 +25,6 @@
 //! # Ok(())
 //! # }
 //! ```
-#![allow(clippy::while_let_loop)]
 
 use alloc::borrow::ToOwned;
 use alloc::boxed::Box;
@@ -72,10 +71,9 @@ impl<R: Read> GifDecoder<R> {
 }
 
 /// Wrapper struct around a `Cursor<Vec<u8>>`
-#[allow(dead_code)]
 #[deprecated]
 pub struct GifReader<R>(Cursor<Vec<u8>>, PhantomData<R>);
-#[allow(deprecated)]
+#[expect(deprecated)]
 impl<R> Read for GifReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.0.read(buf)

--- a/src/codecs/hdr/decoder.rs
+++ b/src/codecs/hdr/decoder.rs
@@ -1,7 +1,11 @@
+use alloc::borrow::ToOwned;
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
+use alloc::{format, vec};
+use core::num::{ParseFloatError, ParseIntError};
+use core::{error, fmt};
 use std::io::{self, Read};
-
-use std::num::{ParseFloatError, ParseIntError};
-use std::{error, fmt};
 
 use crate::color::{ColorType, Rgb};
 use crate::error::{
@@ -701,7 +705,8 @@ fn read_line_u8<R: Read>(r: &mut R) -> io::Result<Option<Vec<u8>>> {
 
 #[cfg(test)]
 mod tests {
-    use std::{borrow::Cow, io::Cursor};
+    use alloc::borrow::Cow;
+    use std::io::Cursor;
 
     use super::*;
 

--- a/src/codecs/hdr/encoder.rs
+++ b/src/codecs/hdr/encoder.rs
@@ -2,7 +2,10 @@ use crate::codecs::hdr::{rgbe8, Rgbe8Pixel, SIGNATURE};
 use crate::color::Rgb;
 use crate::error::{EncodingError, ImageFormatHint, ImageResult};
 use crate::{ExtendedColorType, ImageEncoder, ImageError, ImageFormat};
-use std::cmp::Ordering;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use alloc::{format, vec};
+use core::cmp::Ordering;
 use std::io::{Result, Write};
 
 /// Radiance HDR encoder
@@ -466,7 +469,7 @@ fn noruncombine_test() {
     assert_eq!(rsi.next(), Some(Norun(129, 7)));
     assert_eq!(rsi.next(), None);
 
-    let v: Vec<_> = std::iter::repeat(())
+    let v: Vec<_> = core::iter::repeat(())
         .flat_map(|_| (0..2))
         .take(257)
         .collect();

--- a/src/codecs/ico/decoder.rs
+++ b/src/codecs/ico/decoder.rs
@@ -1,6 +1,8 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use byteorder_lite::{LittleEndian, ReadBytesExt};
+use core::{error, fmt};
 use std::io::{BufRead, Read, Seek, SeekFrom};
-use std::{error, fmt};
 
 use crate::color::ColorType;
 use crate::error::{

--- a/src/codecs/ico/decoder.rs
+++ b/src/codecs/ico/decoder.rs
@@ -123,18 +123,18 @@ struct DirEntry {
     height: u8,
     // We ignore some header fields as they will be replicated in the PNG, BMP and they are not
     // necessary for determining the best_entry.
-    #[allow(unused)]
+    #[expect(unused)]
     color_count: u8,
     // Wikipedia has this to say:
     // Although Microsoft's technical documentation states that this value must be zero, the icon
     // encoder built into .NET (System.Drawing.Icon.Save) sets this value to 255. It appears that
     // the operating system ignores this value altogether.
-    #[allow(unused)]
+    #[expect(unused)]
     reserved: u8,
 
     // We ignore some header fields as they will be replicated in the PNG, BMP and they are not
     // necessary for determining the best_entry.
-    #[allow(unused)]
+    #[expect(unused)]
     num_color_planes: u16,
     bits_per_pixel: u16,
 
@@ -337,7 +337,7 @@ impl<R: BufRead + Seek> ImageDecoder for IcoDecoder<R> {
                 let data_end = u64::from(self.selected_entry.image_offset)
                     + u64::from(self.selected_entry.image_length);
 
-                let mask_row_bytes = ((width + 31) / 32) * 4;
+                let mask_row_bytes = width.div_ceil(32) * 4;
                 let mask_length = u64::from(mask_row_bytes) * u64::from(height);
 
                 // data_end should be image_end + the mask length (mask_row_bytes * height).

--- a/src/codecs/ico/encoder.rs
+++ b/src/codecs/ico/encoder.rs
@@ -1,5 +1,7 @@
+use alloc::borrow::Cow;
+use alloc::format;
+use alloc::vec::Vec;
 use byteorder_lite::{LittleEndian, WriteBytesExt};
-use std::borrow::Cow;
 use std::io::{self, Write};
 
 use crate::error::{ImageError, ImageResult, ParameterError, ParameterErrorKind};

--- a/src/codecs/ico/mod.rs
+++ b/src/codecs/ico/mod.rs
@@ -7,7 +7,6 @@
 //!  * <https://en.wikipedia.org/wiki/ICO_%28file_format%29>
 
 pub use self::decoder::IcoDecoder;
-#[allow(deprecated)]
 pub use self::encoder::{IcoEncoder, IcoFrame};
 
 mod decoder;

--- a/src/codecs/jpeg/decoder.rs
+++ b/src/codecs/jpeg/decoder.rs
@@ -1,5 +1,8 @@
+use alloc::boxed::Box;
+use alloc::format;
+use alloc::vec::Vec;
+use core::marker::PhantomData;
 use std::io::{BufRead, Seek};
-use std::marker::PhantomData;
 
 use crate::color::ColorType;
 use crate::error::{

--- a/src/codecs/jpeg/encoder.rs
+++ b/src/codecs/jpeg/encoder.rs
@@ -7,8 +7,10 @@ use crate::error::{
 use crate::image::{ImageEncoder, ImageFormat};
 use crate::utils::clamp;
 use crate::{ExtendedColorType, GenericImageView, ImageBuffer, Luma, Pixel, Rgb};
+use alloc::borrow::Cow;
+use alloc::vec;
+use alloc::vec::Vec;
 use num_traits::ToPrimitive;
-use std::borrow::Cow;
 use std::io::{self, Write};
 
 use super::entropy::build_huff_lut_const;

--- a/src/codecs/jpeg/encoder.rs
+++ b/src/codecs/jpeg/encoder.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::too_many_arguments)]
-
 use crate::error::{
     ImageError, ImageResult, ParameterError, ParameterErrorKind, UnsupportedError,
     UnsupportedErrorKind,

--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -27,6 +27,9 @@ use crate::{
     ColorType, ExtendedColorType, ImageDecoder, ImageEncoder, ImageError, ImageFormat, ImageResult,
 };
 
+use alloc::boxed::Box;
+use alloc::string::ToString;
+use alloc::{format, vec};
 use std::io::{BufRead, Seek, Write};
 
 /// An OpenEXR decoder. Immediately reads the meta data from the file.

--- a/src/codecs/pcx.rs
+++ b/src/codecs/pcx.rs
@@ -7,10 +7,10 @@
 
 extern crate pcx;
 
+use core::iter;
+use core::marker::PhantomData;
+use core::mem;
 use std::io::{self, BufRead, Cursor, Read, Seek};
-use std::iter;
-use std::marker::PhantomData;
-use std::mem;
 
 use crate::color::{ColorType, ExtendedColorType};
 use crate::error::{ImageError, ImageResult};

--- a/src/codecs/pcx.rs
+++ b/src/codecs/pcx.rs
@@ -45,10 +45,10 @@ impl ImageError {
 }
 
 /// Wrapper struct around a `Cursor<Vec<u8>>`
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[deprecated]
 pub struct PCXReader<R>(Cursor<Vec<u8>>, PhantomData<R>);
-#[allow(deprecated)]
+#[expect(deprecated)]
 impl<R> Read for PCXReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.0.read(buf)

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -5,8 +5,12 @@
 //! # Related Links
 //! * <http://www.w3.org/TR/PNG/> - The PNG Specification
 
-use std::borrow::Cow;
-use std::fmt;
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
+use alloc::string::ToString;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::fmt;
 use std::io::{BufRead, Seek, Write};
 
 use png::{BlendOp, DisposeOp};
@@ -720,7 +724,7 @@ impl fmt::Display for BadPngRepresentation {
     }
 }
 
-impl std::error::Error for BadPngRepresentation {}
+impl core::error::Error for BadPngRepresentation {}
 
 #[cfg(test)]
 mod tests {
@@ -754,7 +758,7 @@ mod tests {
 
     #[test]
     fn underlying_error() {
-        use std::error::Error;
+        use core::error::Error;
 
         let mut not_png =
             std::fs::read("tests/images/png/bugfixes/debug_triangle_corners_widescreen.png")

--- a/src/codecs/pnm/autobreak.rs
+++ b/src/codecs/pnm/autobreak.rs
@@ -1,4 +1,5 @@
 //! Insert line breaks between written buffers when they would overflow the line length.
+use alloc::vec::Vec;
 use std::io;
 
 // The pnm standard says to insert line breaks after 70 characters. Assumes that no line breaks

--- a/src/codecs/pnm/decoder.rs
+++ b/src/codecs/pnm/decoder.rs
@@ -48,7 +48,6 @@ enum DecoderError {
     /// At least one of the required lines were missing from the header (are `None` here)
     ///
     /// Same names as [`PnmHeaderLine`](enum.PnmHeaderLine.html)
-    #[allow(missing_docs)]
     HeaderLineMissing {
         height: Option<u32>,
         width: Option<u32>,
@@ -375,7 +374,6 @@ trait HeaderReader: Read {
         let mut bytes = Vec::new();
 
         // pair input bytes with a bool mask to remove comments
-        #[allow(clippy::unbuffered_bytes)]
         let mark_comments = self.bytes().scan(true, |partof, read| {
             let byte = match read {
                 Err(err) => return Some((*partof, Err(err))),
@@ -495,7 +493,6 @@ trait HeaderReader: Read {
             }
         }
 
-        #[allow(clippy::unbuffered_bytes)]
         match self.bytes().next() {
             None => return Err(ImageError::IoError(io::ErrorKind::UnexpectedEof.into())),
             Some(Err(io)) => return Err(ImageError::IoError(io)),
@@ -520,7 +517,7 @@ trait HeaderReader: Read {
             if !line.is_ascii() {
                 return Err(DecoderError::NonAsciiLineInPamHeader.into());
             }
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             let (identifier, rest) = line
                 .trim_left()
                 .split_at(line.find(char::is_whitespace).unwrap_or(line.len()));
@@ -696,7 +693,6 @@ fn read_separated_ascii<T: TryFrom<u16>>(reader: &mut dyn Read) -> ImageResult<T
 
     let mut v: u16 = 0;
     let mut had_any = false;
-    #[allow(clippy::unbuffered_bytes)]
     for rc in reader
         .bytes()
         .skip_while(|v| v.as_ref().ok().is_some_and(is_separator))
@@ -770,6 +766,7 @@ impl Sample for PbmBit {
 
     fn from_bytes(bytes: &[u8], row_size: usize, output_buf: &mut [u8]) -> ImageResult<()> {
         let mut expanded = utils::expand_bits(1, row_size.try_into().unwrap(), bytes);
+        #[expect(clippy::manual_slice_fill)]
         for b in &mut expanded {
             *b = !*b;
         }
@@ -778,7 +775,6 @@ impl Sample for PbmBit {
     }
 
     fn from_ascii(reader: &mut dyn Read, output_buf: &mut [u8]) -> ImageResult<()> {
-        #[allow(clippy::unbuffered_bytes)]
         let mut bytes = reader.bytes();
         for b in output_buf {
             loop {

--- a/src/codecs/pnm/decoder.rs
+++ b/src/codecs/pnm/decoder.rs
@@ -1,9 +1,14 @@
-use std::error;
-use std::fmt::{self, Display};
+use alloc::borrow::ToOwned;
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use alloc::{format, vec};
+use core::error;
+use core::fmt::{self, Display};
+use core::mem::size_of;
+use core::num::ParseIntError;
+use core::str;
 use std::io::{self, Read};
-use std::mem::size_of;
-use std::num::ParseIntError;
-use std::str;
 
 use super::{ArbitraryHeader, ArbitraryTuplType, BitmapHeader, GraymapHeader, PixmapHeader};
 use super::{HeaderRecord, PnmHeader, PnmSubtype, SampleEncoding};

--- a/src/codecs/pnm/encoder.rs
+++ b/src/codecs/pnm/encoder.rs
@@ -1,8 +1,9 @@
 //! Encoding of PNM Images
-use std::fmt;
-use std::io;
-
-use std::io::Write;
+use alloc::borrow::ToOwned;
+use alloc::format;
+use alloc::vec::Vec;
+use core::fmt;
+use std::io::{self, Write};
 
 use super::AutoBreak;
 use super::{ArbitraryHeader, ArbitraryTuplType, BitmapHeader, GraymapHeader, PixmapHeader};

--- a/src/codecs/pnm/header.rs
+++ b/src/codecs/pnm/header.rs
@@ -1,4 +1,7 @@
-use std::{fmt, io};
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::fmt;
+use std::io;
 
 /// The kind of encoding used to store sample values
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]

--- a/src/codecs/qoi.rs
+++ b/src/codecs/qoi.rs
@@ -1,10 +1,13 @@
 //! Decoding and encoding of QOI images
 
+use alloc::boxed::Box;
+use alloc::format;
+use std::io::{Read, Write};
+
 use crate::error::{DecodingError, EncodingError};
 use crate::{
     ColorType, ExtendedColorType, ImageDecoder, ImageEncoder, ImageError, ImageFormat, ImageResult,
 };
-use std::io::{Read, Write};
 
 /// QOI decoder
 pub struct QoiDecoder<R> {

--- a/src/codecs/tga/decoder.rs
+++ b/src/codecs/tga/decoder.rs
@@ -6,6 +6,9 @@ use crate::{
     },
     image::{ImageDecoder, ImageFormat},
 };
+use alloc::boxed::Box;
+use alloc::vec;
+use alloc::vec::Vec;
 use byteorder_lite::ReadBytesExt;
 use std::io::{self, Read};
 

--- a/src/codecs/tga/decoder.rs
+++ b/src/codecs/tga/decoder.rs
@@ -26,7 +26,7 @@ impl ColorMap {
         num_entries: u16,
         bits_per_entry: u8,
     ) -> ImageResult<ColorMap> {
-        let bytes_per_entry = (bits_per_entry as usize + 7) / 8;
+        let bytes_per_entry = (bits_per_entry as usize).div_ceil(8);
 
         let mut bytes = vec![0; bytes_per_entry * num_entries as usize];
         r.read_exact(&mut bytes)?;
@@ -89,7 +89,7 @@ impl<R: Read> TgaDecoder<R> {
         self.image_type = ImageType::new(self.header.image_type);
         self.width = self.header.image_width as usize;
         self.height = self.header.image_height as usize;
-        self.bytes_per_pixel = (self.header.pixel_depth as usize + 7) / 8;
+        self.bytes_per_pixel = (self.header.pixel_depth as usize).div_ceil(8);
         Ok(())
     }
 
@@ -204,7 +204,7 @@ impl<R: Read> TgaDecoder<R> {
             result
         }
 
-        let bytes_per_entry = (self.header.map_entry_size as usize + 7) / 8;
+        let bytes_per_entry = (self.header.map_entry_size as usize).div_ceil(8);
         let mut result = Vec::with_capacity(self.width * self.height * bytes_per_entry);
 
         if self.bytes_per_pixel == 0 {

--- a/src/codecs/tga/encoder.rs
+++ b/src/codecs/tga/encoder.rs
@@ -3,7 +3,9 @@ use crate::{
     codecs::tga::header::ImageType, error::EncodingError, ExtendedColorType, ImageEncoder,
     ImageError, ImageFormat, ImageResult,
 };
-use std::{error, fmt, io::Write};
+use alloc::vec::Vec;
+use core::{error, fmt};
+use std::io::Write;
 
 /// Errors that can occur during encoding and saving of a TGA image.
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -250,7 +252,8 @@ impl<W: Write> ImageEncoder for TgaEncoder<W> {
 mod tests {
     use super::{EncoderError, TgaEncoder};
     use crate::{codecs::tga::TgaDecoder, ExtendedColorType, ImageDecoder, ImageError};
-    use std::{error::Error, io::Cursor};
+    use core::error::Error;
+    use std::io::Cursor;
 
     #[test]
     fn test_image_width_too_large() {

--- a/src/codecs/tiff.rs
+++ b/src/codecs/tiff.rs
@@ -172,10 +172,9 @@ impl ImageError {
 }
 
 /// Wrapper struct around a `Cursor<Vec<u8>>`
-#[allow(dead_code)]
 #[deprecated]
 pub struct TiffReader<R>(Cursor<Vec<u8>>, PhantomData<R>);
-#[allow(deprecated)]
+#[expect(deprecated)]
 impl<R> Read for TiffReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.0.read(buf)

--- a/src/codecs/tiff.rs
+++ b/src/codecs/tiff.rs
@@ -8,9 +8,13 @@
 
 extern crate tiff;
 
+use alloc::boxed::Box;
+use alloc::format;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use core::marker::PhantomData;
+use core::mem;
 use std::io::{self, BufRead, Cursor, Read, Seek, Write};
-use std::marker::PhantomData;
-use std::mem;
 
 use crate::color::{ColorType, ExtendedColorType};
 use crate::error::{

--- a/src/codecs/webp/decoder.rs
+++ b/src/codecs/webp/decoder.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use std::io::{BufRead, Read, Seek};
 
 use crate::buffer::ConvertBuffer;

--- a/src/codecs/webp/encoder.rs
+++ b/src/codecs/webp/encoder.rs
@@ -1,5 +1,6 @@
 //! Encoding of WebP images.
 
+use alloc::vec::Vec;
 use std::io::Write;
 
 use crate::error::{EncodingError, UnsupportedError, UnsupportedErrorKind};

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,8 +1,11 @@
-use std::ops::{Index, IndexMut};
+use core::ops::{Index, IndexMut};
 
 use num_traits::{NumCast, ToPrimitive, Zero};
 
 use crate::traits::{Enlargeable, Pixel, Primitive};
+
+#[cfg(not(feature = "std"))]
+use num_traits::float::FloatCore as _;
 
 /// An enumeration over supported color types and bit depths
 #[derive(Copy, PartialEq, Eq, Debug, Clone, Hash)]

--- a/src/color.rs
+++ b/src/color.rs
@@ -234,9 +234,10 @@ impl ExtendedColorType {
     }
 
     /// Returns the number of bytes required to hold a width x height image of this color type.
+    #[cfg_attr(not(feature = "std"), expect(dead_code))]
     pub(crate) fn buffer_size(self, width: u32, height: u32) -> u64 {
         let bpp = self.bits_per_pixel() as u64;
-        let row_pitch = (width as u64 * bpp + 7) / 8;
+        let row_pitch = (width as u64 * bpp).div_ceil(8);
         row_pitch.saturating_mul(height as u64)
     }
 }
@@ -446,7 +447,7 @@ impl<T: Primitive> FromPrimitive<T> for T {
 // 1.0 (white) was picked as firefox and chrome choose to map NaN to that.
 #[inline]
 fn normalize_float(float: f32, max: f32) -> f32 {
-    #[allow(clippy::neg_cmp_op_on_partial_ord)]
+    #[expect(clippy::neg_cmp_op_on_partial_ord)]
     let clamped = if !(float < 1.0) { 1.0 } else { float.max(0.0) };
     (clamped * max).round()
 }
@@ -504,7 +505,7 @@ impl FromPrimitive<u8> for u16 {
 /// Provides color conversions for the different pixel types.
 pub trait FromColor<Other> {
     /// Changes `self` to represent `Other` in the color space of `Self`
-    #[allow(clippy::wrong_self_convention)]
+    #[expect(clippy::wrong_self_convention)]
     fn from_color(&mut self, _: &Other);
 }
 
@@ -513,7 +514,7 @@ pub trait FromColor<Other> {
 // rather than assuming sRGB.
 pub(crate) trait IntoColor<Other> {
     /// Constructs a pixel of the target type and converts this pixel into it.
-    #[allow(clippy::wrong_self_convention)]
+    #[expect(clippy::wrong_self_convention)]
     fn into_color(&self) -> Other;
 }
 
@@ -521,11 +522,10 @@ impl<O, S> IntoColor<O> for S
 where
     O: Pixel + FromColor<S>,
 {
-    #[allow(clippy::wrong_self_convention)]
     fn into_color(&self) -> O {
         // Note we cannot use Pixel::CHANNELS_COUNT here to directly construct
         // the pixel due to a current bug/limitation of consts.
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let mut pix = O::from_channels(Zero::zero(), Zero::zero(), Zero::zero(), Zero::zero());
         pix.from_color(self);
         pix

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -18,13 +18,16 @@ use crate::buffer_::{
 use crate::color::{self, FromColor, IntoColor};
 use crate::error::{ImageError, ImageResult, ParameterError, ParameterErrorKind};
 use crate::flat::FlatSamples;
+#[cfg_attr(not(feature = "std"), expect(unused_imports))]
 use crate::image::ImageFormat;
 use crate::image::{GenericImage, GenericImageView, ImageDecoder, ImageEncoder};
+#[cfg_attr(not(feature = "std"), expect(unused_imports))]
 use crate::image_reader::free_functions;
 use crate::imageops;
 use crate::math::resize_dimensions;
 use crate::metadata::Orientation;
 use crate::traits::Pixel;
+#[cfg_attr(not(feature = "std"), expect(unused_imports))]
 use crate::ExtendedColorType;
 use crate::{image, Luma, LumaA};
 use crate::{Rgb32FImage, Rgba32FImage};
@@ -1050,7 +1053,6 @@ impl DynamicImage {
 
         // TODO do not repeat this match statement across the crate
 
-        #[allow(deprecated)]
         match format {
             #[cfg(feature = "png")]
             ImageFormat::Png => {
@@ -1172,7 +1174,6 @@ impl From<ImageBuffer<LumaA<f32>, Vec<f32>>> for DynamicImage {
     }
 }
 
-#[allow(deprecated)]
 impl GenericImageView for DynamicImage {
     type Pixel = color::Rgba<u8>; // TODO use f32 as default for best precision and unbounded color?
 
@@ -1185,7 +1186,7 @@ impl GenericImageView for DynamicImage {
     }
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 impl GenericImage for DynamicImage {
     fn put_pixel(&mut self, x: u32, y: u32, pixel: color::Rgba<u8>) {
         match *self {
@@ -1541,7 +1542,7 @@ mod test {
         // Test that structs wrapping a DynamicImage are able to auto-derive the Default trait
         // ensures that DynamicImage implements Default (if it didn't, this would cause a compile error).
         #[derive(Default)]
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         struct Foo {
             _image: super::DynamicImage,
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -164,7 +164,6 @@ pub struct LimitError {
 /// detailed information or to incorporate other resources types.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 #[non_exhaustive]
-#[allow(missing_copy_implementations)] // Might be non-Copy in the future.
 pub enum LimitErrorKind {
     /// The resulting image exceed dimension limits in either direction.
     DimensionError,
@@ -515,7 +514,7 @@ mod tests {
     use super::*;
     use core::mem::size_of;
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     // This will fail to compile if the size of this type is large.
     const ASSERT_SMALLISH: usize = [0][(size_of::<ImageError>() >= 200) as usize];
 

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -1465,12 +1465,12 @@ where
         P::from_slice_mut(&mut self.inner.samples.as_mut()[pixel_range])
     }
 
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     fn put_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel) {
         *self.get_pixel_mut(x, y) = pixel;
     }
 
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     fn blend_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel) {
         self.get_pixel_mut(x, y).blend(&pixel);
     }
@@ -1623,7 +1623,7 @@ mod tests {
                 .as_view_mut::<LumaA<u16>>()
                 .expect("This should be a valid mutable buffer");
             assert_eq!(view.dimensions(), (3, 3));
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             for i in 0..9 {
                 *view.get_pixel_mut(i % 3, i / 3) = LumaA([2 * i as u16, 2 * i as u16 + 1]);
             }

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -7,8 +7,8 @@
 //! to help you transition from raw memory data to Rust representation.
 //!
 //! ```no_run
-//! use std::ptr;
-//! use std::slice;
+//! use core::ptr;
+//! use core::slice;
 //! use image::Rgb;
 //! use image::flat::{FlatSamples, SampleLayout};
 //! use image::imageops::thumbnail;
@@ -41,9 +41,10 @@
 //! }
 //! ```
 //!
-use std::marker::PhantomData;
-use std::ops::{Deref, Index, IndexMut};
-use std::{cmp, error, fmt};
+use alloc::vec::Vec;
+use core::marker::PhantomData;
+use core::ops::{Deref, Index, IndexMut};
+use core::{cmp, error, fmt};
 
 use num_traits::Zero;
 
@@ -536,7 +537,7 @@ impl<Buffer> FlatSamples<Buffer> {
 
     /// Get a reference to a single sample.
     ///
-    /// This more restrictive than the method based on `std::ops::Index` but guarantees to properly
+    /// This more restrictive than the method based on `core::ops::Index` but guarantees to properly
     /// check all bounds and not panic as long as `Buffer::as_ref` does not do so.
     ///
     /// ```
@@ -565,7 +566,7 @@ impl<Buffer> FlatSamples<Buffer> {
 
     /// Get a mutable reference to a single sample.
     ///
-    /// This more restrictive than the method based on `std::ops::IndexMut` but guarantees to
+    /// This more restrictive than the method based on `core::ops::IndexMut` but guarantees to
     /// properly check all bounds and not panic as long as `Buffer::as_ref` does not do so.
     /// Contrary to conversion to `ViewMut`, this does not require that samples are packed since it
     /// does not need to convert samples to a color representation.

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,10 +1,11 @@
 #![allow(clippy::too_many_arguments)]
-use std::ffi::OsStr;
-use std::io::{self, Write};
-use std::mem::size_of;
-use std::ops::{Deref, DerefMut};
-use std::path::Path;
+use alloc::boxed::Box;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::mem::size_of;
+use core::ops::{Deref, DerefMut};
 
+use crate::animation::Frames;
 use crate::color::{ColorType, ExtendedColorType};
 use crate::error::{
     ImageError, ImageFormatHint, ImageResult, LimitError, LimitErrorKind, ParameterError,
@@ -15,7 +16,12 @@ use crate::metadata::Orientation;
 use crate::traits::Pixel;
 use crate::ImageBuffer;
 
-use crate::animation::Frames;
+#[cfg(feature = "std")]
+use std::ffi::OsStr;
+#[cfg(feature = "std")]
+use std::io::{self, Write};
+#[cfg(feature = "std")]
+use std::path::Path;
 
 /// An enumeration of supported image formats.
 /// Not all formats support both encoding and decoding.
@@ -83,6 +89,7 @@ impl ImageFormat {
     /// let format = ImageFormat::from_extension("jpg");
     /// assert_eq!(format, Some(ImageFormat::Jpeg));
     /// ```
+    #[cfg(feature = "std")]
     #[inline]
     pub fn from_extension<S>(ext: S) -> Option<Self>
     where
@@ -128,6 +135,7 @@ impl ImageFormat {
     ///
     /// # Ok::<(), image::error::ImageError>(())
     /// ```
+    #[cfg(feature = "std")]
     #[inline]
     pub fn from_path<P>(path: P) -> ImageResult<Self>
     where
@@ -654,6 +662,7 @@ pub trait ImageDecoder {
     ///
     /// This is usually obtained from the Exif metadata, if present. Formats that don't support
     /// indicating orientation in their image metadata will return `Ok(Orientation::NoTransforms)`.
+    #[cfg(feature = "std")]
     fn orientation(&mut self) -> ImageResult<Orientation> {
         Ok(self
             .exif_metadata()?

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::too_many_arguments)]
 use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
@@ -12,6 +11,7 @@ use crate::error::{
     ParameterErrorKind, UnsupportedError, UnsupportedErrorKind,
 };
 use crate::math::Rect;
+#[cfg_attr(not(feature = "std"), expect(unused_imports))]
 use crate::metadata::Orientation;
 use crate::traits::Pixel;
 use crate::ImageBuffer;
@@ -401,8 +401,6 @@ impl ImageFormat {
 
 // This struct manages buffering associated with implementing `Read` and `Seek` on decoders that can
 // must decode ranges of bytes at a time.
-#[allow(dead_code)]
-// When no image formats that use it are enabled
 pub(crate) struct ImageReadBuffer {
     scanline_bytes: usize,
     buffer: Vec<u8>,
@@ -417,7 +415,7 @@ impl ImageReadBuffer {
     /// Panics if `scanline_bytes` doesn't fit into a usize, because that would mean reading anything
     /// from the image would take more RAM than the entire virtual address space. In other words,
     /// actually using this struct would instantly OOM so just get it out of the way now.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     // When no image formats that use it are enabled
     pub(crate) fn new(scanline_bytes: u64, total_bytes: u64) -> Self {
         Self {
@@ -429,7 +427,8 @@ impl ImageReadBuffer {
         }
     }
 
-    #[allow(dead_code)]
+    #[cfg(feature = "std")]
+    #[expect(dead_code)]
     // When no image formats that use it are enabled
     pub(crate) fn read<F>(&mut self, buf: &mut [u8], mut read_scanline: F) -> io::Result<usize>
     where
@@ -476,8 +475,8 @@ impl ImageReadBuffer {
 
 /// Decodes a specific region of the image, represented by the rectangle
 /// starting from ```x``` and ```y``` and having ```length``` and ```width```
-#[allow(dead_code)]
-// When no image formats that use it are enabled
+#[cfg(feature = "std")]
+#[expect(clippy::too_many_arguments)]
 pub(crate) fn load_rect<D, F1, F2, E>(
     x: u32,
     y: u32,
@@ -1289,7 +1288,6 @@ where
     }
 }
 
-#[allow(deprecated)]
 impl<I> GenericImageView for SubImageInner<I>
 where
     I: Deref,
@@ -1306,13 +1304,13 @@ where
     }
 }
 
-#[allow(deprecated)]
 impl<I> GenericImage for SubImageInner<I>
 where
     I: DerefMut,
     I::Target: GenericImage + Sized,
 {
     fn get_pixel_mut(&mut self, x: u32, y: u32) -> &mut Self::Pixel {
+        #[expect(deprecated)]
         self.image.get_pixel_mut(x + self.xoffset, y + self.yoffset)
     }
 
@@ -1323,6 +1321,7 @@ where
 
     /// DEPRECATED: This method will be removed. Blend the pixel directly instead.
     fn blend_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel) {
+        #[expect(deprecated)]
         self.image
             .blend_pixel(x + self.xoffset, y + self.yoffset, pixel);
     }
@@ -1343,7 +1342,7 @@ mod tests {
     use crate::{GrayImage, ImageBuffer};
 
     #[test]
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     /// Test that alpha blending works as expected
     fn test_image_alpha_blending() {
         let mut target = ImageBuffer::new(1, 1);

--- a/src/image_reader/free_functions.rs
+++ b/src/image_reader/free_functions.rs
@@ -1,16 +1,25 @@
-use std::fs::File;
-use std::io::{BufRead, BufWriter, Seek};
-use std::iter;
-use std::path::Path;
+use alloc::format;
+use core::iter;
 
-use crate::{codecs::*, ExtendedColorType, ImageReader};
-
+use crate::codecs::*;
 use crate::dynimage::DynamicImage;
+use crate::error::UnsupportedError;
+use crate::error::UnsupportedErrorKind;
 use crate::error::{ImageError, ImageFormatHint, ImageResult};
-use crate::error::{UnsupportedError, UnsupportedErrorKind};
 use crate::image::ImageFormat;
 #[allow(unused_imports)] // When no features are supported
 use crate::image::{ImageDecoder, ImageEncoder};
+use crate::ExtendedColorType;
+
+#[cfg(feature = "std")]
+use crate::ImageReader;
+
+#[cfg(feature = "std")]
+use std::fs::File;
+#[cfg(feature = "std")]
+use std::io::{BufRead, BufWriter, Seek};
+#[cfg(feature = "std")]
+use std::path::Path;
 
 /// Create a new image from a Reader.
 ///
@@ -18,6 +27,7 @@ use crate::image::{ImageDecoder, ImageEncoder};
 /// consider wrapping the reader with a `BufReader::new()`.
 ///
 /// Try [`ImageReader`] for more advanced uses.
+#[cfg(feature = "std")]
 pub fn load<R: BufRead + Seek>(r: R, format: ImageFormat) -> ImageResult<DynamicImage> {
     let mut reader = ImageReader::new(r);
     reader.set_format(format);
@@ -26,6 +36,7 @@ pub fn load<R: BufRead + Seek>(r: R, format: ImageFormat) -> ImageResult<Dynamic
 
 #[allow(unused_variables)]
 // Most variables when no features are supported
+#[cfg(feature = "std")]
 pub(crate) fn save_buffer_impl(
     path: &Path,
     buf: &[u8],
@@ -39,6 +50,7 @@ pub(crate) fn save_buffer_impl(
 
 #[allow(unused_variables)]
 // Most variables when no features are supported
+#[cfg(feature = "std")]
 pub(crate) fn save_buffer_with_format_impl(
     path: &Path,
     buf: &[u8],
@@ -52,6 +64,7 @@ pub(crate) fn save_buffer_with_format_impl(
 }
 
 #[allow(unused_variables)]
+#[cfg(feature = "std")]
 // Most variables when no features are supported
 pub(crate) fn write_buffer_impl<W: std::io::Write + Seek>(
     buffered_write: &mut W,

--- a/src/image_reader/free_functions.rs
+++ b/src/image_reader/free_functions.rs
@@ -1,14 +1,20 @@
+#[cfg_attr(not(feature = "std"), expect(unused_imports))]
 use alloc::format;
 use core::iter;
 
+#[cfg_attr(not(feature = "std"), expect(unused_imports))]
 use crate::codecs::*;
+#[cfg_attr(not(feature = "std"), expect(unused_imports))]
 use crate::dynimage::DynamicImage;
+#[cfg_attr(not(feature = "std"), expect(unused_imports))]
 use crate::error::UnsupportedError;
+#[cfg_attr(not(feature = "std"), expect(unused_imports))]
 use crate::error::UnsupportedErrorKind;
 use crate::error::{ImageError, ImageFormatHint, ImageResult};
 use crate::image::ImageFormat;
 #[allow(unused_imports)] // When no features are supported
 use crate::image::{ImageDecoder, ImageEncoder};
+#[cfg_attr(not(feature = "std"), expect(unused_imports))]
 use crate::ExtendedColorType;
 
 #[cfg(feature = "std")]
@@ -34,7 +40,6 @@ pub fn load<R: BufRead + Seek>(r: R, format: ImageFormat) -> ImageResult<Dynamic
     reader.decode()
 }
 
-#[allow(unused_variables)]
 // Most variables when no features are supported
 #[cfg(feature = "std")]
 pub(crate) fn save_buffer_impl(
@@ -48,7 +53,6 @@ pub(crate) fn save_buffer_impl(
     save_buffer_with_format_impl(path, buf, width, height, color, format)
 }
 
-#[allow(unused_variables)]
 // Most variables when no features are supported
 #[cfg(feature = "std")]
 pub(crate) fn save_buffer_with_format_impl(
@@ -63,7 +67,6 @@ pub(crate) fn save_buffer_with_format_impl(
     write_buffer_impl(buffered_file_write, buf, width, height, color, format)
 }
 
-#[allow(unused_variables)]
 #[cfg(feature = "std")]
 // Most variables when no features are supported
 pub(crate) fn write_buffer_impl<W: std::io::Write + Seek>(

--- a/src/image_reader/image_reader_type.rs
+++ b/src/image_reader/image_reader_type.rs
@@ -1,14 +1,24 @@
+#[cfg_attr(not(feature = "std"), expect(unused_imports))]
 use alloc::boxed::Box;
 
+#[cfg_attr(not(feature = "std"), expect(unused_imports))]
 use crate::dynimage::DynamicImage;
+#[cfg_attr(not(feature = "std"), expect(unused_imports))]
 use crate::error::ImageFormatHint;
+#[cfg_attr(not(feature = "std"), expect(unused_imports))]
 use crate::error::UnsupportedError;
+#[cfg_attr(not(feature = "std"), expect(unused_imports))]
 use crate::error::UnsupportedErrorKind;
+#[cfg_attr(not(feature = "std"), expect(unused_imports))]
 use crate::image::ImageFormat;
+#[cfg_attr(not(feature = "std"), expect(unused_imports))]
 use crate::ImageDecoder;
+#[cfg_attr(not(feature = "std"), expect(unused_imports))]
 use crate::ImageError;
+#[cfg_attr(not(feature = "std"), expect(unused_imports))]
 use crate::ImageResult;
 
+#[cfg_attr(not(feature = "std"), expect(unused_imports))]
 use super::free_functions;
 
 #[cfg(feature = "std")]
@@ -152,10 +162,8 @@ impl<'a, R: 'a + BufRead + Seek> ImageReader<R> {
         reader: R,
         limits_for_png: super::Limits,
     ) -> ImageResult<Box<dyn ImageDecoder + 'a>> {
-        #[allow(unused)]
         use crate::codecs::*;
 
-        #[allow(unreachable_patterns)]
         // Default is unreachable if all features are supported.
         Ok(match format {
             #[cfg(feature = "avif-native")]

--- a/src/image_reader/image_reader_type.rs
+++ b/src/image_reader/image_reader_type.rs
@@ -1,13 +1,22 @@
-use std::fs::File;
-use std::io::{self, BufRead, BufReader, Cursor, Read, Seek, SeekFrom};
-use std::path::Path;
+use alloc::boxed::Box;
 
 use crate::dynimage::DynamicImage;
-use crate::error::{ImageFormatHint, UnsupportedError, UnsupportedErrorKind};
+use crate::error::ImageFormatHint;
+use crate::error::UnsupportedError;
+use crate::error::UnsupportedErrorKind;
 use crate::image::ImageFormat;
-use crate::{ImageDecoder, ImageError, ImageResult};
+use crate::ImageDecoder;
+use crate::ImageError;
+use crate::ImageResult;
 
 use super::free_functions;
+
+#[cfg(feature = "std")]
+use std::fs::File;
+#[cfg(feature = "std")]
+use std::io::{self, BufRead, BufReader, Cursor, Read, Seek, SeekFrom};
+#[cfg(feature = "std")]
+use std::path::Path;
 
 /// A multi-format image reader.
 ///
@@ -58,6 +67,7 @@ use super::free_functions;
 ///
 /// [`set_format`]: #method.set_format
 /// [`ImageDecoder`]: ../trait.ImageDecoder.html
+#[cfg(feature = "std")]
 pub struct ImageReader<R: Read + Seek> {
     /// The reader. Should be buffered.
     inner: R,
@@ -67,6 +77,7 @@ pub struct ImageReader<R: Read + Seek> {
     limits: super::Limits,
 }
 
+#[cfg(feature = "std")]
 impl<'a, R: 'a + BufRead + Seek> ImageReader<R> {
     /// Create a new image reader without a preset format.
     ///
@@ -283,6 +294,7 @@ impl<'a, R: 'a + BufRead + Seek> ImageReader<R> {
     }
 }
 
+#[cfg(feature = "std")]
 impl ImageReader<BufReader<File>> {
     /// Open a file to read, format will be guessed from path.
     ///

--- a/src/image_reader/mod.rs
+++ b/src/image_reader/mod.rs
@@ -10,7 +10,6 @@ pub use self::image_reader_type::ImageReader;
 
 /// Set of supported strict limits for a decoder.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Hash)]
-#[allow(missing_copy_implementations)]
 #[non_exhaustive]
 pub struct LimitSupport {}
 
@@ -36,7 +35,6 @@ pub struct LimitSupport {}
 /// [`LimitSupport`]: ./struct.LimitSupport.html
 /// [`ImageDecoder::set_limits`]: ../trait.ImageDecoder.html#method.set_limits
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
-#[allow(missing_copy_implementations)]
 #[non_exhaustive]
 pub struct Limits {
     /// The maximum allowed image width. This limit is strict. The default is no limit.

--- a/src/image_reader/mod.rs
+++ b/src/image_reader/mod.rs
@@ -5,6 +5,7 @@ use crate::{error, ColorType, ImageError, ImageResult};
 pub(crate) mod free_functions;
 mod image_reader_type;
 
+#[cfg(feature = "std")]
 pub use self::image_reader_type::ImageReader;
 
 /// Set of supported strict limits for a decoder.

--- a/src/imageops/affine.rs
+++ b/src/imageops/affine.rs
@@ -398,7 +398,7 @@ mod test {
         assert_pixels_eq!(&image, &expected);
     }
 
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     fn pixel_diffs<I, J, P>(left: &I, right: &J) -> Vec<((u32, u32, P), (u32, u32, P))>
     where
         I: GenericImage<Pixel = P>,

--- a/src/imageops/affine.rs
+++ b/src/imageops/affine.rs
@@ -1,5 +1,7 @@
 //! Functions for performing affine transformations.
 
+use alloc::vec::Vec;
+
 use crate::error::{ImageError, ParameterError, ParameterErrorKind};
 use crate::image::{GenericImage, GenericImageView};
 use crate::traits::Pixel;
@@ -52,7 +54,7 @@ pub fn rotate90_in<I, Container>(
 where
     I: GenericImageView,
     I::Pixel: 'static,
-    Container: std::ops::DerefMut<Target = [<I::Pixel as Pixel>::Subpixel]>,
+    Container: core::ops::DerefMut<Target = [<I::Pixel as Pixel>::Subpixel]>,
 {
     let ((w0, h0), (w1, h1)) = (image.dimensions(), destination.dimensions());
     if w0 != h1 || h0 != w1 {
@@ -78,7 +80,7 @@ pub fn rotate180_in<I, Container>(
 where
     I: GenericImageView,
     I::Pixel: 'static,
-    Container: std::ops::DerefMut<Target = [<I::Pixel as Pixel>::Subpixel]>,
+    Container: core::ops::DerefMut<Target = [<I::Pixel as Pixel>::Subpixel]>,
 {
     let ((w0, h0), (w1, h1)) = (image.dimensions(), destination.dimensions());
     if w0 != w1 || h0 != h1 {
@@ -104,7 +106,7 @@ pub fn rotate270_in<I, Container>(
 where
     I: GenericImageView,
     I::Pixel: 'static,
-    Container: std::ops::DerefMut<Target = [<I::Pixel as Pixel>::Subpixel]>,
+    Container: core::ops::DerefMut<Target = [<I::Pixel as Pixel>::Subpixel]>,
 {
     let ((w0, h0), (w1, h1)) = (image.dimensions(), destination.dimensions());
     if w0 != h1 || h0 != w1 {
@@ -156,7 +158,7 @@ pub fn flip_horizontal_in<I, Container>(
 where
     I: GenericImageView,
     I::Pixel: 'static,
-    Container: std::ops::DerefMut<Target = [<I::Pixel as Pixel>::Subpixel]>,
+    Container: core::ops::DerefMut<Target = [<I::Pixel as Pixel>::Subpixel]>,
 {
     let ((w0, h0), (w1, h1)) = (image.dimensions(), destination.dimensions());
     if w0 != w1 || h0 != h1 {
@@ -182,7 +184,7 @@ pub fn flip_vertical_in<I, Container>(
 where
     I: GenericImageView,
     I::Pixel: 'static,
-    Container: std::ops::DerefMut<Target = [<I::Pixel as Pixel>::Subpixel]>,
+    Container: core::ops::DerefMut<Target = [<I::Pixel as Pixel>::Subpixel]>,
 {
     let ((w0, h0), (w1, h1)) = (image.dimensions(), destination.dimensions());
     if w0 != w1 || h0 != h1 {

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -256,7 +256,7 @@ where
     for (x, y, pixel) in out.enumerate_pixels_mut() {
         let p = image.get_pixel(x, y);
 
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let (k1, k2, k3, k4) = p.channels4();
         let vec: (f64, f64, f64, f64) = (
             NumCast::from(k1).unwrap(),
@@ -274,7 +274,7 @@ where
         let new_b = matrix[6] * r + matrix[7] * g + matrix[8] * b;
         let max = 255f64;
 
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let outpixel = Pixel::from_channels(
             NumCast::from(clamp(new_r, 0.0, max)).unwrap(),
             NumCast::from(clamp(new_g, 0.0, max)).unwrap(),
@@ -324,7 +324,7 @@ where
         for x in 0..width {
             let pixel = image.get_pixel(x, y);
 
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             let (k1, k2, k3, k4) = pixel.channels4();
 
             let vec: (f64, f64, f64, f64) = (
@@ -343,7 +343,7 @@ where
             let new_b = matrix[6] * r + matrix[7] * g + matrix[8] * b;
             let max = 255f64;
 
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             let outpixel = Pixel::from_channels(
                 NumCast::from(clamp(new_r, 0.0, max)).unwrap(),
                 NumCast::from(clamp(new_g, 0.0, max)).unwrap(),
@@ -642,7 +642,7 @@ mod test {
         assert_pixels_eq!(&image, &expected);
     }
 
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     fn pixel_diffs<I, J, P>(left: &I, right: &J) -> Vec<((u32, u32, P), (u32, u32, P))>
     where
         I: GenericImage<Pixel = P>,

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -1,5 +1,6 @@
 //! Functions for altering and converting the color of pixelbufs
 
+use alloc::vec::Vec;
 use num_traits::NumCast;
 
 use crate::color::{FromColor, IntoColor, Luma, LumaA};
@@ -7,6 +8,12 @@ use crate::image::{GenericImage, GenericImageView};
 use crate::traits::{Pixel, Primitive};
 use crate::utils::clamp;
 use crate::ImageBuffer;
+
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+use num_traits::Float as _;
+
+#[cfg(not(any(feature = "std", feature = "libm")))]
+use num_traits::float::FloatCore as _;
 
 type Subpixel<I> = <<I as GenericImageView>::Pixel as Pixel>::Subpixel;
 
@@ -218,6 +225,7 @@ where
 /// just like the css webkit filter hue-rotate(180)
 ///
 /// *[See also `huerotate_in_place`.][huerotate_in_place]*
+#[cfg(any(feature = "std", feature = "libm"))]
 pub fn huerotate<I, P, S>(image: &I, value: i32) -> ImageBuffer<P, Vec<S>>
 where
     I: GenericImageView<Pixel = P>,
@@ -285,6 +293,7 @@ where
 /// just like the css webkit filter hue-rotate(180)
 ///
 /// *[See also `huerotate`.][huerotate]*
+#[cfg(any(feature = "std", feature = "libm"))]
 pub fn huerotate_in_place<I>(image: &mut I, value: i32)
 where
     I: GenericImage,

--- a/src/imageops/fast_blur.rs
+++ b/src/imageops/fast_blur.rs
@@ -1,3 +1,4 @@
+use alloc::{vec, vec::Vec};
 use num_traits::clamp;
 
 use crate::{ImageBuffer, Pixel, Primitive};

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -1,5 +1,5 @@
 //! Image Processing Functions
-use std::cmp;
+use core::cmp;
 
 use crate::image::{GenericImage, GenericImageView, SubImage};
 use crate::traits::{Lerp, Pixel, Primitive};
@@ -16,23 +16,31 @@ pub use self::affine::{
 };
 
 pub use self::sample::{
-    blur, filter3x3, interpolate_bilinear, interpolate_nearest, resize, sample_bilinear,
-    sample_nearest, thumbnail, unsharpen,
+    filter3x3, interpolate_bilinear, interpolate_nearest, resize, sample_bilinear, sample_nearest,
+    thumbnail,
 };
+
+#[cfg(any(feature = "std", feature = "libm"))]
+pub use self::sample::{blur, unsharpen};
 
 /// Color operations
 pub use self::colorops::{
     brighten, contrast, dither, grayscale, grayscale_alpha, grayscale_with_type,
-    grayscale_with_type_alpha, huerotate, index_colors, invert, BiLevel, ColorMap,
+    grayscale_with_type_alpha, index_colors, invert, BiLevel, ColorMap,
 };
+
+#[cfg(any(feature = "std", feature = "libm"))]
+pub use self::colorops::huerotate;
 
 mod affine;
 // Public only because of Rust bug:
 // https://github.com/rust-lang/rust/issues/18241
 pub mod colorops;
+#[cfg(any(feature = "std", feature = "libm"))]
 mod fast_blur;
 mod sample;
 
+#[cfg(any(feature = "std", feature = "libm"))]
 pub use fast_blur::fast_blur;
 
 /// Return a mutable view into an image

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -303,7 +303,7 @@ where
             for (i, w) in ws.iter().enumerate() {
                 let p = image.get_pixel(left + i as u32, y);
 
-                #[allow(deprecated)]
+                #[expect(deprecated)]
                 let vec = p.channels4();
 
                 t.0 += vec.0 * w;
@@ -312,7 +312,7 @@ where
                 t.3 += vec.3 * w;
             }
 
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             let t = Pixel::from_channels(
                 NumCast::from(FloatNearest(clamp(t.0, min, max))).unwrap(),
                 NumCast::from(FloatNearest(clamp(t.1, min, max))).unwrap(),
@@ -543,7 +543,7 @@ where
             for (i, w) in ws.iter().enumerate() {
                 let p = image.get_pixel(x, left + i as u32);
 
-                #[allow(deprecated)]
+                #[expect(deprecated)]
                 let (k1, k2, k3, k4) = p.channels4();
                 let vec: (f32, f32, f32, f32) = (
                     NumCast::from(k1).unwrap(),
@@ -558,7 +558,7 @@ where
                 t.3 += vec.3 * w;
             }
 
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             // This is not necessarily Rgba.
             let t = Pixel::from_channels(t.0, t.1, t.2, t.3);
 
@@ -587,7 +587,7 @@ impl<S: Primitive + Enlargeable> ThumbnailSum<S> {
     }
 
     fn add_pixel<P: Pixel<Subpixel = S>>(&mut self, pixel: P) {
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         let pixel = pixel.channels4();
         self.0 += Self::sample_val(pixel.0);
         self.1 += Self::sample_val(pixel.1);
@@ -681,7 +681,7 @@ where
                 )
             };
 
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             let pixel = Pixel::from_channels(avg.0, avg.1, avg.2, avg.3);
             out.put_pixel(outx, outy, pixel);
         }
@@ -821,13 +821,13 @@ where
     P: Pixel<Subpixel = S>,
     S: Primitive + Enlargeable,
 {
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     let k_bl = image.get_pixel(left, bottom).channels4();
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     let k_tl = image.get_pixel(left, bottom + 1).channels4();
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     let k_br = image.get_pixel(left + 1, bottom).channels4();
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     let k_tr = image.get_pixel(left + 1, bottom + 1).channels4();
 
     let frac_v = fraction_vertical;
@@ -891,7 +891,7 @@ where
     let max = S::DEFAULT_MAX_VALUE;
     let max: f32 = NumCast::from(max).unwrap();
 
-    #[allow(clippy::redundant_guards)]
+    #[expect(clippy::redundant_guards)]
     let sum = match kernel.iter().fold(0.0, |s, &item| s + item) {
         x if x == 0.0 => 1.0,
         sum => sum,
@@ -912,7 +912,7 @@ where
 
                 let p = image.get_pixel(x0 as u32, y0 as u32);
 
-                #[allow(deprecated)]
+                #[expect(deprecated)]
                 let (k1, k2, k3, k4) = p.channels4();
 
                 let vec: (f32, f32, f32, f32) = (
@@ -930,7 +930,7 @@ where
 
             let (t1, t2, t3, t4) = (t.0 / sum.0, t.1 / sum.1, t.2 / sum.2, t.3 / sum.3);
 
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             let t = Pixel::from_channels(
                 NumCast::from(clamp(t1, 0.0, max)).unwrap(),
                 NumCast::from(clamp(t2, 0.0, max)).unwrap(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,9 @@
 // even to people using the crate as a dependency,
 // so we have to suppress those warnings.
 #![allow(unexpected_cfgs)]
+#![warn(clippy::alloc_instead_of_core)]
+#![warn(clippy::std_instead_of_alloc)]
+#![warn(clippy::alloc_instead_of_core)]
 #![no_std]
 
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,12 @@
 // even to people using the crate as a dependency,
 // so we have to suppress those warnings.
 #![allow(unexpected_cfgs)]
+#![no_std]
+
+#[cfg(feature = "std")]
+extern crate std;
+
+extern crate alloc;
 
 #[cfg(all(test, feature = "benchmarks"))]
 extern crate test;
@@ -170,12 +176,18 @@ pub use crate::flat::FlatSamples;
 pub use crate::traits::{EncodableLayout, Pixel, PixelWithColorType, Primitive};
 
 // Opening and loading images
+#[cfg(feature = "std")]
 pub use crate::dynimage::{
     image_dimensions, load_from_memory, load_from_memory_with_format, open, save_buffer,
     save_buffer_with_format, write_buffer_with_format,
 };
-pub use crate::image_reader::free_functions::{guess_format, load};
-pub use crate::image_reader::{ImageReader, LimitSupport, Limits};
+pub use crate::image_reader::free_functions::guess_format;
+pub use crate::image_reader::{LimitSupport, Limits};
+
+#[cfg(feature = "std")]
+pub use crate::image_reader::free_functions::load;
+#[cfg(feature = "std")]
+pub use crate::image_reader::ImageReader;
 
 pub use crate::dynimage::DynamicImage;
 
@@ -303,6 +315,7 @@ pub mod metadata;
 //TODO delete this module after a few releases
 /// deprecated io module the original io module has been renamed to `image_reader`
 pub mod io {
+    #[cfg(feature = "std")]
     #[deprecated(note = "this type has been moved and renamed to image::ImageReader")]
     /// Deprecated re-export of `ImageReader` as `Reader`
     pub type Reader<R> = super::ImageReader<R>;

--- a/src/math/utils.rs
+++ b/src/math/utils.rs
@@ -1,6 +1,9 @@
 //! Shared mathematical utility functions.
 
-use std::cmp::max;
+use core::cmp::max;
+
+#[cfg(not(feature = "std"))]
+use num_traits::float::FloatCore as _;
 
 /// Calculates the width and height an image should be resized to.
 /// This preserves aspect ratio, and based on the `fill` parameter

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,8 +1,11 @@
 //! Types describing image metadata
 
+#[cfg(feature = "std")]
+use byteorder_lite::ReadBytesExt;
+#[cfg(feature = "std")]
 use std::io::{Cursor, Read};
 
-use byteorder_lite::{BigEndian, LittleEndian, ReadBytesExt};
+use byteorder_lite::{BigEndian, LittleEndian};
 
 /// Describes the transformations to be applied to the image.
 /// Compatible with [Exif orientation](https://web.archive.org/web/20200412005226/https://www.impulseadventure.com/photo/exif-orientation.html).
@@ -63,6 +66,7 @@ impl Orientation {
         }
     }
 
+    #[cfg(feature = "std")]
     pub(crate) fn from_exif_chunk(chunk: &[u8]) -> Option<Self> {
         let mut reader = Cursor::new(chunk);
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -5,6 +5,7 @@ use byteorder_lite::ReadBytesExt;
 #[cfg(feature = "std")]
 use std::io::{Cursor, Read};
 
+#[cfg_attr(not(feature = "std"), expect(unused_imports))]
 use byteorder_lite::{BigEndian, LittleEndian};
 
 /// Describes the transformations to be applied to the image.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -2,8 +2,8 @@
 
 // Note copied from the stdlib under MIT license
 
+use core::ops::AddAssign;
 use num_traits::{Bounded, Num, NumCast};
-use std::ops::AddAssign;
 
 use crate::color::{Luma, LumaA, Rgb, Rgba};
 use crate::ExtendedColorType;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -34,7 +34,6 @@ where
 
 /// Expand a buffer of packed 1, 2, or 4 bits integers into u8's. Assumes that
 /// every `row_size` entries there are padding bits up to the next byte boundary.
-#[allow(dead_code)]
 // When no image formats that use it are enabled
 pub(crate) fn expand_bits(bit_depth: u8, row_size: u32, buf: &[u8]) -> Vec<u8> {
     // Note: this conversion assumes that the scanlines begin on byte boundaries
@@ -65,13 +64,12 @@ pub(crate) fn expand_bits(bit_depth: u8, row_size: u32, buf: &[u8]) -> Vec<u8> {
 }
 
 /// Checks if the provided dimensions would cause an overflow.
-#[allow(dead_code)]
 // When no image formats that use it are enabled
 pub(crate) fn check_dimension_overflow(width: u32, height: u32, bytes_per_pixel: u8) -> bool {
     u64::from(width) * u64::from(height) > u64::MAX / u64::from(bytes_per_pixel)
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 // When no image formats that use it are enabled
 pub(crate) fn vec_copy_to_u8<T>(vec: &[T]) -> Vec<u8>
 where

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,8 @@
 //!  Utilities
 
-use std::iter::repeat;
+use alloc::borrow::ToOwned;
+use alloc::vec::Vec;
+use core::iter::repeat;
 
 #[inline(always)]
 pub(crate) fn expand_packed<F>(buf: &mut [u8], channels: usize, bit_depth: u8, mut func: F)


### PR DESCRIPTION
# Objective

- Fixes #1184
- Supersedes #1868
- Supersedes #2436

## Solution

- Increased MSRV to 1.81 for `core::error::Error`
- Added `libm` and `std` features.
  - `std` provides access to the `std` crate and is required for most existing features.
  - `libm` activates `num-traits/libm`, allowing for existing `f32`/`f64` operations to work without `std`.
- Addressed several Clippy lints using `expect` rather than `allow`
  - This ensures stale exceptions don't remain
- Added a `no_std` CI task which checks against `wasm32v1-none`, a typical `no_std` target. This could be replaced with any other official target that does not have `std`.
- Added `#[cfg(feature = "std")]` to items which require `std`
- Added #[cfg(any(feature = "std", feature = "libm"))]` to items which require full `f32`/`f64` support.
- Made `ImageError` `non_exhaustive` to allow feature gating `ImageError::IoError` behind `std`. This isn't strictly required, but it ensures features are truly additive.
- Imported `num_traits::Float` or `num_traits::float::FloatCore` where required for `f32`/`f64` operations.

---

## Notes

- I have not attempted to add `no_std` support to any of the format features, as that will require careful consideration around how to decouple from `std::io`. For example, [`ciborium-io`](https://crates.io/crates/ciborium-io) (or an equivalent trait local to `image`) could be used as a `no_std`-specific feature.
- Increasing MSRV is only required for `core::error::Error`. Instead of the increase, a feature could be added to enable usage of `core::error::Error`. I opted to just increase MSRV for simplicity. 1.70 to 1.81 isn't too large of a jump IMO.
- This is my first time contributing to this project, please let me know if there's anything I can do to help!