### PR TITLE
chore: Replace `doc_auto_cfg` with `doc_cfg`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@
 #![deny(deprecated)]
 #![deny(missing_copy_implementations)]
 #![cfg_attr(all(test, feature = "benchmarks"), feature(test))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(all(test, feature = "benchmarks"))]
 extern crate test;


### PR DESCRIPTION
<!--
We welcome performance optimizations, bug fixes, and documentation improvements.

Feature additions are also welcome, but we encourage you to open an issue first
to discuss whether it is something we want to add.

Thank you for contributing, you can delete this comment.
-->

`doc_auto_cfg` was merged into `doc_cfg` in rust-lang/rust#138907.

When `docsrs` is enabled, the old `doc_auto_cfg` results in errors on the latest nightlies:

The new `doc_cfg` retains the automatic `cfg` generation that `doc_auto_cfg` used to provide.