### PR TITLE
AVIF image orientation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ walkdir = "2.5.0"
 default = ["rayon", "default-formats"]
 
 # Format features
-default-formats = ["avif", "avif-native", "bmp", "dds", "exr", "ff", "gif", "hdr", "ico", "jpeg", "png", "pnm", "qoi", "tga", "tiff", "webp"]
+default-formats = ["avif", "bmp", "dds", "exr", "ff", "gif", "hdr", "ico", "jpeg", "png", "pnm", "qoi", "tga", "tiff", "webp"]
 avif = ["dep:ravif", "dep:rgb"]
 bmp = []
 dds = []


### PR DESCRIPTION
Instead of something sensible like Exif rotation encoding, they came up with a custom scheme to encode the same thing more verbosely.

Tested on sample images with https://github.com/link-u/avif-sample-images - all pass, but the tests there are non-exhaustive.

Curiously Chromium displays them correctly while Firefox seems to outright reject the sample images with orientation metadata.

Unfortunately this requires some `unsafe` due to mp4parse only exposing pointer API for mirroring, and I don't trust them to make a timely release since the last release was over 2 years ago.