### PR TITLE
Move GenericImage traits into images module

### DIFF
--- a/src/imageops/affine.rs
+++ b/src/imageops/affine.rs
@@ -1,9 +1,8 @@
 //! Functions for performing affine transformations.
 
 use crate::error::{ImageError, ParameterError, ParameterErrorKind};
-use crate::image::{GenericImage, GenericImageView};
 use crate::traits::Pixel;
-use crate::ImageBuffer;
+use crate::{GenericImage, GenericImageView, ImageBuffer};
 
 /// Rotate an image 90 degrees clockwise.
 pub fn rotate90<I: GenericImageView>(
@@ -267,9 +266,9 @@ mod test {
         flip_horizontal, flip_horizontal_in_place, flip_vertical, flip_vertical_in_place,
         rotate180, rotate180_in_place, rotate270, rotate90,
     };
-    use crate::image::GenericImage;
+
     use crate::traits::Pixel;
-    use crate::{GrayImage, ImageBuffer};
+    use crate::{GenericImage, GrayImage, ImageBuffer};
 
     macro_rules! assert_pixels_eq {
         ($actual:expr, $expected:expr) => {{

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -3,10 +3,9 @@
 use num_traits::NumCast;
 
 use crate::color::{FromColor, IntoColor, Luma, LumaA};
-use crate::image::{GenericImage, GenericImageView};
 use crate::traits::{Pixel, Primitive};
 use crate::utils::clamp;
-use crate::ImageBuffer;
+use crate::{GenericImage, GenericImageView, ImageBuffer};
 
 type Subpixel<I> = <<I as GenericImageView>::Pixel as Pixel>::Subpixel;
 

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -1,9 +1,8 @@
 //! Image Processing Functions
 use std::cmp;
 
-use crate::image::{GenericImage, GenericImageView};
 use crate::traits::{Lerp, Pixel, Primitive};
-use crate::SubImage;
+use crate::{GenericImage, GenericImageView, SubImage};
 
 pub use self::sample::FilterType;
 

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -7,10 +7,9 @@ use std::f32;
 
 use num_traits::{NumCast, ToPrimitive, Zero};
 
-use crate::image::{GenericImage, GenericImageView};
 use crate::traits::{Enlargeable, Pixel, Primitive};
 use crate::utils::clamp;
-use crate::{ImageBuffer, Rgba32FImage};
+use crate::{GenericImage, GenericImageView, ImageBuffer, Rgba32FImage};
 
 /// Available Sampling Filters.
 ///

--- a/src/images.rs
+++ b/src/images.rs
@@ -3,5 +3,7 @@ pub(crate) mod buffer;
 #[cfg(feature = "rayon")]
 pub(crate) mod buffer_par;
 pub(crate) mod dynimage;
+pub(crate) mod generic_image;
+// Public as we re-export the whole module including its documentation.
 pub mod flat;
 pub(crate) mod sub_image;

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -9,12 +9,11 @@ use std::slice::{ChunksExact, ChunksExactMut};
 use crate::color::{FromColor, Luma, LumaA, Rgb, Rgba};
 use crate::error::ImageResult;
 use crate::flat::{FlatSamples, SampleLayout};
-use crate::image::{GenericImage, GenericImageView};
 use crate::math::Rect;
 use crate::traits::{EncodableLayout, Pixel, PixelWithColorType};
 use crate::utils::expand_packed;
 use crate::{save_buffer, save_buffer_with_format, write_buffer_with_format};
-use crate::{DynamicImage, ImageEncoder, ImageFormat};
+use crate::{DynamicImage, GenericImage, GenericImageView, ImageEncoder, ImageFormat};
 
 /// Iterate over pixel refs.
 pub struct Pixels<'a, P: Pixel + 'a>

--- a/src/images/dynimage.rs
+++ b/src/images/dynimage.rs
@@ -9,7 +9,6 @@ use crate::codecs::png;
 use crate::color::{self, FromColor, IntoColor};
 use crate::error::{ImageError, ImageResult, ParameterError, ParameterErrorKind};
 use crate::flat::FlatSamples;
-use crate::image::{GenericImage, GenericImageView};
 use crate::images::buffer::{
     ConvertBuffer, Gray16Image, GrayAlpha16Image, GrayAlphaImage, GrayImage, ImageBuffer,
     Rgb16Image, Rgb32FImage, RgbImage, Rgba16Image, Rgba32FImage, RgbaImage,
@@ -19,7 +18,8 @@ use crate::math::resize_dimensions;
 use crate::metadata::Orientation;
 use crate::traits::Pixel;
 use crate::{
-    imageops, ExtendedColorType, ImageDecoder, ImageEncoder, ImageFormat, ImageReader, Luma, LumaA,
+    imageops, ExtendedColorType, GenericImage, GenericImageView, ImageDecoder, ImageEncoder,
+    ImageFormat, ImageReader, Luma, LumaA,
 };
 
 /// A Dynamic Image
@@ -1395,7 +1395,7 @@ mod test {
     }
 
     fn test_grayscale(mut img: super::DynamicImage, alpha_discarded: bool) {
-        use crate::image::{GenericImage, GenericImageView};
+        use crate::{GenericImage as _, GenericImageView as _};
         img.put_pixel(0, 0, crate::color::Rgba([255, 0, 0, 100]));
         let expected_alpha = if alpha_discarded { 255 } else { 100 };
         assert_eq!(

--- a/src/images/flat.rs
+++ b/src/images/flat.rs
@@ -52,9 +52,8 @@ use crate::error::{
     DecodingError, ImageError, ImageFormatHint, ParameterError, ParameterErrorKind,
     UnsupportedError, UnsupportedErrorKind,
 };
-use crate::image::{GenericImage, GenericImageView};
 use crate::traits::Pixel;
-use crate::ImageBuffer;
+use crate::{GenericImage, GenericImageView, ImageBuffer};
 
 /// A flat buffer over a (multi channel) image.
 ///

--- a/src/images/generic_image.rs
+++ b/src/images/generic_image.rs
@@ -3,44 +3,6 @@ use crate::math::Rect;
 use crate::traits::Pixel;
 use crate::SubImage;
 
-/// Immutable pixel iterator
-#[derive(Debug)]
-pub struct Pixels<'a, I: ?Sized + 'a> {
-    image: &'a I,
-    x: u32,
-    y: u32,
-    width: u32,
-    height: u32,
-}
-
-impl<I: GenericImageView> Iterator for Pixels<'_, I> {
-    type Item = (u32, u32, I::Pixel);
-
-    fn next(&mut self) -> Option<(u32, u32, I::Pixel)> {
-        if self.x >= self.width {
-            self.x = 0;
-            self.y += 1;
-        }
-
-        if self.y >= self.height {
-            None
-        } else {
-            let pixel = self.image.get_pixel(self.x, self.y);
-            let p = (self.x, self.y, pixel);
-
-            self.x += 1;
-
-            Some(p)
-        }
-    }
-}
-
-impl<I: ?Sized> Clone for Pixels<'_, I> {
-    fn clone(&self) -> Self {
-        Pixels { ..*self }
-    }
-}
-
 /// Trait to inspect an image.
 ///
 /// ```
@@ -121,6 +83,44 @@ pub trait GenericImageView {
         assert!(u64::from(x) + u64::from(width) <= u64::from(self.width()));
         assert!(u64::from(y) + u64::from(height) <= u64::from(self.height()));
         SubImage::new(self, x, y, width, height)
+    }
+}
+
+/// Immutable pixel iterator
+#[derive(Debug)]
+pub struct Pixels<'a, I: ?Sized + 'a> {
+    image: &'a I,
+    x: u32,
+    y: u32,
+    width: u32,
+    height: u32,
+}
+
+impl<I: GenericImageView> Iterator for Pixels<'_, I> {
+    type Item = (u32, u32, I::Pixel);
+
+    fn next(&mut self) -> Option<(u32, u32, I::Pixel)> {
+        if self.x >= self.width {
+            self.x = 0;
+            self.y += 1;
+        }
+
+        if self.y >= self.height {
+            None
+        } else {
+            let pixel = self.image.get_pixel(self.x, self.y);
+            let p = (self.x, self.y, pixel);
+
+            self.x += 1;
+
+            Some(p)
+        }
+    }
+}
+
+impl<I: ?Sized> Clone for Pixels<'_, I> {
+    fn clone(&self) -> Self {
+        Pixels { ..*self }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ pub use crate::color::{Luma, LumaA, Rgb, Rgba};
 
 pub use crate::error::{ImageError, ImageResult};
 
-pub use crate::image::{GenericImage, GenericImageView, Pixels};
+pub use crate::images::generic_image::{GenericImage, GenericImageView, Pixels};
 
 pub use crate::images::sub_image::SubImage;
 
@@ -290,7 +290,6 @@ pub mod codecs {
 
 mod animation;
 mod color;
-mod image;
 mod images;
 /// Deprecated io module the original io module has been renamed to `image_reader`.
 /// This is going to be internal.


### PR DESCRIPTION
This completes the hierarchy changes from #2481 by moving the remaining items into a separate module in `images/`. As an additional benefit of these changes, most import paths in codecs, imageops, and buffers now match the _public_ paths which are more stable and hopefully implies less changes would be necessary in the future even when modules are split (i.e. free_functions moved to their relevant parent modules).