### PR TITLE
Bump version to 0.25.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "image"
-version = "0.25.6"
+version = "0.25.7"
 edition = "2021"
 resolver = "2"
 


### PR DESCRIPTION
Release notes were drafted earlier, this is the only todo. Last couple of fixes were simply bumping png and tiff to upstream their respective improvements, and tests for those.

Closes: #2551