### PR TITLE
Add `ImageEncoder::set_exif_metadata` and implement for JPEG, PNG, and WebP

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,7 +49,8 @@ jobs:
       if: ${{ matrix.rust == '1.78.0' }}
       run: |
         cargo -Zminimal-versions generate-lockfile
-        cargo update num-bigint --precise 0.4.2
+        cargo update --offline num-bigint --precise 0.4.2
+        cargo update --offline bitflags:1.0.0 --precise 1.3.2
 
     - uses: dtolnay/rust-toolchain@v1
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ exr = { version = "1.5.0", optional = true }
 gif = { version = "0.13.1", optional = true }
 image-webp = { version = "0.2.0", optional = true }
 mp4parse = { version = "0.17.0", optional = true }
-png = { version = "0.17.11", optional = true }
+png = { version = "0.17.16", optional = true }
 qoi = { version = "0.4", optional = true }
 ravif = { version = "0.11.12", default-features = false, optional = true }
 rayon = { version = "1.7.0", optional = true }

--- a/src/codecs/jpeg/encoder.rs
+++ b/src/codecs/jpeg/encoder.rs
@@ -366,14 +366,6 @@ impl<W: Write> JpegEncoder<W> {
         JpegEncoder::new_with_quality(w, 75)
     }
 
-    /// Add an EXIF segment to the JPEG file
-    ///
-    /// Expects a valid TIFF-formatted EXIF block as a byte vector.
-    pub fn with_exif_metadata(mut self, exif: Vec<u8>) -> JpegEncoder<W> {
-        self.exif = exif;
-        self
-    }
-
     /// Create a new encoder that writes its output to ```w```, and has
     /// the quality parameter ```quality``` with a value in the range 1-100
     /// where 1 is the worst and 100 is the best.
@@ -738,6 +730,11 @@ impl<W: Write> ImageEncoder for JpegEncoder<W> {
 
     fn set_icc_profile(&mut self, icc_profile: Vec<u8>) -> Result<(), UnsupportedError> {
         self.icc_profile = icc_profile;
+        Ok(())
+    }
+
+    fn set_exif_metadata(&mut self, exif: Vec<u8>) -> Result<(), UnsupportedError> {
+        self.exif = exif;
         Ok(())
     }
 

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -485,6 +485,7 @@ pub struct PngEncoder<W: Write> {
     compression: CompressionType,
     filter: FilterType,
     icc_profile: Vec<u8>,
+    exif_metadata: Vec<u8>,
 }
 
 /// Compression level of a PNG encoder. The default setting is `Fast`.
@@ -539,6 +540,7 @@ impl<W: Write> PngEncoder<W> {
             compression: CompressionType::default(),
             filter: FilterType::default(),
             icc_profile: Vec::new(),
+            exif_metadata: Vec::new(),
         }
     }
 
@@ -564,6 +566,7 @@ impl<W: Write> PngEncoder<W> {
             compression,
             filter,
             icc_profile: Vec::new(),
+            exif_metadata: Vec::new(),
         }
     }
 
@@ -613,6 +616,9 @@ impl<W: Write> PngEncoder<W> {
 
         if !self.icc_profile.is_empty() {
             info.icc_profile = Some(Cow::Borrowed(&self.icc_profile));
+        }
+        if !self.exif_metadata.is_empty() {
+            info.exif_metadata = Some(Cow::Borrowed(&self.exif_metadata));
         }
 
         let mut encoder =
@@ -688,6 +694,11 @@ impl<W: Write> ImageEncoder for PngEncoder<W> {
 
     fn set_icc_profile(&mut self, icc_profile: Vec<u8>) -> Result<(), UnsupportedError> {
         self.icc_profile = icc_profile;
+        Ok(())
+    }
+
+    fn set_exif_metadata(&mut self, exif: Vec<u8>) -> Result<(), UnsupportedError> {
+        self.exif_metadata = exif;
         Ok(())
     }
 }

--- a/src/codecs/webp/encoder.rs
+++ b/src/codecs/webp/encoder.rs
@@ -98,6 +98,11 @@ impl<W: Write> ImageEncoder for WebPEncoder<W> {
         Ok(())
     }
 
+    fn set_exif_metadata(&mut self, exif: Vec<u8>) -> Result<(), UnsupportedError> {
+        self.inner.set_exif_metadata(exif);
+        Ok(())
+    }
+
     fn make_compatible_img(
         &self,
         _: crate::io::encoder::MethodSealedToImage,

--- a/src/io/encoder.rs
+++ b/src/io/encoder.rs
@@ -60,6 +60,26 @@ pub trait ImageEncoder {
         ))
     }
 
+    /// Set the EXIF metadata to use for the image.
+    ///
+    /// This function is a no-op for formats that don't support EXIF metadata.
+    /// For formats that do support EXIF metadata, the metadata will be embedded
+    /// in the image when it is saved.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if the format does not support EXIF metadata or if the
+    /// encoder doesn't implement saving EXIF metadata yet.
+    fn set_exif_metadata(&mut self, exif: Vec<u8>) -> Result<(), UnsupportedError> {
+        let _ = exif;
+        Err(UnsupportedError::from_format_and_kind(
+            ImageFormatHint::Unknown,
+            UnsupportedErrorKind::GenericFeature(
+                "EXIF metadata is not supported for this format".into(),
+            ),
+        ))
+    }
+
     /// Convert the image to a compatible format for the encoder. This is used by the encoding
     /// methods on `DynamicImage`.
     ///


### PR DESCRIPTION
This PR replaces the single format API introduced in #2537 with a consistent API that we can implement across a range of formats.