### PR TITLE
Improve BMP resumable decoder to resume at row-level

### DIFF
--- a/src/codecs/bmp/decoder.rs
+++ b/src/codecs/bmp/decoder.rs
@@ -1765,12 +1765,12 @@ impl<R: BufRead + Seek> BmpDecoder<R> {
 
     /// Handle the result of a row-based decode operation, updating state accordingly.
     fn finish_row_decode(&mut self, result: Result<u32, (u32, io::Error)>) -> ImageResult<()> {
- 
-    let (Ok(rows) | Err((rows, _))) = result;
-    self.state = DecoderState::ReadingRowData { rows_decoded: rows };
-    match result {
-        Ok(_) => Ok(()),
-        Err((_, e)) => Err(e)?,
+        let (Ok(rows) | Err((rows, _))) = result;
+        self.state = DecoderState::ReadingRowData { rows_decoded: rows };
+        match result {
+            Ok(_) => Ok(()),
+            Err((_, e)) => Err(e)?,
+        }
     }
 
     /// Read the actual pixel data of the image.


### PR DESCRIPTION
This PR extends the coarse-grained resumable decoding from #2738 to support row-level progress tracking for non-RLE BMP formats. When decoding is interrupted by UnexpectedEof, the decoder can now resume from the last successfully decoded row rather than restarting from the beginning.

This is a work towards #2696 
