### PR TITLE
Upgrade dav1d to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ num-traits = { version = "0.2.0" }
 
 # Optional dependencies
 color_quant = { version = "1.1", optional = true }
-dav1d = { version = "0.10.3", optional = true }
+dav1d = { version = "0.11", optional = true }
 exr = { version = "1.74.0", default-features = false, optional = true }
 gif = { version = "0.14.0", optional = true }
 image-webp = { version = "0.2.0", optional = true }


### PR DESCRIPTION
This affects the avif-native feature in particular and is very likely necessary to close #2657 unless they do a backport release. Since it technically triggered UB I think we should bring it on the `0.25` backport branch as well.
