### PR TITLE
Fail CI quicker?

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   test_features:
     runs-on: ubuntu-latest
+    needs: ["clippy"] # only to avoid running on broken builds
     strategy:
       fail-fast: false
       matrix:
@@ -69,6 +70,7 @@ jobs:
     # an emulated mips system. NOTE: you can also use this approach to test for
     # big endian locally.
     runs-on: ubuntu-latest
+    needs: ["rustfmt", "cargo-deny"] # only to avoid running on broken builds
     strategy:
       fail-fast: false
       matrix:
@@ -91,6 +93,7 @@ jobs:
 
   test_avif_decoding:
     runs-on: ubuntu-latest
+    needs: ["clippy"] # only to avoid running on broken builds
     steps:
     - name: install-dependencies
       run: sudo apt update && sudo apt install ninja-build meson nasm
@@ -118,6 +121,7 @@ jobs:
   build_fuzz_afl:
     name: "Fuzz targets (afl)"
     runs-on: ubuntu-latest
+    needs: ["clippy", "cargo-deny"] # only to avoid running on broken builds
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
@@ -144,6 +148,7 @@ jobs:
   build_fuzz_cargo-fuzz:
     name: "Fuzz targets (cargo-fuzz)"
     runs-on: ubuntu-latest
+    needs: ["rustfmt", "cargo-deny"] # only to avoid running on broken builds
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
@@ -158,6 +163,7 @@ jobs:
 
   public_private_dependencies:
     runs-on: ubuntu-latest
+    needs: ["clippy", "cargo-deny"] # only to avoid running on broken builds
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
@@ -176,6 +182,7 @@ jobs:
 
   build_benchmarks:
     runs-on: ubuntu-latest
+    needs: ["rustfmt", "cargo-deny"] # only to avoid running on broken builds
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
@@ -200,6 +207,7 @@ jobs:
 
   cargo-semver-checks:
     runs-on: ubuntu-latest
+    needs: ["rustfmt", "cargo-deny"] # only to avoid running on broken builds
     steps:
       - uses: actions/checkout@v4
       - name: Cache Cargo Dependencies


### PR DESCRIPTION
CI immediately launches a ton of jobs, but may fail due to trivial issues like Clippy. 

Here I'm trying to run some basic tests first before spawning the rest.