### PR TITLE
Remove unsupported `Rgba8` from JPEG encoding benchmarks

### DIFF
--- a/benches/encode.rs
+++ b/benches/encode.rs
@@ -33,7 +33,7 @@ fn encode_all(c: &mut Criterion) {
             with: &Jpeg,
             name: "jpeg",
             sizes: &[64u32, 128, 256],
-            colors: &[ColorType::L8, ColorType::Rgb8, ColorType::Rgba8],
+            colors: &[ColorType::L8, ColorType::Rgb8],
         },
     ];
 


### PR DESCRIPTION
The JPEG encoding benchmarks were failing because they included the unsupported color type `ColorType::Rgba8`.

This commit updates the benchmark configuration to only include color types supported by the JPEG encoder: `L8` and `Rgb8`.

Closes #2227
<!--
We welcome performance optimizations, bug fixes, and documentation improvements.

Feature additions are also welcome, but we encourage you to open an issue first
to discuss whether it is something we want to add.

Thank you for contributing, you can delete this comment.
-->
