### PR TITLE
Make `load_from_memory` generic to improve compile times

### DIFF
--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -1379,8 +1379,8 @@ pub fn write_buffer_with_format<W: Write + Seek>(
 /// TGA is not supported by this function.
 ///
 /// Try [`ImageReader`] for more advanced uses.
-pub fn load_from_memory(buffer: &[u8]) -> ImageResult<DynamicImage> {
-    let format = free_functions::guess_format(buffer)?;
+pub fn load_from_memory(buffer: impl AsRef<[u8]>) -> ImageResult<DynamicImage> {
+    let format = free_functions::guess_format(buffer.as_ref())?;
     load_from_memory_with_format(buffer, format)
 }
 
@@ -1393,8 +1393,8 @@ pub fn load_from_memory(buffer: &[u8]) -> ImageResult<DynamicImage> {
 ///
 /// [`load`]: fn.load.html
 #[inline(always)]
-pub fn load_from_memory_with_format(buf: &[u8], format: ImageFormat) -> ImageResult<DynamicImage> {
-    let b = io::Cursor::new(buf);
+pub fn load_from_memory_with_format(buf: impl AsRef<[u8]>, format: ImageFormat) -> ImageResult<DynamicImage> {
+    let b = io::Cursor::new(buf.as_ref());
     free_functions::load(b, format)
 }
 

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -1393,7 +1393,10 @@ pub fn load_from_memory(buffer: impl AsRef<[u8]>) -> ImageResult<DynamicImage> {
 ///
 /// [`load`]: fn.load.html
 #[inline(always)]
-pub fn load_from_memory_with_format(buf: impl AsRef<[u8]>, format: ImageFormat) -> ImageResult<DynamicImage> {
+pub fn load_from_memory_with_format(
+    buf: impl AsRef<[u8]>,
+    format: ImageFormat,
+) -> ImageResult<DynamicImage> {
     let b = io::Cursor::new(buf.as_ref());
     free_functions::load(b, format)
 }

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -1397,6 +1397,9 @@ pub fn load_from_memory_with_format(
     buf: impl AsRef<[u8]>,
     format: ImageFormat,
 ) -> ImageResult<DynamicImage> {
+    // Note: this function (and `load_from_memory`) are generic over `AsRef<[u8]>` so that we do not
+    // monomorphize copies of all our decoders unless some downsteam crate actually calls one of
+    // these functions. See https://github.com/image-rs/image/pull/2470.
     let b = io::Cursor::new(buf.as_ref());
     free_functions::load(b, format)
 }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -111,7 +111,7 @@ fn bad_gif_oom() {
     //
     // So instead we look for a limits error (or an unsupported error, for the case that we're
     // running these tests without gif being actually supported)
-    let error = image::load_from_memory(&data).unwrap_err();
+    let error = image::load_from_memory(data).unwrap_err();
 
     assert!(
         matches!(error, image::ImageError::Limits(_))


### PR DESCRIPTION
Currently, the `load_from_memory[_with_format]` methods cause rustc to generate code for them when compiling the image crate, even if downstream code never decodes images from in-memory buffers. This PR changes them to be generic so that they only get monomorphized only if they are actually used. 

Reduces time for release builds by ~1.2 seconds on my machine.

See also: #2468, #2469 