### PR TITLE
Expose PNM header for decoder

### DIFF
--- a/src/codecs/pnm/decoder.rs
+++ b/src/codecs/pnm/decoder.rs
@@ -305,6 +305,11 @@ impl<R: Read> PnmDecoder<R> {
         Ok(decoder)
     }
 
+    /// Get the header of the decoded image.
+    pub fn header(&self) -> &PnmHeader {
+        &self.header
+    }
+
     /// Extract the reader and header after an image has been read.
     pub fn into_inner(self) -> (R, PnmHeader) {
         (self.reader, self.header)

--- a/src/codecs/pnm/header.rs
+++ b/src/codecs/pnm/header.rs
@@ -32,11 +32,13 @@ pub enum PnmSubtype {
 /// it is possible to recover the header and construct an encoder. Using the encoder on the just
 /// loaded image should result in a byte copy of the original file (for single image pnms without
 /// additional trailing data).
+#[derive(Clone)]
 pub struct PnmHeader {
     pub(crate) decoded: HeaderRecord,
     pub(crate) encoded: Option<Vec<u8>>,
 }
 
+#[derive(Clone)]
 pub(crate) enum HeaderRecord {
     Bitmap(BitmapHeader),
     Graymap(GraymapHeader),


### PR DESCRIPTION
This allows encoding an image with exactly that header by a `Clone` marker as well as querying more dedicated information. A bit out of sync of our support for other image types but this has no underlying crate that may be used for precise decoding in itself.

Closes: #1558 
