### PR TITLE
Alow extracting orientation from an Exif chunk and optionally clearing it in Exif

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -152,8 +152,7 @@ enum ExifEndian {
     Little,
 }
 
-// The tests module. It's conventional to put it at the end of the file.
-#[cfg(test)] // This attribute tells Rust to compile this code only when running tests.
+#[cfg(all(test, feature = "jpeg"))]
 mod tests {
     use crate::{codecs::jpeg::JpegDecoder, image::ImageDecoder};
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,6 +1,6 @@
 //! Types describing image metadata
 
-use std::io::{Cursor, Read, Write};
+use std::io::{Cursor, Read};
 
 use byteorder_lite::{BigEndian, LittleEndian, ReadBytesExt, WriteBytesExt};
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -63,7 +63,16 @@ impl Orientation {
         }
     }
 
-    pub(crate) fn from_exif_chunk(chunk: &[u8]) -> Option<Self> {
+    /// Extracts the image orientation from a raw Exif chunk.
+    ///
+    /// You can obtain the Exif chunk using
+    /// [ImageDecoder::exif_metadata](crate::ImageDecoder::exif_metadata).
+    ///
+    /// It is more convenient to use [ImageDecoder::orientation](crate::ImageDecoder::orientation)
+    /// than to invoke this function.
+    /// Only use this function if you extract and process the Exif chunk separately.
+    #[must_use]
+    pub fn from_exif_chunk(chunk: &[u8]) -> Option<Self> {
         let mut reader = Cursor::new(chunk);
 
         let mut magic = [0; 4];

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -100,7 +100,7 @@ impl Orientation {
         }
     }
 
-    /// Returns the orientation and the offset in the Exif chunk where it was found,
+    /// Returns the orientation, the offset in the Exif chunk where it was found, and Exif chunk endianness
     #[must_use]
     fn from_exif_chunk_inner(chunk: &[u8]) -> Option<(Self, u64, ExifEndian)> {
         let mut reader = Cursor::new(chunk);

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -93,7 +93,6 @@ impl Orientation {
                 ExifEndian::Big => writer.write_u16::<BigEndian>(no_orientation).unwrap(),
                 ExifEndian::Little => writer.write_u16::<LittleEndian>(no_orientation).unwrap(),
             }
-            writer.write(&[0, 0]).unwrap(); // we have just read this much data from this exact position, it's present
             Some(orientation)
         } else {
             None


### PR DESCRIPTION
Tools that not only display images but also encode or convert them may want to apply the Exif orientation to the image up front, so that they don't have to rely on other software being Exif-aware to display the images with the correct orientation.

Such tools need to clear the orientation data from the Exif chunk, otherwise the image will be rotated twice and display incorrectly in Exif-aware software.

Modifying Exif data is exceptionally cursed, and general-purpose transformation code is bound to break some offset-dependent Exif chunks : https://github.com/kamadak/exif-rs/issues/1

However, in this particular special case we can rely on the fact that we are not changing the length of the data to reset orientation to `NoTransforms` and keep the rest of the Exif chunk intact.

I need this functionality in `wondermagick` and I believe this is the least cursed way to go about it.