### PR TITLE
Add alpha mask utilities to ImageBuffer

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -134,6 +134,8 @@ pub enum ParameterErrorKind {
         /// The cicp that was found.
         found: Cicp,
     },
+    /// The operation is only applicable to pixels with an alpha channel.
+    NoAlphaChannel,
 }
 
 /// An error was encountered while decoding an image.
@@ -442,6 +444,12 @@ impl fmt::Display for ParameterError {
                 write!(
                     fmt,
                     "The color space {found:?} does not match the expected {expected:?}",
+                )
+            }
+            ParameterErrorKind::NoAlphaChannel => {
+                write!(
+                    fmt,
+                    "The operation requires an alpha channel but the pixel type does not have one",
                 )
             }
         }?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -136,6 +136,8 @@ pub enum ParameterErrorKind {
     },
     /// The operation is only applicable to pixels with an alpha channel.
     NoAlphaChannel,
+    /// The operation is only applicable to Luma pixels, which can be used as a mask.
+    NotAValidMask(ExtendedColorType),
 }
 
 /// An error was encountered while decoding an image.
@@ -450,6 +452,12 @@ impl fmt::Display for ParameterError {
                 write!(
                     fmt,
                     "The operation requires an alpha channel but the pixel type does not have one",
+                )
+            }
+            ParameterErrorKind::NotAValidMask(c) => {
+                write!(
+                    fmt,
+                    "The operation requires a luma image as a mask but the input has color {c:?}",
                 )
             }
         }?;

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -778,6 +778,30 @@ where
             .into_view_mut()
             .expect("buffer always uses a non-overlapping strided layout")
     }
+
+    /// Extract the alpha channel as a Luma image.
+    ///
+    /// If the pixel does not have an alpha channel, the value is filled with a fully opaque mask
+    /// using the maximum value of the corresponding subpixel type.
+    pub fn to_alpha_mask(&self) -> ImageBuffer<Luma<P::Subpixel>, Vec<P::Subpixel>> {
+        let pixels = self.subpixels().chunks_exact(P::CHANNEL_COUNT.into());
+        let mut mask = vec![<P::Subpixel as Primitive>::DEFAULT_MAX_VALUE; pixels.len()];
+
+        if P::HAS_ALPHA {
+            assert!(
+                P::CHANNEL_COUNT > 0,
+                "Pixel with zero channels indicated an alpha channel"
+            );
+
+            for (p, alpha) in pixels.zip(mask.iter_mut()) {
+                // If the pixel has an alpha channel, use it.
+                *alpha = *p.last().unwrap();
+            }
+        }
+
+        ImageBuffer::from_vec(self.width, self.height, mask)
+            .expect("used the right pixel and channel count")
+    }
 }
 
 impl<P, Container> ImageBuffer<P, Container>
@@ -941,6 +965,47 @@ where
 
         self.width = selection.width;
         self.height = selection.height;
+    }
+
+    /// Fill the alpha channel of this image from a Luma mask.
+    ///
+    /// Returns an [`ImageError::Parameter`] if the mask dimensions do not match the image
+    /// dimensions. Otherwise, if the pixel type does not have an alpha channel this is a no-op.
+    pub fn apply_alpha_mask<RhsContainer>(
+        &mut self,
+        mask: &ImageBuffer<Luma<P::Subpixel>, RhsContainer>,
+    ) -> ImageResult<()>
+    where
+        RhsContainer: Deref<Target = [P::Subpixel]>,
+    {
+        if (self.width, self.height) != (mask.width(), mask.height()) {
+            return Err(ImageError::Parameter(ParameterError::from_kind(
+                ParameterErrorKind::DimensionMismatch,
+            )));
+        }
+
+        if !P::HAS_ALPHA {
+            return Err(ImageError::Parameter(ParameterError::from_kind(
+                ParameterErrorKind::NoAlphaChannel,
+            )));
+        }
+
+        assert!(
+            P::CHANNEL_COUNT > 0,
+            "Pixel with zero channels indicated an alpha channel"
+        );
+
+        let pixels = self
+            .subpixels_mut()
+            .chunks_exact_mut(P::CHANNEL_COUNT.into());
+
+        let mask = mask.subpixels();
+        for (p, alpha) in pixels.zip(mask.iter()) {
+            // If the pixel has an alpha channel, use it.
+            *p.last_mut().unwrap() = *alpha;
+        }
+
+        Ok(())
     }
 }
 
@@ -2444,6 +2509,27 @@ mod test {
         assert_eq!(expanded.get_pixel(0, 1), &Rgba([255, 255, 255, 255]));
         assert_eq!(expanded.get_pixel(1, 1), &Rgba([255, 255, 255, 255]));
         assert_eq!(expanded.get_pixel(0, 0), &Rgba([255, 255, 255, 255]));
+    }
+
+    #[test]
+    fn alpha_mask_of_gray() {
+        let image: GrayImage = ImageBuffer::new(4, 4);
+        let mask = image.to_alpha_mask();
+        assert_eq!(mask.as_raw(), &[255; 16]);
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn alpha_mask_extraction() {
+        let image: ImageBuffer<LumaA<u8>, _> = ImageBuffer::from_raw(4, 4, vec![
+            0, 1, 0, 2, 0, 3, 0, 4,
+            0, 5, 0, 6, 0, 7, 0, 8,
+            0, 9, 0, 10, 0, 11, 0, 12,
+            0, 13, 0, 14, 0, 15, 0, 16,
+        ]).unwrap();
+
+        let mask = image.to_alpha_mask();
+        assert_eq!(mask.as_raw(), &(1u8..17).collect::<Vec<_>>());
     }
 }
 

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -1049,8 +1049,7 @@ impl<S: Primitive> ImageBuffer<Luma<S>, Vec<S>> {
     }
 }
 
-// TODO: why does this have an Enlargeable bound?
-impl<S: Primitive + crate::traits::Enlargeable> ImageBuffer<Rgb<S>, Vec<S>> {
+impl<S: Primitive> ImageBuffer<Rgb<S>, Vec<S>> {
     /// See: `add_alpha_channel` for `ImageBuffer<Luma<S>>`.
     pub(crate) fn add_alpha_channel(
         &self,

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -970,8 +970,8 @@ where
     /// Fill the alpha channel of this image from a Luma mask.
     ///
     /// Returns an [`ImageError::Parameter`] if the mask dimensions do not match the image
-    /// dimensions. Otherwise, if the pixel type does not have an alpha channel this is a no-op.
-    pub fn apply_alpha_mask<RhsContainer>(
+    /// dimensions or if there is no alpha channel in the pixel's color type.
+    pub fn set_alpha_channel<RhsContainer>(
         &mut self,
         mask: &ImageBuffer<Luma<P::Subpixel>, RhsContainer>,
     ) -> ImageResult<()>
@@ -2530,6 +2530,44 @@ mod test {
 
         let mask = image.to_alpha_mask();
         assert_eq!(mask.as_raw(), &(1u8..17).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn apply_alpha_mask() {
+        let mut image: ImageBuffer<LumaA<u8>, _> = ImageBuffer::new(4, 4);
+
+        let alpha = ImageBuffer::from_pixel(4, 4, Luma([255]));
+        image.set_alpha_channel(&alpha).expect("can apply");
+
+        for pixel in image.pixels() {
+            assert_eq!(pixel.0, [0, 255]);
+        }
+    }
+
+    #[test]
+    fn apply_alpha_mask_rgb() {
+        let mut image: ImageBuffer<Rgba<u8>, _> = ImageBuffer::new(4, 4);
+
+        let alpha = ImageBuffer::from_pixel(4, 4, Luma([255]));
+        image.set_alpha_channel(&alpha).expect("can apply");
+
+        for pixel in image.pixels() {
+            assert_eq!(pixel.0, [0, 0, 0, 255]);
+        }
+    }
+
+    #[test]
+    fn can_not_apply_alpha_mask() {
+        ImageBuffer::<LumaA<u8>, _>::new(4, 4)
+            .set_alpha_channel(&ImageBuffer::new(1, 1))
+            .expect_err("can not apply with wrong dimensions");
+
+        ImageBuffer::<Luma<u8>, _>::new(4, 4)
+            .set_alpha_channel(&ImageBuffer::new(4, 4))
+            .expect_err("can not apply without alpha channel");
+        ImageBuffer::<Rgb<u8>, _>::new(4, 4)
+            .set_alpha_channel(&ImageBuffer::new(4, 4))
+            .expect_err("can not apply without alpha channel");
     }
 }
 

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -784,20 +784,18 @@ where
     /// If the pixel does not have an alpha channel, the value is filled with a fully opaque mask
     /// using the maximum value of the corresponding subpixel type.
     pub fn to_alpha_mask(&self) -> ImageBuffer<Luma<P::Subpixel>, Vec<P::Subpixel>> {
-        let pixels = self.subpixels().chunks_exact(P::CHANNEL_COUNT.into());
-        let mut mask = vec![<P::Subpixel as Primitive>::DEFAULT_MAX_VALUE; pixels.len()];
+        let pixels = self.pixels().iter();
 
-        if P::HAS_ALPHA {
+        let mask = if P::HAS_ALPHA {
             assert!(
                 P::CHANNEL_COUNT > 0,
                 "Pixel with zero channels indicated an alpha channel"
             );
 
-            for (p, alpha) in pixels.zip(mask.iter_mut()) {
-                // If the pixel has an alpha channel, use it.
-                *alpha = *p.last().unwrap();
-            }
-        }
+            pixels.map(|p| p.alpha()).collect()
+        } else {
+            vec![<P::Subpixel as Primitive>::DEFAULT_MAX_VALUE; pixels.len()]
+        };
 
         ImageBuffer::from_vec(self.width, self.height, mask)
             .expect("used the right pixel and channel count")
@@ -995,14 +993,12 @@ where
             "Pixel with zero channels indicated an alpha channel"
         );
 
-        let pixels = self
-            .subpixels_mut()
-            .chunks_exact_mut(P::CHANNEL_COUNT.into());
-
+        let pixels = self.pixels_mut().iter_mut();
         let mask = mask.subpixels();
+
         for (p, alpha) in pixels.zip(mask.iter()) {
             // If the pixel has an alpha channel, use it.
-            *p.last_mut().unwrap() = *alpha;
+            p.apply_with_alpha(|c| c, |_| *alpha);
         }
 
         Ok(())

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -969,6 +969,23 @@ where
     ///
     /// Returns an [`ImageError::Parameter`] if the mask dimensions do not match the image
     /// dimensions or if there is no alpha channel in the pixel's color type.
+    ///
+    /// NOTE: pending the generic constant argument MVP (#132980) this may gain a trait bound on
+    /// available alpha channel instead of an error. Please do consider the design trade-off here.
+    /// The standard library refrained from adding a non-zero bound to the length of
+    /// `slice::as_chunks`. The bound would look like:
+    ///
+    /// ```text
+    /// where
+    ///     P: Pixel<HAS_ALPHA = true>
+    /// ```
+    ///
+    /// Similar arguments apply as presented in [#99471], with post-monomorphization error and
+    /// inability to type-check code on a const-dependent branch. We must consider if a slice length
+    /// of `0` and non-alpha pixel types are similar usage patterns.
+    ///
+    /// [#99471]: https://github.com/rust-lang/rust/pull/99471
+    /// [#132980]: https://github.com/rust-lang/rust/issues/132980
     pub fn set_alpha_channel<RhsContainer>(
         &mut self,
         mask: &ImageBuffer<Luma<P::Subpixel>, RhsContainer>,
@@ -1002,6 +1019,57 @@ where
         }
 
         Ok(())
+    }
+}
+
+impl<S: Primitive> ImageBuffer<Luma<S>, Vec<S>> {
+    /// Insert an alpha channel at every pixel.
+    ///
+    /// Before exposing this:
+    /// - should it be generic, if so, how?
+    /// - buffer reuse would works but only for `Vec` since we must resize.
+    pub(crate) fn add_alpha_channel(
+        &self,
+        mask: &ImageBuffer<Luma<S>, Vec<S>>,
+    ) -> ImageResult<ImageBuffer<LumaA<S>, Vec<S>>> {
+        if (self.width, self.height) != (mask.width(), mask.height()) {
+            return Err(ImageError::Parameter(ParameterError::from_kind(
+                ParameterErrorKind::DimensionMismatch,
+            )));
+        }
+
+        let data = self
+            .pixels()
+            .iter()
+            .zip(mask.subpixels())
+            .map(|(&luma, &alpha)| [luma.0[0], alpha])
+            .collect::<Vec<_>>();
+
+        Ok(ImageBuffer::from_vec(self.width, self.height, data.into_flattened()).unwrap())
+    }
+}
+
+// TODO: why does this have an Enlargeable bound?
+impl<S: Primitive + crate::traits::Enlargeable> ImageBuffer<Rgb<S>, Vec<S>> {
+    /// See: `add_alpha_channel` for `ImageBuffer<Luma<S>>`.
+    pub(crate) fn add_alpha_channel(
+        &self,
+        mask: &ImageBuffer<Luma<S>, Vec<S>>,
+    ) -> ImageResult<ImageBuffer<Rgba<S>, Vec<S>>> {
+        if (self.width, self.height) != (mask.width(), mask.height()) {
+            return Err(ImageError::Parameter(ParameterError::from_kind(
+                ParameterErrorKind::DimensionMismatch,
+            )));
+        }
+
+        let data = self
+            .pixels()
+            .iter()
+            .zip(mask.subpixels())
+            .map(|(&Rgb([r, g, b]), &alpha)| [r, g, b, alpha])
+            .collect::<Vec<_>>();
+
+        Ok(ImageBuffer::from_vec(self.width, self.height, data.into_flattened()).unwrap())
     }
 }
 

--- a/src/images/dynimage.rs
+++ b/src/images/dynimage.rs
@@ -19,8 +19,8 @@ use crate::traits::Pixel;
 use crate::{
     imageops,
     metadata::{Cicp, CicpColorPrimaries, CicpTransferCharacteristics},
-    ConvertColorOptions, ExtendedColorType, GenericImage, GenericImageView, ImageDecoder,
-    ImageEncoder, ImageFormat, ImageReaderOptions, Luma, LumaA,
+    ColorType, ConvertColorOptions, ExtendedColorType, GenericImage, GenericImageView,
+    ImageDecoder, ImageEncoder, ImageFormat, ImageReaderOptions, Luma, LumaA,
 };
 
 /// A Dynamic Image
@@ -174,8 +174,8 @@ impl DynamicImage {
     ///
     /// The color space is initially set to [`sRGB`][`Cicp::SRGB`].
     #[must_use]
-    pub fn new(w: u32, h: u32, color: color::ColorType) -> DynamicImage {
-        use color::ColorType::*;
+    pub fn new(w: u32, h: u32, color: ColorType) -> DynamicImage {
+        use ColorType::*;
         match color {
             L8 => Self::new_luma8(w, h),
             La8 => Self::new_luma_a8(w, h),
@@ -885,20 +885,21 @@ impl DynamicImage {
 
     /// Return this image's color type.
     #[must_use]
-    pub fn color(&self) -> color::ColorType {
+    #[doc(alias = "color_type")]
+    pub fn color(&self) -> ColorType {
         match *self {
-            DynamicImage::ImageLuma8(_) => color::ColorType::L8,
-            DynamicImage::ImageLumaA8(_) => color::ColorType::La8,
-            DynamicImage::ImageRgb8(_) => color::ColorType::Rgb8,
-            DynamicImage::ImageRgba8(_) => color::ColorType::Rgba8,
-            DynamicImage::ImageLuma16(_) => color::ColorType::L16,
-            DynamicImage::ImageLumaA16(_) => color::ColorType::La16,
-            DynamicImage::ImageRgb16(_) => color::ColorType::Rgb16,
-            DynamicImage::ImageRgba16(_) => color::ColorType::Rgba16,
-            DynamicImage::ImageLuma32F(_) => color::ColorType::L32F,
-            DynamicImage::ImageLumaA32F(_) => color::ColorType::La32F,
-            DynamicImage::ImageRgb32F(_) => color::ColorType::Rgb32F,
-            DynamicImage::ImageRgba32F(_) => color::ColorType::Rgba32F,
+            DynamicImage::ImageLuma8(_) => ColorType::L8,
+            DynamicImage::ImageLumaA8(_) => ColorType::La8,
+            DynamicImage::ImageRgb8(_) => ColorType::Rgb8,
+            DynamicImage::ImageRgba8(_) => ColorType::Rgba8,
+            DynamicImage::ImageLuma16(_) => ColorType::L16,
+            DynamicImage::ImageLumaA16(_) => ColorType::La16,
+            DynamicImage::ImageRgb16(_) => ColorType::Rgb16,
+            DynamicImage::ImageRgba16(_) => ColorType::Rgba16,
+            DynamicImage::ImageLuma32F(_) => ColorType::L32F,
+            DynamicImage::ImageLumaA32F(_) => ColorType::La32F,
+            DynamicImage::ImageRgb32F(_) => ColorType::Rgb32F,
+            DynamicImage::ImageRgba32F(_) => ColorType::Rgba32F,
         }
     }
 
@@ -962,6 +963,30 @@ impl DynamicImage {
     #[must_use]
     pub fn has_alpha(&self) -> bool {
         self.color().has_alpha()
+    }
+
+    /// Extract the alpha channel as a Luma image.
+    ///
+    /// If the pixel does not have an alpha channel, the value is filled with a fully opaque mask
+    /// using the maximum value of the corresponding subpixel type. The subpixels / channel type of
+    /// the luma image is the same as the channel type of the input.
+    pub fn to_alpha_mask(&self) -> DynamicImage {
+        use DynamicImage::*;
+
+        match self {
+            ImageLuma8(image_buffer) => ImageLuma8(image_buffer.to_alpha_mask()),
+            ImageLumaA8(image_buffer) => ImageLuma8(image_buffer.to_alpha_mask()),
+            ImageRgb8(image_buffer) => ImageLuma8(image_buffer.to_alpha_mask()),
+            ImageRgba8(image_buffer) => ImageLuma8(image_buffer.to_alpha_mask()),
+            ImageLuma16(image_buffer) => ImageLuma16(image_buffer.to_alpha_mask()),
+            ImageLumaA16(image_buffer) => ImageLuma16(image_buffer.to_alpha_mask()),
+            ImageRgb16(image_buffer) => ImageLuma16(image_buffer.to_alpha_mask()),
+            ImageRgba16(image_buffer) => ImageLuma16(image_buffer.to_alpha_mask()),
+            ImageLuma32F(image_buffer) => ImageLuma32F(image_buffer.to_alpha_mask()),
+            ImageLumaA32F(image_buffer) => ImageLuma32F(image_buffer.to_alpha_mask()),
+            ImageRgb32F(image_buffer) => ImageLuma32F(image_buffer.to_alpha_mask()),
+            ImageRgba32F(image_buffer) => ImageLuma32F(image_buffer.to_alpha_mask()),
+        }
     }
 
     /// Return a grayscale version of this image.
@@ -1467,7 +1492,7 @@ impl DynamicImage {
         &mut self,
         cicp: Cicp,
         options: ConvertColorOptions,
-        color: color::ColorType,
+        color: ColorType,
     ) -> ImageResult<()> {
         if self.color() == color {
             return self.apply_color_space(cicp, options);
@@ -1689,73 +1714,73 @@ pub(crate) fn decoder_to_image(
     let attr;
 
     *image = match color_type {
-        color::ColorType::Rgb8 => {
+        ColorType::Rgb8 => {
             let buf;
             (buf, attr) = free_functions::decoder_to_vec(decoder)?;
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageRgb8)
         }
 
-        color::ColorType::Rgba8 => {
+        ColorType::Rgba8 => {
             let buf;
             (buf, attr) = free_functions::decoder_to_vec(decoder)?;
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageRgba8)
         }
 
-        color::ColorType::L8 => {
+        ColorType::L8 => {
             let buf;
             (buf, attr) = free_functions::decoder_to_vec(decoder)?;
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLuma8)
         }
 
-        color::ColorType::La8 => {
+        ColorType::La8 => {
             let buf;
             (buf, attr) = free_functions::decoder_to_vec(decoder)?;
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLumaA8)
         }
 
-        color::ColorType::Rgb16 => {
+        ColorType::Rgb16 => {
             let buf;
             (buf, attr) = free_functions::decoder_to_vec(decoder)?;
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageRgb16)
         }
 
-        color::ColorType::Rgba16 => {
+        ColorType::Rgba16 => {
             let buf;
             (buf, attr) = free_functions::decoder_to_vec(decoder)?;
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageRgba16)
         }
 
-        color::ColorType::Rgb32F => {
+        ColorType::Rgb32F => {
             let buf;
             (buf, attr) = free_functions::decoder_to_vec(decoder)?;
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageRgb32F)
         }
 
-        color::ColorType::Rgba32F => {
+        ColorType::Rgba32F => {
             let buf;
             (buf, attr) = free_functions::decoder_to_vec(decoder)?;
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageRgba32F)
         }
 
-        color::ColorType::L16 => {
+        ColorType::L16 => {
             let buf;
             (buf, attr) = free_functions::decoder_to_vec(decoder)?;
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLuma16)
         }
 
-        color::ColorType::La16 => {
+        ColorType::La16 => {
             let buf;
             (buf, attr) = free_functions::decoder_to_vec(decoder)?;
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLumaA16)
         }
 
-        color::ColorType::L32F => {
+        ColorType::L32F => {
             let buf;
             (buf, attr) = free_functions::decoder_to_vec(decoder)?;
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLuma32F)
         }
 
-        color::ColorType::La32F => {
+        ColorType::La32F => {
             let buf;
             (buf, attr) = free_functions::decoder_to_vec(decoder)?;
             ImageBuffer::from_raw(w, h, buf).map(DynamicImage::ImageLumaA32F)
@@ -1866,7 +1891,7 @@ mod bench {
 mod test {
     use crate::metadata::{CicpColorPrimaries, CicpTransform};
     use crate::ConvertColorOptions;
-    use crate::{color::ColorType, images::dynimage::Gray16Image};
+    use crate::{images::dynimage::Gray16Image, ColorType};
     use crate::{metadata::Cicp, ImageBuffer, Luma, Rgb, Rgba};
 
     const TYPES: [ColorType; 12] = [
@@ -2327,6 +2352,43 @@ mod test {
                     .expect("Failed to convert color space");
             }
         }
+    }
+
+    #[test]
+    fn alpha_mask_of_luma_32f() {
+        let pairs = [
+            (ColorType::L32F, ColorType::L32F),
+            (ColorType::La32F, ColorType::L32F),
+            (ColorType::Rgb32F, ColorType::L32F),
+            (ColorType::Rgba32F, ColorType::L32F),
+        ];
+
+        for (input, output) in pairs {
+            let image = super::DynamicImage::new(4, 4, input);
+            let mask = image.to_alpha_mask();
+            assert_eq!(mask.color(), output);
+        }
+    }
+
+    #[test]
+    fn alpha_mask_of_luma_alpha_32f() {
+        let image = super::DynamicImage::new(4, 4, ColorType::La32F);
+        let mask = image.to_alpha_mask();
+        assert_eq!(mask.as_luma32f().unwrap().subpixels(), &[0.0; 16]);
+    }
+
+    #[test]
+    fn alpha_mask_of_rgb_f32() {
+        let image = super::DynamicImage::new(4, 4, ColorType::Rgb32F);
+        let mask = image.to_alpha_mask();
+        assert_eq!(mask.as_luma32f().unwrap().subpixels(), &[1.0; 16]);
+    }
+
+    #[test]
+    fn alpha_mask_of_rgba_f32() {
+        let image = super::DynamicImage::new(4, 4, ColorType::Rgba32F);
+        let mask = image.to_alpha_mask();
+        assert_eq!(mask.as_luma32f().unwrap().subpixels(), &[0.0; 16]);
     }
 
     /// Check that operations that are not cicp-aware behave as such. We introduce new methods (not

--- a/src/images/dynimage.rs
+++ b/src/images/dynimage.rs
@@ -993,8 +993,10 @@ impl DynamicImage {
     /// Fill the alpha channel of this image from a Luma mask.
     ///
     /// Returns an [`ImageError::Parameter`] if the mask dimensions do not match the image
-    /// dimensions or if there is no alpha channel in this image's color type or if the mask image
-    /// is not a `Luma` image. The mask's luma channel is converted to this image's subpixel type.
+    /// dimensions or if the mask image is not a `Luma` image. The mask's luma channel is converted
+    /// to this image's subpixel type. If this image currently does not have an alpha channel it is
+    /// augmented with the mask as its alpha channel, converting it into the appropriate color type
+    /// in the process.
     pub fn set_alpha_channel(&mut self, mask: &DynamicImage) -> ImageResult<()> {
         if mask.color().channel_count() != 1 {
             return Err(ImageError::Parameter(ParameterError::from_kind(
@@ -1041,14 +1043,36 @@ impl DynamicImage {
                 let mask = as_cow_buf(mask, DynamicImage::as_luma32f, DynamicImage::to_luma32f);
                 img.set_alpha_channel(&mask)
             }
-            DynamicImage::ImageLuma8(_)
-            | DynamicImage::ImageRgb8(_)
-            | DynamicImage::ImageLuma16(_)
-            | DynamicImage::ImageRgb16(_)
-            | DynamicImage::ImageLuma32F(_)
-            | DynamicImage::ImageRgb32F(_) => Err(ImageError::Parameter(
-                ParameterError::from_kind(ParameterErrorKind::NoAlphaChannel),
-            )),
+            DynamicImage::ImageLuma8(img) => {
+                let mask = as_cow_buf(mask, DynamicImage::as_luma8, DynamicImage::to_luma8);
+                *self = DynamicImage::ImageLumaA8(img.add_alpha_channel(&mask)?);
+                Ok(())
+            }
+            DynamicImage::ImageRgb8(img) => {
+                let mask = as_cow_buf(mask, DynamicImage::as_luma8, DynamicImage::to_luma8);
+                *self = DynamicImage::ImageRgba8(img.add_alpha_channel(&mask)?);
+                Ok(())
+            }
+            DynamicImage::ImageLuma16(img) => {
+                let mask = as_cow_buf(mask, DynamicImage::as_luma16, DynamicImage::to_luma16);
+                *self = DynamicImage::ImageLumaA16(img.add_alpha_channel(&mask)?);
+                Ok(())
+            }
+            DynamicImage::ImageRgb16(img) => {
+                let mask = as_cow_buf(mask, DynamicImage::as_luma16, DynamicImage::to_luma16);
+                *self = DynamicImage::ImageRgba16(img.add_alpha_channel(&mask)?);
+                Ok(())
+            }
+            DynamicImage::ImageLuma32F(img) => {
+                let mask = as_cow_buf(mask, DynamicImage::as_luma32f, DynamicImage::to_luma32f);
+                *self = DynamicImage::ImageLumaA32F(img.add_alpha_channel(&mask)?);
+                Ok(())
+            }
+            DynamicImage::ImageRgb32F(img) => {
+                let mask = as_cow_buf(mask, DynamicImage::as_luma32f, DynamicImage::to_luma32f);
+                *self = DynamicImage::ImageRgba32F(img.add_alpha_channel(&mask)?);
+                Ok(())
+            }
         }
     }
 

--- a/src/images/dynimage.rs
+++ b/src/images/dynimage.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fs::File;
 use std::io::{self, BufWriter, Seek, Write};
 use std::path::Path;
@@ -986,6 +987,68 @@ impl DynamicImage {
             ImageLumaA32F(image_buffer) => ImageLuma32F(image_buffer.to_alpha_mask()),
             ImageRgb32F(image_buffer) => ImageLuma32F(image_buffer.to_alpha_mask()),
             ImageRgba32F(image_buffer) => ImageLuma32F(image_buffer.to_alpha_mask()),
+        }
+    }
+
+    /// Fill the alpha channel of this image from a Luma mask.
+    ///
+    /// Returns an [`ImageError::Parameter`] if the mask dimensions do not match the image
+    /// dimensions or if there is no alpha channel in this image's color type or if the mask image
+    /// is not a `Luma` image. The mask's luma channel is converted to this image's subpixel type.
+    pub fn set_alpha_channel(&mut self, mask: &DynamicImage) -> ImageResult<()> {
+        if mask.color().channel_count() != 1 {
+            return Err(ImageError::Parameter(ParameterError::from_kind(
+                ParameterErrorKind::NotAValidMask(mask.color().into()),
+            )));
+        }
+
+        // Convert the mask if necessary. Optimally we would do a block-based alpha assignment
+        // instead where a fixed chunk of channels is converted at a time repeatedly in the same
+        // allocation instead of converting a very large image but that is a future optimization.
+        // Importantly we do not allocate if the input buffer is exactly as expected.
+        fn as_cow_buf<P: Pixel>(
+            mask: &DynamicImage,
+            borrow: impl FnOnce(&DynamicImage) -> Option<&ImageBuffer<P, Vec<P::Subpixel>>>,
+            owned: impl FnOnce(&DynamicImage) -> ImageBuffer<P, Vec<P::Subpixel>>,
+        ) -> Cow<'_, ImageBuffer<P, Vec<P::Subpixel>>> {
+            borrow(mask)
+                .map(Cow::Borrowed)
+                .unwrap_or_else(|| Cow::Owned(owned(mask)))
+        }
+
+        match self {
+            DynamicImage::ImageLumaA8(img) => {
+                let mask = as_cow_buf(mask, DynamicImage::as_luma8, DynamicImage::to_luma8);
+                img.set_alpha_channel(&mask)
+            }
+            DynamicImage::ImageRgba8(img) => {
+                let mask = as_cow_buf(mask, DynamicImage::as_luma8, DynamicImage::to_luma8);
+                img.set_alpha_channel(&mask)
+            }
+            DynamicImage::ImageLumaA16(img) => {
+                let mask = as_cow_buf(mask, DynamicImage::as_luma16, DynamicImage::to_luma16);
+                img.set_alpha_channel(&mask)
+            }
+            DynamicImage::ImageRgba16(img) => {
+                let mask = as_cow_buf(mask, DynamicImage::as_luma16, DynamicImage::to_luma16);
+                img.set_alpha_channel(&mask)
+            }
+            DynamicImage::ImageLumaA32F(img) => {
+                let mask = as_cow_buf(mask, DynamicImage::as_luma32f, DynamicImage::to_luma32f);
+                img.set_alpha_channel(&mask)
+            }
+            DynamicImage::ImageRgba32F(img) => {
+                let mask = as_cow_buf(mask, DynamicImage::as_luma32f, DynamicImage::to_luma32f);
+                img.set_alpha_channel(&mask)
+            }
+            DynamicImage::ImageLuma8(_)
+            | DynamicImage::ImageRgb8(_)
+            | DynamicImage::ImageLuma16(_)
+            | DynamicImage::ImageRgb16(_)
+            | DynamicImage::ImageLuma32F(_)
+            | DynamicImage::ImageRgb32F(_) => Err(ImageError::Parameter(
+                ParameterError::from_kind(ParameterErrorKind::NoAlphaChannel),
+            )),
         }
     }
 


### PR DESCRIPTION
The respective methods on `DynamicImage` are blocked on the type representation. We can't use any specific pixel type if the goal is preserving the type but `DynamicImage` has no Luma32F variant. For applying a mask we would have to take the parameter type as a non-`DynamicImage` somehow? Feels weird, we should just resolve to add at least 32-bit Luma to the crate, even if we do not add 32-bit LumaAlpha.

Update: since #2934 this is all possible.

Closes: #1786
