### PR TITLE
Format conversion only for DynamicImage encoding methods

### DIFF
--- a/src/codecs/bmp/encoder.rs
+++ b/src/codecs/bmp/encoder.rs
@@ -4,7 +4,7 @@ use std::io::{self, Write};
 use crate::error::{
     EncodingError, ImageError, ImageFormatHint, ImageResult, ParameterError, ParameterErrorKind,
 };
-use crate::{ColorType, ExtendedColorType, ImageEncoder, ImageFormat};
+use crate::{DynamicImage, ExtendedColorType, ImageEncoder, ImageFormat};
 
 const BITMAPFILEHEADER_SIZE: u32 = 14;
 const BITMAPINFOHEADER_SIZE: u32 = 40;
@@ -283,12 +283,12 @@ impl<W: Write> ImageEncoder for BmpEncoder<'_, W> {
         self.encode(buf, width, height, color_type)
     }
 
-    fn dynimage_conversion_sequence(
-        &mut self,
+    fn make_compatible_img(
+        &self,
         _: crate::io::encoder::MethodSealedToImage,
-        color: ColorType,
-    ) -> Option<ColorType> {
-        crate::io::encoder::dynimage_conversion_8bit(color)
+        img: &DynamicImage,
+    ) -> Option<DynamicImage> {
+        crate::io::encoder::dynimage_conversion_8bit(img)
     }
 }
 

--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -41,7 +41,10 @@ use crate::error::{
     ParameterError, ParameterErrorKind, UnsupportedError, UnsupportedErrorKind,
 };
 use crate::traits::Pixel;
-use crate::{AnimationDecoder, ExtendedColorType, ImageBuffer, ImageDecoder, ImageFormat, Limits};
+use crate::{
+    AnimationDecoder, ExtendedColorType, ImageBuffer, ImageDecoder, ImageEncoder, ImageFormat,
+    Limits,
+};
 
 /// GIF decoder
 pub struct GifDecoder<R: Read> {
@@ -613,6 +616,17 @@ impl<W: Write> GifEncoder<W> {
         gif_encoder
             .write_frame(&frame)
             .map_err(ImageError::from_encoding)
+    }
+}
+impl<W: Write> ImageEncoder for GifEncoder<W> {
+    fn write_image(
+        mut self,
+        buf: &[u8],
+        width: u32,
+        height: u32,
+        color_type: ExtendedColorType,
+    ) -> ImageResult<()> {
+        self.encode(buf, width, height, color_type)
     }
 }
 

--- a/src/codecs/jpeg/encoder.rs
+++ b/src/codecs/jpeg/encoder.rs
@@ -9,8 +9,8 @@ use crate::error::{
 use crate::traits::PixelWithColorType;
 use crate::utils::clamp;
 use crate::{
-    ColorType, ExtendedColorType, GenericImageView, ImageBuffer, ImageEncoder, ImageFormat, Luma,
-    Pixel, Rgb,
+    ColorType, DynamicImage, ExtendedColorType, GenericImageView, ImageBuffer, ImageEncoder,
+    ImageFormat, Luma, Pixel, Rgb,
 };
 
 use num_traits::ToPrimitive;
@@ -715,17 +715,16 @@ impl<W: Write> ImageEncoder for JpegEncoder<W> {
         Ok(())
     }
 
-    fn dynimage_conversion_sequence(
-        &mut self,
+    fn make_compatible_img(
+        &self,
         _: crate::io::encoder::MethodSealedToImage,
-        color: ColorType,
-    ) -> Option<ColorType> {
+        img: &DynamicImage,
+    ) -> Option<DynamicImage> {
         use ColorType::*;
-
-        match color {
+        match img.color() {
             L8 | Rgb8 => None,
-            La8 | L16 | La16 => Some(L8),
-            Rgba8 | Rgb16 | Rgb32F | Rgba16 | Rgba32F => Some(Rgb8),
+            La8 | L16 | La16 => Some(img.to_luma8().into()),
+            Rgba8 | Rgb16 | Rgb32F | Rgba16 | Rgba32F => Some(img.to_rgb8().into()),
         }
     }
 }

--- a/src/codecs/tga/encoder.rs
+++ b/src/codecs/tga/encoder.rs
@@ -1,6 +1,6 @@
 use super::header::Header;
 use crate::{codecs::tga::header::ImageType, error::EncodingError, utils::vec_try_with_capacity};
-use crate::{ColorType, ExtendedColorType, ImageEncoder, ImageError, ImageFormat, ImageResult};
+use crate::{DynamicImage, ExtendedColorType, ImageEncoder, ImageError, ImageFormat, ImageResult};
 use std::{error, fmt, io::Write};
 
 /// Errors that can occur during encoding and saving of a TGA image.
@@ -243,12 +243,12 @@ impl<W: Write> ImageEncoder for TgaEncoder<W> {
         self.encode(buf, width, height, color_type)
     }
 
-    fn dynimage_conversion_sequence(
-        &mut self,
+    fn make_compatible_img(
+        &self,
         _: crate::io::encoder::MethodSealedToImage,
-        color: ColorType,
-    ) -> Option<ColorType> {
-        crate::io::encoder::dynimage_conversion_8bit(color)
+        img: &DynamicImage,
+    ) -> Option<DynamicImage> {
+        crate::io::encoder::dynimage_conversion_8bit(img)
     }
 }
 

--- a/src/codecs/webp/encoder.rs
+++ b/src/codecs/webp/encoder.rs
@@ -3,7 +3,7 @@
 use std::io::Write;
 
 use crate::error::{EncodingError, UnsupportedError, UnsupportedErrorKind};
-use crate::{ColorType, ExtendedColorType, ImageEncoder, ImageError, ImageFormat, ImageResult};
+use crate::{DynamicImage, ExtendedColorType, ImageEncoder, ImageError, ImageFormat, ImageResult};
 
 /// WebP Encoder.
 ///
@@ -98,12 +98,12 @@ impl<W: Write> ImageEncoder for WebPEncoder<W> {
         Ok(())
     }
 
-    fn dynimage_conversion_sequence(
-        &mut self,
+    fn make_compatible_img(
+        &self,
         _: crate::io::encoder::MethodSealedToImage,
-        color: ColorType,
-    ) -> Option<ColorType> {
-        crate::io::encoder::dynimage_conversion_8bit(color)
+        img: &DynamicImage,
+    ) -> Option<DynamicImage> {
+        crate::io::encoder::dynimage_conversion_8bit(img)
     }
 }
 


### PR DESCRIPTION
This PR changes things so that the methods on `DynamicImage` -- and only the methods on `DynamicImage` -- attempt to convert images to a compatible format before encoding them. The reasoning is that all the other places in this crate that involve encoding directly specify the color type statically (in the case of `ImageBuffer`) or as a function argument (like in the case of the free functions).

To simplify the implementation here, I also made `GifEncoder` implement `ImageEncoder`.

Fixes #2521, #2497
