### PR TITLE
add const `HAS_ALPHA` to trait `Pixel`

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -286,6 +286,8 @@ impl<T: $($bound+)*> Pixel for $ident<T> {
 
     const COLOR_MODEL: &'static str = $interpretation;
 
+    const HAS_ALPHA: bool = $alphas > 0;
+
     fn channels4(&self) -> (T, T, T, T) {
         const CHANNELS: usize = $channels;
         let mut channels = [T::DEFAULT_MAX_VALUE; 4];

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -250,6 +250,9 @@ pub trait Pixel: Copy + Clone {
     /// See [gimp babl](http://gegl.org/babl/).
     const COLOR_MODEL: &'static str;
 
+    /// Returns true if the alpha channel is contained.
+    const HAS_ALPHA: bool;
+
     /// Returns the channels of this pixel as a 4 tuple. If the pixel
     /// has less than 4 channels the remainder is filled with the maximum value
     #[deprecated(since = "0.24.0", note = "Use `channels()` or `channels_mut()`")]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -251,7 +251,7 @@ pub trait Pixel: Copy + Clone {
     const COLOR_MODEL: &'static str;
 
     /// Returns true if the alpha channel is contained.
-    const HAS_ALPHA: bool;
+    const HAS_ALPHA: bool = false;
 
     /// Returns the channels of this pixel as a 4 tuple. If the pixel
     /// has less than 4 channels the remainder is filled with the maximum value


### PR DESCRIPTION
### Problem: How to determine has_alpha from a Pixel type?

While working on a bug fix https://github.com/image-rs/imageproc/pull/719 in the `imageproc` crate, I needed to check `Pixel` type has an alpha channel.

The only way I found to do this was by comparing the `COLOR_MODEL: &str` value in the `Pixel` trait, which feels a bit indirect and error-prone.

I think it would be much clearer and easier to use if the `Pixel` trait had a `HAS_ALPHA: bool` constant to indicate this directly.