### PR TITLE
tga: fix orientation flip for color mapped images

### DIFF
--- a/src/codecs/tga/decoder.rs
+++ b/src/codecs/tga/decoder.rs
@@ -379,7 +379,7 @@ impl<R: Read> ImageDecoder for TgaDecoder<R> {
             self.r.read_exact(&mut buf[..num_raw_bytes])?;
         }
 
-        self.fixup_orientation(buf);
+        self.fixup_orientation(&mut buf[..num_raw_bytes]);
 
         // Expand the indices using the color map if necessary
         if let Some(ref color_map) = self.color_map {


### PR DESCRIPTION
This fixes a decoding error observed with the TGA image `football_seal.tga`, from https://people.math.sc.edu/Burkardt/data/tga/tga.html, which was mentioned in https://github.com/image-rs/image/issues/2603.  (Note: 2603 is a freshly created issue and it isn't clear whether this patch resolves all the problems described in it.)

On color mapped images, the TGA decoder had placed the raw image data before applying the color maps in a prefix of the the provided buffer. However, `fixup_orientation()` was being called on the entire buffer, making it swap the first half of the raw image data (A) with whatever was in the end region (D) instead of A with B (the second half of the raw image data).
```
Example layout of `buf` at the time `fixup_orientation()` was applied, expanding 1 byte indices to 3 bytes of color data:

|pre cmap|
AAAAABBBBBCCCCCCCCCCCCCCCDDDDD
|----------post cmap---------|
```