### PR TITLE
Add utility from_raw_bgr{,a} for ImageBuffer

### DIFF
--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -1406,6 +1406,60 @@ impl<P: Pixel> ImageBuffer<P, Vec<P::Subpixel>> {
     }
 }
 
+impl<S, Container> ImageBuffer<Rgb<S>, Container>
+where
+    S: crate::Primitive + crate::traits::Enlargeable,
+    Rgb<S>: Pixel,
+    Container: DerefMut<Target = [<Rgb<S> as Pixel>::Subpixel]>,
+{
+    /// Construct an image by swapping `Bgr` channels into an `Rgb` order.
+    pub fn from_raw_bgr(width: u32, height: u32, container: Container) -> Option<Self> {
+        let mut img = Self::from_raw(width, height, container)?;
+
+        for pix in img.pixels_mut() {
+            pix.0.reverse();
+        }
+
+        Some(img)
+    }
+
+    /// Return the underlying raw buffer after converting it into `Bgr` channel order.
+    pub fn into_raw_bgr(mut self) -> Container {
+        for pix in self.pixels_mut() {
+            pix.0.reverse();
+        }
+
+        self.into_raw()
+    }
+}
+
+impl<S, Container> ImageBuffer<Rgba<S>, Container>
+where
+    S: crate::Primitive + crate::traits::Enlargeable,
+    Rgb<S>: Pixel,
+    Container: DerefMut<Target = [<Rgba<S> as Pixel>::Subpixel]>,
+{
+    /// Construct an image by swapping `BgrA` channels into an `RgbA` order.
+    pub fn from_raw_bgra(width: u32, height: u32, container: Container) -> Option<Self> {
+        let mut img = Self::from_raw(width, height, container)?;
+
+        for pix in img.pixels_mut() {
+            pix.0[..3].reverse();
+        }
+
+        Some(img)
+    }
+
+    /// Return the underlying raw buffer after converting it into `BgrA` channel order.
+    pub fn into_raw_bgra(mut self) -> Container {
+        for pix in self.pixels_mut() {
+            pix.0[..3].reverse();
+        }
+
+        self.into_raw()
+    }
+}
+
 /// Provides color conversions for whole image buffers.
 pub trait ConvertBuffer<T> {
     /// Converts `self` to a buffer of type T


### PR DESCRIPTION
It is one of the most common channel orders other than Rgb and the construction involves nothing complicated, just swapping the channels around. We don't support that layout during computation, where it would complicate significant parts of `Pixel`, but as a helper for transferring a buffer we can easily have both on the `Rgb{,A}` typed containers.

See: https://github.com/image-rs/image/discussions/2595 which seems like a paper cut that can be easily and confidently solved.