### PR TITLE
Fix color indication for zune-jpeg 0.5.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ rayon = { version = "1.7.0", optional = true }
 rgb = { version = "0.8.48", default-features = false, optional = true }
 tiff = { version = "0.10.3", optional = true }
 zune-core = { version = "0.5.0", default-features = false, optional = true }
-zune-jpeg = { version = "0.5.1", optional = true }
+zune-jpeg = { version = "0.5.5", optional = true }
 serde = { version = "1.0.214", optional = true, features = ["derive"] }
 
 [dev-dependencies]


### PR DESCRIPTION
The crate now supports color expansion from Luma to Rgb via an indicated output color space in its DecoderOptions. The default for this is RGB, the only value guaranteed to be supported (per docs) for all input color spaces (this statement seems a bit bold; can't there be ICC profile indicated YCbCr transforms requiring full ICC parsing?).

We can only configure our own intended color space from the input color space so we do a dance where the headers are read first. Fortunately, this was already part of the setup code so it is a straightforward extension.

<!--
We welcome performance optimizations, bug fixes, and documentation improvements.

Feature additions are also welcome, but we encourage you to open an issue first
to discuss whether it is something we want to add.

Thank you for contributing, you can delete this comment.
-->
