### PR TITLE
Rename ImageBuffer to PixelBuffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "image"
-version = "0.25.6"
+version = "1.0.0-preview"
 edition = "2021"
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Maintainers: [@HeroicKatora](https://github.com/HeroicKatora), [@fintelia](https
 
 This crate provides basic image processing functions and methods for converting to and from various image formats.
 
-All image processing functions provided operate on types that implement the `GenericImageView` and `GenericImage` traits and return an `ImageBuffer`.
+All image processing functions provided operate on types that implement the `GenericImageView` and `GenericImage` traits and return a `PixelBuffer`.
 
 ## High level API
 
@@ -67,13 +67,13 @@ image format encoders and decoders.
 This crate provides a number of different types for representing images.
 Individual pixels within images are indexed with (0,0) at the top left corner.
 
-### [`ImageBuffer`](https://docs.rs/image/*/image/struct.ImageBuffer.html)
+### [`PixelBuffer`](https://docs.rs/image/*/image/struct.PixelBuffer.html)
 An image parameterised by its Pixel type, represented by a width and height and
 a vector of pixels. It provides direct access to its pixels and implements the
 `GenericImageView` and `GenericImage` traits.
 
 ### [`DynamicImage`](https://docs.rs/image/*/image/enum.DynamicImage.html)
-A `DynamicImage` is an enumeration over all supported `ImageBuffer<P>` types.
+A `DynamicImage` is an enumeration over all supported `PixelBuffer<P>` types.
 Its exact image type is determined at runtime. It is the type returned when
 opening an image. For convenience `DynamicImage` reimplements all image
 processing functions.
@@ -168,7 +168,7 @@ let scalex = 3.0 / imgx as f32;
 let scaley = 3.0 / imgy as f32;
 
 // Create a new ImgBuf with width: imgx and height: imgy
-let mut imgbuf = image::ImageBuffer::new(imgx, imgy);
+let mut imgbuf = image::PixelBuffer::new(imgx, imgy);
 
 // Iterate over the coordinates and pixels of the image
 for (x, y, pixel) in imgbuf.enumerate_pixels_mut() {

--- a/benches/blur.rs
+++ b/benches/blur.rs
@@ -1,8 +1,8 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use image::{imageops::blur, ImageBuffer, Rgb};
+use image::{imageops::blur, PixelBuffer, Rgb};
 
 pub fn bench_fast_blur(c: &mut Criterion) {
-    let src = ImageBuffer::from_pixel(1024, 768, Rgb([255u8, 0, 0]));
+    let src = PixelBuffer::from_pixel(1024, 768, Rgb([255u8, 0, 0]));
 
     c.bench_function("blur", |b| {
         b.iter(|| blur(&src, 50.0));

--- a/benches/copy_from.rs
+++ b/benches/copy_from.rs
@@ -1,9 +1,9 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use image::{GenericImage, ImageBuffer, Rgba};
+use image::{GenericImage, PixelBuffer, Rgba};
 
 pub fn bench_copy_from(c: &mut Criterion) {
-    let src = ImageBuffer::from_pixel(2048, 2048, Rgba([255u8, 0, 0, 255]));
-    let mut dst = ImageBuffer::from_pixel(2048, 2048, Rgba([0u8, 0, 0, 255]));
+    let src = PixelBuffer::from_pixel(2048, 2048, Rgba([255u8, 0, 0, 255]));
+    let mut dst = PixelBuffer::from_pixel(2048, 2048, Rgba([0u8, 0, 0, 255]));
 
     c.bench_function("copy_from", |b| {
         b.iter(|| dst.copy_from(black_box(&src), 0, 0));

--- a/benches/fast_blur.rs
+++ b/benches/fast_blur.rs
@@ -1,8 +1,8 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use image::{imageops::fast_blur, ImageBuffer, Rgb};
+use image::{imageops::fast_blur, PixelBuffer, Rgb};
 
 pub fn bench_fast_blur(c: &mut Criterion) {
-    let src = ImageBuffer::from_pixel(1024, 768, Rgb([255u8, 0, 0]));
+    let src = PixelBuffer::from_pixel(1024, 768, Rgb([255u8, 0, 0]));
 
     c.bench_function("fast_blur", |b| {
         b.iter(|| fast_blur(&src, 50.0));

--- a/examples/concat/main.rs
+++ b/examples/concat/main.rs
@@ -1,4 +1,4 @@
-use image::{GenericImage, GenericImageView, ImageBuffer, Pixel, Primitive};
+use image::{GenericImage, GenericImageView, Pixel, PixelBuffer, Primitive};
 
 /// Example showcasing a generic implementation of image concatenation.
 ///
@@ -17,7 +17,7 @@ fn main() {
 }
 
 /// Concatenate horizontally images with the same pixel type.
-fn h_concat<I, P, S>(images: &[I]) -> ImageBuffer<P, Vec<S>>
+fn h_concat<I, P, S>(images: &[I]) -> PixelBuffer<P, Vec<S>>
 where
     I: GenericImageView<Pixel = P>,
     P: Pixel<Subpixel = S> + 'static,
@@ -30,7 +30,7 @@ where
     let img_height_out: u32 = images.iter().map(|im| im.height()).max().unwrap_or(0);
 
     // Initialize an image buffer with the appropriate size.
-    let mut imgbuf = image::ImageBuffer::new(img_width_out, img_height_out);
+    let mut imgbuf = image::PixelBuffer::new(img_width_out, img_height_out);
     let mut accumulated_width = 0;
 
     // Copy each input image at the correct location in the output image.

--- a/examples/fractal.rs
+++ b/examples/fractal.rs
@@ -10,7 +10,7 @@ fn main() {
     let scaley = 3.0 / imgy as f32;
 
     // Create a new ImgBuf with width: imgx and height: imgy
-    let mut imgbuf = image::ImageBuffer::new(imgx, imgy);
+    let mut imgbuf = image::PixelBuffer::new(imgx, imgy);
 
     // Iterate over the coordinates and pixels of the image
     for (x, y, pixel) in imgbuf.enumerate_pixels_mut() {

--- a/fuzz/fuzzers/roundtrip_webp.rs
+++ b/fuzz/fuzzers/roundtrip_webp.rs
@@ -5,7 +5,7 @@
 
 use std::io::Cursor;
 
-use image::{ImageBuffer, Rgba};
+use image::{PixelBuffer, Rgba};
 #[macro_use] extern crate libfuzzer_sys;
 extern crate image;
 
@@ -22,7 +22,7 @@ fuzz_target!(|data: &[u8]| {
         let content_len = width * height * 4;
         if content.len() >= content_len {
             let content = content[..content_len].to_owned();
-            let image : ImageBuffer<Rgba<u8>, Vec<u8>> = ImageBuffer::from_vec(
+            let image : PixelBuffer<Rgba<u8>, Vec<u8>> = PixelBuffer::from_vec(
                 width as u32, height as u32, 
                 content
             ).unwrap();

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,4 +1,4 @@
-//! Contains the generic `ImageBuffer` struct.
+//! Contains the generic `PixelBuffer` struct.
 use num_traits::Zero;
 use std::fmt;
 use std::marker::PhantomData;
@@ -140,9 +140,9 @@ where
 
 /// Iterate over rows of an image
 ///
-/// This iterator is created with [`ImageBuffer::rows`]. See its document for details.
+/// This iterator is created with [`PixelBuffer::rows`]. See its document for details.
 ///
-/// [`ImageBuffer::rows`]: ../struct.ImageBuffer.html#method.rows
+/// [`PixelBuffer::rows`]: ../struct.PixelBuffer.html#method.rows
 pub struct Rows<'a, P: Pixel + 'a>
 where
     <P as Pixel>::Subpixel: 'a,
@@ -238,9 +238,9 @@ where
 
 /// Iterate over mutable rows of an image
 ///
-/// This iterator is created with [`ImageBuffer::rows_mut`]. See its document for details.
+/// This iterator is created with [`PixelBuffer::rows_mut`]. See its document for details.
 ///
-/// [`ImageBuffer::rows_mut`]: ../struct.ImageBuffer.html#method.rows_mut
+/// [`PixelBuffer::rows_mut`]: ../struct.PixelBuffer.html#method.rows_mut
 pub struct RowsMut<'a, P: Pixel + 'a>
 where
     <P as Pixel>::Subpixel: 'a,
@@ -630,10 +630,10 @@ where
 /// Overlays an image on top of a larger background raster.
 ///
 /// ```no_run
-/// use image::{GenericImage, GenericImageView, ImageBuffer, open};
+/// use image::{GenericImage, GenericImageView, PixelBuffer, open};
 ///
 /// let on_top = open("path/to/some.png").unwrap().into_rgb8();
-/// let mut img = ImageBuffer::from_fn(512, 512, |x, y| {
+/// let mut img = PixelBuffer::from_fn(512, 512, |x, y| {
 ///     if (x + y) % 2 == 0 {
 ///         image::Rgb([0, 0, 0])
 ///     } else {
@@ -653,7 +653,7 @@ where
 /// let gray = DynamicImage::ImageRgba8(rgba).into_luma8();
 /// ```
 #[derive(Debug, Hash, PartialEq, Eq)]
-pub struct ImageBuffer<P: Pixel, Container> {
+pub struct PixelBuffer<P: Pixel, Container> {
     width: u32,
     height: u32,
     _phantom: PhantomData<P>,
@@ -661,7 +661,7 @@ pub struct ImageBuffer<P: Pixel, Container> {
 }
 
 // generic implementation, shared along all image buffers
-impl<P, Container> ImageBuffer<P, Container>
+impl<P, Container> PixelBuffer<P, Container>
 where
     P: Pixel,
     Container: Deref<Target = [P::Subpixel]>,
@@ -671,9 +671,9 @@ where
     ///
     /// Returns `None` if the container is not big enough (including when the image dimensions
     /// necessitate an allocation of more bytes than supported by the container).
-    pub fn from_raw(width: u32, height: u32, buf: Container) -> Option<ImageBuffer<P, Container>> {
+    pub fn from_raw(width: u32, height: u32, buf: Container) -> Option<PixelBuffer<P, Container>> {
         if Self::check_image_fits(width, height, buf.len()) {
-            Some(ImageBuffer {
+            Some(PixelBuffer {
                 data: buf,
                 width,
                 height,
@@ -883,7 +883,7 @@ where
     }
 }
 
-impl<P, Container> ImageBuffer<P, Container>
+impl<P, Container> PixelBuffer<P, Container>
 where
     P: Pixel,
     Container: Deref<Target = [P::Subpixel]> + DerefMut,
@@ -984,7 +984,7 @@ where
     }
 }
 
-impl<P, Container> ImageBuffer<P, Container>
+impl<P, Container> PixelBuffer<P, Container>
 where
     P: Pixel,
     [P::Subpixel]: EncodableLayout,
@@ -1008,7 +1008,7 @@ where
     }
 }
 
-impl<P, Container> ImageBuffer<P, Container>
+impl<P, Container> PixelBuffer<P, Container>
 where
     P: Pixel,
     [P::Subpixel]: EncodableLayout,
@@ -1036,7 +1036,7 @@ where
     }
 }
 
-impl<P, Container> ImageBuffer<P, Container>
+impl<P, Container> PixelBuffer<P, Container>
 where
     P: Pixel,
     [P::Subpixel]: EncodableLayout,
@@ -1063,7 +1063,7 @@ where
     }
 }
 
-impl<P, Container> ImageBuffer<P, Container>
+impl<P, Container> PixelBuffer<P, Container>
 where
     P: Pixel,
     [P::Subpixel]: EncodableLayout,
@@ -1085,7 +1085,7 @@ where
     }
 }
 
-impl<P, Container> Default for ImageBuffer<P, Container>
+impl<P, Container> Default for PixelBuffer<P, Container>
 where
     P: Pixel,
     Container: Default,
@@ -1100,7 +1100,7 @@ where
     }
 }
 
-impl<P, Container> Deref for ImageBuffer<P, Container>
+impl<P, Container> Deref for PixelBuffer<P, Container>
 where
     P: Pixel,
     Container: Deref<Target = [P::Subpixel]>,
@@ -1112,7 +1112,7 @@ where
     }
 }
 
-impl<P, Container> DerefMut for ImageBuffer<P, Container>
+impl<P, Container> DerefMut for PixelBuffer<P, Container>
 where
     P: Pixel,
     Container: Deref<Target = [P::Subpixel]> + DerefMut,
@@ -1122,7 +1122,7 @@ where
     }
 }
 
-impl<P, Container> Index<(u32, u32)> for ImageBuffer<P, Container>
+impl<P, Container> Index<(u32, u32)> for PixelBuffer<P, Container>
 where
     P: Pixel,
     Container: Deref<Target = [P::Subpixel]>,
@@ -1134,7 +1134,7 @@ where
     }
 }
 
-impl<P, Container> IndexMut<(u32, u32)> for ImageBuffer<P, Container>
+impl<P, Container> IndexMut<(u32, u32)> for PixelBuffer<P, Container>
 where
     P: Pixel,
     Container: Deref<Target = [P::Subpixel]> + DerefMut,
@@ -1144,13 +1144,13 @@ where
     }
 }
 
-impl<P, Container> Clone for ImageBuffer<P, Container>
+impl<P, Container> Clone for PixelBuffer<P, Container>
 where
     P: Pixel,
     Container: Deref<Target = [P::Subpixel]> + Clone,
 {
-    fn clone(&self) -> ImageBuffer<P, Container> {
-        ImageBuffer {
+    fn clone(&self) -> PixelBuffer<P, Container> {
+        PixelBuffer {
             data: self.data.clone(),
             width: self.width,
             height: self.height,
@@ -1165,7 +1165,7 @@ where
     }
 }
 
-impl<P, Container> GenericImageView for ImageBuffer<P, Container>
+impl<P, Container> GenericImageView for PixelBuffer<P, Container>
 where
     P: Pixel,
     Container: Deref<Target = [P::Subpixel]> + Deref,
@@ -1188,7 +1188,7 @@ where
     }
 }
 
-impl<P, Container> GenericImage for ImageBuffer<P, Container>
+impl<P, Container> GenericImage for PixelBuffer<P, Container>
 where
     P: Pixel,
     Container: Deref<Target = [P::Subpixel]> + DerefMut,
@@ -1260,7 +1260,7 @@ where
 // there is no such function as `into_vec`, whereas `into_raw` did work, and
 // `into_vec` is redundant anyway, because `into_raw` will give you the vector,
 // and it is more generic.
-impl<P: Pixel> ImageBuffer<P, Vec<P::Subpixel>> {
+impl<P: Pixel> PixelBuffer<P, Vec<P::Subpixel>> {
     /// Creates a new image buffer based on a `Vec<P::Subpixel>`.
     ///
     /// all the pixels of this image have a value of zero, regardless of the data type or number of channels.
@@ -1269,10 +1269,10 @@ impl<P: Pixel> ImageBuffer<P, Vec<P::Subpixel>> {
     ///
     /// Panics when the resulting image is larger than the maximum size of a vector.
     #[must_use]
-    pub fn new(width: u32, height: u32) -> ImageBuffer<P, Vec<P::Subpixel>> {
+    pub fn new(width: u32, height: u32) -> PixelBuffer<P, Vec<P::Subpixel>> {
         let size = Self::image_buffer_len(width, height)
-            .expect("Buffer length in `ImageBuffer::new` overflows usize");
-        ImageBuffer {
+            .expect("Buffer length in `PixelBuffer::new` overflows usize");
+        PixelBuffer {
             data: vec![Zero::zero(); size],
             width,
             height,
@@ -1280,31 +1280,31 @@ impl<P: Pixel> ImageBuffer<P, Vec<P::Subpixel>> {
         }
     }
 
-    /// Constructs a new `ImageBuffer` by copying a pixel
+    /// Constructs a new `PixelBuffer` by copying a pixel
     ///
     /// # Panics
     ///
     /// Panics when the resulting image is larger than the maximum size of a vector.
-    pub fn from_pixel(width: u32, height: u32, pixel: P) -> ImageBuffer<P, Vec<P::Subpixel>> {
-        let mut buf = ImageBuffer::new(width, height);
+    pub fn from_pixel(width: u32, height: u32, pixel: P) -> PixelBuffer<P, Vec<P::Subpixel>> {
+        let mut buf = PixelBuffer::new(width, height);
         for p in buf.pixels_mut() {
             *p = pixel;
         }
         buf
     }
 
-    /// Constructs a new `ImageBuffer` by repeated application of the supplied function.
+    /// Constructs a new `PixelBuffer` by repeated application of the supplied function.
     ///
     /// The arguments to the function are the pixel's x and y coordinates.
     ///
     /// # Panics
     ///
     /// Panics when the resulting image is larger than the maximum size of a vector.
-    pub fn from_fn<F>(width: u32, height: u32, mut f: F) -> ImageBuffer<P, Vec<P::Subpixel>>
+    pub fn from_fn<F>(width: u32, height: u32, mut f: F) -> PixelBuffer<P, Vec<P::Subpixel>>
     where
         F: FnMut(u32, u32) -> P,
     {
-        let mut buf = ImageBuffer::new(width, height);
+        let mut buf = PixelBuffer::new(width, height);
         for (x, y, p) in buf.enumerate_pixels_mut() {
             *p = f(x, y);
         }
@@ -1318,8 +1318,8 @@ impl<P: Pixel> ImageBuffer<P, Vec<P::Subpixel>> {
         width: u32,
         height: u32,
         buf: Vec<P::Subpixel>,
-    ) -> Option<ImageBuffer<P, Vec<P::Subpixel>>> {
-        ImageBuffer::from_raw(width, height, buf)
+    ) -> Option<PixelBuffer<P, Vec<P::Subpixel>>> {
+        PixelBuffer::from_raw(width, height, buf)
     }
 
     /// Consumes the image buffer and returns the underlying data
@@ -1354,7 +1354,7 @@ impl GrayImage {
         let mut data = self.into_raw();
         let entries = data.len();
         data.resize(entries.checked_mul(4).unwrap(), 0);
-        let mut buffer = ImageBuffer::from_vec(width, height, data).unwrap();
+        let mut buffer = PixelBuffer::from_vec(width, height, data).unwrap();
         expand_packed(&mut buffer, 4, 8, |idx, pixel| {
             let (r, g, b) = palette[idx as usize];
             let a = if let Some(t_idx) = transparent_idx {
@@ -1379,7 +1379,7 @@ impl GrayImage {
 // are, the T parameter should be removed in favor of ToType::Subpixel, which
 // will then be FromType::Subpixel.
 impl<Container, FromType: Pixel, ToType: Pixel>
-    ConvertBuffer<ImageBuffer<ToType, Vec<ToType::Subpixel>>> for ImageBuffer<FromType, Container>
+    ConvertBuffer<PixelBuffer<ToType, Vec<ToType::Subpixel>>> for PixelBuffer<FromType, Container>
 where
     Container: Deref<Target = [FromType::Subpixel]>,
     ToType: FromColor<FromType>,
@@ -1397,9 +1397,9 @@ where
     ///
     /// let gray_image: GrayImage = image.convert();
     /// ```
-    fn convert(&self) -> ImageBuffer<ToType, Vec<ToType::Subpixel>> {
-        let mut buffer: ImageBuffer<ToType, Vec<ToType::Subpixel>> =
-            ImageBuffer::new(self.width, self.height);
+    fn convert(&self) -> PixelBuffer<ToType, Vec<ToType::Subpixel>> {
+        let mut buffer: PixelBuffer<ToType, Vec<ToType::Subpixel>> =
+            PixelBuffer::new(self.width, self.height);
         for (to, from) in buffer.pixels_mut().zip(self.pixels()) {
             to.from_color(from);
         }
@@ -1408,29 +1408,29 @@ where
 }
 
 /// Sendable Rgb image buffer
-pub type RgbImage = ImageBuffer<Rgb<u8>, Vec<u8>>;
+pub type RgbImage = PixelBuffer<Rgb<u8>, Vec<u8>>;
 /// Sendable Rgb + alpha channel image buffer
-pub type RgbaImage = ImageBuffer<Rgba<u8>, Vec<u8>>;
+pub type RgbaImage = PixelBuffer<Rgba<u8>, Vec<u8>>;
 /// Sendable grayscale image buffer
-pub type GrayImage = ImageBuffer<Luma<u8>, Vec<u8>>;
+pub type GrayImage = PixelBuffer<Luma<u8>, Vec<u8>>;
 /// Sendable grayscale + alpha channel image buffer
-pub type GrayAlphaImage = ImageBuffer<LumaA<u8>, Vec<u8>>;
+pub type GrayAlphaImage = PixelBuffer<LumaA<u8>, Vec<u8>>;
 /// Sendable 16-bit Rgb image buffer
-pub(crate) type Rgb16Image = ImageBuffer<Rgb<u16>, Vec<u16>>;
+pub(crate) type Rgb16Image = PixelBuffer<Rgb<u16>, Vec<u16>>;
 /// Sendable 16-bit Rgb + alpha channel image buffer
-pub(crate) type Rgba16Image = ImageBuffer<Rgba<u16>, Vec<u16>>;
+pub(crate) type Rgba16Image = PixelBuffer<Rgba<u16>, Vec<u16>>;
 /// Sendable 16-bit grayscale image buffer
-pub(crate) type Gray16Image = ImageBuffer<Luma<u16>, Vec<u16>>;
+pub(crate) type Gray16Image = PixelBuffer<Luma<u16>, Vec<u16>>;
 /// Sendable 16-bit grayscale + alpha channel image buffer
-pub(crate) type GrayAlpha16Image = ImageBuffer<LumaA<u16>, Vec<u16>>;
+pub(crate) type GrayAlpha16Image = PixelBuffer<LumaA<u16>, Vec<u16>>;
 
 /// An image buffer for 32-bit float RGB pixels,
 /// where the backing container is a flattened vector of floats.
-pub type Rgb32FImage = ImageBuffer<Rgb<f32>, Vec<f32>>;
+pub type Rgb32FImage = PixelBuffer<Rgb<f32>, Vec<f32>>;
 
 /// An image buffer for 32-bit float RGBA pixels,
 /// where the backing container is a flattened vector of floats.
-pub type Rgba32FImage = ImageBuffer<Rgba<f32>, Vec<f32>>;
+pub type Rgba32FImage = PixelBuffer<Rgba<f32>, Vec<f32>>;
 
 impl From<DynamicImage> for RgbImage {
     fn from(value: DynamicImage) -> Self {
@@ -1488,7 +1488,7 @@ impl From<DynamicImage> for Rgba32FImage {
 
 #[cfg(test)]
 mod test {
-    use super::{GrayImage, ImageBuffer, RgbImage};
+    use super::{GrayImage, PixelBuffer, RgbImage};
     use crate::math::Rect;
     use crate::GenericImage as _;
     use crate::ImageFormat;
@@ -1499,7 +1499,7 @@ mod test {
     /// Tests if image buffers from slices work
     fn slice_buffer() {
         let data = [0; 9];
-        let buf: ImageBuffer<Luma<u8>, _> = ImageBuffer::from_raw(3, 3, &data[..]).unwrap();
+        let buf: PixelBuffer<Luma<u8>, _> = PixelBuffer::from_raw(3, 3, &data[..]).unwrap();
         assert_eq!(&*buf, &data[..]);
     }
 
@@ -1507,7 +1507,7 @@ mod test {
         ($test_name:ident, $pxt:ty) => {
             #[test]
             fn $test_name() {
-                let buffer = ImageBuffer::<$pxt, Vec<<$pxt as Pixel>::Subpixel>>::new(2, 2);
+                let buffer = PixelBuffer::<$pxt, Vec<<$pxt as Pixel>::Subpixel>>::new(2, 2);
                 assert!(buffer
                     .iter()
                     .all(|p| *p == <$pxt as Pixel>::Subpixel::zero()));
@@ -1530,7 +1530,7 @@ mod test {
 
     #[test]
     fn get_pixel() {
-        let mut a: RgbImage = ImageBuffer::new(10, 10);
+        let mut a: RgbImage = PixelBuffer::new(10, 10);
         {
             let b = a.get_mut(3 * 10).unwrap();
             *b = 255;
@@ -1540,7 +1540,7 @@ mod test {
 
     #[test]
     fn get_pixel_checked() {
-        let mut a: RgbImage = ImageBuffer::new(10, 10);
+        let mut a: RgbImage = PixelBuffer::new(10, 10);
         a.get_pixel_mut_checked(0, 1).unwrap()[0] = 255;
 
         assert_eq!(a.get_pixel_checked(0, 1), Some(&Rgb([255, 0, 0])));
@@ -1561,7 +1561,7 @@ mod test {
 
     #[test]
     fn mut_iter() {
-        let mut a: RgbImage = ImageBuffer::new(10, 10);
+        let mut a: RgbImage = PixelBuffer::new(10, 10);
         {
             let val = a.pixels_mut().next().unwrap();
             *val = Rgb([42, 0, 0]);
@@ -1614,14 +1614,14 @@ mod test {
 
     #[test]
     fn default() {
-        let image = ImageBuffer::<Rgb<u8>, Vec<u8>>::default();
+        let image = PixelBuffer::<Rgb<u8>, Vec<u8>>::default();
         assert_eq!(image.dimensions(), (0, 0));
     }
 
     #[test]
     #[rustfmt::skip]
     fn test_image_buffer_copy_within_oob() {
-        let mut image: GrayImage = ImageBuffer::from_raw(4, 4, vec![0u8; 16]).unwrap();
+        let mut image: GrayImage = PixelBuffer::from_raw(4, 4, vec![0u8; 16]).unwrap();
         assert!(!image.copy_within(Rect { x: 0, y: 0, width: 5, height: 4 }, 0, 0));
         assert!(!image.copy_within(Rect { x: 0, y: 0, width: 4, height: 5 }, 0, 0));
         assert!(!image.copy_within(Rect { x: 1, y: 0, width: 4, height: 4 }, 0, 0));
@@ -1635,7 +1635,7 @@ mod test {
     fn test_image_buffer_copy_within_tl() {
         let data = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
         let expected = [0, 1, 2, 3, 4, 0, 1, 2, 8, 4, 5, 6, 12, 8, 9, 10];
-        let mut image: GrayImage = ImageBuffer::from_raw(4, 4, Vec::from(&data[..])).unwrap();
+        let mut image: GrayImage = PixelBuffer::from_raw(4, 4, Vec::from(&data[..])).unwrap();
         assert!(image.copy_within(
             Rect {
                 x: 0,
@@ -1653,7 +1653,7 @@ mod test {
     fn test_image_buffer_copy_within_tr() {
         let data = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
         let expected = [0, 1, 2, 3, 1, 2, 3, 7, 5, 6, 7, 11, 9, 10, 11, 15];
-        let mut image: GrayImage = ImageBuffer::from_raw(4, 4, Vec::from(&data[..])).unwrap();
+        let mut image: GrayImage = PixelBuffer::from_raw(4, 4, Vec::from(&data[..])).unwrap();
         assert!(image.copy_within(
             Rect {
                 x: 1,
@@ -1671,7 +1671,7 @@ mod test {
     fn test_image_buffer_copy_within_bl() {
         let data = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
         let expected = [0, 4, 5, 6, 4, 8, 9, 10, 8, 12, 13, 14, 12, 13, 14, 15];
-        let mut image: GrayImage = ImageBuffer::from_raw(4, 4, Vec::from(&data[..])).unwrap();
+        let mut image: GrayImage = PixelBuffer::from_raw(4, 4, Vec::from(&data[..])).unwrap();
         assert!(image.copy_within(
             Rect {
                 x: 0,
@@ -1689,7 +1689,7 @@ mod test {
     fn test_image_buffer_copy_within_br() {
         let data = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
         let expected = [5, 6, 7, 3, 9, 10, 11, 7, 13, 14, 15, 11, 12, 13, 14, 15];
-        let mut image: GrayImage = ImageBuffer::from_raw(4, 4, Vec::from(&data[..])).unwrap();
+        let mut image: GrayImage = PixelBuffer::from_raw(4, 4, Vec::from(&data[..])).unwrap();
         assert!(image.copy_within(
             Rect {
                 x: 1,
@@ -1708,7 +1708,7 @@ mod test {
     fn write_to_with_large_buffer() {
         // A buffer of 1 pixel, padded to 4 bytes as would be common in, e.g. BMP.
 
-        let img: GrayImage = ImageBuffer::from_raw(1, 1, vec![0u8; 4]).unwrap();
+        let img: GrayImage = PixelBuffer::from_raw(1, 1, vec![0u8; 4]).unwrap();
         let mut buffer = std::io::Cursor::new(vec![]);
         assert!(img.write_to(&mut buffer, ImageFormat::Png).is_ok());
     }
@@ -1760,11 +1760,11 @@ mod test {
 #[cfg(test)]
 #[cfg(feature = "benchmarks")]
 mod benchmarks {
-    use super::{ConvertBuffer, GrayImage, ImageBuffer, Pixel, RgbImage};
+    use super::{ConvertBuffer, GrayImage, Pixel, PixelBuffer, RgbImage};
 
     #[bench]
     fn conversion(b: &mut test::Bencher) {
-        let mut a: RgbImage = ImageBuffer::new(1000, 1000);
+        let mut a: RgbImage = PixelBuffer::new(1000, 1000);
         for p in a.pixels_mut() {
             let rgb = p.channels_mut();
             rgb[0] = 255;
@@ -1783,7 +1783,7 @@ mod benchmarks {
 
     #[bench]
     fn image_access_row_by_row(b: &mut test::Bencher) {
-        let mut a: RgbImage = ImageBuffer::new(1000, 1000);
+        let mut a: RgbImage = PixelBuffer::new(1000, 1000);
         for p in a.pixels_mut() {
             let rgb = p.channels_mut();
             rgb[0] = 255;
@@ -1810,7 +1810,7 @@ mod benchmarks {
 
     #[bench]
     fn image_access_col_by_col(b: &mut test::Bencher) {
-        let mut a: RgbImage = ImageBuffer::new(1000, 1000);
+        let mut a: RgbImage = PixelBuffer::new(1000, 1000);
         for p in a.pixels_mut() {
             let rgb = p.channels_mut();
             rgb[0] = 255;

--- a/src/buffer_par.rs
+++ b/src/buffer_par.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use std::ops::{Deref, DerefMut};
 
 use crate::traits::Pixel;
-use crate::ImageBuffer;
+use crate::PixelBuffer;
 
 /// Parallel iterator over pixel refs.
 #[derive(Clone)]
@@ -311,7 +311,7 @@ where
     }
 }
 
-impl<P, Container> ImageBuffer<P, Container>
+impl<P, Container> PixelBuffer<P, Container>
 where
     P: Pixel + Sync,
     P::Subpixel: Sync,
@@ -341,7 +341,7 @@ where
     }
 }
 
-impl<P, Container> ImageBuffer<P, Container>
+impl<P, Container> PixelBuffer<P, Container>
 where
     P: Pixel + Send + Sync,
     P::Subpixel: Send + Sync,
@@ -372,12 +372,12 @@ where
     }
 }
 
-impl<P> ImageBuffer<P, Vec<P::Subpixel>>
+impl<P> PixelBuffer<P, Vec<P::Subpixel>>
 where
     P: Pixel + Send + Sync,
     P::Subpixel: Send + Sync,
 {
-    /// Constructs a new `ImageBuffer` by repeated application of the supplied function,
+    /// Constructs a new `PixelBuffer` by repeated application of the supplied function,
     /// utilizing multi-threading via `rayon`.
     ///
     /// The arguments to the function are the pixel's x and y coordinates.
@@ -385,11 +385,11 @@ where
     /// # Panics
     ///
     /// Panics when the resulting image is larger than the maximum size of a vector.
-    pub fn from_par_fn<F>(width: u32, height: u32, f: F) -> ImageBuffer<P, Vec<P::Subpixel>>
+    pub fn from_par_fn<F>(width: u32, height: u32, f: F) -> PixelBuffer<P, Vec<P::Subpixel>>
     where
         F: Fn(u32, u32) -> P + Send + Sync,
     {
-        let mut buf = ImageBuffer::new(width, height);
+        let mut buf = PixelBuffer::new(width, height);
         buf.par_enumerate_pixels_mut().for_each(|(x, y, p)| {
             *p = f(x, y);
         });

--- a/src/codecs/jpeg/encoder.rs
+++ b/src/codecs/jpeg/encoder.rs
@@ -6,7 +6,7 @@ use crate::error::{
 };
 use crate::image::{ImageEncoder, ImageFormat};
 use crate::utils::clamp;
-use crate::{ExtendedColorType, GenericImageView, ImageBuffer, Luma, Pixel, Rgb};
+use crate::{ExtendedColorType, GenericImageView, Luma, Pixel, PixelBuffer, Rgb};
 use num_traits::ToPrimitive;
 use std::borrow::Cow;
 use std::io::{self, Write};
@@ -457,13 +457,13 @@ impl<W: Write> JpegEncoder<W> {
 
         match color_type {
             ExtendedColorType::L8 => {
-                let image: ImageBuffer<Luma<_>, _> =
-                    ImageBuffer::from_raw(width, height, image).unwrap();
+                let image: PixelBuffer<Luma<_>, _> =
+                    PixelBuffer::from_raw(width, height, image).unwrap();
                 self.encode_image(&image)
             }
             ExtendedColorType::Rgb8 => {
-                let image: ImageBuffer<Rgb<_>, _> =
-                    ImageBuffer::from_raw(width, height, image).unwrap();
+                let image: PixelBuffer<Rgb<_>, _> =
+                    PixelBuffer::from_raw(width, height, image).unwrap();
                 self.encode_image(&image)
             }
             _ => Err(ImageError::Unsupported(

--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -340,7 +340,7 @@ mod test {
 
     use crate::buffer_::{Rgb32FImage, Rgba32FImage};
     use crate::error::{LimitError, LimitErrorKind};
-    use crate::{DynamicImage, ImageBuffer, Rgb, Rgba};
+    use crate::{DynamicImage, PixelBuffer, Rgb, Rgba};
 
     const BASE_PATH: &[&str] = &[".", "tests", "images", "exr"];
 
@@ -386,7 +386,7 @@ mod test {
         let (width, height) = decoder.dimensions();
         let buffer: Vec<f32> = crate::image::decoder_to_vec(decoder)?;
 
-        ImageBuffer::from_raw(width, height, buffer)
+        PixelBuffer::from_raw(width, height, buffer)
             // this should be the only reason for the "from raw" call to fail,
             // even though such a large allocation would probably cause an error much earlier
             .ok_or_else(|| {
@@ -400,7 +400,7 @@ mod test {
         let (width, height) = decoder.dimensions();
         let buffer: Vec<f32> = crate::image::decoder_to_vec(decoder)?;
 
-        ImageBuffer::from_raw(width, height, buffer)
+        PixelBuffer::from_raw(width, height, buffer)
             // this should be the only reason for the "from raw" call to fail,
             // even though such a large allocation would probably cause an error much earlier
             .ok_or_else(|| {
@@ -454,7 +454,7 @@ mod test {
             .cycle();
         let mut next_random = move || next_random.next().unwrap();
 
-        let generated_image: Rgba32FImage = ImageBuffer::from_fn(9, 31, |_x, _y| {
+        let generated_image: Rgba32FImage = PixelBuffer::from_fn(9, 31, |_x, _y| {
             Rgba([next_random(), next_random(), next_random(), next_random()])
         });
 
@@ -472,7 +472,7 @@ mod test {
             .cycle();
         let mut next_random = move || next_random.next().unwrap();
 
-        let generated_image: Rgb32FImage = ImageBuffer::from_fn(9, 31, |_x, _y| {
+        let generated_image: Rgb32FImage = PixelBuffer::from_fn(9, 31, |_x, _y| {
             Rgb([next_random(), next_random(), next_random()])
         });
 

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -18,7 +18,7 @@ use crate::error::{
     ParameterError, ParameterErrorKind, UnsupportedError, UnsupportedErrorKind,
 };
 use crate::image::{AnimationDecoder, ImageDecoder, ImageEncoder, ImageFormat};
-use crate::{DynamicImage, GenericImage, ImageBuffer, Luma, LumaA, Rgb, Rgba, RgbaImage};
+use crate::{DynamicImage, GenericImage, Luma, LumaA, PixelBuffer, Rgb, Rgba, RgbaImage};
 use crate::{GenericImageView, Limits};
 
 // http://www.w3.org/TR/PNG-Structure.html
@@ -391,18 +391,18 @@ impl<R: BufRead + Seek> ApngDecoder<R> {
         limits.reserve_buffer(width, height, COLOR_TYPE)?;
         let source = match self.inner.color_type {
             ColorType::L8 => {
-                let image = ImageBuffer::<Luma<_>, _>::from_raw(width, height, buffer).unwrap();
+                let image = PixelBuffer::<Luma<_>, _>::from_raw(width, height, buffer).unwrap();
                 DynamicImage::ImageLuma8(image).into_rgba8()
             }
             ColorType::La8 => {
-                let image = ImageBuffer::<LumaA<_>, _>::from_raw(width, height, buffer).unwrap();
+                let image = PixelBuffer::<LumaA<_>, _>::from_raw(width, height, buffer).unwrap();
                 DynamicImage::ImageLumaA8(image).into_rgba8()
             }
             ColorType::Rgb8 => {
-                let image = ImageBuffer::<Rgb<_>, _>::from_raw(width, height, buffer).unwrap();
+                let image = PixelBuffer::<Rgb<_>, _>::from_raw(width, height, buffer).unwrap();
                 DynamicImage::ImageRgb8(image).into_rgba8()
             }
-            ColorType::Rgba8 => ImageBuffer::<Rgba<_>, _>::from_raw(width, height, buffer).unwrap(),
+            ColorType::Rgba8 => PixelBuffer::<Rgba<_>, _>::from_raw(width, height, buffer).unwrap(),
             ColorType::L16 | ColorType::Rgb16 | ColorType::La16 | ColorType::Rgba16 => {
                 // TODO: to enable remove restriction in `animatable_color_type` method.
                 unreachable!("16-bit apng not yet support")

--- a/src/dynimage.rs
+++ b/src/dynimage.rs
@@ -7,7 +7,7 @@ use crate::codecs::gif;
 use crate::codecs::png;
 
 use crate::buffer_::{
-    ConvertBuffer, Gray16Image, GrayAlpha16Image, GrayAlphaImage, GrayImage, ImageBuffer,
+    ConvertBuffer, Gray16Image, GrayAlpha16Image, GrayAlphaImage, GrayImage, PixelBuffer,
     Rgb16Image, RgbImage, Rgba16Image, RgbaImage,
 };
 use crate::color::{self, FromColor, IntoColor};
@@ -31,7 +31,7 @@ use crate::{Rgb32FImage, Rgba32FImage};
 ///
 /// # Usage
 ///
-/// This type can act as a converter between specific `ImageBuffer` instances.
+/// This type can act as a converter between specific `PixelBuffer` instances.
 ///
 /// ```
 /// use image::{DynamicImage, GrayImage, RgbImage};
@@ -158,63 +158,63 @@ impl DynamicImage {
     /// Creates a dynamic image backed by a buffer of gray pixels.
     #[must_use]
     pub fn new_luma8(w: u32, h: u32) -> DynamicImage {
-        DynamicImage::ImageLuma8(ImageBuffer::new(w, h))
+        DynamicImage::ImageLuma8(PixelBuffer::new(w, h))
     }
 
     /// Creates a dynamic image backed by a buffer of gray
     /// pixels with transparency.
     #[must_use]
     pub fn new_luma_a8(w: u32, h: u32) -> DynamicImage {
-        DynamicImage::ImageLumaA8(ImageBuffer::new(w, h))
+        DynamicImage::ImageLumaA8(PixelBuffer::new(w, h))
     }
 
     /// Creates a dynamic image backed by a buffer of RGB pixels.
     #[must_use]
     pub fn new_rgb8(w: u32, h: u32) -> DynamicImage {
-        DynamicImage::ImageRgb8(ImageBuffer::new(w, h))
+        DynamicImage::ImageRgb8(PixelBuffer::new(w, h))
     }
 
     /// Creates a dynamic image backed by a buffer of RGBA pixels.
     #[must_use]
     pub fn new_rgba8(w: u32, h: u32) -> DynamicImage {
-        DynamicImage::ImageRgba8(ImageBuffer::new(w, h))
+        DynamicImage::ImageRgba8(PixelBuffer::new(w, h))
     }
 
     /// Creates a dynamic image backed by a buffer of gray pixels.
     #[must_use]
     pub fn new_luma16(w: u32, h: u32) -> DynamicImage {
-        DynamicImage::ImageLuma16(ImageBuffer::new(w, h))
+        DynamicImage::ImageLuma16(PixelBuffer::new(w, h))
     }
 
     /// Creates a dynamic image backed by a buffer of gray
     /// pixels with transparency.
     #[must_use]
     pub fn new_luma_a16(w: u32, h: u32) -> DynamicImage {
-        DynamicImage::ImageLumaA16(ImageBuffer::new(w, h))
+        DynamicImage::ImageLumaA16(PixelBuffer::new(w, h))
     }
 
     /// Creates a dynamic image backed by a buffer of RGB pixels.
     #[must_use]
     pub fn new_rgb16(w: u32, h: u32) -> DynamicImage {
-        DynamicImage::ImageRgb16(ImageBuffer::new(w, h))
+        DynamicImage::ImageRgb16(PixelBuffer::new(w, h))
     }
 
     /// Creates a dynamic image backed by a buffer of RGBA pixels.
     #[must_use]
     pub fn new_rgba16(w: u32, h: u32) -> DynamicImage {
-        DynamicImage::ImageRgba16(ImageBuffer::new(w, h))
+        DynamicImage::ImageRgba16(PixelBuffer::new(w, h))
     }
 
     /// Creates a dynamic image backed by a buffer of RGB pixels.
     #[must_use]
     pub fn new_rgb32f(w: u32, h: u32) -> DynamicImage {
-        DynamicImage::ImageRgb32F(ImageBuffer::new(w, h))
+        DynamicImage::ImageRgb32F(PixelBuffer::new(w, h))
     }
 
     /// Creates a dynamic image backed by a buffer of RGBA pixels.
     #[must_use]
     pub fn new_rgba32f(w: u32, h: u32) -> DynamicImage {
-        DynamicImage::ImageRgba32F(ImageBuffer::new(w, h))
+        DynamicImage::ImageRgba32F(PixelBuffer::new(w, h))
     }
 
     /// Decodes an encoded image into a dynamic image.
@@ -238,7 +238,7 @@ impl DynamicImage {
             + FromColor<LumaA<u8>>,
     >(
         &self,
-    ) -> ImageBuffer<T, Vec<T::Subpixel>> {
+    ) -> PixelBuffer<T, Vec<T::Subpixel>> {
         dynamic_map!(*self, ref p, p.convert())
     }
 
@@ -292,7 +292,7 @@ impl DynamicImage {
 
     /// Returns a copy of this image as a Luma image.
     #[must_use]
-    pub fn to_luma32f(&self) -> ImageBuffer<Luma<f32>, Vec<f32>> {
+    pub fn to_luma32f(&self) -> PixelBuffer<Luma<f32>, Vec<f32>> {
         self.to()
     }
 
@@ -310,7 +310,7 @@ impl DynamicImage {
 
     /// Returns a copy of this image as a `LumaA` image.
     #[must_use]
-    pub fn to_luma_alpha32f(&self) -> ImageBuffer<LumaA<f32>, Vec<f32>> {
+    pub fn to_luma_alpha32f(&self) -> PixelBuffer<LumaA<f32>, Vec<f32>> {
         self.to()
     }
 
@@ -656,7 +656,7 @@ impl DynamicImage {
     /// Return this image's pixels as a native endian byte slice.
     #[must_use]
     pub fn as_bytes(&self) -> &[u8] {
-        // we can do this because every variant contains an `ImageBuffer<_, Vec<_>>`
+        // we can do this because every variant contains an `PixelBuffer<_, Vec<_>>`
         dynamic_map!(
             *self,
             ref image_buffer,
@@ -666,7 +666,7 @@ impl DynamicImage {
 
     // TODO: choose a name under which to expose?
     fn inner_bytes(&self) -> &[u8] {
-        // we can do this because every variant contains an `ImageBuffer<_, Vec<_>>`
+        // we can do this because every variant contains an `PixelBuffer<_, Vec<_>>`
         dynamic_map!(
             *self,
             ref image_buffer,
@@ -674,12 +674,12 @@ impl DynamicImage {
         )
     }
 
-    /// Return this image's pixels as a byte vector. If the `ImageBuffer`
+    /// Return this image's pixels as a byte vector. If the `PixelBuffer`
     /// container is `Vec<u8>`, this operation is free. Otherwise, a copy
     /// is returned.
     #[must_use]
     pub fn into_bytes(self) -> Vec<u8> {
-        // we can do this because every variant contains an `ImageBuffer<_, Vec<_>>`
+        // we can do this because every variant contains an `PixelBuffer<_, Vec<_>>`
         dynamic_map!(self, image_buffer, {
             match bytemuck::allocation::try_cast_vec(image_buffer.into_raw()) {
                 Ok(vec) => vec,
@@ -1143,14 +1143,14 @@ impl From<Rgba32FImage> for DynamicImage {
     }
 }
 
-impl From<ImageBuffer<Luma<f32>, Vec<f32>>> for DynamicImage {
-    fn from(image: ImageBuffer<Luma<f32>, Vec<f32>>) -> Self {
+impl From<PixelBuffer<Luma<f32>, Vec<f32>>> for DynamicImage {
+    fn from(image: PixelBuffer<Luma<f32>, Vec<f32>>) -> Self {
         DynamicImage::ImageRgb32F(image.convert())
     }
 }
 
-impl From<ImageBuffer<LumaA<f32>, Vec<f32>>> for DynamicImage {
-    fn from(image: ImageBuffer<LumaA<f32>, Vec<f32>>) -> Self {
+impl From<PixelBuffer<LumaA<f32>, Vec<f32>>> for DynamicImage {
+    fn from(image: PixelBuffer<LumaA<f32>, Vec<f32>>) -> Self {
         DynamicImage::ImageRgba32F(image.convert())
     }
 }
@@ -1228,52 +1228,52 @@ fn decoder_to_image<I: ImageDecoder>(decoder: I) -> ImageResult<DynamicImage> {
     let image = match color_type {
         color::ColorType::Rgb8 => {
             let buf = image::decoder_to_vec(decoder)?;
-            ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageRgb8)
+            PixelBuffer::from_raw(w, h, buf).map(DynamicImage::ImageRgb8)
         }
 
         color::ColorType::Rgba8 => {
             let buf = image::decoder_to_vec(decoder)?;
-            ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageRgba8)
+            PixelBuffer::from_raw(w, h, buf).map(DynamicImage::ImageRgba8)
         }
 
         color::ColorType::L8 => {
             let buf = image::decoder_to_vec(decoder)?;
-            ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLuma8)
+            PixelBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLuma8)
         }
 
         color::ColorType::La8 => {
             let buf = image::decoder_to_vec(decoder)?;
-            ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLumaA8)
+            PixelBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLumaA8)
         }
 
         color::ColorType::Rgb16 => {
             let buf = image::decoder_to_vec(decoder)?;
-            ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageRgb16)
+            PixelBuffer::from_raw(w, h, buf).map(DynamicImage::ImageRgb16)
         }
 
         color::ColorType::Rgba16 => {
             let buf = image::decoder_to_vec(decoder)?;
-            ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageRgba16)
+            PixelBuffer::from_raw(w, h, buf).map(DynamicImage::ImageRgba16)
         }
 
         color::ColorType::Rgb32F => {
             let buf = image::decoder_to_vec(decoder)?;
-            ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageRgb32F)
+            PixelBuffer::from_raw(w, h, buf).map(DynamicImage::ImageRgb32F)
         }
 
         color::ColorType::Rgba32F => {
             let buf = image::decoder_to_vec(decoder)?;
-            ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageRgba32F)
+            PixelBuffer::from_raw(w, h, buf).map(DynamicImage::ImageRgba32F)
         }
 
         color::ColorType::L16 => {
             let buf = image::decoder_to_vec(decoder)?;
-            ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLuma16)
+            PixelBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLuma16)
         }
 
         color::ColorType::La16 => {
             let buf = image::decoder_to_vec(decoder)?;
-            ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLumaA16)
+            PixelBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLumaA16)
         }
     };
 
@@ -1358,7 +1358,7 @@ mod bench {
     #[bench]
     #[cfg(feature = "benchmarks")]
     fn bench_conversion(b: &mut test::Bencher) {
-        let a = super::DynamicImage::ImageRgb8(crate::ImageBuffer::new(1000, 1000));
+        let a = super::DynamicImage::ImageRgb8(crate::PixelBuffer::new(1000, 1000));
         b.iter(|| a.to_luma8());
         b.bytes = 1000 * 1000 * 3
     }
@@ -1487,7 +1487,7 @@ mod test {
     #[test]
     fn issue_1705_can_turn_16bit_image_into_bytes() {
         let pixels = vec![65535u16; 64 * 64];
-        let img = super::ImageBuffer::from_vec(64, 64, pixels).unwrap();
+        let img = super::PixelBuffer::from_vec(64, 64, pixels).unwrap();
 
         let img = super::DynamicImage::ImageLuma16(img);
         assert!(img.as_luma16().is_some());

--- a/src/flat.rs
+++ b/src/flat.rs
@@ -54,11 +54,11 @@ use crate::error::{
 };
 use crate::image::{GenericImage, GenericImageView};
 use crate::traits::Pixel;
-use crate::ImageBuffer;
+use crate::PixelBuffer;
 
 /// A flat buffer over a (multi channel) image.
 ///
-/// In contrast to `ImageBuffer`, this representation of a sample collection is much more lenient
+/// In contrast to `PixelBuffer`, this representation of a sample collection is much more lenient
 /// in the layout thereof. It also allows grouping by color planes instead of by pixel as long as
 /// the strides of each extent are constant. This struct itself has no invariants on the strides
 /// but not every possible configuration can be interpreted as a [`GenericImageView`] or
@@ -67,14 +67,14 @@ use crate::ImageBuffer;
 /// use [`is_normal`] or [`has_aliased_samples`].
 ///
 /// Instances can be constructed not only by hand. The buffer instances returned by library
-/// functions such as [`ImageBuffer::as_flat_samples`] guarantee that the conversion to a generic
+/// functions such as [`PixelBuffer::as_flat_samples`] guarantee that the conversion to a generic
 /// image or generic view succeeds. A very different constructor is [`with_monocolor`]. It uses a
 /// single pixel as the backing storage for an arbitrarily sized read-only raster by mapping each
 /// pixel to the same samples by setting some strides to `0`.
 ///
 /// [`GenericImage`]: ../trait.GenericImage.html
 /// [`GenericImageView`]: ../trait.GenericImageView.html
-/// [`ImageBuffer::as_flat_samples`]: ../struct.ImageBuffer.html#method.as_flat_samples
+/// [`PixelBuffer::as_flat_samples`]: ../struct.PixelBuffer.html#method.as_flat_samples
 /// [`is_normal`]: #method.is_normal
 /// [`has_aliased_samples`]: #method.has_aliased_samples
 /// [`as_view`]: #method.as_view
@@ -128,7 +128,7 @@ impl SampleLayout {
     /// Describe a row-major image packed in all directions.
     ///
     /// The resulting will surely be `NormalForm::RowMajorPacked`. It can therefore be converted to
-    /// safely to an `ImageBuffer` with a large enough underlying buffer.
+    /// safely to an `PixelBuffer` with a large enough underlying buffer.
     ///
     /// ```
     /// # use image::flat::{NormalForm, SampleLayout};
@@ -680,11 +680,11 @@ impl<Buffer> FlatSamples<Buffer> {
     /// pixel must be packed (i.e. `channel_stride` is `1`). The number of channels must be
     /// consistent with the channel count expected by the pixel format.
     ///
-    /// This is similar to an `ImageBuffer` except it is a temporary view that is not normalized as
-    /// strongly. To get an owning version, consider copying the data into an `ImageBuffer`. This
+    /// This is similar to an `PixelBuffer` except it is a temporary view that is not normalized as
+    /// strongly. To get an owning version, consider copying the data into an `PixelBuffer`. This
     /// provides many more operations, is possibly faster (if not you may want to open an issue) is
     /// generally polished. You can also try to convert this buffer inline, see
-    /// `ImageBuffer::from_raw`.
+    /// `PixelBuffer::from_raw`.
     pub fn as_view_mut<P>(&mut self) -> Result<ViewMut<&mut [P::Subpixel], P>, Error>
     where
         P: Pixel,
@@ -777,7 +777,7 @@ impl<Buffer> FlatSamples<Buffer> {
     /// This does **not** convert the sample layout. The buffer needs to be in packed row-major form
     /// before calling this function. In case of an error, returns the buffer again so that it does
     /// not release any allocation.
-    pub fn try_into_buffer<P>(self) -> Result<ImageBuffer<P, Buffer>, (Error, Self)>
+    pub fn try_into_buffer<P>(self) -> Result<PixelBuffer<P, Buffer>, (Error, Self)>
     where
         P: Pixel + 'static,
         P::Subpixel: 'static,
@@ -799,7 +799,7 @@ impl<Buffer> FlatSamples<Buffer> {
         }
 
         Ok(
-            ImageBuffer::from_raw(self.layout.width, self.layout.height, self.samples)
+            PixelBuffer::from_raw(self.layout.width, self.layout.height, self.samples)
                 .unwrap_or_else(|| {
                     panic!("Preconditions should have been ensured before conversion")
                 }),
@@ -997,8 +997,8 @@ where
 
 /// A mutable owning version of a flat buffer.
 ///
-/// While this wraps a buffer similar to `ImageBuffer`, this is mostly intended as a utility. The
-/// library endorsed normalized representation is still `ImageBuffer`. Also, the implementation of
+/// While this wraps a buffer similar to `PixelBuffer`, this is mostly intended as a utility. The
+/// library endorsed normalized representation is still `PixelBuffer`. Also, the implementation of
 /// `AsMut<[P::Subpixel]>` must always yield the same buffer. Therefore there is no public way to
 /// construct this with an owning buffer.
 ///
@@ -1019,7 +1019,7 @@ where
 
 /// Denotes invalid flat sample buffers when trying to convert to stricter types.
 ///
-/// The biggest use case being `ImageBuffer` which expects closely packed
+/// The biggest use case being `PixelBuffer` which expects closely packed
 /// samples in a row major matrix representation. But this error type may be
 /// reused for other import functions. A more versatile user may also try to
 /// correct the underlying representation depending on the error variant.

--- a/src/image.rs
+++ b/src/image.rs
@@ -13,7 +13,7 @@ use crate::error::{
 use crate::math::Rect;
 use crate::metadata::Orientation;
 use crate::traits::Pixel;
-use crate::ImageBuffer;
+use crate::PixelBuffer;
 
 use crate::animation::Frames;
 
@@ -1173,13 +1173,13 @@ impl<I> SubImage<I> {
         (self.inner.xoffset, self.inner.yoffset)
     }
 
-    /// Convert this subimage to an `ImageBuffer`
-    pub fn to_image(&self) -> ImageBuffer<DerefPixel<I>, Vec<DerefSubpixel<I>>>
+    /// Convert this subimage to an `PixelBuffer`
+    pub fn to_image(&self) -> PixelBuffer<DerefPixel<I>, Vec<DerefSubpixel<I>>>
     where
         I: Deref,
         I::Target: GenericImageView + 'static,
     {
-        let mut out = ImageBuffer::new(self.inner.xstride, self.inner.ystride);
+        let mut out = PixelBuffer::new(self.inner.xstride, self.inner.ystride);
         let borrowed = &*self.inner.image;
 
         for y in 0..self.inner.ystride {
@@ -1331,13 +1331,13 @@ mod tests {
     };
     use crate::color::Rgba;
     use crate::math::Rect;
-    use crate::{GrayImage, ImageBuffer};
+    use crate::{GrayImage, PixelBuffer};
 
     #[test]
     #[allow(deprecated)]
     /// Test that alpha blending works as expected
     fn test_image_alpha_blending() {
-        let mut target = ImageBuffer::new(1, 1);
+        let mut target = PixelBuffer::new(1, 1);
         target.put_pixel(0, 0, Rgba([255u8, 0, 0, 255]));
         assert!(*target.get_pixel(0, 0) == Rgba([255, 0, 0, 255]));
         target.blend_pixel(0, 0, Rgba([0, 255, 0, 255]));
@@ -1355,7 +1355,7 @@ mod tests {
 
     #[test]
     fn test_in_bounds() {
-        let mut target = ImageBuffer::new(2, 2);
+        let mut target = PixelBuffer::new(2, 2);
         target.put_pixel(0, 0, Rgba([255u8, 0, 0, 255]));
 
         assert!(target.in_bounds(0, 0));
@@ -1370,7 +1370,7 @@ mod tests {
 
     #[test]
     fn test_can_subimage_clone_nonmut() {
-        let mut source = ImageBuffer::new(3, 3);
+        let mut source = PixelBuffer::new(3, 3);
         source.put_pixel(1, 1, Rgba([255u8, 0, 0, 255]));
 
         // A non-mutable copy of the source image
@@ -1384,7 +1384,7 @@ mod tests {
 
     #[test]
     fn test_can_nest_views() {
-        let mut source = ImageBuffer::from_pixel(3, 3, Rgba([255u8, 0, 0, 255]));
+        let mut source = PixelBuffer::from_pixel(3, 3, Rgba([255u8, 0, 0, 255]));
 
         {
             let mut sub1 = source.sub_image(0, 0, 2, 2);
@@ -1404,48 +1404,48 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_view_out_of_bounds() {
-        let source = ImageBuffer::from_pixel(3, 3, Rgba([255u8, 0, 0, 255]));
+        let source = PixelBuffer::from_pixel(3, 3, Rgba([255u8, 0, 0, 255]));
         source.view(1, 1, 3, 3);
     }
 
     #[test]
     #[should_panic]
     fn test_view_coordinates_out_of_bounds() {
-        let source = ImageBuffer::from_pixel(3, 3, Rgba([255u8, 0, 0, 255]));
+        let source = PixelBuffer::from_pixel(3, 3, Rgba([255u8, 0, 0, 255]));
         source.view(3, 3, 3, 3);
     }
 
     #[test]
     #[should_panic]
     fn test_view_width_out_of_bounds() {
-        let source = ImageBuffer::from_pixel(3, 3, Rgba([255u8, 0, 0, 255]));
+        let source = PixelBuffer::from_pixel(3, 3, Rgba([255u8, 0, 0, 255]));
         source.view(1, 1, 3, 2);
     }
 
     #[test]
     #[should_panic]
     fn test_view_height_out_of_bounds() {
-        let source = ImageBuffer::from_pixel(3, 3, Rgba([255u8, 0, 0, 255]));
+        let source = PixelBuffer::from_pixel(3, 3, Rgba([255u8, 0, 0, 255]));
         source.view(1, 1, 2, 3);
     }
 
     #[test]
     #[should_panic]
     fn test_view_x_out_of_bounds() {
-        let source = ImageBuffer::from_pixel(3, 3, Rgba([255u8, 0, 0, 255]));
+        let source = PixelBuffer::from_pixel(3, 3, Rgba([255u8, 0, 0, 255]));
         source.view(3, 1, 3, 3);
     }
 
     #[test]
     #[should_panic]
     fn test_view_y_out_of_bounds() {
-        let source = ImageBuffer::from_pixel(3, 3, Rgba([255u8, 0, 0, 255]));
+        let source = PixelBuffer::from_pixel(3, 3, Rgba([255u8, 0, 0, 255]));
         source.view(1, 3, 3, 3);
     }
 
     #[test]
     fn test_view_in_bounds() {
-        let source = ImageBuffer::from_pixel(3, 3, Rgba([255u8, 0, 0, 255]));
+        let source = PixelBuffer::from_pixel(3, 3, Rgba([255u8, 0, 0, 255]));
         source.view(0, 0, 3, 3);
         source.view(1, 1, 2, 2);
         source.view(2, 2, 0, 0);
@@ -1453,7 +1453,7 @@ mod tests {
 
     #[test]
     fn test_copy_sub_image() {
-        let source = ImageBuffer::from_pixel(3, 3, Rgba([255u8, 0, 0, 255]));
+        let source = PixelBuffer::from_pixel(3, 3, Rgba([255u8, 0, 0, 255]));
         let view = source.view(0, 0, 3, 3);
         let _view2 = view;
         view.to_image();
@@ -1667,7 +1667,7 @@ mod tests {
 
     #[test]
     fn test_generic_image_copy_within_oob() {
-        let mut image: GrayImage = ImageBuffer::from_raw(4, 4, vec![0u8; 16]).unwrap();
+        let mut image: GrayImage = PixelBuffer::from_raw(4, 4, vec![0u8; 16]).unwrap();
         assert!(!image.sub_image(0, 0, 4, 4).copy_within(
             Rect {
                 x: 0,
@@ -1744,7 +1744,7 @@ mod tests {
     fn test_generic_image_copy_within_tl() {
         let data = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
         let expected = [0, 1, 2, 3, 4, 0, 1, 2, 8, 4, 5, 6, 12, 8, 9, 10];
-        let mut image: GrayImage = ImageBuffer::from_raw(4, 4, Vec::from(&data[..])).unwrap();
+        let mut image: GrayImage = PixelBuffer::from_raw(4, 4, Vec::from(&data[..])).unwrap();
         assert!(image.sub_image(0, 0, 4, 4).copy_within(
             Rect {
                 x: 0,
@@ -1762,7 +1762,7 @@ mod tests {
     fn test_generic_image_copy_within_tr() {
         let data = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
         let expected = [0, 1, 2, 3, 1, 2, 3, 7, 5, 6, 7, 11, 9, 10, 11, 15];
-        let mut image: GrayImage = ImageBuffer::from_raw(4, 4, Vec::from(&data[..])).unwrap();
+        let mut image: GrayImage = PixelBuffer::from_raw(4, 4, Vec::from(&data[..])).unwrap();
         assert!(image.sub_image(0, 0, 4, 4).copy_within(
             Rect {
                 x: 1,
@@ -1780,7 +1780,7 @@ mod tests {
     fn test_generic_image_copy_within_bl() {
         let data = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
         let expected = [0, 4, 5, 6, 4, 8, 9, 10, 8, 12, 13, 14, 12, 13, 14, 15];
-        let mut image: GrayImage = ImageBuffer::from_raw(4, 4, Vec::from(&data[..])).unwrap();
+        let mut image: GrayImage = PixelBuffer::from_raw(4, 4, Vec::from(&data[..])).unwrap();
         assert!(image.sub_image(0, 0, 4, 4).copy_within(
             Rect {
                 x: 0,
@@ -1798,7 +1798,7 @@ mod tests {
     fn test_generic_image_copy_within_br() {
         let data = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
         let expected = [5, 6, 7, 3, 9, 10, 11, 7, 13, 14, 15, 11, 12, 13, 14, 15];
-        let mut image: GrayImage = ImageBuffer::from_raw(4, 4, Vec::from(&data[..])).unwrap();
+        let mut image: GrayImage = PixelBuffer::from_raw(4, 4, Vec::from(&data[..])).unwrap();
         assert!(image.sub_image(0, 0, 4, 4).copy_within(
             Rect {
                 x: 1,

--- a/src/image_reader/mod.rs
+++ b/src/image_reader/mod.rs
@@ -130,9 +130,9 @@ impl Limits {
     }
 
     /// This function acts identically to [`reserve`], but accepts the width, height and color type
-    /// used to create an [`ImageBuffer`] and does all the math for you.
+    /// used to create an [`PixelBuffer`] and does all the math for you.
     ///
-    /// [`ImageBuffer`]: crate::ImageBuffer
+    /// [`PixelBuffer`]: crate::PixelBuffer
     /// [`reserve`]: #method.reserve
     pub fn reserve_buffer(
         &mut self,

--- a/src/imageops/affine.rs
+++ b/src/imageops/affine.rs
@@ -3,17 +3,17 @@
 use crate::error::{ImageError, ParameterError, ParameterErrorKind};
 use crate::image::{GenericImage, GenericImageView};
 use crate::traits::Pixel;
-use crate::ImageBuffer;
+use crate::PixelBuffer;
 
 /// Rotate an image 90 degrees clockwise.
 pub fn rotate90<I: GenericImageView>(
     image: &I,
-) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+) -> PixelBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
 where
     I::Pixel: 'static,
 {
     let (width, height) = image.dimensions();
-    let mut out = ImageBuffer::new(height, width);
+    let mut out = PixelBuffer::new(height, width);
     let _ = rotate90_in(image, &mut out);
     out
 }
@@ -21,12 +21,12 @@ where
 /// Rotate an image 180 degrees clockwise.
 pub fn rotate180<I: GenericImageView>(
     image: &I,
-) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+) -> PixelBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
 where
     I::Pixel: 'static,
 {
     let (width, height) = image.dimensions();
-    let mut out = ImageBuffer::new(width, height);
+    let mut out = PixelBuffer::new(width, height);
     let _ = rotate180_in(image, &mut out);
     out
 }
@@ -34,20 +34,20 @@ where
 /// Rotate an image 270 degrees clockwise.
 pub fn rotate270<I: GenericImageView>(
     image: &I,
-) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+) -> PixelBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
 where
     I::Pixel: 'static,
 {
     let (width, height) = image.dimensions();
-    let mut out = ImageBuffer::new(height, width);
+    let mut out = PixelBuffer::new(height, width);
     let _ = rotate270_in(image, &mut out);
     out
 }
 
-/// Rotate an image 90 degrees clockwise and put the result into the destination [`ImageBuffer`].
+/// Rotate an image 90 degrees clockwise and put the result into the destination [`PixelBuffer`].
 pub fn rotate90_in<I, Container>(
     image: &I,
-    destination: &mut ImageBuffer<I::Pixel, Container>,
+    destination: &mut PixelBuffer<I::Pixel, Container>,
 ) -> crate::ImageResult<()>
 where
     I: GenericImageView,
@@ -70,10 +70,10 @@ where
     Ok(())
 }
 
-/// Rotate an image 180 degrees clockwise and put the result into the destination [`ImageBuffer`].
+/// Rotate an image 180 degrees clockwise and put the result into the destination [`PixelBuffer`].
 pub fn rotate180_in<I, Container>(
     image: &I,
-    destination: &mut ImageBuffer<I::Pixel, Container>,
+    destination: &mut PixelBuffer<I::Pixel, Container>,
 ) -> crate::ImageResult<()>
 where
     I: GenericImageView,
@@ -96,10 +96,10 @@ where
     Ok(())
 }
 
-/// Rotate an image 270 degrees clockwise and put the result into the destination [`ImageBuffer`].
+/// Rotate an image 270 degrees clockwise and put the result into the destination [`PixelBuffer`].
 pub fn rotate270_in<I, Container>(
     image: &I,
-    destination: &mut ImageBuffer<I::Pixel, Container>,
+    destination: &mut PixelBuffer<I::Pixel, Container>,
 ) -> crate::ImageResult<()>
 where
     I: GenericImageView,
@@ -125,12 +125,12 @@ where
 /// Flip an image horizontally
 pub fn flip_horizontal<I: GenericImageView>(
     image: &I,
-) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+) -> PixelBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
 where
     I::Pixel: 'static,
 {
     let (width, height) = image.dimensions();
-    let mut out = ImageBuffer::new(width, height);
+    let mut out = PixelBuffer::new(width, height);
     let _ = flip_horizontal_in(image, &mut out);
     out
 }
@@ -138,20 +138,20 @@ where
 /// Flip an image vertically
 pub fn flip_vertical<I: GenericImageView>(
     image: &I,
-) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
+) -> PixelBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
 where
     I::Pixel: 'static,
 {
     let (width, height) = image.dimensions();
-    let mut out = ImageBuffer::new(width, height);
+    let mut out = PixelBuffer::new(width, height);
     let _ = flip_vertical_in(image, &mut out);
     out
 }
 
-/// Flip an image horizontally and put the result into the destination [`ImageBuffer`].
+/// Flip an image horizontally and put the result into the destination [`PixelBuffer`].
 pub fn flip_horizontal_in<I, Container>(
     image: &I,
-    destination: &mut ImageBuffer<I::Pixel, Container>,
+    destination: &mut PixelBuffer<I::Pixel, Container>,
 ) -> crate::ImageResult<()>
 where
     I: GenericImageView,
@@ -174,10 +174,10 @@ where
     Ok(())
 }
 
-/// Flip an image vertically and put the result into the destination [`ImageBuffer`].
+/// Flip an image vertically and put the result into the destination [`PixelBuffer`].
 pub fn flip_vertical_in<I, Container>(
     image: &I,
-    destination: &mut ImageBuffer<I::Pixel, Container>,
+    destination: &mut PixelBuffer<I::Pixel, Container>,
 ) -> crate::ImageResult<()>
 where
     I: GenericImageView,
@@ -269,7 +269,7 @@ mod test {
     };
     use crate::image::GenericImage;
     use crate::traits::Pixel;
-    use crate::{GrayImage, ImageBuffer};
+    use crate::{GrayImage, PixelBuffer};
 
     macro_rules! assert_pixels_eq {
         ($actual:expr, $expected:expr) => {{
@@ -305,10 +305,10 @@ mod test {
     #[test]
     fn test_rotate90() {
         let image: GrayImage =
-            ImageBuffer::from_raw(3, 2, vec![0u8, 1u8, 2u8, 10u8, 11u8, 12u8]).unwrap();
+            PixelBuffer::from_raw(3, 2, vec![0u8, 1u8, 2u8, 10u8, 11u8, 12u8]).unwrap();
 
         let expected: GrayImage =
-            ImageBuffer::from_raw(2, 3, vec![10u8, 0u8, 11u8, 1u8, 12u8, 2u8]).unwrap();
+            PixelBuffer::from_raw(2, 3, vec![10u8, 0u8, 11u8, 1u8, 12u8, 2u8]).unwrap();
 
         assert_pixels_eq!(&rotate90(&image), &expected);
     }
@@ -316,10 +316,10 @@ mod test {
     #[test]
     fn test_rotate180() {
         let image: GrayImage =
-            ImageBuffer::from_raw(3, 2, vec![0u8, 1u8, 2u8, 10u8, 11u8, 12u8]).unwrap();
+            PixelBuffer::from_raw(3, 2, vec![0u8, 1u8, 2u8, 10u8, 11u8, 12u8]).unwrap();
 
         let expected: GrayImage =
-            ImageBuffer::from_raw(3, 2, vec![12u8, 11u8, 10u8, 2u8, 1u8, 0u8]).unwrap();
+            PixelBuffer::from_raw(3, 2, vec![12u8, 11u8, 10u8, 2u8, 1u8, 0u8]).unwrap();
 
         assert_pixels_eq!(&rotate180(&image), &expected);
     }
@@ -327,10 +327,10 @@ mod test {
     #[test]
     fn test_rotate270() {
         let image: GrayImage =
-            ImageBuffer::from_raw(3, 2, vec![0u8, 1u8, 2u8, 10u8, 11u8, 12u8]).unwrap();
+            PixelBuffer::from_raw(3, 2, vec![0u8, 1u8, 2u8, 10u8, 11u8, 12u8]).unwrap();
 
         let expected: GrayImage =
-            ImageBuffer::from_raw(2, 3, vec![2u8, 12u8, 1u8, 11u8, 0u8, 10u8]).unwrap();
+            PixelBuffer::from_raw(2, 3, vec![2u8, 12u8, 1u8, 11u8, 0u8, 10u8]).unwrap();
 
         assert_pixels_eq!(&rotate270(&image), &expected);
     }
@@ -338,10 +338,10 @@ mod test {
     #[test]
     fn test_rotate180_in_place() {
         let mut image: GrayImage =
-            ImageBuffer::from_raw(3, 2, vec![0u8, 1u8, 2u8, 10u8, 11u8, 12u8]).unwrap();
+            PixelBuffer::from_raw(3, 2, vec![0u8, 1u8, 2u8, 10u8, 11u8, 12u8]).unwrap();
 
         let expected: GrayImage =
-            ImageBuffer::from_raw(3, 2, vec![12u8, 11u8, 10u8, 2u8, 1u8, 0u8]).unwrap();
+            PixelBuffer::from_raw(3, 2, vec![12u8, 11u8, 10u8, 2u8, 1u8, 0u8]).unwrap();
 
         rotate180_in_place(&mut image);
 
@@ -351,10 +351,10 @@ mod test {
     #[test]
     fn test_flip_horizontal() {
         let image: GrayImage =
-            ImageBuffer::from_raw(3, 2, vec![0u8, 1u8, 2u8, 10u8, 11u8, 12u8]).unwrap();
+            PixelBuffer::from_raw(3, 2, vec![0u8, 1u8, 2u8, 10u8, 11u8, 12u8]).unwrap();
 
         let expected: GrayImage =
-            ImageBuffer::from_raw(3, 2, vec![2u8, 1u8, 0u8, 12u8, 11u8, 10u8]).unwrap();
+            PixelBuffer::from_raw(3, 2, vec![2u8, 1u8, 0u8, 12u8, 11u8, 10u8]).unwrap();
 
         assert_pixels_eq!(&flip_horizontal(&image), &expected);
     }
@@ -362,10 +362,10 @@ mod test {
     #[test]
     fn test_flip_vertical() {
         let image: GrayImage =
-            ImageBuffer::from_raw(3, 2, vec![0u8, 1u8, 2u8, 10u8, 11u8, 12u8]).unwrap();
+            PixelBuffer::from_raw(3, 2, vec![0u8, 1u8, 2u8, 10u8, 11u8, 12u8]).unwrap();
 
         let expected: GrayImage =
-            ImageBuffer::from_raw(3, 2, vec![10u8, 11u8, 12u8, 0u8, 1u8, 2u8]).unwrap();
+            PixelBuffer::from_raw(3, 2, vec![10u8, 11u8, 12u8, 0u8, 1u8, 2u8]).unwrap();
 
         assert_pixels_eq!(&flip_vertical(&image), &expected);
     }
@@ -373,10 +373,10 @@ mod test {
     #[test]
     fn test_flip_horizontal_in_place() {
         let mut image: GrayImage =
-            ImageBuffer::from_raw(3, 2, vec![0u8, 1u8, 2u8, 10u8, 11u8, 12u8]).unwrap();
+            PixelBuffer::from_raw(3, 2, vec![0u8, 1u8, 2u8, 10u8, 11u8, 12u8]).unwrap();
 
         let expected: GrayImage =
-            ImageBuffer::from_raw(3, 2, vec![2u8, 1u8, 0u8, 12u8, 11u8, 10u8]).unwrap();
+            PixelBuffer::from_raw(3, 2, vec![2u8, 1u8, 0u8, 12u8, 11u8, 10u8]).unwrap();
 
         flip_horizontal_in_place(&mut image);
 
@@ -386,10 +386,10 @@ mod test {
     #[test]
     fn test_flip_vertical_in_place() {
         let mut image: GrayImage =
-            ImageBuffer::from_raw(3, 2, vec![0u8, 1u8, 2u8, 10u8, 11u8, 12u8]).unwrap();
+            PixelBuffer::from_raw(3, 2, vec![0u8, 1u8, 2u8, 10u8, 11u8, 12u8]).unwrap();
 
         let expected: GrayImage =
-            ImageBuffer::from_raw(3, 2, vec![10u8, 11u8, 12u8, 0u8, 1u8, 2u8]).unwrap();
+            PixelBuffer::from_raw(3, 2, vec![10u8, 11u8, 12u8, 0u8, 1u8, 2u8]).unwrap();
 
         flip_vertical_in_place(&mut image);
 

--- a/src/imageops/fast_blur.rs
+++ b/src/imageops/fast_blur.rs
@@ -1,6 +1,6 @@
 use num_traits::clamp;
 
-use crate::{ImageBuffer, Pixel, Primitive};
+use crate::{Pixel, PixelBuffer, Primitive};
 
 /// Approximation of Gaussian blur.
 ///
@@ -18,9 +18,9 @@ use crate::{ImageBuffer, Pixel, Primitive};
 /// Recognition Society Conference: DICTA 2010. December 2010. Sydney.
 #[must_use]
 pub fn fast_blur<P: Pixel>(
-    image_buffer: &ImageBuffer<P, Vec<P::Subpixel>>,
+    image_buffer: &PixelBuffer<P, Vec<P::Subpixel>>,
     sigma: f32,
-) -> ImageBuffer<P, Vec<P::Subpixel>> {
+) -> PixelBuffer<P, Vec<P::Subpixel>> {
     let (width, height) = image_buffer.dimensions();
 
     if width == 0 || height == 0 {
@@ -47,7 +47,7 @@ pub fn fast_blur<P: Pixel>(
             P::CHANNEL_COUNT as usize,
         );
     }
-    ImageBuffer::from_raw(width, height, samples).unwrap()
+    PixelBuffer::from_raw(width, height, samples).unwrap()
 }
 
 fn boxes_for_gauss(sigma: f32, n: usize) -> Vec<usize> {

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -358,7 +358,7 @@ mod tests {
     use crate::color::Rgb;
     use crate::GrayAlphaImage;
     use crate::GrayImage;
-    use crate::ImageBuffer;
+    use crate::PixelBuffer;
     use crate::RgbImage;
     use crate::RgbaImage;
 
@@ -401,8 +401,8 @@ mod tests {
     #[test]
     /// Test that images written into other images works
     fn test_image_in_image() {
-        let mut target = ImageBuffer::new(32, 32);
-        let source = ImageBuffer::from_pixel(16, 16, Rgb([255u8, 0, 0]));
+        let mut target = PixelBuffer::new(32, 32);
+        let source = PixelBuffer::from_pixel(16, 16, Rgb([255u8, 0, 0]));
         overlay(&mut target, &source, 0, 0);
         assert!(*target.get_pixel(0, 0) == Rgb([255u8, 0, 0]));
         assert!(*target.get_pixel(15, 0) == Rgb([255u8, 0, 0]));
@@ -414,8 +414,8 @@ mod tests {
     #[test]
     /// Test that images written outside of a frame doesn't blow up
     fn test_image_in_image_outside_of_bounds() {
-        let mut target = ImageBuffer::new(32, 32);
-        let source = ImageBuffer::from_pixel(32, 32, Rgb([255u8, 0, 0]));
+        let mut target = PixelBuffer::new(32, 32);
+        let source = PixelBuffer::from_pixel(32, 32, Rgb([255u8, 0, 0]));
         overlay(&mut target, &source, 1, 1);
         assert!(*target.get_pixel(0, 0) == Rgb([0, 0, 0]));
         assert!(*target.get_pixel(1, 1) == Rgb([255u8, 0, 0]));
@@ -426,8 +426,8 @@ mod tests {
     /// Test that images written to coordinates out of the frame doesn't blow up
     /// (issue came up in #848)
     fn test_image_outside_image_no_wrap_around() {
-        let mut target = ImageBuffer::new(32, 32);
-        let source = ImageBuffer::from_pixel(32, 32, Rgb([255u8, 0, 0]));
+        let mut target = PixelBuffer::new(32, 32);
+        let source = PixelBuffer::from_pixel(32, 32, Rgb([255u8, 0, 0]));
         overlay(&mut target, &source, 33, 33);
         assert!(*target.get_pixel(0, 0) == Rgb([0, 0, 0]));
         assert!(*target.get_pixel(1, 1) == Rgb([0, 0, 0]));
@@ -437,8 +437,8 @@ mod tests {
     #[test]
     /// Test that images written to coordinates with overflow works
     fn test_image_coordinate_overflow() {
-        let mut target = ImageBuffer::new(16, 16);
-        let source = ImageBuffer::from_pixel(32, 32, Rgb([255u8, 0, 0]));
+        let mut target = PixelBuffer::new(16, 16);
+        let source = PixelBuffer::from_pixel(32, 32, Rgb([255u8, 0, 0]));
         // Overflows to 'sane' coordinates but top is larger than bot.
         overlay(
             &mut target,
@@ -456,7 +456,7 @@ mod tests {
     #[test]
     /// Test that horizontal gradients are correctly generated
     fn test_image_horizontal_gradient_limits() {
-        let mut img = ImageBuffer::new(100, 1);
+        let mut img = PixelBuffer::new(100, 1);
 
         let start = Rgb([0u8, 128, 0]);
         let end = Rgb([255u8, 255, 255]);
@@ -470,7 +470,7 @@ mod tests {
     #[test]
     /// Test that vertical gradients are correctly generated
     fn test_image_vertical_gradient_limits() {
-        let mut img = ImageBuffer::new(1, 100);
+        let mut img = PixelBuffer::new(1, 100);
 
         let start = Rgb([0u8, 128, 0]);
         let end = Rgb([255u8, 255, 255]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,8 +54,8 @@
 //! # Image buffers
 //!
 //! The two main types for storing images:
-//! * [`ImageBuffer`] which holds statically typed image contents.
-//! * [`DynamicImage`] which is an enum over the supported `ImageBuffer` formats
+//! * [`PixelBuffer`] which holds statically typed image contents.
+//! * [`DynamicImage`] which is an enum over the supported `PixelBuffer` formats
 //!   and supports conversions between them.
 //!
 //! As well as a few more specialized options:
@@ -66,7 +66,7 @@
 //!
 //! [`GenericImageView`]: trait.GenericImageView.html
 //! [`GenericImage`]: trait.GenericImage.html
-//! [`ImageBuffer`]: struct.ImageBuffer.html
+//! [`PixelBuffer`]: struct.PixelBuffer.html
 //! [`DynamicImage`]: enum.DynamicImage.html
 //! [`flat`]: flat/index.html
 //!
@@ -157,7 +157,7 @@ pub use crate::buffer_::{
     GrayAlphaImage,
     GrayImage,
     // Image types
-    ImageBuffer,
+    PixelBuffer,
     Rgb32FImage,
     RgbImage,
     Rgba32FImage,
@@ -186,7 +186,7 @@ pub use crate::animation::{Delay, Frame, Frames};
 // More detailed error type
 pub mod error;
 
-/// Iterators and other auxiliary structure for the `ImageBuffer` type.
+/// Iterators and other auxiliary structure for the [`PixelBuffer`] type.
 pub mod buffer {
     // Only those not exported at the top-level
     pub use crate::buffer_::{

--- a/tests/conversions.rs
+++ b/tests/conversions.rs
@@ -1,34 +1,34 @@
 use image::buffer::ConvertBuffer;
-use image::{ImageBuffer, Rgb, Rgba};
+use image::{PixelBuffer, Rgb, Rgba};
 
 #[test]
 fn test_rgbu8_to_rgbu16() {
     // Create an all white image using Rgb<u16>s for pixel values
     let image_u16 =
-        ImageBuffer::from_pixel(2, 2, image::Rgb::<u16>([u16::MAX, u16::MAX, u16::MAX]));
+        PixelBuffer::from_pixel(2, 2, image::Rgb::<u16>([u16::MAX, u16::MAX, u16::MAX]));
 
     // Create an all white image using Rgb<u8>s for pixel values and convert it
     // to Rgb<u16>s.
-    let image_u8 = ImageBuffer::from_pixel(2, 2, image::Rgb::<u8>([u8::MAX, u8::MAX, u8::MAX]));
-    let image_converted: ImageBuffer<Rgb<u16>, _> = image_u8.convert();
+    let image_u8 = PixelBuffer::from_pixel(2, 2, image::Rgb::<u8>([u8::MAX, u8::MAX, u8::MAX]));
+    let image_converted: PixelBuffer<Rgb<u16>, _> = image_u8.convert();
 
     assert_eq!(image_u16, image_converted);
 }
 
 #[test]
 fn test_rgbau8_to_rgbau16() {
-    let image_u16 = ImageBuffer::from_pixel(
+    let image_u16 = PixelBuffer::from_pixel(
         2,
         2,
         image::Rgba::<u16>([u16::MAX, u16::MAX, u16::MAX, u16::MAX]),
     );
 
-    let image_u8 = ImageBuffer::from_pixel(
+    let image_u8 = PixelBuffer::from_pixel(
         2,
         2,
         image::Rgba::<u8>([u8::MAX, u8::MAX, u8::MAX, u8::MAX]),
     );
-    let image_converted: ImageBuffer<Rgba<u16>, _> = image_u8.convert();
+    let image_converted: PixelBuffer<Rgba<u16>, _> = image_u8.convert();
 
     assert_eq!(image_u16, image_converted);
 }


### PR DESCRIPTION
Let's get started on the larger API changes for better color treatment etc.

As discussed previously in relation to the `Pixel` trait, we could free up terminology for non-Pixel representations and in particular for an internal type that also has associated metadata. These pixel buffer are good for simplified representations, constructors, and static typed code paths but not a unified representation of generic real-world complexity.

See: https://github.com/image-rs/image/issues/1523#issuecomment-2156194262 and following comments. @kornelski You were most spoken about removing strong typing but as far as I read into it, not against having _some_ untyped representations. I'd just like to clarify with you.