### PR TITLE
Implement seek_relative for hooks::GenericReader

### DIFF
--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -68,8 +68,9 @@ impl Seek for GenericReader<'_> {
     fn stream_position(&mut self) -> std::io::Result<u64> {
         self.0.stream_position()
     }
-
-    // TODO: Add `seek_relative` once MSRV is at least 1.80.0
+    fn seek_relative(&mut self, offset: i64) -> std::io::Result<()> {
+        self.0.seek_relative(offset)
+    }
 }
 
 /// A function to produce an [`ImageDecoder`] for a given image format.


### PR DESCRIPTION
Directly forwarding Seek::seek_relative to the underlying BufReader can make decoders using the format hook mechanism much more efficient in edge cases with many short seeks. See also https://github.com/image-rs/image-extras/pull/38.
