### PR TITLE
Uniform error for unsupported encoder colors

### DIFF
--- a/src/codecs/hdr/encoder.rs
+++ b/src/codecs/hdr/encoder.rs
@@ -3,7 +3,7 @@ use std::io::{Result, Write};
 
 use crate::codecs::hdr::{rgbe8, Rgbe8Pixel, SIGNATURE};
 use crate::color::Rgb;
-use crate::error::{EncodingError, ImageFormatHint, ImageResult};
+use crate::error::{ImageResult, UnsupportedError, UnsupportedErrorKind};
 use crate::{ExtendedColorType, ImageEncoder, ImageError, ImageFormat};
 
 /// Radiance HDR encoder
@@ -29,11 +29,12 @@ impl<W: Write> ImageEncoder for HdrEncoder<W> {
                 // the length will be checked inside encode_pixels
                 self.encode_pixels(rgbe_pixels, width as usize, height as usize)
             }
-
-            _ => Err(ImageError::Encoding(EncodingError::new(
-                ImageFormatHint::Exact(ImageFormat::Hdr),
-                "hdr format currently only supports the `Rgb32F` color type".to_string(),
-            ))),
+            _ => Err(ImageError::Unsupported(
+                UnsupportedError::from_format_and_kind(
+                    ImageFormat::Hdr.into(),
+                    UnsupportedErrorKind::Color(color_type),
+                ),
+            )),
         }
     }
 }

--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -22,7 +22,7 @@
 //!     - (chroma) subsampling not supported yet by the exr library
 use exr::prelude::*;
 
-use crate::error::{DecodingError, EncodingError, ImageFormatHint};
+use crate::error::{DecodingError, ImageFormatHint, UnsupportedError, UnsupportedErrorKind};
 use crate::{
     ColorType, ExtendedColorType, ImageDecoder, ImageEncoder, ImageError, ImageFormat, ImageResult,
 };
@@ -272,10 +272,12 @@ fn write_buffer(
 
         // TODO other color types and channel types
         unsupported_color_type => {
-            return Err(ImageError::Encoding(EncodingError::new(
-                ImageFormatHint::Exact(ImageFormat::OpenExr),
-                format!("writing color type {unsupported_color_type:?} not yet supported"),
-            )))
+            return Err(ImageError::Unsupported(
+                UnsupportedError::from_format_and_kind(
+                    ImageFormat::OpenExr.into(),
+                    UnsupportedErrorKind::Color(unsupported_color_type),
+                ),
+            ))
         }
     }
 

--- a/src/codecs/pnm/encoder.rs
+++ b/src/codecs/pnm/encoder.rs
@@ -300,11 +300,12 @@ impl<W: Write> PnmEncoder<W> {
                 }
             }
             (_, _) => {
-                return Err(ImageError::Parameter(ParameterError::from_kind(
-                    ParameterErrorKind::Generic(
-                        "Color type can not be represented in the chosen format".to_owned(),
+                return Err(ImageError::Unsupported(
+                    UnsupportedError::from_format_and_kind(
+                        ImageFormat::Pnm.into(),
+                        UnsupportedErrorKind::Color(color),
                     ),
-                )));
+                ))
             }
         };
 

--- a/src/codecs/qoi.rs
+++ b/src/codecs/qoi.rs
@@ -1,6 +1,6 @@
 //! Decoding and encoding of QOI images
 
-use crate::error::{DecodingError, EncodingError};
+use crate::error::{DecodingError, EncodingError, UnsupportedError, UnsupportedErrorKind};
 use crate::{
     ColorType, ExtendedColorType, ImageDecoder, ImageEncoder, ImageError, ImageFormat, ImageResult,
 };
@@ -77,10 +77,12 @@ impl<W: Write> ImageEncoder for QoiEncoder<W> {
             color_type,
             ExtendedColorType::Rgba8 | ExtendedColorType::Rgb8
         ) {
-            return Err(ImageError::Encoding(EncodingError::new(
-                ImageFormat::Qoi.into(),
-                format!("unsupported color type {color_type:?}. Supported are Rgba8 and Rgb8."),
-            )));
+            return Err(ImageError::Unsupported(
+                UnsupportedError::from_format_and_kind(
+                    ImageFormat::Qoi.into(),
+                    UnsupportedErrorKind::Color(color_type),
+                ),
+            ));
         }
 
         let expected_buffer_len = color_type.buffer_size(width, height);


### PR DESCRIPTION
Closes: #2456 

Addresses everything on the list, _except_ one case in pnm. This is a collection of sub-formats, it is also the only format that allows the caller to use an _exact_ pre-configured header. In that code path the error is kept as `ParameterError` since it verifies if the caller matched their header to the color, both under the callers control, and not if the color in principle can work with the format. The expected use case here is a roundtrip of extended options including the color type, hence the fault is indicative of a bug on the caller side.

All paths reachable through `ImageEncoder` should result in `ImageError::Unsupported` now (exact for the color type negotiation introduced earlier).