### PR TITLE
Add API to set `ImageReader` format by extension to support hooks

### DIFF
--- a/src/io/image_reader_type.rs
+++ b/src/io/image_reader_type.rs
@@ -119,6 +119,12 @@ impl<'a, R: 'a + BufRead + Seek> ImageReader<R> {
     pub fn set_format(&mut self, format: ImageFormat) {
         self.format = Some(Format::BuiltIn(format));
     }
+    /// Supply the extension of the format as which to interpret the read image.
+    ///
+    /// The extension must be without the leading dot. E.g. `"png"` or `"jpeg"`.
+    pub fn set_format_with_extension(&mut self, ext: OsString) {
+        self.format = Some(Format::Extension(ext));
+    }
 
     /// Remove the current information on the image format.
     ///


### PR DESCRIPTION
Right now, plugin decoders can only be used when decoding a file. It's impossible to use them to decode arbitrary `BufRead+Seek` data. This is because hooks are currently only used by `ImageReader` and the only way to set its internal `format` to an extension is via `ImageReader::open(&Path)`.

This PR solves this API limitation by adding a new `set_format_with_extension` method, which sets the internal `format` to the given extension string.

Bike shedding: I'm not sure about the name. Other options I've considered: `set_format_from_extension`, `set_format_by_extension`, `set_extension`.

---

Related to #2616