### PR TITLE
Write ICC profiles to TIFF files

### DIFF
--- a/src/codecs/tiff.rs
+++ b/src/codecs/tiff.rs
@@ -616,6 +616,11 @@ impl<W: Write + Seek> ImageEncoder for TiffEncoder<W> {
     ) -> ImageResult<()> {
         self.encode(buf, width, height, color_type)
     }
+
+    fn set_icc_profile(&mut self, icc_profile: Vec<u8>) -> Result<(), UnsupportedError> {
+        self.icc = Some(icc_profile);
+        Ok(())
+    }
 }
 
 /// Private wrapper function to conveniently write an ICC profile the same Image File Directory (IFD) as the image data


### PR DESCRIPTION
Tested manually using https://github.com/Shnatsel/wondermagick/pull/84 and the image from https://github.com/image-rs/image/issues/1756

I've confirmed that the ICC profile written this way can be read back both by `image` and by imagemagick.