### PR TITLE
Add {ImageBuffer,DynamicImage}::crop_in_place

### DIFF
--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -996,6 +996,9 @@ where
     /// allocation takes place. The width and height of this buffer are adjusted as part of the
     /// operation. The selection is shrunk to the overlap with this image if it is out of bounds.
     ///
+    /// The pixel buffer is *not* shrunk and will continue to occupy the same amount of memory as
+    /// before. See [`ImageBuffer::shrink_to_fit`] if the container is a [`Vec`].
+    ///
     /// # Examples
     ///
     /// ```
@@ -1475,6 +1478,27 @@ impl<P: Pixel> ImageBuffer<P, Vec<P::Subpixel>> {
     #[must_use]
     pub fn into_vec(self) -> Vec<P::Subpixel> {
         self.into_raw()
+    }
+
+    /// Shrink the length and capacity of the data buffer to fit the image size.
+    ///
+    /// This is useful after shrinking an image in-place, e.g. via cropping, to free unused memory
+    /// or in case the image was created from a buffer with excess capacity.
+    ///
+    /// ```
+    /// use image::RgbImage;
+    ///
+    /// let data = vec![0u8; 10000];
+    /// // `from_raw` allows excess data
+    /// let mut img = RgbImage::from_raw(16, 16, data).unwrap();
+    /// img.shrink_to_fit();
+    ///
+    /// assert_eq!(img.into_vec().len(), 16 * 16 * 3);
+    /// ```
+    pub fn shrink_to_fit(&mut self) {
+        let need = self.inner_pixels().len();
+        self.data.truncate(need);
+        self.data.shrink_to_fit();
     }
 
     /// Transfer the meta data, not the pixel values.

--- a/src/images/dynimage.rs
+++ b/src/images/dynimage.rs
@@ -503,7 +503,8 @@ impl DynamicImage {
     /// Crop this image in place, removing pixels outside of the bounding rectangle.
     ///
     /// See [`ImageBuffer::crop_in_place`] for more details. This changes the image with its
-    /// current color type.
+    /// current color type. The pixel buffer is *not* shrunk and will continue to occupy the same
+    /// amount of memory as before. See [`Self::shrink_to_fit`].
     pub fn crop_in_place(&mut self, selection: Rect) {
         dynamic_map!(self, ref mut p, p.crop_in_place(selection))
     }
@@ -721,6 +722,14 @@ impl DynamicImage {
             ref image_buffer,
             bytemuck::cast_slice(image_buffer.as_raw())
         )
+    }
+
+    /// Shrink the capacity of the underlying [`Vec`] buffer to fit its length.
+    ///
+    /// The data may have excess capacity or padding for a number of reasons, depending on how it
+    /// was created or from in-place manipulation such as [`Self::crop_in_place`].
+    pub fn shrink_to_fit(&mut self) {
+        dynamic_map!(self, ref mut p, p.shrink_to_fit());
     }
 
     /// Return this image's pixels as a byte vector. If the `ImageBuffer`


### PR DESCRIPTION
Similar to `flipv_in_place` this never needs to grow the underlying container. Our behavior of clipping the crop selection to the images dimensions ensures that the target dimensions are always smaller.

As discussed, besides the obvious performance advantages over other forms of cropping into a new allocation this would also be relevant to #2672 .

As a complementary method introduce `ImageBuffer::shrink_to_fit`.