### PR TITLE
Refactor TGA decoder

### DIFF
--- a/src/codecs/tga/decoder.rs
+++ b/src/codecs/tga/decoder.rs
@@ -378,6 +378,8 @@ impl<R: Read> ImageDecoder for TgaDecoder<R> {
             self.r.read_exact(&mut buf[..num_raw_bytes])?;
         };
 
+        self.fixup_orientation(buf);
+
         // Expand the indices using the color map if necessary
         if let Some(ref color_map) = self.color_map {
             // This allocation could be avoided by expanding each row (or block of pixels) as it is
@@ -390,8 +392,6 @@ impl<R: Read> ImageDecoder for TgaDecoder<R> {
         }
 
         self.reverse_encoding_in_output(buf);
-
-        self.fixup_orientation(buf);
 
         Ok(())
     }

--- a/src/codecs/tga/decoder.rs
+++ b/src/codecs/tga/decoder.rs
@@ -151,21 +151,22 @@ impl<R: Read> TgaDecoder<R> {
             });
         }
 
-        // Compute color information
-        let num_other_bits = if header.map_type == 1 {
+        // Compute output pixel depth
+        let total_pixel_bits = if header.map_type == 1 {
             header.map_entry_size
         } else {
-            header
-                .pixel_depth
-                .checked_sub(num_alpha_bits)
-                .ok_or_else(|| {
-                    ImageError::Decoding(DecodingError::new(
-                        ImageFormat::Tga.into(),
-                        "Inconsistent values for pixel depth and alpha bits",
-                    ))
-                })?
+            header.pixel_depth
         };
+        let num_other_bits = total_pixel_bits
+            .checked_sub(num_alpha_bits)
+            .ok_or_else(|| {
+                ImageError::Decoding(DecodingError::new(
+                    ImageFormat::Tga.into(),
+                    "More alpha bits than pixel bits",
+                ))
+            })?;
 
+        // Determine color type
         let color_type;
         let mut original_color_type = None;
         match (num_alpha_bits, num_other_bits, image_type.is_color()) {

--- a/src/codecs/tga/decoder.rs
+++ b/src/codecs/tga/decoder.rs
@@ -95,6 +95,19 @@ impl<R: Read> TgaDecoder<R> {
                 ),
             ));
         }
+        if image_type.is_color_mapped() {
+            if header.map_type != 1 {
+                return Err(ImageError::Decoding(DecodingError::new(
+                    ImageFormat::Tga.into(),
+                    "Color map type must be 1 for color mapped images",
+                )));
+            } else if ![8, 16].contains(&header.pixel_depth) {
+                return Err(ImageError::Decoding(DecodingError::new(
+                    ImageFormat::Tga.into(),
+                    "Color map must use 1 or 2 byte indexes",
+                )));
+            }
+        }
 
         // TODO: validate the rest of the fields in the header.
 

--- a/src/codecs/tga/decoder.rs
+++ b/src/codecs/tga/decoder.rs
@@ -103,14 +103,10 @@ impl<R: Read> TgaDecoder<R> {
                     "Color map type must be 1 for color mapped images",
                 )));
             } else if ![8, 16].contains(&header.pixel_depth) {
-                return Err(ImageError::Unsupported(
-                    UnsupportedError::from_format_and_kind(
-                        ImageFormat::Tga.into(),
-                        UnsupportedErrorKind::GenericFeature(
-                            "Color map must use 1 or 2 byte indexes".into(),
-                        ),
-                    ),
-                ));
+                return Err(ImageError::Decoding(DecodingError::new(
+                    ImageFormat::Tga.into(),
+                    "Color map must use 1 or 2 byte indexes",
+                )));
             } else if header.pixel_depth > header.map_entry_size {
                 return Err(ImageError::Unsupported(
                     UnsupportedError::from_format_and_kind(

--- a/src/codecs/tga/decoder.rs
+++ b/src/codecs/tga/decoder.rs
@@ -20,6 +20,7 @@ struct ColorMap {
 impl ColorMap {
     /// Get one entry from the color map
     pub(crate) fn get(&self, index: usize) -> Option<&[u8]> {
+        // TODO: Should we actually be *subtracting* start_offset from the index here?
         let entry = self.start_offset + self.entry_size * index;
         self.bytes.get(entry..entry + self.entry_size)
     }

--- a/src/codecs/tga/decoder.rs
+++ b/src/codecs/tga/decoder.rs
@@ -276,13 +276,6 @@ impl<R: Read> TgaDecoder<R> {
         Ok(pixel_data)
     }
 
-    /// Reads a run length encoded packet
-    fn read_all_encoded_data(&mut self) -> ImageResult<Vec<u8>> {
-        let num_bytes = self.width * self.height * self.bytes_per_pixel;
-
-        Ok(self.read_encoded_data(num_bytes)?)
-    }
-
     /// Reverse from BGR encoding to RGB encoding
     ///
     /// TGA files are stored in the BGRA encoding. This function swaps
@@ -363,7 +356,9 @@ impl<R: Read> ImageDecoder for TgaDecoder<R> {
         let mut fallback_buf = vec![];
         // read the pixels from the data region
         let rawbuf = if self.image_type.is_encoded() {
-            let pixel_data = self.read_all_encoded_data()?;
+            let num_bytes = self.width * self.height * self.bytes_per_pixel;
+            let pixel_data = self.read_encoded_data(num_bytes)?;
+
             if self.bytes_per_pixel <= usize::from(self.color_type.bytes_per_pixel()) {
                 buf[..pixel_data.len()].copy_from_slice(&pixel_data);
                 &buf[..pixel_data.len()]

--- a/src/codecs/tga/decoder.rs
+++ b/src/codecs/tga/decoder.rs
@@ -4,9 +4,7 @@ use crate::io::ReadExt;
 use crate::utils::vec_try_with_capacity;
 use crate::{
     color::{ColorType, ExtendedColorType},
-    error::{
-        ImageError, ImageResult, LimitError, LimitErrorKind, UnsupportedError, UnsupportedErrorKind,
-    },
+    error::{ImageError, ImageResult, UnsupportedError, UnsupportedErrorKind},
     ImageDecoder, ImageFormat,
 };
 use byteorder_lite::ReadBytesExt;
@@ -102,10 +100,23 @@ impl<R: Read> TgaDecoder<R> {
                     "Color map type must be 1 for color mapped images",
                 )));
             } else if ![8, 16].contains(&header.pixel_depth) {
-                return Err(ImageError::Decoding(DecodingError::new(
-                    ImageFormat::Tga.into(),
-                    "Color map must use 1 or 2 byte indexes",
-                )));
+                return Err(ImageError::Unsupported(
+                    UnsupportedError::from_format_and_kind(
+                        ImageFormat::Tga.into(),
+                        UnsupportedErrorKind::GenericFeature(
+                            "Color map must use 1 or 2 byte indexes".into(),
+                        ),
+                    ),
+                ));
+            } else if header.pixel_depth > header.map_entry_size {
+                return Err(ImageError::Unsupported(
+                    UnsupportedError::from_format_and_kind(
+                        ImageFormat::Tga.into(),
+                        UnsupportedErrorKind::GenericFeature(
+                            "Indices larger than pixel values".into(),
+                        ),
+                    ),
+                ));
             }
         }
 
@@ -118,7 +129,8 @@ impl<R: Read> TgaDecoder<R> {
         // Read color map
         let mut color_map = None;
         if header.map_type == 1 {
-            if ![16, 24, 32].contains(&header.map_entry_size) {
+            let entry_size = (header.map_entry_size as usize).div_ceil(8);
+            if ![2, 3, 4].contains(&entry_size) {
                 return Err(ImageError::Unsupported(
                     UnsupportedError::from_format_and_kind(
                         ImageFormat::Tga.into(),
@@ -130,18 +142,17 @@ impl<R: Read> TgaDecoder<R> {
             }
 
             let mut bytes = Vec::new();
-            let bytes_per_entry = (header.map_entry_size as usize).div_ceil(8);
-            r.read_exact_vec(&mut bytes, bytes_per_entry * header.map_length as usize)?;
+            r.read_exact_vec(&mut bytes, entry_size * header.map_length as usize)?;
 
             color_map = Some(ColorMap {
-                entry_size: bytes_per_entry,
+                entry_size,
                 start_offset: header.map_origin as usize,
                 bytes,
             });
         }
 
         // Compute color information
-        let num_other_bits = if header.map_type != 0 {
+        let num_other_bits = if header.map_type == 1 {
             header.map_entry_size
         } else {
             header
@@ -196,50 +207,14 @@ impl<R: Read> TgaDecoder<R> {
         })
     }
 
-    /// Expands indices into its mapped color
-    fn expand_color_map(&self, pixel_data: &[u8]) -> io::Result<Vec<u8>> {
-        #[inline]
-        fn bytes_to_index(bytes: &[u8]) -> usize {
-            let mut result = 0usize;
-            for byte in bytes {
-                result = (result << 8) | *byte as usize;
-            }
-            result
-        }
-
-        let bytes_per_entry = (self.header.map_entry_size as usize).div_ceil(8);
-        let mut result = vec_try_with_capacity(self.width * self.height * bytes_per_entry)?;
-
-        if self.bytes_per_pixel == 0 {
-            return Err(io::ErrorKind::Other.into());
-        }
-
-        let color_map = self.color_map.as_ref().ok_or(io::ErrorKind::Other)?;
-
-        for chunk in pixel_data.chunks(self.bytes_per_pixel) {
-            let index = bytes_to_index(chunk);
-            let color = color_map
-                .get(index)
-                .and_then(|slice| slice.get(..bytes_per_entry));
-            debug_assert!(color.is_some());
-            result.extend_from_slice(color.unwrap_or_default());
-        }
-
-        Ok(result)
-    }
-
     /// Reads a run length encoded data for given number of bytes
-    fn read_encoded_data(&mut self, num_bytes: usize) -> io::Result<Vec<u8>> {
-        let mut pixel_data = vec_try_with_capacity(num_bytes)?;
-
-        if self.bytes_per_pixel > 16 {
-            debug_assert!(false, "the size shoudl be valid");
-            return Err(io::ErrorKind::InvalidInput.into());
-        }
-        let mut repeat_buf = [0; 16];
+    fn read_encoded_data(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        assert!(self.bytes_per_pixel <= 4);
+        let mut repeat_buf = [0; 4];
         let repeat_buf = &mut repeat_buf[..self.bytes_per_pixel];
 
-        while pixel_data.len() < num_bytes {
+        let mut index = 0;
+        while index < buf.len() {
             let run_packet = self.r.read_u8()?;
             // If the highest bit in `run_packet` is set, then we repeat pixels
             //
@@ -250,30 +225,67 @@ impl<R: Read> TgaDecoder<R> {
                 let repeat_count = ((run_packet & !0x80) + 1) as usize;
                 self.r.read_exact(repeat_buf)?;
 
-                // get the repeating pixels from the bytes of the pixel stored in `repeat_buf`
-                let data = repeat_buf
-                    .iter()
-                    .cycle()
-                    .take(repeat_count * self.bytes_per_pixel);
-                pixel_data.extend(data);
+                for chunk in buf[index..]
+                    .chunks_exact_mut(self.bytes_per_pixel)
+                    .take(repeat_count)
+                {
+                    chunk.copy_from_slice(repeat_buf);
+                }
+                index += repeat_count * self.bytes_per_pixel;
             } else {
                 // not set, so `run_packet+1` is the number of non-encoded pixels
-                let num_raw_bytes = (run_packet + 1) as usize * self.bytes_per_pixel;
-                self.r
-                    .by_ref()
-                    .take(num_raw_bytes as u64)
-                    .read_to_end(&mut pixel_data)?;
+                let num_raw_bytes =
+                    ((run_packet + 1) as usize * self.bytes_per_pixel).min(buf.len() - index);
+
+                self.r.read_exact(&mut buf[index..][..num_raw_bytes])?;
+                index += num_raw_bytes;
             }
         }
 
-        if pixel_data.len() > num_bytes {
-            // FIXME: the last packet contained more data than we asked for!
-            // This is at least a warning. We truncate the data since some methods rely on the
-            // length to be accurate in the success case.
-            pixel_data.truncate(num_bytes);
+        Ok(())
+    }
+
+    /// Expands indices into its mapped color
+    fn expand_color_map(
+        &self,
+        input: &[u8],
+        output: &mut [u8],
+        color_map: &ColorMap,
+    ) -> ImageResult<()> {
+        if self.bytes_per_pixel == 1 {
+            for (&index, chunk) in input
+                .iter()
+                .zip(output.chunks_exact_mut(color_map.entry_size))
+            {
+                if let Some(color) = color_map.get(index as usize) {
+                    chunk.copy_from_slice(color);
+                } else {
+                    return Err(ImageError::Decoding(DecodingError::new(
+                        ImageFormat::Tga.into(),
+                        "Invalid color map index",
+                    )));
+                }
+            }
+        } else if self.bytes_per_pixel == 2 {
+            for (index, chunk) in input
+                .chunks_exact(2)
+                .zip(output.chunks_exact_mut(color_map.entry_size))
+            {
+                let index = u16::from_le_bytes(index.try_into().unwrap());
+                if let Some(color) = color_map.get(index as usize) {
+                    chunk.copy_from_slice(color);
+                } else {
+                    return Err(ImageError::Decoding(DecodingError::new(
+                        ImageFormat::Tga.into(),
+                        "Invalid color map index",
+                    )));
+                }
+            }
+        } else {
+            unreachable!("Supported bytes_per_pixel values are checked in TgaDecoder::new");
         }
 
-        Ok(pixel_data)
+        Ok(())
     }
 
     /// Reverse from BGR encoding to RGB encoding
@@ -351,45 +363,26 @@ impl<R: Read> ImageDecoder for TgaDecoder<R> {
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
         assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
 
-        // In indexed images, we might need more bytes than pixels to read them. That's nonsensical
-        // to encode but we'll not want to crash.
-        let mut fallback_buf = vec![];
-        // read the pixels from the data region
-        let rawbuf = if self.image_type.is_encoded() {
-            let num_bytes = self.width * self.height * self.bytes_per_pixel;
-            let pixel_data = self.read_encoded_data(num_bytes)?;
-
-            if self.bytes_per_pixel <= usize::from(self.color_type.bytes_per_pixel()) {
-                buf[..pixel_data.len()].copy_from_slice(&pixel_data);
-                &buf[..pixel_data.len()]
-            } else {
-                fallback_buf = pixel_data;
-                &fallback_buf[..]
-            }
+        // Decode the raw data
+        //
+        // We have already checked in `TgaDecoder::new` that the indices take less space than the
+        // pixels they encode, so it is safe to read the raw data into `buf`.
+        let num_raw_bytes = self.width * self.height * self.bytes_per_pixel;
+        if self.image_type.is_encoded() {
+            self.read_encoded_data(&mut buf[..num_raw_bytes])?;
         } else {
-            let num_raw_bytes = self.width * self.height * self.bytes_per_pixel;
-            if self.bytes_per_pixel <= usize::from(self.color_type.bytes_per_pixel()) {
-                self.r.by_ref().read_exact(&mut buf[..num_raw_bytes])?;
-                &buf[..num_raw_bytes]
-            } else {
-                fallback_buf.resize(num_raw_bytes, 0u8);
-                self.r
-                    .by_ref()
-                    .read_exact(&mut fallback_buf[..num_raw_bytes])?;
-                &fallback_buf[..num_raw_bytes]
-            }
+            self.r.read_exact(&mut buf[..num_raw_bytes])?;
         };
 
-        // expand the indices using the color map if necessary
-        if self.image_type.is_color_mapped() {
-            let pixel_data = self.expand_color_map(rawbuf)?;
-            // not enough data to fill the buffer, or would overflow the buffer
-            if pixel_data.len() != buf.len() {
-                return Err(ImageError::Limits(LimitError::from_kind(
-                    LimitErrorKind::DimensionError,
-                )));
-            }
-            buf.copy_from_slice(&pixel_data);
+        // Expand the indices using the color map if necessary
+        if let Some(ref color_map) = self.color_map {
+            // This allocation could be avoided by expanding each row (or block of pixels) as it is
+            // read, or by doing the color map expansion in-place. But those may be more effort than
+            // it is worth.
+            let mut rawbuf = vec_try_with_capacity(num_raw_bytes)?;
+            rawbuf.extend_from_slice(&buf[..num_raw_bytes]);
+
+            self.expand_color_map(&rawbuf, buf, color_map)?;
         }
 
         self.reverse_encoding_in_output(buf);

--- a/src/codecs/tga/decoder.rs
+++ b/src/codecs/tga/decoder.rs
@@ -144,11 +144,15 @@ impl<R: Read> TgaDecoder<R> {
             let mut bytes = Vec::new();
             r.read_exact_vec(&mut bytes, entry_size * header.map_length as usize)?;
 
-            color_map = Some(ColorMap {
-                entry_size,
-                start_offset: header.map_origin as usize,
-                bytes,
-            });
+            // Color maps are technically allowed in non-color-mapped images, so check that we
+            // actually need the color map before storing it.
+            if image_type.is_color_mapped() {
+                color_map = Some(ColorMap {
+                    entry_size,
+                    start_offset: header.map_origin as usize,
+                    bytes,
+                });
+            }
         }
 
         // Compute output pixel depth


### PR DESCRIPTION
This simplifies the TGA decoder and in the process fixes a few bugs and eliminates some allocations.

A few bugs identified:
* Multi-byte color map indices are decoded little-endian rather than big-endian as previously.
* Out-of-bounds color map indices are now a decoding error. They were previously an I/O error, though #2514 accidentally changed them to being a debug_assert! and silently ignored in release builds.
* `fixup_orientation` uses "raw_bytes_per_pixel" (which previously had the more confusing name of "bytes_per_pixel"), so it has been moved to before the application of the color map.
* Calculation of color type used to double-count the alpha channel bits for color mapped images.

I also added a few restrictions which simplify the code:
* Only 8-bit alpha channels are allowed.
* Color map indices can now only be 1 or 2 bytes. Since color maps can have at most 2^16-1 entries, I'm skeptical anyone would have used larger values.
* The size of color map indices must be less than or equal to the size the output pixels. The previous code had a bunch of complexity to deal with hypothetical cases where this wasn't true (but due to the previous bugs didn't actually decode such images correctly...)

I also left a TODO about the color map start offset. I strongly suspect that this value is mean to be subtracted rather than added from each index before looking up into the color map, but the wording in the format documentation isn't super clear and none of our test images have a non-zero value for the offset.