### PR TITLE
Fixed guess format hooks for short files

### DIFF
--- a/src/io/image_reader_type.rs
+++ b/src/io/image_reader_type.rs
@@ -269,6 +269,7 @@ impl<'a, R: 'a + BufRead + Seek> ImageReader<R> {
             &mut Cursor::new(&mut start[..]),
         )?;
         self.inner.seek(SeekFrom::Start(cur))?;
+        let start = &start[..len as usize];
 
         let hooks = GUESS_FORMAT_HOOKS.read().unwrap();
         for &(signature, mask, ref extension) in &*hooks {
@@ -287,7 +288,7 @@ impl<'a, R: 'a + BufRead + Seek> ImageReader<R> {
             }
         }
 
-        if let Some(format) = free_functions::guess_format_impl(&start[..len as usize]) {
+        if let Some(format) = free_functions::guess_format_impl(start) {
             return Ok(Some(Format::BuiltIn(format)));
         }
 


### PR DESCRIPTION
I noticed a small bug. If the file is very short (<16 bytes), then the `start` buffer is padded with zeros. Guess format hooks were using the padded buffer, while the function for built-in formats was given the buffer without padding. This may have led to false positives for guess format hook, since they might be seeing more zeros than are there. Very unlikely, but it's better for both to use the same buffer to make guesses anyway.