### PR TITLE
Replace `ImageDecoder::set_limits` with `ImageDecoder::set_allocation_limit`

### DIFF
--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -40,16 +40,16 @@ use crate::error::{
     DecodingError, EncodingError, ImageError, ImageResult, LimitError, LimitErrorKind,
     ParameterError, ParameterErrorKind, UnsupportedError, UnsupportedErrorKind,
 };
+use crate::io::limits;
 use crate::traits::Pixel;
 use crate::{
     AnimationDecoder, ExtendedColorType, ImageBuffer, ImageDecoder, ImageEncoder, ImageFormat,
-    Limits,
 };
 
 /// GIF decoder
 pub struct GifDecoder<R: Read> {
     reader: gif::Decoder<R>,
-    limits: Limits,
+    allocation_limit: u64,
 }
 
 impl<R: Read> GifDecoder<R> {
@@ -60,7 +60,7 @@ impl<R: Read> GifDecoder<R> {
 
         Ok(GifDecoder {
             reader: decoder.read_info(r).map_err(ImageError::from_decoding)?,
-            limits: Limits::no_limits(),
+            allocation_limit: u64::MAX,
         })
     }
 }
@@ -97,14 +97,8 @@ impl<R: BufRead + Seek> ImageDecoder for GifDecoder<R> {
         ColorType::Rgba8
     }
 
-    fn set_limits(&mut self, limits: Limits) -> ImageResult<()> {
-        limits.check_support(&crate::LimitSupport::default())?;
-
-        let (width, height) = self.dimensions();
-        limits.check_dimensions(width, height)?;
-
-        self.limits = limits;
-
+    fn set_allocation_limit(&mut self, limit: u64) -> ImageResult<()> {
+        self.allocation_limit = limit;
         Ok(())
     }
 
@@ -169,9 +163,9 @@ impl<R: BufRead + Seek> ImageDecoder for GifDecoder<R> {
                     LimitErrorKind::InsufficientMemory,
                 )))?;
 
-            self.limits.reserve_usize(buffer_size)?;
+            limits::reserve_usize(&mut self.allocation_limit, buffer_size)?;
             let mut frame_buffer = vec![0; buffer_size];
-            self.limits.free_usize(buffer_size);
+            limits::free_usize(&mut self.allocation_limit, buffer_size);
 
             self.reader
                 .read_into_buffer(&mut frame_buffer[..])
@@ -236,7 +230,7 @@ struct GifFrameIterator<R: Read> {
     height: u32,
 
     non_disposed_frame: Option<ImageBuffer<Rgba<u8>, Vec<u8>>>,
-    limits: Limits,
+    allocation_limit: u64,
     // `is_end` is used to indicate whether the iterator has reached the end of the frames.
     // Or encounter any un-recoverable error.
     is_end: bool,
@@ -245,7 +239,6 @@ struct GifFrameIterator<R: Read> {
 impl<R: BufRead + Seek> GifFrameIterator<R> {
     fn new(decoder: GifDecoder<R>) -> GifFrameIterator<R> {
         let (width, height) = decoder.dimensions();
-        let limits = decoder.limits.clone();
 
         // intentionally ignore the background color for web compatibility
 
@@ -254,7 +247,7 @@ impl<R: BufRead + Seek> GifFrameIterator<R> {
             width,
             height,
             non_disposed_frame: None,
-            limits,
+            allocation_limit: decoder.allocation_limit,
             is_end: false,
         }
     }
@@ -275,10 +268,12 @@ impl<R: Read> Iterator for GifFrameIterator<R> {
         // This is done here and not in the constructor because
         // the constructor cannot return an error when the allocation limit is exceeded.
         if self.non_disposed_frame.is_none() {
-            if let Err(e) = self
-                .limits
-                .reserve_buffer(self.width, self.height, COLOR_TYPE)
-            {
+            if let Err(e) = limits::reserve_buffer(
+                &mut self.allocation_limit,
+                self.width,
+                self.height,
+                COLOR_TYPE,
+            ) {
                 return Some(Err(e));
             }
             self.non_disposed_frame = Some(ImageBuffer::from_pixel(
@@ -319,10 +314,12 @@ impl<R: Read> Iterator for GifFrameIterator<R> {
         // Therefore, do not count them towards the persistent limits.
         // Instead, create a local instance of `Limits` for this function alone
         // which will be dropped along with all the buffers when they go out of scope.
-        let mut local_limits = self.limits.clone();
+        let mut local_limit = self.allocation_limit;
 
         // Check the allocation we're about to perform against the limits
-        if let Err(e) = local_limits.reserve_buffer(frame.width, frame.height, COLOR_TYPE) {
+        if let Err(e) =
+            limits::reserve_buffer(&mut local_limit, frame.width, frame.height, COLOR_TYPE)
+        {
             return Some(Err(e));
         }
         // Allocate the buffer now that the limits allowed it
@@ -393,7 +390,9 @@ impl<R: Read> Iterator for GifFrameIterator<R> {
             frame_buffer
         } else {
             // Check limits before allocating the buffer
-            if let Err(e) = local_limits.reserve_buffer(self.width, self.height, COLOR_TYPE) {
+            if let Err(e) =
+                limits::reserve_buffer(&mut local_limit, self.width, self.height, COLOR_TYPE)
+            {
                 return Some(Err(e));
             }
             ImageBuffer::from_fn(self.width, self.height, |x, y| {

--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -97,9 +97,8 @@ impl<R: BufRead + Seek> ImageDecoder for GifDecoder<R> {
         ColorType::Rgba8
     }
 
-    fn set_allocation_limit(&mut self, limit: u64) -> ImageResult<()> {
+    fn set_allocation_limit(&mut self, limit: u64) {
         self.allocation_limit = limit;
-        Ok(())
     }
 
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {

--- a/src/codecs/ico/decoder.rs
+++ b/src/codecs/ico/decoder.rs
@@ -249,12 +249,8 @@ impl DirEntry {
         self.seek_to_start(&mut r)?;
 
         if is_png {
-            let limits = crate::Limits {
-                max_image_width: Some(self.real_width().into()),
-                max_image_height: Some(self.real_height().into()),
-                max_alloc: Some(256 * 256 * 4 * 2), // width * height * 4 bytes per pixel * safety factor of 2
-            };
-            Ok(Png(Box::new(PngDecoder::with_limits(r, limits)?)))
+            let max_alloc = 256 * 256 * 4 * 2; // width * height * 4 bytes per pixel * safety factor of 2
+            Ok(Png(Box::new(PngDecoder::with_limits(r, max_alloc)?)))
         } else {
             Ok(Bmp(BmpDecoder::new_with_ico_format(r)?))
         }

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -259,9 +259,8 @@ impl<R: BufRead + Seek> ImageDecoder for PngDecoder<R> {
         (*self).read_image(buf)
     }
 
-    fn set_allocation_limit(&mut self, limit: u64) -> ImageResult<()> {
+    fn set_allocation_limit(&mut self, limit: u64) {
         self.allocation_limit = limit;
-        Ok(())
     }
 }
 

--- a/src/codecs/tiff.rs
+++ b/src/codecs/tiff.rs
@@ -299,13 +299,7 @@ impl<R: BufRead + Seek> ImageDecoder for TiffDecoder<R> {
         }
     }
 
-    fn set_limits(&mut self, limits: crate::Limits) -> ImageResult<()> {
-        limits.check_support(&crate::LimitSupport::default())?;
-
-        let (width, height) = self.dimensions();
-        limits.check_dimensions(width, height)?;
-
-        let max_alloc = limits.max_alloc.unwrap_or(u64::MAX);
+    fn set_allocation_limit(&mut self, max_alloc: u64) -> ImageResult<()> {
         let max_intermediate_alloc = max_alloc.saturating_sub(self.total_bytes_buffer());
 
         let mut tiff_limits: tiff::decoder::Limits = Default::default();

--- a/src/codecs/tiff.rs
+++ b/src/codecs/tiff.rs
@@ -299,7 +299,7 @@ impl<R: BufRead + Seek> ImageDecoder for TiffDecoder<R> {
         }
     }
 
-    fn set_allocation_limit(&mut self, max_alloc: u64) -> ImageResult<()> {
+    fn set_allocation_limit(&mut self, max_alloc: u64) {
         let max_intermediate_alloc = max_alloc.saturating_sub(self.total_bytes_buffer());
 
         let mut tiff_limits: tiff::decoder::Limits = Default::default();
@@ -309,8 +309,6 @@ impl<R: BufRead + Seek> ImageDecoder for TiffDecoder<R> {
             usize::try_from(max_intermediate_alloc).unwrap_or(usize::MAX);
         tiff_limits.ifd_value_size = tiff_limits.intermediate_buffer_size;
         self.inner = Some(self.inner.take().unwrap().with_limits(tiff_limits));
-
-        Ok(())
     }
 
     fn read_image(self, buf: &mut [u8]) -> ImageResult<()> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -177,13 +177,13 @@ pub enum LimitErrorKind {
     DimensionError,
     /// The operation would have performed an allocation larger than allowed.
     InsufficientMemory,
-    /// The specified strict limits are not supported for this operation
-    Unsupported {
-        /// The given limits
-        limits: crate::Limits,
-        /// The supported strict limits
-        supported: crate::LimitSupport,
-    },
+    // /// The specified strict limits are not supported for this operation
+    // Unsupported {
+    //     /// The given limits
+    //     limits: crate::Limits,
+    //     /// The supported strict limits
+    //     supported: crate::LimitSupport,
+    // },
 }
 
 /// A best effort representation for image formats.
@@ -519,10 +519,10 @@ impl fmt::Display for LimitError {
         match self.kind {
             LimitErrorKind::InsufficientMemory => write!(fmt, "Memory limit exceeded"),
             LimitErrorKind::DimensionError => write!(fmt, "Image size exceeds limit"),
-            LimitErrorKind::Unsupported { .. } => {
-                write!(fmt, "The following strict limits are specified but not supported by the opertation: ")?;
-                Ok(())
-            }
+            // LimitErrorKind::Unsupported { .. } => {
+            //     write!(fmt, "The following strict limits are specified but not supported by the opertation: ")?;
+            //     Ok(())
+            // }
         }
     }
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -19,9 +19,6 @@ pub type Reader<R> = ImageReader<R>;
 #[deprecated(note = "this type has been moved to image::Limits")]
 /// Deprecated re-export of `Limits`
 pub type Limits = limits::Limits;
-#[deprecated(note = "this type has been moved to image::LimitSupport")]
-/// Deprecated re-export of `LimitSupport`
-pub type LimitSupport = limits::LimitSupport;
 
 pub(crate) use self::image_reader_type::ImageReader;
 

--- a/src/io/decoder.rs
+++ b/src/io/decoder.rs
@@ -112,8 +112,7 @@ pub trait ImageDecoder {
     /// [`Limits`]: ./io/struct.Limits.html
     /// [`Limits::check_support`]: ./io/struct.Limits.html#method.check_support
     /// [`Limits::check_dimensions`]: ./io/struct.Limits.html#method.check_dimensions
-    fn set_allocation_limit(&mut self, _limit: u64) -> ImageResult<()> {
-        Ok(())
+    fn set_allocation_limit(&mut self, _limit: u64) {
     }
 
     /// Use `read_image` instead; this method is an implementation detail needed so the trait can
@@ -167,7 +166,7 @@ impl<T: ?Sized + ImageDecoder> ImageDecoder for Box<T> {
     fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
         T::read_image_boxed(*self, buf)
     }
-    fn set_allocation_limit(&mut self, limit: u64) -> ImageResult<()> {
+    fn set_allocation_limit(&mut self, limit: u64) {
         (**self).set_allocation_limit(limit)
     }
 }

--- a/src/io/decoder.rs
+++ b/src/io/decoder.rs
@@ -112,10 +112,7 @@ pub trait ImageDecoder {
     /// [`Limits`]: ./io/struct.Limits.html
     /// [`Limits::check_support`]: ./io/struct.Limits.html#method.check_support
     /// [`Limits::check_dimensions`]: ./io/struct.Limits.html#method.check_dimensions
-    fn set_limits(&mut self, limits: crate::Limits) -> ImageResult<()> {
-        limits.check_support(&crate::LimitSupport::default())?;
-        let (width, height) = self.dimensions();
-        limits.check_dimensions(width, height)?;
+    fn set_allocation_limit(&mut self, _limit: u64) -> ImageResult<()> {
         Ok(())
     }
 
@@ -170,8 +167,8 @@ impl<T: ?Sized + ImageDecoder> ImageDecoder for Box<T> {
     fn read_image_boxed(self: Box<Self>, buf: &mut [u8]) -> ImageResult<()> {
         T::read_image_boxed(*self, buf)
     }
-    fn set_limits(&mut self, limits: crate::Limits) -> ImageResult<()> {
-        (**self).set_limits(limits)
+    fn set_allocation_limit(&mut self, limit: u64) -> ImageResult<()> {
+        (**self).set_allocation_limit(limit)
     }
 }
 

--- a/src/io/image_reader_type.rs
+++ b/src/io/image_reader_type.rs
@@ -218,7 +218,7 @@ impl<'a, R: 'a + BufRead + Seek> ImageReader<R> {
             self.inner,
             self.limits.max_alloc.unwrap_or(u64::MAX),
         )?;
-        decoder.set_allocation_limit(self.limits.max_alloc.unwrap_or(u64::MAX))?;
+        decoder.set_allocation_limit(self.limits.max_alloc.unwrap_or(u64::MAX));
         Ok(decoder)
     }
 
@@ -307,7 +307,7 @@ impl<'a, R: 'a + BufRead + Seek> ImageReader<R> {
         // Check that we do not allocate a bigger buffer than we are allowed to
         // FIXME: should this rather go in `DynamicImage::from_decoder` somehow?
         limits::reserve(&mut max_alloc, decoder.total_bytes())?;
-        decoder.set_allocation_limit(max_alloc)?;
+        decoder.set_allocation_limit(max_alloc);
 
         DynamicImage::from_decoder(decoder)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ pub use crate::io::{
     encoder::ImageEncoder,
     format::ImageFormat,
     image_reader_type::ImageReader,
-    limits::{LimitSupport, Limits},
+    limits::Limits,
 };
 
 pub use crate::images::dynimage::DynamicImage;

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -15,9 +15,7 @@
 
 use std::io::Cursor;
 
-use image::{
-    load_from_memory_with_format, ImageDecoder, ImageFormat, ImageReader, Limits, RgbImage,
-};
+use image::{load_from_memory_with_format, ImageFormat, ImageReader, Limits, RgbImage};
 
 const WIDTH: u32 = 256;
 const HEIGHT: u32 = 256;
@@ -69,8 +67,6 @@ fn load_through_reader(
 #[test]
 #[cfg(feature = "gif")]
 fn gif() {
-    use image::codecs::gif::GifDecoder;
-
     let image = test_image(ImageFormat::Gif);
     // sanity check that our image loads successfully without limits
     assert!(load_from_memory_with_format(&image, ImageFormat::Gif).is_ok());
@@ -78,29 +74,13 @@ fn gif() {
     assert!(load_through_reader(&image, ImageFormat::Gif, permissive_limits()).is_ok());
     // image::ImageReader
     assert!(load_through_reader(&image, ImageFormat::Gif, width_height_limits()).is_err());
-    assert!(load_through_reader(&image, ImageFormat::Gif, allocation_limits()).is_err()); // BROKEN!
-
-    // GifDecoder
-    let mut decoder = GifDecoder::new(Cursor::new(&image)).unwrap();
-    assert!(decoder.set_limits(width_height_limits()).is_err());
-    // no tests for allocation limits because the caller is responsible for allocating the buffer in this case
-
-    // Custom constructor on GifDecoder
-    #[allow(deprecated)]
-    {
-        assert!(GifDecoder::new(Cursor::new(&image))
-            .unwrap()
-            .set_limits(width_height_limits())
-            .is_err());
-        // no tests for allocation limits because the caller is responsible for allocating the buffer in this case
-    }
+    assert!(load_through_reader(&image, ImageFormat::Gif, allocation_limits()).is_err());
+    // BROKEN!
 }
 
 #[test]
 #[cfg(feature = "png")]
 fn png() {
-    use image::codecs::png::PngDecoder;
-
     let image = test_image(ImageFormat::Png);
     // sanity check that our image loads successfully without limits
     assert!(load_from_memory_with_format(&image, ImageFormat::Png).is_ok());
@@ -109,25 +89,11 @@ fn png() {
     // image::ImageReader
     assert!(load_through_reader(&image, ImageFormat::Png, width_height_limits()).is_err());
     assert!(load_through_reader(&image, ImageFormat::Png, allocation_limits()).is_err());
-
-    // PngDecoder
-    let mut decoder = PngDecoder::new(Cursor::new(&image)).unwrap();
-    assert!(decoder.set_limits(width_height_limits()).is_err());
-    // No tests for allocation limits because the caller is responsible for allocating the buffer in this case.
-    // Unlike many others, the `png` crate does natively support memory limits for auxiliary buffers,
-    // but they are not passed down from `set_limits` - only from the `with_limits` constructor.
-    // The proper fix is known to require an API break: https://github.com/image-rs/image/issues/2084
-
-    // Custom constructor on PngDecoder
-    assert!(PngDecoder::with_limits(Cursor::new(&image), width_height_limits()).is_err());
-    // No tests for allocation limits because the caller is responsible for allocating the buffer in this case.
 }
 
 #[test]
 #[cfg(feature = "jpeg")]
 fn jpeg() {
-    use image::codecs::jpeg::JpegDecoder;
-
     let image = test_image(ImageFormat::Jpeg);
     // sanity check that our image loads successfully without limits
     assert!(load_from_memory_with_format(&image, ImageFormat::Jpeg).is_ok());
@@ -136,18 +102,11 @@ fn jpeg() {
     // image::ImageReader
     assert!(load_through_reader(&image, ImageFormat::Jpeg, width_height_limits()).is_err());
     assert!(load_through_reader(&image, ImageFormat::Jpeg, allocation_limits()).is_err());
-
-    // JpegDecoder
-    let mut decoder = JpegDecoder::new(Cursor::new(&image)).unwrap();
-    assert!(decoder.set_limits(width_height_limits()).is_err());
-    // No tests for allocation limits because the caller is responsible for allocating the buffer in this case.
 }
 
 #[test]
 #[cfg(feature = "webp")]
 fn webp() {
-    use image::codecs::webp::WebPDecoder;
-
     let image = test_image(ImageFormat::WebP);
     // sanity check that our image loads successfully without limits
     assert!(load_from_memory_with_format(&image, ImageFormat::WebP).is_ok());
@@ -156,18 +115,11 @@ fn webp() {
     // image::ImageReader
     assert!(load_through_reader(&image, ImageFormat::WebP, width_height_limits()).is_err());
     assert!(load_through_reader(&image, ImageFormat::WebP, allocation_limits()).is_err());
-
-    // WebPDecoder
-    let mut decoder = WebPDecoder::new(Cursor::new(&image)).unwrap();
-    assert!(decoder.set_limits(width_height_limits()).is_err());
-    // No tests for allocation limits because the caller is responsible for allocating the buffer in this case.
 }
 
 #[test]
 #[cfg(feature = "tiff")]
 fn tiff() {
-    use image::codecs::tiff::TiffDecoder;
-
     let image = test_image(ImageFormat::Tiff);
     // sanity check that our image loads successfully without limits
     assert!(load_from_memory_with_format(&image, ImageFormat::Tiff).is_ok());
@@ -183,11 +135,6 @@ fn tiff() {
     // image::ImageReader
     assert!(load_through_reader(&image, ImageFormat::Tiff, width_height_limits()).is_err());
     assert!(load_through_reader(&image, ImageFormat::Tiff, allocation_limits()).is_err());
-
-    // TiffDecoder
-    let mut decoder = TiffDecoder::new(Cursor::new(&image)).unwrap();
-    assert!(decoder.set_limits(width_height_limits()).is_err());
-    // No tests for allocation limits because the caller is responsible for allocating the buffer in this case.
 }
 
 #[test]
@@ -203,18 +150,11 @@ fn avif() {
     // image::ImageReader
     assert!(load_through_reader(&image, ImageFormat::Avif, width_height_limits()).is_err());
     assert!(load_through_reader(&image, ImageFormat::Avif, allocation_limits()).is_err());
-
-    // AvifDecoder
-    let mut decoder = AvifDecoder::new(Cursor::new(&image)).unwrap();
-    assert!(decoder.set_limits(width_height_limits()).is_err());
-    // No tests for allocation limits because the caller is responsible for allocating the buffer in this case.
 }
 
 #[test]
 #[cfg(feature = "bmp")]
 fn bmp() {
-    use image::codecs::bmp::BmpDecoder;
-
     let image = test_image(ImageFormat::Bmp);
     // sanity check that our image loads successfully without limits
     assert!(load_from_memory_with_format(&image, ImageFormat::Bmp).is_ok());
@@ -223,9 +163,4 @@ fn bmp() {
     // image::ImageReader
     assert!(load_through_reader(&image, ImageFormat::Bmp, width_height_limits()).is_err());
     assert!(load_through_reader(&image, ImageFormat::Bmp, allocation_limits()).is_err());
-
-    // BmpDecoder
-    let mut decoder = BmpDecoder::new(Cursor::new(&image)).unwrap();
-    assert!(decoder.set_limits(width_height_limits()).is_err());
-    // No tests for allocation limits because the caller is responsible for allocating the buffer in this case.
 }

--- a/tests/limits_anim.rs
+++ b/tests/limits_anim.rs
@@ -10,7 +10,7 @@ fn gif_decode(data: &[u8], limits: Limits) -> ImageResult<()> {
     use std::io::Cursor;
 
     let mut decoder = GifDecoder::new(Cursor::new(data)).unwrap();
-    decoder.set_allocation_limit(limits.max_alloc.unwrap_or(u64::MAX))?;
+    decoder.set_allocation_limit(limits.max_alloc.unwrap_or(u64::MAX));
 
     // The decoder doesn't check dimension limits, so we have to.
     if decoder.dimensions().0 > limits.max_image_width.unwrap_or(u32::MAX)


### PR DESCRIPTION
The goal of this PR is to give the `Limits` struct a single purpose of controlling limits for `ImageReader` while the lower-level API directly expects the caller to check dimensions (and output buffer sizes) so the only remaining limit is memory allocation.

This also makes the concept of strict limits (if we add any) clearer. Now the `ImageReader` is responsible for figuring out which limits can be supported and directly returning an error if necessary. No more need for every decoder to check its supported limits against the requested ones.

Another inspiration for this PR was the idea from #2708 of having a shared `Arc<AtomicU64>` for the allocation limit. In particular, in a followup we could switch things so that `set_allocation_limit` took an atomic limit, while having the higher-level `Limits` object keeps its existing non-atomic `max_alloc` field. The interfacing between the two could then be fully encapsulated within the `ImageReader` type.