### PR TITLE
Make the Primitive trait sealed

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -33,9 +33,28 @@ impl EncodableLayout for [f32] {
     }
 }
 
+mod sealed {
+    pub trait PrimitiveSealed: Sized {}
+}
+
+impl sealed::PrimitiveSealed for usize {}
+impl sealed::PrimitiveSealed for u8 {}
+impl sealed::PrimitiveSealed for u16 {}
+impl sealed::PrimitiveSealed for u32 {}
+impl sealed::PrimitiveSealed for u64 {}
+impl sealed::PrimitiveSealed for isize {}
+impl sealed::PrimitiveSealed for i8 {}
+impl sealed::PrimitiveSealed for i16 {}
+impl sealed::PrimitiveSealed for i32 {}
+impl sealed::PrimitiveSealed for i64 {}
+impl sealed::PrimitiveSealed for f32 {}
+impl sealed::PrimitiveSealed for f64 {}
+
 /// The type of each channel in a pixel. For example, this can be `u8`, `u16`, `f32`.
 // TODO rename to `PixelComponent`? Split up into separate traits? Seal?
-pub trait Primitive: Copy + NumCast + Num + PartialOrd<Self> + Clone + Bounded {
+pub trait Primitive:
+    Copy + NumCast + Num + PartialOrd<Self> + Clone + Bounded + sealed::PrimitiveSealed
+{
     /// The maximum value for this type of primitive within the context of color.
     /// For floats, the maximum is `1.0`, whereas the integer types inherit their usual maximum values.
     const DEFAULT_MAX_VALUE: Self;


### PR DESCRIPTION
By sealing the `Primitive` trait, we gain flexibility for adding internally visible functionality on the trait.

For instance, https://github.com/image-rs/image/commit/123eef91b915ccc1ff661a8cf56cae2052d2bd27 demonstrates how these changes allows us to specialize the implementation of the `ImageBuffer<Rgb<u8>>` conversion methods from/to BGR order to use std::simd.

I believe this same strategy should enable performant implementations of many other methods on `ImageBuffer` without needing further changes to the API.