### PR TITLE
Adjust bounds on from_raw_rgb

### DIFF
--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -1408,9 +1408,8 @@ impl<P: Pixel> ImageBuffer<P, Vec<P::Subpixel>> {
 
 impl<S, Container> ImageBuffer<Rgb<S>, Container>
 where
-    S: crate::Primitive + crate::traits::Enlargeable,
-    Rgb<S>: Pixel,
-    Container: DerefMut<Target = [<Rgb<S> as Pixel>::Subpixel]>,
+    Rgb<S>: PixelWithColorType<Subpixel = S>,
+    Container: DerefMut<Target = [S]>,
 {
     /// Construct an image by swapping `Bgr` channels into an `Rgb` order.
     pub fn from_raw_bgr(width: u32, height: u32, container: Container) -> Option<Self> {
@@ -1435,9 +1434,8 @@ where
 
 impl<S, Container> ImageBuffer<Rgba<S>, Container>
 where
-    S: crate::Primitive + crate::traits::Enlargeable,
-    Rgb<S>: Pixel,
-    Container: DerefMut<Target = [<Rgba<S> as Pixel>::Subpixel]>,
+    Rgba<S>: PixelWithColorType<Subpixel = S>,
+    Container: DerefMut<Target = [S]>,
 {
     /// Construct an image by swapping `BgrA` channels into an `RgbA` order.
     pub fn from_raw_bgra(width: u32, height: u32, container: Container) -> Option<Self> {


### PR DESCRIPTION
These new bounds ensure that only our own pixel types can be used. That prepares changing our approach of algorithms such that we can optimize for individual cases without falling prey to needs for specialization.

More context can be found here:

<https://github.com/image-rs/image/pull/2596#issuecomment-3643133007>

<!--
We welcome performance optimizations, bug fixes, and documentation improvements.

Feature additions are also welcome, but we encourage you to open an issue first
to discuss whether it is something we want to add.

Thank you for contributing, you can delete this comment.
-->
