### PR TITLE
Propagate copy_from through SubImage

### DIFF
--- a/benches/copy_from.rs
+++ b/benches/copy_from.rs
@@ -4,8 +4,8 @@ use image::{GenericImage, ImageBuffer, Rgba};
 pub fn bench_copy_from(c: &mut Criterion) {
     let at = image::math::Rect::from_xy_ranges(256..1280, 256..1280);
 
+    let mut target = ImageBuffer::from_pixel(2048, 2048, Rgba([0u8, 0, 0, 255]));
     let src = ImageBuffer::from_pixel(2048, 2048, Rgba([255u8, 0, 0, 255]));
-    let mut dst = ImageBuffer::from_pixel(2048, 2048, Rgba([0u8, 0, 0, 255]));
     let part = ImageBuffer::from_pixel(at.width, at.height, Rgba([255u8, 0, 0, 255]));
 
     let view = image::GenericImageView::view(&src, at);
@@ -22,25 +22,68 @@ pub fn bench_copy_from(c: &mut Criterion) {
     let skip = samples.as_view().unwrap();
 
     c.bench_function("copy_from", |b| {
-        b.iter(|| dst.copy_from(black_box(&src), 0, 0));
+        b.iter(|| target.copy_from(black_box(&src), 0, 0));
     });
 
     c.bench_function("copy_at", |b| {
-        b.iter(|| dst.copy_from(black_box(&part), at.x, at.y));
+        b.iter(|| target.copy_from(black_box(&part), at.x, at.y));
     });
 
     c.bench_function("copy_view", |b| {
-        b.iter(|| dst.copy_from(black_box(&*view), at.x, at.y));
+        b.iter(|| target.copy_from(black_box(&*view), at.x, at.y));
     });
 
     c.bench_function("copy_fill", |b| {
-        b.iter(|| dst.copy_from(black_box(&singular), at.x, at.y));
+        b.iter(|| target.copy_from(black_box(&singular), at.x, at.y));
     });
 
     c.bench_function("copy_strides", |b| {
-        b.iter(|| dst.copy_from(black_box(&skip), at.x, at.y));
+        b.iter(|| target.copy_from(black_box(&skip), at.x, at.y));
     });
 }
 
-criterion_group!(benches, bench_copy_from);
+pub fn bench_copy_subimage_from(c: &mut Criterion) {
+    let viewport = image::math::Rect::from_xy_ranges(256..1280, 256..1280);
+    let at = image::math::Rect::from_xy_ranges(128..512, 128..512);
+
+    let mut target = ImageBuffer::from_pixel(2048, 2048, Rgba([0u8, 0, 0, 255]));
+    let mut target = target.sub_image(viewport);
+
+    let src = ImageBuffer::from_pixel(viewport.width, viewport.height, Rgba([255u8, 0, 0, 255]));
+    let part = ImageBuffer::from_pixel(at.width, at.height, Rgba([255u8, 0, 0, 255]));
+    let view = image::GenericImageView::view(&src, at);
+
+    const BG: Rgba<u8> = Rgba([0u8, 0, 0, 255]);
+    let samples = image::flat::FlatSamples::with_monocolor(&BG, at.width, at.height);
+    let singular = samples.as_view().unwrap();
+
+    let mut samples = src.as_flat_samples();
+    samples.layout.width = at.width / 2;
+    samples.layout.width_stride *= 2;
+    samples.layout.height = at.height / 2;
+    samples.layout.height_stride *= 2;
+    let skip = samples.as_view().unwrap();
+
+    c.bench_function("copy_subimage_from", |b| {
+        b.iter(|| target.copy_from(black_box(&src), 0, 0));
+    });
+
+    c.bench_function("copy_subimage_at", |b| {
+        b.iter(|| target.copy_from(black_box(&part), at.x, at.y));
+    });
+
+    c.bench_function("copy_subimage_view", |b| {
+        b.iter(|| target.copy_from(black_box(&*view), at.x, at.y));
+    });
+
+    c.bench_function("copy_subimage_fill", |b| {
+        b.iter(|| target.copy_from(black_box(&singular), at.x, at.y));
+    });
+
+    c.bench_function("copy_subimage_strides", |b| {
+        b.iter(|| target.copy_from(black_box(&skip), at.x, at.y));
+    });
+}
+
+criterion_group!(benches, bench_copy_from, bench_copy_subimage_from);
 criterion_main!(benches);

--- a/src/images/sub_image.rs
+++ b/src/images/sub_image.rs
@@ -237,6 +237,17 @@ where
         self.image
             .blend_pixel(x + self.xoffset, y + self.yoffset, pixel);
     }
+
+    fn copy_from<O>(&mut self, other: &O, x: u32, y: u32) -> Result<(), crate::ImageError>
+    where
+        O: GenericImageView<Pixel = Self::Pixel>,
+    {
+        Rect::from_image_at(other, x, y).test_in_bounds(self)?;
+        // Dispatch the inner images `copy_from` method with adjusted offsets. this ensures its
+        // potentially optimized implementation gets used.
+        self.image
+            .copy_from(other, x + self.xoffset, y + self.yoffset)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
See #2766 but for all `SubImage<I>` that is improved. Gains from this are even more absurd, as previous code would unroll or elide much based on the in-bounds verification—complicating the indexing in the tight loop significantly.

<details>

```
copy_subimage_from      time:   [530.38 µs 548.81 µs 565.15 µs]
                        change: [-92.413% -92.100% -91.797%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

copy_subimage_at        time:   [39.675 µs 40.163 µs 40.747 µs]
                        change: [-95.561% -95.440% -95.324%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) high mild
  6 (6.00%) high severe

copy_subimage_view      time:   [42.345 µs 42.665 µs 43.014 µs]
                        change: [-94.854% -94.675% -94.494%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

copy_subimage_fill      time:   [132.67 µs 133.60 µs 134.73 µs]
                        change: [-83.000% -82.719% -82.424%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

copy_subimage_strides   time:   [36.394 µs 36.609 µs 36.860 µs]
                        change: [-81.753% -81.251% -80.794%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  8 (8.00%) high mild
  1 (1.00%) high severe
```

</details>