### PR TITLE
recognize .pnm extension for PNM format

### DIFF
--- a/src/io/format.rs
+++ b/src/io/format.rs
@@ -91,7 +91,7 @@ impl ImageFormat {
                 "ico" => ImageFormat::Ico,
                 "hdr" => ImageFormat::Hdr,
                 "exr" => ImageFormat::OpenExr,
-                "pbm" | "pam" | "ppm" | "pgm" => ImageFormat::Pnm,
+                "pbm" | "pam" | "ppm" | "pgm" | "pnm" => ImageFormat::Pnm,
                 "ff" => ImageFormat::Farbfeld,
                 "qoi" => ImageFormat::Qoi,
                 "pcx" => ImageFormat::Pcx,


### PR DESCRIPTION
It is recognized as such by both imagemagick and wikipedia: https://en.wikipedia.org/wiki/Netpbm