### PR TITLE
Remove unnecessary type constraint for `ImageBuffer::as_flat_samples`

### DIFF
--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -1320,13 +1320,7 @@ where
     }
 
     fn to_pixel_view(&self) -> Option<ViewOfPixel<'_, Self::Pixel>> {
-        let samples = FlatSamples {
-            samples: &*self.data,
-            layout: self.sample_layout(),
-            color_hint: None,
-        };
-
-        samples.into_view().ok()
+        self.as_flat_samples().into_view().ok()
     }
 
     /// Returns the pixel located at (x, y), ignoring bounds checking.


### PR DESCRIPTION
I noticed that the constraint `Container: AsRef<[P::Subpixel]>` was completely unnecessary for the implementation of `as_flat_samples`. Since the impl already has the constraint `Container: Deref<Target = [P::SubPixel]>`, we can just use that.

However, while unnecessary for the implementation of `as_flat_samples`, callers of `as_flat_samples` still had to satisfy the constraint. With the unnecessary restriction gone, most generic instances of `ImageBuffer` can use `as_flat_samples` now.