### PR TITLE
Minor optimization for TGA's BGR -> RGB conversion

### DIFF
--- a/src/codecs/tga/decoder.rs
+++ b/src/codecs/tga/decoder.rs
@@ -307,7 +307,7 @@ impl<R: Read> TgaDecoder<R> {
         // We only need to reverse the encoding of color images
         match self.color_type {
             ColorType::Rgb8 | ColorType::Rgba8 => {
-                for chunk in pixels.chunks_mut(self.color_type.bytes_per_pixel().into()) {
+                for chunk in pixels.chunks_exact_mut(self.color_type.bytes_per_pixel().into()) {
                     chunk.swap(0, 2);
                 }
             }


### PR DESCRIPTION
We know that `pixels.len()` is visible by `color_type.bytes_per_pixel()`, so we can use `chunks_exact_mut`. This has the effect that LLVM can optimize away the bounds checking `swap` does, since it now knows that chunks at least 3 elements. This removes a branch from the inner loop, so it should be slightly faster now. Probably not by much, since the branch is easy to predict. I haven't benchmarked it, I just looked at the assembly.