### PR TITLE
Extract exif metadata from pngs

### DIFF
--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -178,6 +178,15 @@ impl<R: BufRead + Seek> ImageDecoder for PngDecoder<R> {
         Ok(self.reader.info().icc_profile.as_ref().map(|x| x.to_vec()))
     }
 
+    fn exif_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {
+        Ok(self
+            .reader
+            .info()
+            .exif_metadata
+            .as_ref()
+            .map(|x| x.to_vec()))
+    }
+
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
         use byteorder_lite::{BigEndian, ByteOrder, NativeEndian};
 


### PR DESCRIPTION
The png crate supports extracting exif metadata as of recently, so this is wiring this up to the `ImageDecoder`  type.

This is related to #2494.