### PR TITLE
Fix lints mismatched_lifetime_syntaxes

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -717,7 +717,7 @@ where
 
     /// Returns an iterator over the pixels of this image.
     /// The iteration order is x = 0 to width then y = 0 to height
-    pub fn pixels(&self) -> Pixels<P> {
+    pub fn pixels(&self) -> Pixels<'_, P> {
         Pixels {
             chunks: self
                 .inner_pixels()
@@ -730,7 +730,7 @@ where
     /// Only non-empty rows can be iterated in this manner. In particular the iterator will not
     /// yield any item when the width of the image is `0` or a pixel type without any channels is
     /// used. This ensures that its length can always be represented by `usize`.
-    pub fn rows(&self) -> Rows<P> {
+    pub fn rows(&self) -> Rows<'_, P> {
         Rows::with_image(&self.data, self.width, self.height)
     }
 
@@ -739,7 +739,7 @@ where
     /// along with a reference to them.
     /// The iteration order is x = 0 to width then y = 0 to height
     /// Starting from the top left.
-    pub fn enumerate_pixels(&self) -> EnumeratePixels<P> {
+    pub fn enumerate_pixels(&self) -> EnumeratePixels<'_, P> {
         EnumeratePixels {
             pixels: self.pixels(),
             x: 0,
@@ -751,7 +751,7 @@ where
     /// Enumerates over the rows of the image.
     /// The iterator yields the y-coordinate of each row
     /// along with a reference to them.
-    pub fn enumerate_rows(&self) -> EnumerateRows<P> {
+    pub fn enumerate_rows(&self) -> EnumerateRows<'_, P> {
         EnumerateRows {
             rows: self.rows(),
             y: 0,
@@ -895,7 +895,7 @@ where
     }
 
     /// Returns an iterator over the mutable pixels of this image.
-    pub fn pixels_mut(&mut self) -> PixelsMut<P> {
+    pub fn pixels_mut(&mut self) -> PixelsMut<'_, P> {
         PixelsMut {
             chunks: self
                 .inner_pixels_mut()
@@ -908,14 +908,14 @@ where
     /// Only non-empty rows can be iterated in this manner. In particular the iterator will not
     /// yield any item when the width of the image is `0` or a pixel type without any channels is
     /// used. This ensures that its length can always be represented by `usize`.
-    pub fn rows_mut(&mut self) -> RowsMut<P> {
+    pub fn rows_mut(&mut self) -> RowsMut<'_, P> {
         RowsMut::with_image(&mut self.data, self.width, self.height)
     }
 
     /// Enumerates over the pixels of the image.
     /// The iterator yields the coordinates of each pixel
     /// along with a mutable reference to them.
-    pub fn enumerate_pixels_mut(&mut self) -> EnumeratePixelsMut<P> {
+    pub fn enumerate_pixels_mut(&mut self) -> EnumeratePixelsMut<'_, P> {
         let width = self.width;
         EnumeratePixelsMut {
             pixels: self.pixels_mut(),
@@ -928,7 +928,7 @@ where
     /// Enumerates over the rows of the image.
     /// The iterator yields the y-coordinate of each row
     /// along with a mutable reference to them.
-    pub fn enumerate_rows_mut(&mut self) -> EnumerateRowsMut<P> {
+    pub fn enumerate_rows_mut(&mut self) -> EnumerateRowsMut<'_, P> {
         let width = self.width;
         EnumerateRowsMut {
             rows: self.rows_mut(),

--- a/src/buffer_par.rs
+++ b/src/buffer_par.rs
@@ -321,7 +321,7 @@ where
     /// See [`pixels`] for more information.
     ///
     /// [`pixels`]: #method.pixels
-    pub fn par_pixels(&self) -> PixelsPar<P> {
+    pub fn par_pixels(&self) -> PixelsPar<'_, P> {
         PixelsPar {
             chunks: self
                 .inner_pixels()
@@ -333,7 +333,7 @@ where
     /// See [`enumerate_pixels`] for more information.
     ///
     /// [`enumerate_pixels`]: #method.enumerate_pixels
-    pub fn par_enumerate_pixels(&self) -> EnumeratePixelsPar<P> {
+    pub fn par_enumerate_pixels(&self) -> EnumeratePixelsPar<'_, P> {
         EnumeratePixelsPar {
             pixels: self.par_pixels(),
             width: self.width(),
@@ -351,7 +351,7 @@ where
     /// See [`pixels_mut`] for more information.
     ///
     /// [`pixels_mut`]: #method.pixels_mut
-    pub fn par_pixels_mut(&mut self) -> PixelsMutPar<P> {
+    pub fn par_pixels_mut(&mut self) -> PixelsMutPar<'_, P> {
         PixelsMutPar {
             chunks: self
                 .inner_pixels_mut()
@@ -363,7 +363,7 @@ where
     /// See [`enumerate_pixels_mut`] for more information.
     ///
     /// [`enumerate_pixels_mut`]: #method.enumerate_pixels_mut
-    pub fn par_enumerate_pixels_mut(&mut self) -> EnumeratePixelsMutPar<P> {
+    pub fn par_enumerate_pixels_mut(&mut self) -> EnumeratePixelsMutPar<'_, P> {
         let width = self.width();
         EnumeratePixelsMutPar {
             pixels: self.par_pixels_mut(),

--- a/src/codecs/avif/decoder.rs
+++ b/src/codecs/avif/decoder.rs
@@ -155,7 +155,7 @@ fn transmute_y_plane16(
     stride: usize,
     width: usize,
     height: usize,
-) -> Plane16View {
+) -> Plane16View<'_> {
     let mut y_plane_stride = stride >> 1;
 
     let mut bind_y = vec![];
@@ -196,7 +196,7 @@ fn transmute_chroma_plane16(
     stride: usize,
     width: usize,
     height: usize,
-) -> Plane16View {
+) -> Plane16View<'_> {
     let plane_ref = plane.as_ref();
     let mut chroma_plane_stride = stride >> 1;
     let mut bind_chroma = vec![];

--- a/src/codecs/avif/encoder.rs
+++ b/src/codecs/avif/encoder.rs
@@ -176,7 +176,7 @@ impl<W: Write> AvifEncoder<W> {
 
         // Cast the input slice using few buffer allocations if possible.
         // In particular try not to allocate if the caller did the infallible reverse.
-        fn cast_buffer<Channel>(buf: &[u8]) -> ImageResult<Cow<[Channel]>>
+        fn cast_buffer<Channel>(buf: &[u8]) -> ImageResult<Cow<'_, [Channel]>>
         where
             Channel: Pod + Zero,
         {

--- a/src/image.rs
+++ b/src/image.rs
@@ -924,7 +924,7 @@ pub trait GenericImageView {
     /// Returns an Iterator over the pixels of this image.
     /// The iterator yields the coordinates of each pixel
     /// along with their value
-    fn pixels(&self) -> Pixels<Self>
+    fn pixels(&self) -> Pixels<'_, Self>
     where
         Self: Sized,
     {

--- a/tests/reference_images.rs
+++ b/tests/reference_images.rs
@@ -307,7 +307,7 @@ fn check_references() {
                 let filename = PathBuf::from(tmpdir).join(filename);
                 match test_img.save(&filename) {
                     Ok(()) => format!("\nNew reference saved to: {}", filename.display()),
-                    Err(e) => format!("\nFailed to save new reference: {}", e),
+                    Err(e) => format!("\nFailed to save new reference: {e}"),
                 }
             } else {
                 String::new()


### PR DESCRIPTION
This is introduced in nightly matching what the standard library has been doing for years now. The idea is to clearly indicate to the caller in the signature that data is being borrowed even when the name for such lifetimes are elided. The lint only indicates 'non-trivial' or unexpected borrows, e.g. it does not fire when the borrow happens from an output reference type.

With this PR our CI should once again be clean.
