### PR TITLE
Make rayon optional when exr is enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ num-traits = { version = "0.2.0" }
 # Optional dependencies
 color_quant = { version = "1.1", optional = true }
 dav1d = { version = "0.10.3", optional = true }
-exr = { version = "1.5.0", optional = true }
+exr = { version = "1.74.0", default-features = false, optional = true }
 gif = { version = "0.13.1", optional = true }
 image-webp = { version = "0.2.0", optional = true }
 mp4parse = { version = "0.17.0", optional = true }
@@ -86,7 +86,7 @@ tiff = ["dep:tiff"]
 webp = ["dep:image-webp"]
 
 # Other features
-rayon = ["dep:rayon", "ravif?/threading"] # Enables multi-threading
+rayon = ["dep:rayon", "ravif?/threading", "exr?/rayon"] # Enables multi-threading
 nasm = ["ravif?/asm"] # Enables use of nasm by rav1e (requires nasm to be installed)
 color_quant = ["dep:color_quant"] # Enables color quantization
 avif-native = ["dep:mp4parse", "dep:dav1d"] # Enable native dependency libdav1d


### PR DESCRIPTION
Disabling the `rayon` feature now actually removes the `rayon` dependency.

Previously `exr` would always pull in rayon and enable multithreading unconditionally.

Upstream https://github.com/johannesvollmer/exrs/issues/242 was fixed in git a long time ago but only shipped to crates.io now.

It is debatable whether this constitutes a semver break, so I'm OK with merging it both before and after #2640.