### PR TITLE
Bump cargo-deny-action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -188,7 +188,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: EmbarkStudios/cargo-deny-action@v2
 
   cargo-semver-checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The previous version has a very outdated docker image by now which will conflict with our MSRV choices in the future (and partially does already for some potential dependencies).
