### PR TITLE
Implement faster RgbaImage::(from/into)_raw_bgra variants specialized for [u8] buffers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,13 @@
 Breaking Changes:
  - Trait `ImageDecoderRect` has been removed (#2355, #2681)
 
+Features:
+ - Added `RbgImage::from_raw_bgr` and `RbgaImage::from_raw_bgra` constructors, which convert
+   from `BGR(A)` with an optimized specialization for bytes of `BGRA`
+
+Structural changes:
+  - Increased MSRV to 1.88.0 (from 1.85.0)
+
 ### Version 0.25.9
 
 Features:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,11 @@ path = "tests/reference_images.rs"
 name = "reference_images"
 harness = false
 
+[[bench]]
+path = "benches/bgra_to_rgba.rs"
+name = "bgra_to_rgba"
+harness = false
+
 # because of https://github.com/image-rs/image/pull/2583
 # TODO: remove when shipping the next major release after 0.25
 [package.metadata.cargo-semver-checks.lints]

--- a/benches/bgra_to_rgba.rs
+++ b/benches/bgra_to_rgba.rs
@@ -1,0 +1,30 @@
+use std::time::Duration;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use image::{ImageBuffer, Rgba, RgbaImage};
+
+pub fn bench_bgra_to_rgba(c: &mut Criterion) {
+    let width = 2048;
+    let height = 2048;
+    // Create src as a Rgba image, but later treat it as a Bgra buffer
+    let src = ImageBuffer::from_pixel(2048, 2048, Rgba([255u8, 0, 0, 255])).to_vec();
+    let mut group = c.benchmark_group("bgra_to_rgba");
+    group.measurement_time(Duration::from_secs(15));
+    group.bench_function("from_raw_bgra", |b| {
+        b.iter_batched(
+            || src.clone(),
+            |input| RgbaImage::from_raw_bgra(width, height, input),
+            criterion::BatchSize::LargeInput,
+        );
+    });
+    group.bench_function("from_raw_bgra_bytes", |b| {
+        b.iter_batched(
+            || src.clone(),
+            |input| RgbaImage::from_raw_bgra_bytes(width, height, input),
+            criterion::BatchSize::LargeInput,
+        );
+    });
+}
+
+criterion_group!(benches, bench_bgra_to_rgba);
+criterion_main!(benches);

--- a/benches/bgra_to_rgba.rs
+++ b/benches/bgra_to_rgba.rs
@@ -1,26 +1,56 @@
 use std::time::Duration;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use image::{ImageBuffer, Rgba, RgbaImage};
+use image::{ImageBuffer, Rgb, RgbImage, Rgba, RgbaImage};
+
+pub fn from_raw_bgra_old(width: u32, height: u32, container: Vec<u8>) -> Option<RgbaImage> {
+    let mut img = RgbaImage::from_raw(width, height, container)?;
+    for pix in img.pixels_mut() {
+        pix.0[..3].reverse();
+    }
+    Some(img)
+}
+pub fn from_raw_bgra_newdefault(width: u32, height: u32, container: Vec<u8>) -> Option<RgbaImage> {
+    let mut img = RgbaImage::from_raw(width, height, container)?;
+    for pix in img.as_chunks_mut::<4>().0 {
+        pix.swap(0, 2);
+    }
+    Some(img)
+}
 
 pub fn bench_bgra_to_rgba(c: &mut Criterion) {
     let width = 2048;
     let height = 2048;
     // Create src as a Rgba image, but later treat it as a Bgra buffer
-    let src = ImageBuffer::from_pixel(2048, 2048, Rgba([255u8, 0, 0, 255])).to_vec();
+    let src = ImageBuffer::from_pixel(width, height, Rgba([255u8, 0, 0, 255])).to_vec();
+    let src_s = ImageBuffer::from_pixel(width, height, Rgb([255u8, 0, 0])).to_vec();
     let mut group = c.benchmark_group("bgra_to_rgba");
     group.measurement_time(Duration::from_secs(15));
-    group.bench_function("from_raw_bgra", |b| {
+    group.bench_function("from_raw_bgra (new+optimized)", |b| {
         b.iter_batched(
             || src.clone(),
             |input| RgbaImage::from_raw_bgra(width, height, input),
             criterion::BatchSize::LargeInput,
         );
     });
-    group.bench_function("from_raw_bgra_bytes", |b| {
+    group.bench_function("from_raw_bgra (old)", |b| {
         b.iter_batched(
             || src.clone(),
-            |input| RgbaImage::from_raw_bgra_bytes(width, height, input),
+            |input| from_raw_bgra_old(width, height, input),
+            criterion::BatchSize::LargeInput,
+        );
+    });
+    group.bench_function("from_raw_bgra (new)", |b| {
+        b.iter_batched(
+            || src.clone(),
+            |input| from_raw_bgra_newdefault(width, height, input),
+            criterion::BatchSize::LargeInput,
+        );
+    });
+    group.bench_function("from_raw_bgr (new)", |b| {
+        b.iter_batched(
+            || src_s.clone(),
+            |input| RgbImage::from_raw_bgr(width, height, input),
             criterion::BatchSize::LargeInput,
         );
     });

--- a/benches/bgra_to_rgba.rs
+++ b/benches/bgra_to_rgba.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use criterion::{criterion_group, criterion_main, Criterion};
 use image::{ImageBuffer, Rgb, RgbImage, Rgba, RgbaImage};
 
+// variant wiht the old default, before https://github.com/image-rs/image/pull/2712
 pub fn from_raw_bgra_old(width: u32, height: u32, container: Vec<u8>) -> Option<RgbaImage> {
     let mut img = RgbaImage::from_raw(width, height, container)?;
     for pix in img.pixels_mut() {
@@ -10,6 +11,7 @@ pub fn from_raw_bgra_old(width: u32, height: u32, container: Vec<u8>) -> Option<
     }
     Some(img)
 }
+// variant without the new Rgba<u8> specialized optimisation
 pub fn from_raw_bgra_newdefault(width: u32, height: u32, container: Vec<u8>) -> Option<RgbaImage> {
     let mut img = RgbaImage::from_raw(width, height, container)?;
     for pix in img.as_chunks_mut::<4>().0 {

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -1454,6 +1454,8 @@ where
     Container: DerefMut<Target = [S]>,
 {
     /// Construct an image by swapping `BgrA` channels into an `RgbA` order.
+    ///
+    /// If you have a container of u8, use the faster [Self::from_raw_bgra_bytes]
     pub fn from_raw_bgra(width: u32, height: u32, container: Container) -> Option<Self> {
         let mut img = Self::from_raw(width, height, container)?;
 
@@ -1465,12 +1467,83 @@ where
     }
 
     /// Return the underlying raw buffer after converting it into `BgrA` channel order.
+    ///
+    /// If you have a container of u8, use the faster [Self::from_raw_bgra_bytes]
     pub fn into_raw_bgra(mut self) -> Container {
         for pix in self.pixels_mut() {
             pix.0[..3].reverse();
         }
 
         self.into_raw()
+    }
+}
+
+/// This is a inlined version of as_chunks_mut::<4>() with some shuffling to avoid duplicate division
+/// replace usages with buf.as_chunks_mut::<4>() when MSRV is bumped to 1.88 or above
+///
+/// SAFETY: Callers need to ensure buf.len() >= N
+#[inline(always)]
+pub(crate) unsafe fn as_chunks_mut<const N: usize, T>(buf: &mut [T]) -> (&mut [[T; 4]], &mut [T]) {
+    let new_len = buf.len() / N;
+    let len_rounded_down = new_len * N;
+    // SAFETY: The rounded-down value is always the same or smaller than the
+    // original length, and thus must be in-bounds of the slice.
+    let (multiple_of_n, remainder) = unsafe { buf.split_at_mut_unchecked(len_rounded_down) };
+    // SAFETY: Self::from_raw already returned , and ensured by construction
+    // that the length of the subslice is a multiple of N.
+    // We cast a slice of `new_len * 4` elements into
+    // a slice of `new_len` many `4` elements chunks.
+    let array_slice =
+        unsafe { std::slice::from_raw_parts_mut(multiple_of_n.as_mut_ptr().cast(), new_len) };
+    (array_slice, remainder)
+}
+
+impl<Container> ImageBuffer<Rgba<u8>, Container>
+where
+    Container: DerefMut<Target = [u8]>,
+{
+    /// SAFETY: Callers need to ensure buf.len() >= 4
+    #[inline]
+    unsafe fn _swap_bgra_rgba_buf_bytes_inplace(buf: &mut [u8]) {
+        // Replace with let (chunked, _) = img.as_chunks_mut::<4>(); when MSRV is bumped to 1.88 or above
+        // SAFETY: Ensured by caller
+        let (chunked, _) = unsafe { as_chunks_mut::<4, _>(buf) };
+
+        for p in chunked {
+            let bgra = u32::from_be_bytes(*p);
+            let argb = bgra.swap_bytes();
+            let rgba = argb.rotate_left(8);
+            *p = rgba.to_be_bytes();
+        }
+    }
+    /// Construct an image by swapping `BgrA` channels into an `RgbA` order.
+    ///
+    /// Optimized method for u8-based containers
+    pub fn from_raw_bgra_bytes(width: u32, height: u32, container: Container) -> Option<Self> {
+        let mut img = Self::from_raw(width, height, container)?;
+        if img.len() < 4 {
+            return None;
+        }
+
+        // SAFETY: Early-return when img < 4
+        unsafe { Self::_swap_bgra_rgba_buf_bytes_inplace(&mut img) };
+
+        Some(img)
+    }
+
+    /// Return the underlying raw buffer after converting it into `BgrA` channel order.
+    ///
+    /// Optimized method for u8-based containers
+    pub fn into_raw_bgra_bytes(self) -> Container {
+        if self.len() < 4 {
+            return self.into_raw();
+        }
+        let mut buf = self.into_raw();
+
+        // SAFETY: Early-return when img < 4
+        unsafe { Self::_swap_bgra_rgba_buf_bytes_inplace(&mut buf) };
+
+        buf
     }
 }
 

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -18,7 +18,7 @@ use crate::{
     metadata::{Cicp, CicpColorPrimaries, CicpTransferCharacteristics, CicpTransform},
     save_buffer, save_buffer_with_format, write_buffer_with_format, ImageError,
 };
-use crate::{DynamicImage, GenericImage, GenericImageView, ImageEncoder, ImageFormat};
+use crate::{DynamicImage, GenericImage, GenericImageView, ImageEncoder, ImageFormat, Primitive};
 
 /// Iterate over rows of an image
 ///
@@ -1425,25 +1425,19 @@ impl<P: Pixel> ImageBuffer<P, Vec<P::Subpixel>> {
 impl<S, Container> ImageBuffer<Rgb<S>, Container>
 where
     Rgb<S>: PixelWithColorType<Subpixel = S>,
+    S: Primitive,
     Container: DerefMut<Target = [S]>,
 {
     /// Construct an image by swapping `Bgr` channels into an `Rgb` order.
     pub fn from_raw_bgr(width: u32, height: u32, container: Container) -> Option<Self> {
         let mut img = Self::from_raw(width, height, container)?;
-
-        for pix in img.pixels_mut() {
-            pix.0.reverse();
-        }
-
+        S::swizzle_rgb_bgr(img.as_mut());
         Some(img)
     }
 
     /// Return the underlying raw buffer after converting it into `Bgr` channel order.
     pub fn into_raw_bgr(mut self) -> Container {
-        for pix in self.pixels_mut() {
-            pix.0.reverse();
-        }
-
+        S::swizzle_rgb_bgr(self.as_mut());
         self.into_raw()
     }
 }
@@ -1451,99 +1445,20 @@ where
 impl<S, Container> ImageBuffer<Rgba<S>, Container>
 where
     Rgba<S>: PixelWithColorType<Subpixel = S>,
+    S: Primitive,
     Container: DerefMut<Target = [S]>,
 {
     /// Construct an image by swapping `BgrA` channels into an `RgbA` order.
-    ///
-    /// If you have a container of u8, use the faster [Self::from_raw_bgra_bytes]
     pub fn from_raw_bgra(width: u32, height: u32, container: Container) -> Option<Self> {
         let mut img = Self::from_raw(width, height, container)?;
-
-        for pix in img.pixels_mut() {
-            pix.0[..3].reverse();
-        }
-
+        S::swizzle_rgba_bgra(img.as_mut());
         Some(img)
     }
 
     /// Return the underlying raw buffer after converting it into `BgrA` channel order.
-    ///
-    /// If you have a container of u8, use the faster [Self::from_raw_bgra_bytes]
     pub fn into_raw_bgra(mut self) -> Container {
-        for pix in self.pixels_mut() {
-            pix.0[..3].reverse();
-        }
-
+        S::swizzle_rgba_bgra(self.as_mut());
         self.into_raw()
-    }
-}
-
-/// This is a inlined version of as_chunks_mut::<4>() with some shuffling to avoid duplicate division
-/// replace usages with buf.as_chunks_mut::<4>() when MSRV is bumped to 1.88 or above
-///
-/// SAFETY: Callers need to ensure buf.len() >= N
-#[inline(always)]
-pub(crate) unsafe fn as_chunks_mut<const N: usize, T>(buf: &mut [T]) -> (&mut [[T; 4]], &mut [T]) {
-    let new_len = buf.len() / N;
-    let len_rounded_down = new_len * N;
-    // SAFETY: The rounded-down value is always the same or smaller than the
-    // original length, and thus must be in-bounds of the slice.
-    let (multiple_of_n, remainder) = unsafe { buf.split_at_mut_unchecked(len_rounded_down) };
-    // SAFETY: Self::from_raw already returned , and ensured by construction
-    // that the length of the subslice is a multiple of N.
-    // We cast a slice of `new_len * 4` elements into
-    // a slice of `new_len` many `4` elements chunks.
-    let array_slice =
-        unsafe { std::slice::from_raw_parts_mut(multiple_of_n.as_mut_ptr().cast(), new_len) };
-    (array_slice, remainder)
-}
-
-impl<Container> ImageBuffer<Rgba<u8>, Container>
-where
-    Container: DerefMut<Target = [u8]>,
-{
-    /// SAFETY: Callers need to ensure buf.len() >= 4
-    #[inline]
-    unsafe fn _swap_bgra_rgba_buf_bytes_inplace(buf: &mut [u8]) {
-        // Replace with let (chunked, _) = img.as_chunks_mut::<4>(); when MSRV is bumped to 1.88 or above
-        // SAFETY: Ensured by caller
-        let (chunked, _) = unsafe { as_chunks_mut::<4, _>(buf) };
-
-        for p in chunked {
-            let bgra = u32::from_be_bytes(*p);
-            let argb = bgra.swap_bytes();
-            let rgba = argb.rotate_left(8);
-            *p = rgba.to_be_bytes();
-        }
-    }
-    /// Construct an image by swapping `BgrA` channels into an `RgbA` order.
-    ///
-    /// Optimized method for u8-based containers
-    pub fn from_raw_bgra_bytes(width: u32, height: u32, container: Container) -> Option<Self> {
-        let mut img = Self::from_raw(width, height, container)?;
-        if img.len() < 4 {
-            return None;
-        }
-
-        // SAFETY: Early-return when img < 4
-        unsafe { Self::_swap_bgra_rgba_buf_bytes_inplace(&mut img) };
-
-        Some(img)
-    }
-
-    /// Return the underlying raw buffer after converting it into `BgrA` channel order.
-    ///
-    /// Optimized method for u8-based containers
-    pub fn into_raw_bgra_bytes(self) -> Container {
-        if self.len() < 4 {
-            return self.into_raw();
-        }
-        let mut buf = self.into_raw();
-
-        // SAFETY: Early-return when img < 4
-        unsafe { Self::_swap_bgra_rgba_buf_bytes_inplace(&mut buf) };
-
-        buf
     }
 }
 
@@ -1807,7 +1722,7 @@ where
         let transform =
             options.as_transform_fn::<SelfPixel, SelfPixel>(self.color_space(), color)?;
 
-        let mut scratch = [<SelfPixel::Subpixel as crate::Primitive>::DEFAULT_MIN_VALUE; 1200];
+        let mut scratch = [<SelfPixel::Subpixel as Primitive>::DEFAULT_MIN_VALUE; 1200];
         let chunk_len = scratch.len() / usize::from(<SelfPixel as Pixel>::CHANNEL_COUNT)
             * usize::from(<SelfPixel as Pixel>::CHANNEL_COUNT);
 

--- a/src/primitive_sealed.rs
+++ b/src/primitive_sealed.rs
@@ -7,7 +7,7 @@ use crate::imageops::fast_blur::BlurAccumulator;
 /// This trait is `pub` but not exported, so it cannot be implemented outside
 /// this crate.
 #[allow(private_bounds)]
-pub trait PrimitiveSealed: Sized + NearestFrom<f32> + WithBlurAcc {}
+pub trait PrimitiveSealed: Sized + NearestFrom<f32> + WithBlurAcc + BgraSwizzle {}
 
 impl PrimitiveSealed for usize {}
 impl PrimitiveSealed for u8 {}
@@ -21,6 +21,47 @@ impl PrimitiveSealed for i32 {}
 impl PrimitiveSealed for i64 {}
 impl PrimitiveSealed for f32 {}
 impl PrimitiveSealed for f64 {}
+
+/// Defines specialized methods for rgb<->bgr and rgba<->bgra swizzles
+///
+/// By default, uses as_chunks_mut and swaps the first and third elements in the pixel slice.
+/// For u8 rgba however, benchmarks have shown that interpreting the 4 bytes as a u32 and swap+rotate
+/// ends up autovectorizing better.
+// Note: no attempts have been made to find if a similar optimization could apply to primitives beyond u8 or to bgr instead of bgra.
+pub(crate) trait BgraSwizzle: Sized {
+    fn swizzle_rgb_bgr(pixels: &mut [Self]) {
+        for pixel in pixels.as_chunks_mut::<3>().0 {
+            pixel.swap(0, 2);
+        }
+    }
+    fn swizzle_rgba_bgra(pixels: &mut [Self]) {
+        for pix in pixels.as_chunks_mut::<4>().0 {
+            pix.swap(0, 2);
+        }
+    }
+}
+
+impl BgraSwizzle for usize {}
+impl BgraSwizzle for u8 {
+    fn swizzle_rgba_bgra(pixels: &mut [Self]) {
+        for pix in pixels.as_chunks_mut::<4>().0 {
+            let bgra = u32::from_be_bytes(*pix);
+            let argb = bgra.swap_bytes(); // reverses order of pixels (bytes)
+            let rgba = argb.rotate_left(8); // rotate first byte to last place
+            *pix = rgba.to_be_bytes();
+        }
+    }
+}
+impl BgraSwizzle for u16 {}
+impl BgraSwizzle for u32 {}
+impl BgraSwizzle for u64 {}
+impl BgraSwizzle for isize {}
+impl BgraSwizzle for i8 {}
+impl BgraSwizzle for i16 {}
+impl BgraSwizzle for i32 {}
+impl BgraSwizzle for i64 {}
+impl BgraSwizzle for f32 {}
+impl BgraSwizzle for f64 {}
 
 /// Returns the nearest value of `Self` to a given value.
 ///

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -34,48 +34,6 @@ impl EncodableLayout for [f32] {
     }
 }
 
-mod sealed {
-    pub trait PrimitiveSealed: Sized {
-        fn swizzle_rgb_bgr(pixels: &mut [Self]) {
-            for pixel in pixels.as_chunks_mut::<3>().0 {
-                pixel.swap(0, 2);
-            }
-        }
-        fn swizzle_rgba_bgra(pixels: &mut [Self]) {
-            for pix in pixels.as_chunks_mut::<4>().0 {
-                pix.swap(0, 2);
-            }
-        }
-    }
-}
-
-impl sealed::PrimitiveSealed for usize {}
-impl sealed::PrimitiveSealed for u8 {
-    fn swizzle_rgb_bgr(pixels: &mut [Self]) {
-        for pixel in pixels.as_chunks_mut::<3>().0 {
-            pixel.reverse();
-        }
-    }
-    fn swizzle_rgba_bgra(pixels: &mut [Self]) {
-        for pix in pixels.as_chunks_mut::<4>().0 {
-            let bgra = u32::from_be_bytes(*pix);
-            let argb = bgra.swap_bytes();
-            let rgba = argb.rotate_left(8);
-            *pix = rgba.to_be_bytes();
-        }
-    }
-}
-impl sealed::PrimitiveSealed for u16 {}
-impl sealed::PrimitiveSealed for u32 {}
-impl sealed::PrimitiveSealed for u64 {}
-impl sealed::PrimitiveSealed for isize {}
-impl sealed::PrimitiveSealed for i8 {}
-impl sealed::PrimitiveSealed for i16 {}
-impl sealed::PrimitiveSealed for i32 {}
-impl sealed::PrimitiveSealed for i64 {}
-impl sealed::PrimitiveSealed for f32 {}
-impl sealed::PrimitiveSealed for f64 {}
-
 /// The type of each channel in a pixel. For example, this can be `u8`, `u16`, `f32`.
 // TODO rename to `PixelComponent`? Split up into separate traits? Seal?
 pub trait Primitive:

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -34,6 +34,48 @@ impl EncodableLayout for [f32] {
     }
 }
 
+mod sealed {
+    pub trait PrimitiveSealed: Sized {
+        fn swizzle_rgb_bgr(pixels: &mut [Self]) {
+            for pixel in pixels.as_chunks_mut::<3>().0 {
+                pixel.swap(0, 2);
+            }
+        }
+        fn swizzle_rgba_bgra(pixels: &mut [Self]) {
+            for pix in pixels.as_chunks_mut::<4>().0 {
+                pix.swap(0, 2);
+            }
+        }
+    }
+}
+
+impl sealed::PrimitiveSealed for usize {}
+impl sealed::PrimitiveSealed for u8 {
+    fn swizzle_rgb_bgr(pixels: &mut [Self]) {
+        for pixel in pixels.as_chunks_mut::<3>().0 {
+            pixel.reverse();
+        }
+    }
+    fn swizzle_rgba_bgra(pixels: &mut [Self]) {
+        for pix in pixels.as_chunks_mut::<4>().0 {
+            let bgra = u32::from_be_bytes(*pix);
+            let argb = bgra.swap_bytes();
+            let rgba = argb.rotate_left(8);
+            *pix = rgba.to_be_bytes();
+        }
+    }
+}
+impl sealed::PrimitiveSealed for u16 {}
+impl sealed::PrimitiveSealed for u32 {}
+impl sealed::PrimitiveSealed for u64 {}
+impl sealed::PrimitiveSealed for isize {}
+impl sealed::PrimitiveSealed for i8 {}
+impl sealed::PrimitiveSealed for i16 {}
+impl sealed::PrimitiveSealed for i32 {}
+impl sealed::PrimitiveSealed for i64 {}
+impl sealed::PrimitiveSealed for f32 {}
+impl sealed::PrimitiveSealed for f64 {}
+
 /// The type of each channel in a pixel. For example, this can be `u8`, `u16`, `f32`.
 // TODO rename to `PixelComponent`? Split up into separate traits? Seal?
 pub trait Primitive:


### PR DESCRIPTION
This PR adds an optimized version of from_raw_bgra/into_raw_bgra for Rgba<u8> images. 

## Why

I've repeatedly run into wanting to convert a bgra buffer, like pipewire screen capture seems to prefer, to an RgbaImage. So i was very happy to see this addition:
- https://github.com/image-rs/image/pull/2596

Since I've run into this problem a few times, I've come up with a snippet I keept copying around between projects. Its based on [this rust forum thread](https://users.rust-lang.org/t/the-fastest-way-to-copy-a-buffer-bgra-to-rgba/126651/12) and it autovectorizes incredibly well.

Sadly, this simple, safe, function (shown below) needs MSRV 1.88 due to `as_chunks_mut`.

## What

This is the snippet around which i've written this PR. 
```rs
let (chunked, _) = img.as_chunks_mut::<4>();

for p in chunked {
    let bgra = u32::from_be_bytes(*p);
    let argb = bgra.swap_bytes();
    let rgba = argb.rotate_left(8);
    *p = rgba.to_be_bytes();
}
```

This PR bypasses the MSRV 1.88 requirement of `as_chunks_mut` by inlining it until only stable functions are left, which sadly needs a bunch of unsafe. I've then removed some redundant calculations, like dividing by N twice. This whole custom implementation can be removed and replaced with safe calls to `as_chunks_mut` once MSRV gets bumped to or above 1.88.

## Benchmarks

All benchmarks were done on my Ryzen 9900x using the criterion benchmark included in this PR.

target: `x86-64` (default used by rustc)
<img width="1691" height="312" alt="image" src="https://github.com/user-attachments/assets/df835aca-5dd7-4e5a-8c6b-ed15bef1fc80" />

target: `x86-64-v3` (`avx`, `avx2`, `movbe`, ...):
<img width="1691" height="312" alt="image" src="https://github.com/user-attachments/assets/805595ad-8b1f-42e7-9e66-50fa2376277d" />

target: `x86-64-v4` (various `avx512` sets):
<img width="1691" height="312" alt="image" src="https://github.com/user-attachments/assets/420c97de-1414-492f-bf47-f52c32c76f0e" />


As you can see, by default its not too much better than the built-in variant, but once i enable some more modern instruction sets it gets optimized *far* better.
