### PR TITLE
fix: avoid panic multi planar tif images

### DIFF
--- a/src/codecs/tiff.rs
+++ b/src/codecs/tiff.rs
@@ -11,7 +11,6 @@ extern crate tiff;
 use std::io::{self, BufRead, Cursor, Read, Seek, Write};
 use std::marker::PhantomData;
 use std::mem;
-use std::str::FromStr;
 
 use crate::color::{ColorType, ExtendedColorType};
 use crate::error::{

--- a/src/codecs/tiff.rs
+++ b/src/codecs/tiff.rs
@@ -60,7 +60,7 @@ where
             .unwrap_or_default();
 
         // Decode not supported for non Chunky Planar Configuration
-        if planar_config <= 1 {
+        if planar_config > 1 {
             Err(ImageError::Unsupported(
                 UnsupportedError::from_format_and_kind(
                     ImageFormat::Tiff.into(),


### PR DESCRIPTION
### Motivation

Avoid panics for tif images with multi planar configuration.

### todo

- [x] Fail early on decode for tif images with multi planar support, otherwise it may produce a panic
- [ ] Provide test cases.

I have just made a fix for usage by a company I work at, lmk if you folks would prefer it fixed in some other way.

It's a draft as it hasn't quite been extensively tested, yet. And might require more changes to target only cases which aren't quite supported correctly.


Lmk if you folks want any other changes.

Fixes https://github.com/image-rs/image/issues/2179