### PR TITLE
Implement `exif_metadata` for TIFF

### DIFF
--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -22,6 +22,8 @@ const EXPECTED_WEBP_TIFF_METADATA: &str = "<?xpacket begin='\u{feff}' id='W5M0Mp
 
 const XMP_TIFF_PATH: &str = "tests/images/tiff/testsuite/l1_xmp.tiff";
 
+const EXIF_TIFF_PATH: &str = "tests/images/tiff/testsuite/l1.tiff";
+
 #[test]
 #[cfg(feature = "png")]
 fn test_read_xmp_png() -> Result<(), image::ImageError> {
@@ -61,6 +63,20 @@ fn test_read_xmp_tiff() -> Result<(), image::ImageError> {
     let metadata = tiff_decoder.xmp_metadata()?;
     assert!(metadata.is_some());
     assert_eq!(EXPECTED_WEBP_TIFF_METADATA.as_bytes(), metadata.unwrap());
+
+    Ok(())
+}
+
+#[test]
+#[cfg(feature = "tiff")]
+fn test_read_exif_tiff() -> Result<(), image::ImageError> {
+    let img_path = PathBuf::from_str(EXIF_TIFF_PATH).unwrap();
+
+    let data = fs::read(img_path)?;
+    let mut tiff_decoder = TiffDecoder::new(std::io::Cursor::new(&data))?;
+    let metadata = tiff_decoder.exif_metadata()?;
+    assert!(metadata.is_some());
+    assert_eq!(data, metadata.unwrap());
 
     Ok(())
 }


### PR DESCRIPTION
Exif metadata for TIFF is funny, as the Tiff file itself is stored in the exif directory structure. So the trivial answer to what is Exif metadata is just the bytes of the file itself.

Note: This is not the most efficient way of obtaining the metadata as it also copies the image bytes, which we technically don't need. The alternative here is to add this to the tiff create and copy the correct metadata sections together. We didn't pursue this route as there were ideas to rework the entire `tiff::Value` type and this would likely add a huge dependency on the current behavior. We're open for feedback if we should to go down that route, though.