### PR TITLE
support more color type in Jpeg Encoder

### DIFF
--- a/src/codecs/jpeg/encoder.rs
+++ b/src/codecs/jpeg/encoder.rs
@@ -228,6 +228,18 @@ impl<W: Write> JpegEncoder<W> {
                 let color = jpeg_encoder::ColorType::Rgb;
                 encode_jpeg(color)
             }
+            ExtendedColorType::Rgba8 => {
+                let color = jpeg_encoder::ColorType::Rgba;
+                encode_jpeg(color)
+            }
+            ExtendedColorType::Bgr8 => {
+                let color = jpeg_encoder::ColorType::Bgr;
+                encode_jpeg(color)
+            }
+            ExtendedColorType::Bgra8 => {
+                let color = jpeg_encoder::ColorType::Bgra;
+                encode_jpeg(color)
+            }
             _ => Err(ImageError::Unsupported(
                 UnsupportedError::from_format_and_kind(
                     ImageFormat::Jpeg.into(),


### PR DESCRIPTION
<!--
We welcome performance optimizations, bug fixes, and documentation improvements.

Feature additions are also welcome, but we encourage you to open an issue first
to discuss whether it is something we want to add.

Thank you for contributing, you can delete this comment.
-->
In https://github.com/image-rs/image/commit/c8984578a5349208ed72462efeea2c153ab98b3, we change to encoder in `jpeg_encoder` instead of our own implementation, this PR add more `ExtendedColorType` that is supported in `jpeg_encoder` crate, but is previously not supported by our own implementation.