### PR TITLE
Avoid monomorphizing encoders if not used

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -7,7 +7,6 @@ use std::path::Path;
 use std::slice::{ChunksExact, ChunksExactMut};
 
 use crate::color::{FromColor, Luma, LumaA, Rgb, Rgba};
-use crate::{save_buffer, save_buffer_with_format, write_buffer_with_format};
 use crate::error::ImageResult;
 use crate::flat::{FlatSamples, SampleLayout};
 use crate::image::{GenericImage, GenericImageView, ImageEncoder, ImageFormat};
@@ -15,6 +14,7 @@ use crate::math::Rect;
 use crate::traits::{EncodableLayout, Pixel, PixelWithColorType};
 use crate::utils::expand_packed;
 use crate::DynamicImage;
+use crate::{save_buffer, save_buffer_with_format, write_buffer_with_format};
 
 /// Iterate over pixel refs.
 pub struct Pixels<'a, P: Pixel + 'a>

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use std::slice::{ChunksExact, ChunksExactMut};
 
 use crate::color::{FromColor, Luma, LumaA, Rgb, Rgba};
-use crate::dynimage::{save_buffer, save_buffer_with_format, write_buffer_with_format};
+use crate::{save_buffer, save_buffer_with_format, write_buffer_with_format};
 use crate::error::ImageResult;
 use crate::flat::{FlatSamples, SampleLayout};
 use crate::image::{GenericImage, GenericImageView, ImageEncoder, ImageFormat};

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -1309,51 +1309,6 @@ where
     ImageReader::open(path)?.into_dimensions()
 }
 
-/// Saves the supplied buffer to a file at the path specified.
-///
-/// The image format is derived from the file extension. The buffer is assumed to have
-/// the correct format according to the specified color type.
-///
-/// This will lead to corrupted files if the buffer contains malformed data. Currently only
-/// jpeg, png, ico, pnm, bmp, exr and tiff files are supported.
-pub fn save_buffer(
-    path: impl AsRef<Path>,
-    buf: &[u8],
-    width: u32,
-    height: u32,
-    color: impl Into<ExtendedColorType>,
-) -> ImageResult<()> {
-    // thin wrapper function to strip generics before calling save_buffer_impl
-    free_functions::save_buffer_impl(path.as_ref(), buf, width, height, color.into())
-}
-
-/// Saves the supplied buffer to a file at the path specified
-/// in the specified format.
-///
-/// The buffer is assumed to have the correct format according
-/// to the specified color type.
-/// This will lead to corrupted files if the buffer contains
-/// malformed data. Currently only jpeg, png, ico, bmp, exr and
-/// tiff files are supported.
-pub fn save_buffer_with_format(
-    path: impl AsRef<Path>,
-    buf: &[u8],
-    width: u32,
-    height: u32,
-    color: impl Into<ExtendedColorType>,
-    format: ImageFormat,
-) -> ImageResult<()> {
-    // thin wrapper function to strip generics
-    free_functions::save_buffer_with_format_impl(
-        path.as_ref(),
-        buf,
-        width,
-        height,
-        color.into(),
-        format,
-    )
-}
-
 /// Writes the supplied buffer to a writer in the specified format.
 ///
 /// The buffer is assumed to have the correct format according to the specified color type. This

--- a/src/image_reader/free_functions.rs
+++ b/src/image_reader/free_functions.rs
@@ -24,31 +24,42 @@ pub fn load<R: BufRead + Seek>(r: R, format: ImageFormat) -> ImageResult<Dynamic
     reader.decode()
 }
 
-#[allow(unused_variables)]
-// Most variables when no features are supported
-pub(crate) fn save_buffer_impl(
-    path: &Path,
+/// Saves the supplied buffer to a file at the path specified.
+///
+/// The image format is derived from the file extension. The buffer is assumed to have
+/// the correct format according to the specified color type.
+///
+/// This will lead to corrupted files if the buffer contains malformed data. Currently only
+/// jpeg, png, ico, pnm, bmp, exr and tiff files are supported.
+pub fn save_buffer(
+    path: impl AsRef<Path>,
     buf: &[u8],
     width: u32,
     height: u32,
-    color: ExtendedColorType,
+    color: impl Into<ExtendedColorType>,
 ) -> ImageResult<()> {
-    let format = ImageFormat::from_path(path)?;
-    save_buffer_with_format_impl(path, buf, width, height, color, format)
+    let format = ImageFormat::from_path(path.as_ref())?;
+    save_buffer_with_format(path, buf, width, height, color, format)
 }
 
-#[allow(unused_variables)]
-// Most variables when no features are supported
-pub(crate) fn save_buffer_with_format_impl(
-    path: &Path,
+/// Saves the supplied buffer to a file at the path specified
+/// in the specified format.
+///
+/// The buffer is assumed to have the correct format according
+/// to the specified color type.
+/// This will lead to corrupted files if the buffer contains
+/// malformed data. Currently only jpeg, png, ico, bmp, exr and
+/// tiff files are supported.
+pub fn save_buffer_with_format(
+    path: impl AsRef<Path>,
     buf: &[u8],
     width: u32,
     height: u32,
-    color: ExtendedColorType,
+    color: impl Into<ExtendedColorType>,
     format: ImageFormat,
 ) -> ImageResult<()> {
     let buffered_file_write = &mut BufWriter::new(File::create(path)?); // always seekable
-    write_buffer_impl(buffered_file_write, buf, width, height, color, format)
+    write_buffer_impl(buffered_file_write, buf, width, height, color.into(), format)
 }
 
 #[allow(unused_variables)]

--- a/src/image_reader/free_functions.rs
+++ b/src/image_reader/free_functions.rs
@@ -26,11 +26,9 @@ pub fn load<R: BufRead + Seek>(r: R, format: ImageFormat) -> ImageResult<Dynamic
 
 /// Saves the supplied buffer to a file at the path specified.
 ///
-/// The image format is derived from the file extension. The buffer is assumed to have
-/// the correct format according to the specified color type.
-///
-/// This will lead to corrupted files if the buffer contains malformed data. Currently only
-/// jpeg, png, ico, pnm, bmp, exr and tiff files are supported.
+/// The image format is derived from the file extension. The buffer is assumed to have the correct
+/// format according to the specified color type. This will lead to corrupted files if the buffer
+/// contains malformed data.
 pub fn save_buffer(
     path: impl AsRef<Path>,
     buf: &[u8],
@@ -42,14 +40,10 @@ pub fn save_buffer(
     save_buffer_with_format(path, buf, width, height, color, format)
 }
 
-/// Saves the supplied buffer to a file at the path specified
-/// in the specified format.
+/// Saves the supplied buffer to a file given the path and desired format.
 ///
-/// The buffer is assumed to have the correct format according
-/// to the specified color type.
-/// This will lead to corrupted files if the buffer contains
-/// malformed data. Currently only jpeg, png, ico, bmp, exr and
-/// tiff files are supported.
+/// The buffer is assumed to have the correct format according to the specified color type. This
+/// will lead to corrupted files if the buffer contains malformed data.
 pub fn save_buffer_with_format(
     path: impl AsRef<Path>,
     buf: &[u8],

--- a/src/image_reader/free_functions.rs
+++ b/src/image_reader/free_functions.rs
@@ -53,7 +53,14 @@ pub fn save_buffer_with_format(
     format: ImageFormat,
 ) -> ImageResult<()> {
     let buffered_file_write = &mut BufWriter::new(File::create(path)?); // always seekable
-    write_buffer_impl(buffered_file_write, buf, width, height, color.into(), format)
+    write_buffer_impl(
+        buffered_file_write,
+        buf,
+        width,
+        height,
+        color.into(),
+        format,
+    )
 }
 
 #[allow(unused_variables)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,10 +171,12 @@ pub use crate::traits::{EncodableLayout, Pixel, PixelWithColorType, Primitive};
 
 // Opening and loading images
 pub use crate::dynimage::{
-    image_dimensions, load_from_memory, load_from_memory_with_format, open, save_buffer,
-    save_buffer_with_format, write_buffer_with_format,
+    image_dimensions, load_from_memory, load_from_memory_with_format, open,
+    write_buffer_with_format,
 };
-pub use crate::image_reader::free_functions::{guess_format, load};
+pub use crate::image_reader::free_functions::{
+    guess_format, load, save_buffer, save_buffer_with_format,
+};
 pub use crate::image_reader::{ImageReader, LimitSupport, Limits};
 
 pub use crate::dynimage::DynamicImage;


### PR DESCRIPTION
I decided to look into improving compile times inspired by https://github.com/image-rs/image/issues/2244#issuecomment-2544563417

It turns out that a lot of time is spent compiling image format encoders for reasons that are somewhat subtle: Due to how the Rust compiler is implemented, methods with generic arguments get compiled when building a crate that uses them, while methods with concrete types get compiled when building the crate that defines them. 

In particular, the `save` family of methods in this crate take a generic argument (their "path" parameter) but were previously implemented to call a concrete `save_buffer_with_format_impl` version to handle the actual encoding / saving of the data. However at the same time, the various format crates that we depend on expose encoders that are themselves generic over the `std::io::Write` implementation that they output data to. That means that the actual concrete instantiation of the encoders would happen inside the _image_ crate, which is perhaps the worst time. It is too early to know whether downstream code actually needs encoding functionality, but too late to fully parallelize the compilation of different format encoders because in rustc (portions?) of crate compilation are sequential.

This PR shifts things around so that the encoders will get monomorphized in downstream code, but only if someone actually calls one of the `save` methods in their own code. On my machine it speeds up release build times by 3+ seconds.

---
Additionally this PR rewords the doc comments and moves the definitions of `save_buffer` and `save_buffer_with_format` to free_functions.rs where their implementations already were.