### PR TITLE
Implement loop_count for AnimationDecoder Trait.

### DIFF
--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -41,10 +41,11 @@ use crate::error::{
     DecodingError, EncodingError, ImageError, ImageResult, LimitError, LimitErrorKind,
     ParameterError, ParameterErrorKind, UnsupportedError, UnsupportedErrorKind,
 };
+use crate::metadata::LoopCount;
 use crate::traits::Pixel;
 use crate::{
     AnimationDecoder, ExtendedColorType, ImageBuffer, ImageDecoder, ImageEncoder, ImageFormat,
-    Limits, LoopTimes,
+    Limits,
 };
 
 /// GIF decoder
@@ -423,12 +424,12 @@ impl<R: Read> Iterator for GifFrameIterator<R> {
 }
 
 impl<'a, R: BufRead + Seek + 'a> AnimationDecoder<'a> for GifDecoder<R> {
-    fn loop_count(&self) -> LoopTimes {
+    fn loop_count(&self) -> LoopCount {
         match self.reader.repeat() {
-            gif::Repeat::Finite(n) => LoopTimes::Finite(
+            gif::Repeat::Finite(n) => LoopCount::Finite(
                 NonZeroU32::new(n.into()).expect("Repeat::Finite should be non-zero"),
             ),
-            gif::Repeat::Infinite => LoopTimes::Infinite,
+            gif::Repeat::Infinite => LoopCount::Infinite,
         }
     }
     fn into_frames(self) -> animation::Frames<'a> {

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -18,10 +18,11 @@ use crate::error::{
     ParameterErrorKind, UnsupportedError, UnsupportedErrorKind,
 };
 use crate::math::Rect;
+use crate::metadata::LoopCount;
 use crate::utils::vec_try_with_capacity;
 use crate::{
     AnimationDecoder, DynamicImage, GenericImage, GenericImageView, ImageBuffer, ImageDecoder,
-    ImageEncoder, ImageFormat, Limits, LoopTimes, Luma, LumaA, Rgb, Rgba, RgbaImage,
+    ImageEncoder, ImageFormat, Limits, Luma, LumaA, Rgb, Rgba, RgbaImage,
 };
 
 // http://www.w3.org/TR/PNG-Structure.html
@@ -520,11 +521,11 @@ impl<R: BufRead + Seek> ApngDecoder<R> {
 }
 
 impl<'a, R: BufRead + Seek + 'a> AnimationDecoder<'a> for ApngDecoder<R> {
-    fn loop_count(&self) -> LoopTimes {
+    fn loop_count(&self) -> LoopCount {
         match self.inner.reader.info().animation_control() {
-            None => LoopTimes::Infinite,
-            Some(actl) if actl.num_plays == 0 => LoopTimes::Infinite,
-            Some(actl) => LoopTimes::Finite(
+            None => LoopCount::Infinite,
+            Some(actl) if actl.num_plays == 0 => LoopCount::Infinite,
+            Some(actl) => LoopCount::Finite(
                 NonZeroU32::new(actl.num_plays).expect("num_plays should be non-zero"),
             ),
         }

--- a/src/codecs/webp/decoder.rs
+++ b/src/codecs/webp/decoder.rs
@@ -7,8 +7,8 @@ use crate::buffer::ConvertBuffer;
 use crate::error::{DecodingError, ImageError, ImageResult};
 use crate::metadata::Orientation;
 use crate::{
-    AnimationDecoder, ColorType, Delay, Frame, Frames, ImageDecoder, ImageFormat, LoopTimes,
-    RgbImage, Rgba, RgbaImage,
+    AnimationDecoder, ColorType, Delay, Frame, Frames, ImageDecoder, ImageFormat, RgbImage, Rgba,
+    RgbaImage,
 };
 
 /// WebP Image format decoder.
@@ -103,10 +103,10 @@ impl<R: BufRead + Seek> ImageDecoder for WebPDecoder<R> {
 }
 
 impl<'a, R: 'a + BufRead + Seek> AnimationDecoder<'a> for WebPDecoder<R> {
-    fn loop_count(&self) -> LoopTimes {
+    fn loop_count(&self) -> crate::metadata::LoopCount {
         match self.inner.loop_count() {
-            LoopCount::Forever => LoopTimes::Infinite,
-            LoopCount::Times(n) => LoopTimes::Finite(
+            LoopCount::Forever => crate::metadata::LoopCount::Infinite,
+            LoopCount::Times(n) => crate::metadata::LoopCount::Finite(
                 NonZeroU32::new(n.get().into()).expect("LoopCount::Times should be non-zero"),
             ),
         }

--- a/src/io/decoder.rs
+++ b/src/io/decoder.rs
@@ -1,9 +1,7 @@
-use std::num::NonZeroU32;
-
 use crate::animation::Frames;
 use crate::color::{ColorType, ExtendedColorType};
 use crate::error::ImageResult;
-use crate::metadata::Orientation;
+use crate::metadata::{LoopCount, Orientation};
 
 /// The trait that all decoders implement
 pub trait ImageDecoder {
@@ -182,16 +180,7 @@ pub trait AnimationDecoder<'a> {
     /// Consume the decoder producing a series of frames.
     fn into_frames(self) -> Frames<'a>;
     /// Loop count of the animated image.
-    fn loop_count(&self) -> LoopTimes;
-}
-
-/// The number of times animated image should loop over.
-#[derive(Clone, Copy)]
-pub enum LoopTimes {
-    /// Loop the image Infinitely
-    Infinite,
-    /// Loop the image within Finite times.
-    Finite(NonZeroU32),
+    fn loop_count(&self) -> LoopCount;
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@ pub use crate::images::dynimage::{
 pub use crate::io::free_functions::{guess_format, load, save_buffer, save_buffer_with_format};
 
 pub use crate::io::{
-    decoder::{AnimationDecoder, ImageDecoder, LoopTimes},
+    decoder::{AnimationDecoder, ImageDecoder},
     encoder::ImageEncoder,
     format::ImageFormat,
     image_reader_type::ImageReader,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,7 +1,10 @@
 //! Types describing image metadata
 pub(crate) mod cicp;
 
-use std::io::{Cursor, Read};
+use std::{
+    io::{Cursor, Read},
+    num::NonZeroU32,
+};
 
 use byteorder_lite::{BigEndian, LittleEndian, ReadBytesExt, WriteBytesExt};
 
@@ -156,6 +159,15 @@ impl Orientation {
 enum ExifEndian {
     Big,
     Little,
+}
+
+/// The number of times animated image should loop over.
+#[derive(Clone, Copy)]
+pub enum LoopCount {
+    /// Loop the image Infinitely
+    Infinite,
+    /// Loop the image within Finite times.
+    Finite(NonZeroU32),
 }
 
 #[cfg(all(test, feature = "jpeg"))]


### PR DESCRIPTION
<!--
We welcome performance optimizations, bug fixes, and documentation improvements.

Feature additions are also welcome, but we encourage you to open an issue first
to discuss whether it is something we want to add.

Thank you for contributing, you can delete this comment.
-->

As described in https://github.com/image-rs/image/issues/2715, This PR implements `loop_count` function for `AnimationDecoder` Trait, currently there are three type (Gif, Webp and Apng) implementing `AnimationDecoder` Trait, so implementation on these specific format decoders are added.