### PR TITLE
Refactored internal use of hooks

### DIFF
--- a/src/io/image_reader_type.rs
+++ b/src/io/image_reader_type.rs
@@ -1,11 +1,10 @@
 use std::ffi::OsString;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, Cursor, Read, Seek, SeekFrom};
-use std::iter;
 use std::path::Path;
 
 use crate::error::{ImageFormatHint, ImageResult, UnsupportedError, UnsupportedErrorKind};
-use crate::hooks::{GenericReader, DECODING_HOOKS, GUESS_FORMAT_HOOKS};
+use crate::hooks;
 use crate::io::limits::Limits;
 use crate::{DynamicImage, ImageDecoder, ImageError, ImageFormat};
 
@@ -159,13 +158,8 @@ impl<'a, R: 'a + BufRead + Seek> ImageReader<R> {
         let format = match format {
             Format::BuiltIn(format) => format,
             Format::Extension(ext) => {
-                {
-                    let hooks = DECODING_HOOKS.read().unwrap();
-                    if let Some(hooks) = hooks.as_ref() {
-                        if let Some(hook) = hooks.get(&ext.to_ascii_lowercase()) {
-                            return hook(GenericReader(BufReader::new(Box::new(reader))));
-                        }
-                    }
+                if let Some(hook) = hooks::get_decoding_hook(&ext) {
+                    return hook(hooks::GenericReader::new(reader));
                 }
 
                 ImageFormat::from_extension(&ext).ok_or(ImageError::Unsupported(
@@ -271,21 +265,8 @@ impl<'a, R: 'a + BufRead + Seek> ImageReader<R> {
         self.inner.seek(SeekFrom::Start(cur))?;
         let start = &start[..len as usize];
 
-        let hooks = GUESS_FORMAT_HOOKS.read().unwrap();
-        for &(signature, mask, ref extension) in &*hooks {
-            if mask.is_empty() {
-                if start.starts_with(signature) {
-                    return Ok(Some(Format::Extension(extension.clone())));
-                }
-            } else if start.len() >= signature.len()
-                && start
-                    .iter()
-                    .zip(signature.iter())
-                    .zip(mask.iter().chain(iter::repeat(&0xFF)))
-                    .all(|((&byte, &sig), &mask)| byte & mask == sig)
-            {
-                return Ok(Some(Format::Extension(extension.clone())));
-            }
+        if let Some(extension) = hooks::guess_format_extension(start) {
+            return Ok(Some(Format::Extension(extension)));
         }
 
         if let Some(format) = free_functions::guess_format_impl(start) {


### PR DESCRIPTION
I refactored the internal usage of hooks. This should also make it easier to expand the usage of hooks in other places in the future.

Changes:
- Added `GenericReader::new` to create a new instance from a reader that is `Read + Seek`. This simplifies usage and means that `ImageReader` no longer has to worry about the internals of the type.
- Added `hooks::get_decoding_hook` to get a hook fn from a given extension. So consumers of hooks no longer have to know about the internal structure of `GUESS_FORMAT_HOOKS`.
- Added `hooks::guess_format_extension`. This function takes a slice of bytes and guesses the format extension using registered format detection hooks. This simplifies usage of detection hooks and means that `ImageReader` no longer has to worry about how detection is implemented.
- Use `OsString::make_ascii_lowercase` to avoid allocation where possible.

In general, most of the implementation details of hooks are now confined to the `hooks` module, without leaking into other parts of the library.