### PR TITLE
Enforce (at compile-time) that `imageops::filter3x3()` is provided an array of length 9

### DIFF
--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -868,7 +868,7 @@ where
 ///
 /// This method typically assumes that the input is scene-linear light.
 /// If it is not, color distortion may occur.
-pub fn filter3x3<I, P, S>(image: &I, kernel: &[f32]) -> ImageBuffer<P, Vec<S>>
+pub fn filter3x3<I, P, S>(image: &I, kernel: &[f32; 9]) -> ImageBuffer<P, Vec<S>>
 where
     I: GenericImageView<Pixel = P>,
     P: Pixel<Subpixel = S> + 'static,

--- a/src/images/dynimage.rs
+++ b/src/images/dynimage.rs
@@ -1039,15 +1039,13 @@ impl DynamicImage {
     ///
     /// # Arguments
     ///
-    /// * `kernel` - slice contains filter. Only slice len is 9 length is accepted.
+    /// * `kernel` - array contains filter.
     ///
     /// This method typically assumes that the input is scene-linear light. It operates on pixel
     /// channel values directly without taking into account color space data. If it is not, color
     /// distortion may occur.
     #[must_use]
-    pub fn filter3x3(&self, kernel: &[f32]) -> DynamicImage {
-        assert_eq!(9, kernel.len(), "filter must be 3 x 3");
-
+    pub fn filter3x3(&self, kernel: &[f32; 9]) -> DynamicImage {
         dynamic_map!(*self, ref p => imageops::filter3x3(p, kernel))
     }
 


### PR DESCRIPTION
This PR was made in response to https://github.com/image-rs/image/discussions/2599#discussioncomment-14360021.

This changes the function signature of `crate::imageops::filter3x3()` (and its accompanying function in `crate::DynamicImage`). Rather than take a `&[f32]` as before, now it takes a `&[f32; 9]`, enforcing that the kernel provided is of length 9.

Notably, not every user of `filter3x3()` may need to change their code to fit. For example, one test in `image` contains this line, which didn't need to be changed:

https://github.com/image-rs/image/blob/ceb71e59496a32dbe2a56599ff60d09cb0b8cb20/src/images/dynimage.rs#L2230

However, for those that do, they can likely just use the [`TryFrom<&[T]> for &[T; N]` impl](https://doc.rust-lang.org/1.85.0/std/primitive.array.html#impl-TryFrom%3C%26[T]%3E-for-%26[T;+N]) to convert a `&[f32]` to a `&[f32; 9]`. ([`slice.as_array()`](https://doc.rust-lang.org/1.85.0/std/primitive.slice.html#method.as_array) is also available if the user is on nightly)

In summary, the effects of this change are as follows:
* `crate::imageops::filter3x3()` no longer assumes the kernel is of length 9 (it appears to have done so before)
* `DynamicImage.filter3x3()` now errors at compile-time if given the wrong length, rather than checking at run-time and killing the program there.
* For users that need to change their code to use `TryFrom`, this has the incidental effect of treating this issue as a potentially-recoverable error, rather than a fatal error - which can be useful for programs with a user interface.
