### PR TITLE
tga: reject empty images

### DIFF
--- a/src/codecs/tga/decoder.rs
+++ b/src/codecs/tga/decoder.rs
@@ -87,6 +87,13 @@ impl<R: Read> TgaDecoder<R> {
         let raw_bytes_per_pixel = (header.pixel_depth as usize).div_ceil(8);
         let num_alpha_bits = header.image_desc & ALPHA_BIT_MASK;
 
+        if width == 0 || height == 0 {
+            return Err(ImageError::Decoding(DecodingError::new(
+                ImageFormat::Tga.into(),
+                "Invalid empty image",
+            )));
+        }
+
         // Validate header
         if ![8, 16, 24, 32].contains(&header.pixel_depth) || ![0, 8].contains(&num_alpha_bits) {
             return Err(ImageError::Unsupported(

--- a/src/codecs/tga/encoder.rs
+++ b/src/codecs/tga/encoder.rs
@@ -11,6 +11,9 @@ enum EncoderError {
 
     /// Invalid TGA height.
     HeightInvalid(u32),
+
+    /// Empty
+    Empty(u32, u32),
 }
 
 impl fmt::Display for EncoderError {
@@ -18,6 +21,7 @@ impl fmt::Display for EncoderError {
         match self {
             EncoderError::WidthInvalid(s) => f.write_fmt(format_args!("Invalid TGA width: {s}")),
             EncoderError::HeightInvalid(s) => f.write_fmt(format_args!("Invalid TGA height: {s}")),
+            EncoderError::Empty(w, h) => f.write_fmt(format_args!("Invalid TGA size: {w}x{h}")),
         }
     }
 }
@@ -173,6 +177,10 @@ impl<W: Write> TgaEncoder<W> {
         );
 
         // Validate dimensions.
+        if width == 0 || height == 0 {
+            return Err(ImageError::from(EncoderError::Empty(width, height)));
+        }
+
         let width = u16::try_from(width)
             .map_err(|_| ImageError::from(EncoderError::WidthInvalid(width)))?;
 


### PR DESCRIPTION
This is one the approach to resolving https://github.com/image-rs/image/issues/2575. (Alternatively, if one wants to create TGA images which have zero width or height fields, the change is simple, see https://github.com/mstoeckl/image/tree/tga-empty.)

While the TGA spec does not explicitly prohibit images with zero width and height, it also permits a number of other weird images that are de-facto prohibited by implementations (e.g. pixels with bpp not in [8,15,16,24,32] that don't correspond to original hardware patterns; >2 byte color map indices). Since many implementations* do not create and do not accept zero sized TGA images, I would recommend doing the same.

*Specifically, ImageMagick does not decode empty TGA images, printing a `negative or zero image size` warning; `ffmpeg` prints that e.g. `Picture size 0x0 is invalid``; and I have not been able to find an image viewer that displays zero sized images of any format without logging an error.

Even in the absence of existing decoders, I would prefer to not decode empty images, because I expect people using this library (possibly through multiple intermediate layers) are unlikely to expect them. From a security perspective, empty images also have the problem that different implementations and library users may disagree on how to interpret or use a "0x5" image. The general security problem of differing interpretations of images is that one library might display an ambiguous image with one content (a picture of the word YES), and another with different (a picture of the word no), while people rely on them behaving the same. For empty images, this specific problem is unlikely because they have no content; but I can't be certain that supporting empty images would not make rare security bug categories (implementation fingerprinting, parser differentials) in code using the `image` crate more likely.

Also, we know that nobody using `image` is relying on creating empty TGA images, because per #2575 the output is invalid/all zero.

The `image` crate itself appears to be split on whether empty sized images can be made and read -- for example, it can create/load empty PNM images, but not PNG, AVIF, WEBP, ICO; it can also create but not read empty JPG images.