### PR TITLE
Add metadata and changelog for v0.25.8 to main

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,16 @@
 
 ## Changes
 
-### Version 0.25.7
+### Version 0.25.8
+
+Re-release of `0.25.7`
+
+Fixes:
+- Reverted a signature change to `load_from_memory` that lead to large scale
+  type inference breakage despite being technically compatible.
+- Color conversion Luma to Rgb used incorrect coefficients instead of broadcasting.
+
+### Version 0.25.7 (yanked)
 
 Features:
   - Added an API for external image format implementations to register themselves as decoders for a specific format in `image` (#2372)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "image"
-version = "0.25.7"
+version = "0.25.8"
 edition = "2021"
 resolver = "2"
 


### PR DESCRIPTION
Bumping the git version to 0.25.8 is necessary for projects depending on `image` from git via `[patch]` section in Cargo.toml, like wondermagick.

Without this PR, and with a dependency that requires image v0.25.8, it is impossible to depend on a git version of `image` via `[patch]`:

> warning: Patch `image v0.25.7 (https://github.com/image-rs/image.git#add781b6)` was not used in the crate graph.