### PR TITLE
Improving Fast Blur

### DIFF
--- a/src/imageops/fast_blur.rs
+++ b/src/imageops/fast_blur.rs
@@ -454,7 +454,7 @@ fn box_blur_vertical_pass_impl<T: Primitive, const CN: usize>(
 
 #[cfg(test)]
 mod tests {
-    use crate::{DynamicImage, GrayAlphaImage, GrayImage, RgbImage};
+    use crate::{DynamicImage, GrayAlphaImage, GrayImage, RgbImage, RgbaImage};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     struct Rng {
@@ -483,9 +483,7 @@ mod tests {
 
     #[test]
     fn test_box_blur() {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards");
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
         let mut rng = Rng::new((now.as_millis() & 0xffff_ffff_ffff_ffff) as u64);
         for _ in 0..35 {
             let width = rng.next_u8();
@@ -530,7 +528,7 @@ mod tests {
                 3 => {
                     let vc = vec![px; width as usize * height as usize * 4];
                     let image = DynamicImage::from(
-                        GrayAlphaImage::from_vec(width as u32, height as u32, vc).unwrap(),
+                        RgbaImage::from_vec(width as u32, height as u32, vc).unwrap(),
                     );
                     let res = image.fast_blur(sigma);
                     for clr in res.as_bytes().iter() {

--- a/src/imageops/fast_blur.rs
+++ b/src/imageops/fast_blur.rs
@@ -1,4 +1,4 @@
-use num_traits::clamp;
+use num_traits::Bounded;
 
 use crate::{ImageBuffer, Pixel, Primitive};
 
@@ -26,28 +26,66 @@ pub fn fast_blur<P: Pixel>(
     if width == 0 || height == 0 {
         return image_buffer.clone();
     }
-    let mut samples = image_buffer.as_flat_samples().samples.to_vec();
     let num_passes = 3;
 
     let boxes = boxes_for_gauss(sigma, num_passes);
+    if boxes.is_empty() {
+        return image_buffer.clone();
+    }
 
-    for radius in boxes.iter().take(num_passes) {
-        let horizontally_blurred_transposed = horizontal_fast_blur_half::<P::Subpixel>(
-            &samples,
-            width as usize,
-            height as usize,
-            (*radius - 1) / 2,
-            P::CHANNEL_COUNT as usize,
+    let samples = image_buffer.as_flat_samples().samples;
+
+    let first_box = boxes[0];
+
+    let mut transient = vec![
+        P::Subpixel::min_value();
+        width as usize * height as usize * P::CHANNEL_COUNT as usize
+    ];
+    let mut dst = vec![
+        P::Subpixel::min_value();
+        width as usize * height as usize * P::CHANNEL_COUNT as usize
+    ];
+
+    box_blur_horizontal_pass_strategy::<P, P::Subpixel>(
+        samples,
+        width * P::CHANNEL_COUNT as u32,
+        &mut transient,
+        width * P::CHANNEL_COUNT as u32,
+        width,
+        first_box as u32,
+    );
+
+    box_blur_vertical_pass_strategy::<P, P::Subpixel>(
+        &transient,
+        width * P::CHANNEL_COUNT as u32,
+        &mut dst,
+        width * P::CHANNEL_COUNT as u32,
+        width,
+        height,
+        first_box as u32,
+    );
+
+    for &box_container in boxes.iter().skip(1) {
+        box_blur_horizontal_pass_strategy::<P, P::Subpixel>(
+            &dst,
+            width * P::CHANNEL_COUNT as u32,
+            &mut transient,
+            width * P::CHANNEL_COUNT as u32,
+            width,
+            box_container as u32,
         );
-        samples = horizontal_fast_blur_half::<P::Subpixel>(
-            &horizontally_blurred_transposed,
-            height as usize,
-            width as usize,
-            (*radius - 1) / 2,
-            P::CHANNEL_COUNT as usize,
+
+        box_blur_vertical_pass_strategy::<P, P::Subpixel>(
+            &transient,
+            width * P::CHANNEL_COUNT as u32,
+            &mut dst,
+            width * P::CHANNEL_COUNT as u32,
+            width,
+            height,
+            box_container as u32,
         );
     }
-    ImageBuffer::from_raw(width, height, samples).unwrap()
+    ImageBuffer::from_raw(width, height, dst).unwrap()
 }
 
 fn boxes_for_gauss(sigma: f32, n: usize) -> Vec<usize> {
@@ -64,101 +102,443 @@ fn boxes_for_gauss(sigma: f32, n: usize) -> Vec<usize> {
 
     (0..n)
         .map(|i| if i < m { w_l as usize } else { w_u as usize })
+        .map(|i| ceil_to_odd(i.saturating_sub(1) / 2))
         .collect::<Vec<_>>()
 }
 
-fn channel_idx(channel: usize, idx: usize, channel_num: usize) -> usize {
-    channel_num * idx + channel
+#[inline]
+fn ceil_to_odd(x: usize) -> usize {
+    if x % 2 == 0 {
+        x + 1
+    } else {
+        x
+    }
 }
 
-fn horizontal_fast_blur_half<P: Primitive>(
-    samples: &[P],
-    width: usize,
-    height: usize,
-    r: usize,
-    channel_num: usize,
-) -> Vec<P> {
-    let channel_size = width * height;
+#[inline]
+#[allow(clippy::manual_clamp)]
+fn rounding_saturated_mul<T: Primitive>(v: f32, w: f32) -> T {
+    if T::DEFAULT_MAX_VALUE.to_f32().unwrap() != 1.0 {
+        T::from(
+            (v * w)
+                .round()
+                .min(T::DEFAULT_MAX_VALUE.to_f32().unwrap())
+                .max(T::DEFAULT_MIN_VALUE.to_f32().unwrap()),
+        )
+        .unwrap()
+    } else {
+        T::from(
+            (v * w)
+                .min(T::DEFAULT_MAX_VALUE.to_f32().unwrap())
+                .max(T::DEFAULT_MIN_VALUE.to_f32().unwrap()),
+        )
+        .unwrap()
+    }
+}
 
-    let mut out_samples = vec![P::from(0).unwrap(); channel_size * channel_num];
-    let mut vals = vec![0.0; channel_num];
+fn box_blur_horizontal_pass_strategy<T, P: Primitive>(
+    src: &[P],
+    src_stride: u32,
+    dst: &mut [P],
+    dst_stride: u32,
+    width: u32,
+    radius: u32,
+) where
+    T: Pixel,
+{
+    if T::CHANNEL_COUNT == 1 {
+        box_blur_horizontal_pass_impl::<P, 1>(src, src_stride, dst, dst_stride, width, radius);
+    } else if T::CHANNEL_COUNT == 2 {
+        box_blur_horizontal_pass_impl::<P, 2>(src, src_stride, dst, dst_stride, width, radius);
+    } else if T::CHANNEL_COUNT == 3 {
+        box_blur_horizontal_pass_impl::<P, 3>(src, src_stride, dst, dst_stride, width, radius);
+    } else if T::CHANNEL_COUNT == 4 {
+        box_blur_horizontal_pass_impl::<P, 4>(src, src_stride, dst, dst_stride, width, radius);
+    } else {
+        unimplemented!("More than 4 channels is not yet implemented");
+    }
+}
 
-    let min_value = P::DEFAULT_MIN_VALUE.to_f32().unwrap();
-    let max_value = P::DEFAULT_MAX_VALUE.to_f32().unwrap();
+fn box_blur_vertical_pass_strategy<T: Pixel, P: Primitive>(
+    src: &[P],
+    src_stride: u32,
+    dst: &mut [P],
+    dst_stride: u32,
+    width: u32,
+    height: u32,
+    radius: u32,
+) {
+    if T::CHANNEL_COUNT == 1 {
+        box_blur_vertical_pass_impl::<P, 1>(
+            src, src_stride, dst, dst_stride, width, height, radius,
+        );
+    } else if T::CHANNEL_COUNT == 2 {
+        box_blur_vertical_pass_impl::<P, 2>(
+            src, src_stride, dst, dst_stride, width, height, radius,
+        );
+    } else if T::CHANNEL_COUNT == 3 {
+        box_blur_vertical_pass_impl::<P, 3>(
+            src, src_stride, dst, dst_stride, width, height, radius,
+        );
+    } else if T::CHANNEL_COUNT == 4 {
+        box_blur_vertical_pass_impl::<P, 4>(
+            src, src_stride, dst, dst_stride, width, height, radius,
+        );
+    } else {
+        unimplemented!("More than 4 channels is not yet implemented");
+    }
+}
 
-    for row in 0..height {
-        for (channel, value) in vals.iter_mut().enumerate().take(channel_num) {
-            *value = ((-(r as isize))..(r + 1) as isize)
-                .map(|x| {
-                    extended_f(
-                        samples,
-                        width,
-                        height,
-                        x,
-                        row as isize,
-                        channel,
-                        channel_num,
-                    )
-                    .to_f32()
-                    .unwrap_or(0.0)
-                })
-                .sum();
+fn box_blur_horizontal_pass_impl<T, const CN: usize>(
+    src: &[T],
+    src_stride: u32,
+    dst: &mut [T],
+    dst_stride: u32,
+    width: u32,
+    radius: u32,
+) where
+    T: Primitive,
+{
+    let kernel_size = radius * 2 + 1;
+    let edge_count = ((kernel_size / 2) + 1) as f32;
+    let half_kernel = kernel_size / 2;
+
+    let weight = 1f32 / (radius * 2 + 1) as f32;
+
+    // Horizontal blurring consists from 4 phases
+    // 1 - Fill initial sliding window
+    // 2 - Blur dangerous leading zone where clamping is required
+    // 3 - Blur *normal* zone where clamping is not required
+    // 4 - Blur dangerous trailing zone where clamping is required
+
+    for (dst, src) in dst
+        .chunks_exact_mut(dst_stride as usize)
+        .zip(src.chunks_exact(src_stride as usize))
+    {
+        let mut weight1: f32 = 0.;
+        let mut weight2: f32 = 0.;
+        let mut weight3: f32 = 0.;
+
+        let chunk0 = &src[..CN];
+
+        // replicate edge
+        let mut weight0 = chunk0[0].to_f32().unwrap() * edge_count;
+        if CN > 1 {
+            weight1 = chunk0[1].to_f32().unwrap() * edge_count;
+        }
+        if CN > 2 {
+            weight2 = chunk0[2].to_f32().unwrap() * edge_count;
+        }
+        if CN == 4 {
+            weight3 = chunk0[3].to_f32().unwrap() * edge_count;
         }
 
-        for column in 0..width {
-            for (channel, channel_val) in vals.iter_mut().enumerate() {
-                let val = *channel_val / (2.0 * r as f32 + 1.0);
-                let val = clamp(val, min_value, max_value);
-                let val = P::from(val).unwrap();
+        for x in 1..=half_kernel as usize {
+            let px = x.min(width as usize - 1) * CN;
+            let chunk0 = &src[px..px + CN];
+            weight0 += chunk0[0].to_f32().unwrap();
+            if CN > 1 {
+                weight1 += chunk0[1].to_f32().unwrap();
+            }
+            if CN > 2 {
+                weight2 += chunk0[2].to_f32().unwrap();
+            }
+            if CN == 4 {
+                weight3 += chunk0[3].to_f32().unwrap();
+            }
+        }
 
-                let destination_row = column;
-                let destination_column = row;
-                let destination_sample_index = channel_idx(
-                    channel,
-                    destination_column + destination_row * height,
-                    channel_num,
-                );
-                out_samples[destination_sample_index] = val;
-                *channel_val = *channel_val
-                    - extended_f(
-                        samples,
-                        width,
-                        height,
-                        column as isize - r as isize,
-                        row as isize,
-                        channel,
-                        channel_num,
-                    )
-                    .to_f32()
-                    .unwrap_or(0.0)
-                    + extended_f(
-                        samples,
-                        width,
-                        height,
-                        { column + r + 1 } as isize,
-                        row as isize,
-                        channel,
-                        channel_num,
-                    )
-                    .to_f32()
-                    .unwrap_or(0.0);
+        for x in 0..(half_kernel as usize).min(width as usize) {
+            let next = (x + half_kernel as usize + 1).min(width as usize - 1) * CN;
+            let previous = (x as i64 - half_kernel as i64).max(0) as usize * CN;
+
+            let dst_chunk = &mut dst[x * CN..x * CN + CN];
+            dst_chunk[0] = rounding_saturated_mul(weight0, weight);
+            if CN > 1 {
+                dst_chunk[1] = rounding_saturated_mul(weight1, weight);
+            }
+            if CN > 2 {
+                dst_chunk[2] = rounding_saturated_mul(weight2, weight);
+            }
+            if CN == 4 {
+                dst_chunk[3] = rounding_saturated_mul(weight3, weight);
+            }
+
+            let next_chunk = &src[next..next + CN];
+            let previous_chunk = &src[previous..previous + CN];
+
+            weight0 += next_chunk[0].to_f32().unwrap();
+            if CN > 1 {
+                weight1 += next_chunk[1].to_f32().unwrap();
+            }
+            if CN > 2 {
+                weight2 += next_chunk[2].to_f32().unwrap();
+            }
+            if CN == 4 {
+                weight3 += next_chunk[3].to_f32().unwrap();
+            }
+
+            weight0 -= previous_chunk[0].to_f32().unwrap();
+            if CN > 1 {
+                weight1 -= previous_chunk[1].to_f32().unwrap();
+            }
+            if CN > 2 {
+                weight2 -= previous_chunk[2].to_f32().unwrap();
+            }
+            if CN == 4 {
+                weight3 -= previous_chunk[3].to_f32().unwrap();
+            }
+        }
+
+        let max_x_before_clamping = (width - 1).saturating_sub(half_kernel + 1);
+        let row_length = src.len();
+
+        let mut last_processed_item = half_kernel;
+
+        if ((half_kernel as usize * 2 + 1) * CN < row_length)
+            && ((max_x_before_clamping as usize * CN) < row_length)
+        {
+            let data_section = src;
+            let advanced_kernel_part = &data_section[(half_kernel as usize * 2 + 1) * CN..];
+            let section_length = max_x_before_clamping as usize - half_kernel as usize;
+            let dst = &mut dst
+                [half_kernel as usize * CN..(half_kernel as usize * CN + section_length * CN)];
+
+            for ((dst, src_previous), src_next) in dst
+                .chunks_exact_mut(CN)
+                .zip(data_section.chunks_exact(CN))
+                .zip(advanced_kernel_part.chunks_exact(CN))
+            {
+                let dst_chunk = &mut dst[..CN];
+                dst_chunk[0] = rounding_saturated_mul(weight0, weight);
+                if CN > 1 {
+                    dst_chunk[1] = rounding_saturated_mul(weight1, weight);
+                }
+                if CN > 2 {
+                    dst_chunk[2] = rounding_saturated_mul(weight2, weight);
+                }
+                if CN == 4 {
+                    dst_chunk[3] = rounding_saturated_mul(weight3, weight);
+                }
+
+                weight0 += src_next[0].to_f32().unwrap();
+                if CN > 1 {
+                    weight1 += src_next[1].to_f32().unwrap();
+                }
+                if CN > 2 {
+                    weight2 += src_next[2].to_f32().unwrap();
+                }
+                if CN == 4 {
+                    weight3 += src_next[3].to_f32().unwrap();
+                }
+
+                weight0 -= src_previous[0].to_f32().unwrap();
+                if CN > 1 {
+                    weight1 -= src_previous[1].to_f32().unwrap();
+                }
+                if CN > 2 {
+                    weight2 -= src_previous[2].to_f32().unwrap();
+                }
+                if CN == 4 {
+                    weight3 -= src_previous[3].to_f32().unwrap();
+                }
+            }
+
+            last_processed_item = max_x_before_clamping;
+        }
+
+        for x in last_processed_item as usize..width as usize {
+            let next = (x + half_kernel as usize + 1).min(width as usize - 1) * CN;
+            let previous = (x as i64 - half_kernel as i64).max(0) as usize * CN;
+            let dst_chunk = &mut dst[x * CN..x * CN + CN];
+            dst_chunk[0] = rounding_saturated_mul(weight0, weight);
+            if CN > 1 {
+                dst_chunk[1] = rounding_saturated_mul(weight1, weight);
+            }
+            if CN > 2 {
+                dst_chunk[2] = rounding_saturated_mul(weight2, weight);
+            }
+            if CN == 4 {
+                dst_chunk[3] = rounding_saturated_mul(weight3, weight);
+            }
+
+            let next_chunk = &src[next..next + CN];
+            let previous_chunk = &src[previous..previous + CN];
+
+            weight0 += next_chunk[0].to_f32().unwrap();
+            if CN > 1 {
+                weight1 += next_chunk[1].to_f32().unwrap()
+            }
+            if CN > 2 {
+                weight2 += next_chunk[2].to_f32().unwrap();
+            }
+            if CN == 4 {
+                weight3 += next_chunk[3].to_f32().unwrap();
+            }
+
+            weight0 -= previous_chunk[0].to_f32().unwrap();
+            if CN > 1 {
+                weight1 -= previous_chunk[1].to_f32().unwrap();
+            }
+            if CN > 2 {
+                weight2 -= previous_chunk[2].to_f32().unwrap();
+            }
+            if CN == 4 {
+                weight3 -= previous_chunk[3].to_f32().unwrap();
             }
         }
     }
-
-    out_samples
 }
 
-fn extended_f<P: Primitive>(
-    samples: &[P],
-    width: usize,
-    height: usize,
-    x: isize,
-    y: isize,
-    channel: usize,
-    channel_num: usize,
-) -> P {
-    let x = clamp(x, 0, width as isize - 1) as usize;
-    let y = clamp(y, 0, height as isize - 1) as usize;
-    samples[channel_idx(channel, y * width + x, channel_num)]
+fn box_blur_vertical_pass_impl<T: Primitive, const CN: usize>(
+    src: &[T],
+    src_stride: u32,
+    dst: &mut [T],
+    dst_stride: u32,
+    width: u32,
+    height: u32,
+    radius: u32,
+) {
+    let kernel_size = radius * 2 + 1;
+
+    let edge_count = ((kernel_size / 2) + 1) as f32;
+    let half_kernel = kernel_size / 2;
+
+    let weight = 1f32 / (radius * 2 + 1) as f32;
+
+    let buf_size = width as usize * CN;
+
+    let buf_cap = buf_size;
+
+    // Instead of summing each column separately we use here transient buffer that
+    // averages columns in row manner.
+    // So, we make the initial buffer at the top edge
+    // and then doing blur by averaging the whole row ( which is in buffer )
+    // and subtracting and adding next and previous rows in horizontal manner.
+
+    let mut buffer = vec![0f32; buf_cap];
+
+    for (x, (v, bf)) in src.iter().zip(buffer.iter_mut()).enumerate() {
+        let mut w = v.to_f32().unwrap() * edge_count;
+        for y in 1..=half_kernel as usize {
+            let y_src_shift = y.min(height as usize - 1) * src_stride as usize;
+            w += src[y_src_shift + x].to_f32().unwrap();
+        }
+        *bf = w;
+    }
+
+    for (dst, y) in dst.chunks_exact_mut(dst_stride as usize).zip(0..height) {
+        let next = (y + half_kernel + 1).min(height - 1) as usize * src_stride as usize;
+        let previous = (y as i64 - half_kernel as i64).max(0) as usize * src_stride as usize;
+
+        let next_row = &src[next..next + width as usize * CN];
+        let previous_row = &src[previous..previous + width as usize * CN];
+
+        for (((src_next, src_previous), buffer), dst) in next_row
+            .iter()
+            .zip(previous_row.iter())
+            .zip(buffer.iter_mut())
+            .zip(dst.iter_mut())
+        {
+            let mut weight0 = *buffer;
+
+            *dst = rounding_saturated_mul(weight0, weight);
+
+            weight0 += src_next.to_f32().unwrap();
+            weight0 -= src_previous.to_f32().unwrap();
+
+            *buffer = weight0;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{DynamicImage, GrayAlphaImage, GrayImage, RgbImage};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct Rng {
+        state: u64,
+    }
+
+    impl Rng {
+        fn new(seed: u64) -> Self {
+            Self { state: seed }
+        }
+        fn next_u32(&mut self) -> u32 {
+            self.state = self.state.wrapping_mul(6364136223846793005).wrapping_add(1);
+            (self.state >> 32) as u32
+        }
+
+        fn next_u8(&mut self) -> u8 {
+            (self.next_u32() % 256) as u8
+        }
+
+        fn next_f32_in_range(&mut self, a: f32, b: f32) -> f32 {
+            let u = self.next_u32();
+            let unit = (u as f32) / (u32::MAX as f32 + 1.0);
+            a + (b - a) * unit
+        }
+    }
+
+    #[test]
+    fn test_box_blur() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards");
+        let mut rng = Rng::new((now.as_millis() & 0xffff_ffff_ffff_ffff) as u64);
+        for _ in 0..35 {
+            let width = rng.next_u8();
+            let height = rng.next_u8();
+            let sigma = rng.next_f32_in_range(0., 100.);
+            let px = rng.next_u8();
+            let cn = rng.next_u8();
+            if width == 0 || height == 0 || sigma <= 0. {
+                continue;
+            }
+            match cn % 4 {
+                0 => {
+                    let vc = vec![px; width as usize * height as usize];
+                    let image = DynamicImage::from(
+                        GrayImage::from_vec(width as u32, height as u32, vc).unwrap(),
+                    );
+                    let res = image.fast_blur(sigma);
+                    for clr in res.as_bytes().iter() {
+                        assert_eq!(*clr, px);
+                    }
+                }
+                1 => {
+                    let vc = vec![px; width as usize * height as usize * 2];
+                    let image = DynamicImage::from(
+                        GrayAlphaImage::from_vec(width as u32, height as u32, vc).unwrap(),
+                    );
+                    let res = image.fast_blur(sigma);
+                    for clr in res.as_bytes().iter() {
+                        assert_eq!(*clr, px);
+                    }
+                }
+                2 => {
+                    let vc = vec![px; width as usize * height as usize * 3];
+                    let image = DynamicImage::from(
+                        RgbImage::from_vec(width as u32, height as u32, vc).unwrap(),
+                    );
+                    let res = image.fast_blur(sigma);
+                    for clr in res.as_bytes().iter() {
+                        assert_eq!(*clr, px);
+                    }
+                }
+                3 => {
+                    let vc = vec![px; width as usize * height as usize * 4];
+                    let image = DynamicImage::from(
+                        GrayAlphaImage::from_vec(width as u32, height as u32, vc).unwrap(),
+                    );
+                    let res = image.fast_blur(sigma);
+                    for clr in res.as_bytes().iter() {
+                        assert_eq!(*clr, px);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
 }

--- a/src/imageops/fast_blur.rs
+++ b/src/imageops/fast_blur.rs
@@ -314,7 +314,7 @@ fn box_blur_horizontal_pass_impl<T, const CN: usize>(
             }
         }
 
-        let max_x_before_clamping = (width as usize - 1).saturating_sub(half_kernel + 1);
+        let max_x_before_clamping = width_bound.saturating_sub(half_kernel + 1);
         let row_length = src.len();
 
         let mut last_processed_item = half_kernel;

--- a/src/imageops/filter_1d.rs
+++ b/src/imageops/filter_1d.rs
@@ -43,11 +43,11 @@ fn mla<T: Copy + Mul<T, Output = T> + Add<T, Output = T> + MulAdd<T, Output = T>
     acc + a * b
 }
 
-trait SafeMul<S> {
+pub(crate) trait SafeMul<S> {
     fn safe_mul(&self, rhs: S) -> Result<S, ImageError>;
 }
 
-trait SafeAdd<S> {
+pub(crate) trait SafeAdd<S> {
     fn safe_add(&self, rhs: S) -> Result<S, ImageError>;
 }
 


### PR DESCRIPTION
Closes #2511 

It’s possible to push it even further using a ring buffer and fixed point arithmetic, but that would at least double the amount of code, and this version already gives a nice performance boost.

<details>
<summary>Benchmark</summary>

```
fast blur: sigma 3.0    time:   [10.750 ms 10.758 ms 10.766 ms]
                        change: [-52.185% -52.000% -51.832%] (p = 0.00 < 0.05)

fast blur: sigma 7.0    time:   [10.851 ms 10.873 ms 10.896 ms]
                        change: [-51.702% -51.598% -51.494%] (p = 0.00 < 0.05)

fast blur: sigma 50.0   time:   [11.371 ms 11.426 ms 11.486 ms]
                        change: [-50.958% -50.681% -50.399%] (p = 0.00 < 0.05)

gaussian blur: sigma 3.0
                        time:   [9.4690 ms 9.7881 ms 10.273 ms]

gaussian blur: sigma 7.0
                        time:   [20.815 ms 20.922 ms 21.042 ms]

gaussian blur: sigma 50.0
                        time:   [173.84 ms 174.37 ms 174.92 ms]

gaussian blur (dynamic image): sigma 3.0
                        time:   [5.2525 ms 5.2611 ms 5.2702 ms]

gaussian blur (dynamic image): sigma 7.0
                        time:   [13.056 ms 13.084 ms 13.118 ms]

gaussian blur (dynamic image): sigma 50.0
                        time:   [94.538 ms 94.824 ms 95.138 ms]
```

</details>