### PR TITLE
hdr: Document RGBE decoding formula

### DIFF
--- a/src/codecs/hdr/mod.rs
+++ b/src/codecs/hdr/mod.rs
@@ -1,11 +1,30 @@
 //!  Decoding of Radiance HDR Images
 //!
-//!  A decoder for Radiance HDR images
+//! A decoder for Radiance HDR images
 //!
-//!  # Related Links
+//! Radiance HDR is an image format using run-length encoding, with floating
+//! point pixels in a shared-exponent representation. Each pixel is encoded
+//! by three 8-bit unsigned color channel values (R, G, B) and one 8-bit
+//! unsigned exponent value E. This decoder, like most other implementations
+//! of the format, uses the following formula to convert encoded RGBE pixels
+//! with positive exponent E > 0 to real (r,g,b) values:
 //!
-//!  * <http://radsite.lbl.gov/radiance/refer/filefmts.pdf>
-//!  * <http://www.graphics.cornell.edu/~bjw/rgbe/rgbe.c>
+//! <center>(r,g,b) = (R × 2<sup>E - (128 + 8)</sup>,
+//! B × 2<sup>E - (128 + 8)</sup>, G × 2<sup>E - (128 + 8)</sup>)</center>
+//!
+//! For example, (R,G,B,E)=(128,64,192,129) maps to (r,g,b) = (1.0,0.5,1.5).
+//!
+//! The original Radiance programs and specification differ slightly from the
+//! above formula and would produce very slightly larger values, but the current
+//! behavior is well established and has the benefit of making round floating
+//! point numbers (like 0.375, 1.0, or 16.0) directly representable.
+//!
+//! # Related Links
+//!
+//! * <http://radsite.lbl.gov/radiance/refer/filefmts.pdf> -- Radiance .hdr
+//!   format specification on page 28, under "Picture File Format"
+//! * <http://www.graphics.cornell.edu/~bjw/rgbe/rgbe.c> -- an implementation
+//! *  from 1995 introducing the new conversion formula
 
 mod decoder;
 mod encoder;


### PR DESCRIPTION
I noticed that the spec for Radiance HDR doesn't clearly explain the RGBE pixel format, and that in fact common implementations of the format (ImageMagick, OpenImageIO; anything descended from [Bruce Walter's implementation](https://www.graphics.cornell.edu/~bjw/rgbe.html)) use a slightly different formula than the original Radiance renderer. Since I couldn't find an implementation other than the original Radiance using the original +0.5-biased decoding formula, I think `image` is doing the right thing. Still, discrepancies may be worth documenting, so I've made this PR.

#### Details:

Quoting the original spec:

> we use a 4-byte/pixel encoding described in Chapter II.5 of Graphics Gems II [Arvo91,p.80]. The basic idea is to store a 1-byte mantissa for each of three primaries, and a common 1-byte exponent.

And as far as I can tell, Chapter II.5 of Graphics Gems, "Real Pixels", has a formula exactly matching the Radiance source code's behavior (https://github.com/LBNL-ETA/Radiance/tree/master, `src/common/color.c`, function `scolr2scolor()`; it uses an exponent lookup table instead of a function to compute the scaling factor.). (The Graphics Gems book has associated code that was published online, see [1](https://web.archive.org/web/20170602093049/http://www.realtimerendering.com/resources/GraphicsGems/) and [2](https://web.archive.org/web/20220601233739/http://www.realtimerendering.com/resources/GraphicsGems/gemsii/RealPixels/color.c.).)  Here the u8 color values have 0.5 added to them before being scaled (so that the red channel has value `(R + 0.5) x factor` instead of `R x factor`.) 

