### PR TITLE
Update image URLs

### DIFF
--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -39,23 +39,23 @@ use crate::{
 /// <!-- NOTE: To test new test images locally, replace the GitHub path with `../../../docs/` -->
 /// <div style="display: flex; flex-wrap: wrap; align-items: flex-start;">
 ///   <div style="margin: 0 8px 8px 0;">
-///     <img src="https://raw.githubusercontent.com/image-rs/image/master/examples/scaledown/scaledown-test-near.png" title="Nearest"><br>
+///     <img src="https://raw.githubusercontent.com/image-rs/image/main/examples/scaledown/scaledown-test-near.png" title="Nearest"><br>
 ///     Nearest Neighbor
 ///   </div>
 ///   <div style="margin: 0 8px 8px 0;">
-///     <img src="https://raw.githubusercontent.com/image-rs/image/master/examples/scaledown/scaledown-test-tri.png" title="Triangle"><br>
+///     <img src="https://raw.githubusercontent.com/image-rs/image/main/examples/scaledown/scaledown-test-tri.png" title="Triangle"><br>
 ///     Linear: Triangle
 ///   </div>
 ///   <div style="margin: 0 8px 8px 0;">
-///     <img src="https://raw.githubusercontent.com/image-rs/image/master/examples/scaledown/scaledown-test-cmr.png" title="CatmullRom"><br>
+///     <img src="https://raw.githubusercontent.com/image-rs/image/main/examples/scaledown/scaledown-test-cmr.png" title="CatmullRom"><br>
 ///     Cubic: Catmull-Rom
 ///   </div>
 ///   <div style="margin: 0 8px 8px 0;">
-///     <img src="https://raw.githubusercontent.com/image-rs/image/master/examples/scaledown/scaledown-test-gauss.png" title="Gaussian"><br>
+///     <img src="https://raw.githubusercontent.com/image-rs/image/main/examples/scaledown/scaledown-test-gauss.png" title="Gaussian"><br>
 ///     Gaussian
 ///   </div>
 ///   <div style="margin: 0 8px 8px 0;">
-///     <img src="https://raw.githubusercontent.com/image-rs/image/master/examples/scaledown/scaledown-test-lcz2.png" title="Lanczos3"><br>
+///     <img src="https://raw.githubusercontent.com/image-rs/image/main/examples/scaledown/scaledown-test-lcz2.png" title="Lanczos3"><br>
 ///     Lanczos with window 3
 ///   </div>
 /// </div>


### PR DESCRIPTION
I missed these in #2577. The original URLs still work but this changes them to use the updated branch name.