### PR TITLE
Add L8 support to GIF encoder

### DIFF
--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -528,6 +528,13 @@ impl<W: Write> GifEncoder<W> {
                 &mut data.to_owned(),
                 self.speed,
             )),
+            ExtendedColorType::L8 => {
+                let palette: Vec<u8> = (0..=255).flat_map(|i| [i, i, i]).collect();
+
+                self.encode_gif(Frame::from_palette_pixels(
+                    width, height, data, palette, None,
+                ))
+            }
             _ => Err(ImageError::Unsupported(
                 UnsupportedError::from_format_and_kind(
                     ImageFormat::Gif.into(),


### PR DESCRIPTION
Fixes #2589 

Adds `ExtendedColorType::L8` encoding support to the GIF encoder.

Instead of converting to RGB, this builds a grayscale palette directly with 256 entries where each value `i` maps to `(i, i, i)`. Since grayscale has exactly 256 values, it can be fully represented by a GIF palette without quantization.