### PR TITLE
Allow setting DEFLATE compression level in the PNG encoder

### DIFF
--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -557,7 +557,7 @@ pub enum FilterType {
 /// it may be marked deprecated and remapped to a different option.
 /// You will see a deprecation notice when compiling code relying on such options.
 #[non_exhaustive]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum DeflateCompressionType {
     /// Do not compress the data at all.
     ///


### PR DESCRIPTION
Not the most elegant API, but semver-compatible. 

My ideal API would be two functions: `new_with_compression(CompressionType)` and `new_with_compression_advanced(DeflateCompression, FilterType)` but that would require an API break.

This is badly needed for `wondermagick`, but it will keep tracking `image` from git for the foreseeable future anyway. So if you'd rather skip straight to the semver-breaking version, I'm fine with that.