### PR TITLE
Fix documentation nits

### DIFF
--- a/src/codecs/farbfeld.rs
+++ b/src/codecs/farbfeld.rs
@@ -9,7 +9,7 @@
 //! | 8      | "farbfeld" magic value                                  |
 //! | 4      | 32-Bit BE unsigned integer (width)                      |
 //! | 4      | 32-Bit BE unsigned integer (height)                     |
-//! | [2222] | 4⋅16-Bit BE unsigned integers [RGBA] / pixel, row-major |
+//! | (2222) | 4⋅16-Bit BE unsigned integers (RGBA) / pixel, row-major |
 //!
 //! The RGB-data should be sRGB for best interoperability and not alpha-premultiplied.
 //!

--- a/src/io/encoder.rs
+++ b/src/io/encoder.rs
@@ -25,10 +25,10 @@ pub struct MethodSealedToImage;
 pub trait ImageEncoder {
     /// Writes all the bytes in an image to the encoder.
     ///
-    /// This function takes a slice of bytes of the pixel data of the image
-    /// and encodes them. Just like for [`ImageDecoder::read_image`], no particular
-    /// alignment is required and data is expected to be in native endian.
-    /// The implementation will reorder the endianness as necessary for the target encoding format.
+    /// This function takes a slice of bytes of the pixel data of the image and encodes them. Just
+    /// like for [`ImageDecoder::read_image`](crate::ImageDecoder), no particular alignment is
+    /// required and data is expected to be in native endian. The implementation will reorder the
+    /// endianness as necessary for the target encoding format.
     ///
     /// # Panics
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! # High level API
 //!
-//! Load images using [`ImageReader`](crate::ImageReader):
+//! Load images using [`ImageReader`]:
 //!
 //! ```rust,no_run
 //! use std::io::Cursor;


### PR DESCRIPTION
Four warnings from `cargo doc` in total, all of them rather simple oversights that were left over from a rework or introduced accidentally presumably copying non-markdown formatted content. Could also escape the braces.