### PR TITLE
Opt out of clippy lint

### DIFF
--- a/src/codecs/hdr/decoder.rs
+++ b/src/codecs/hdr/decoder.rs
@@ -561,6 +561,7 @@ impl HdrMetadata {
         // parse known attributes
         match maybe_key_value {
             Some(("FORMAT", val)) => {
+                #[allow(clippy::collapsible_match)] // clippy wants confusing guard syntax here
                 if val.trim() != "32-bit_rle_rgbe" {
                     // XYZE isn't supported yet
                     return Err(ImageError::Unsupported(


### PR DESCRIPTION
Fixes Clippy CI failure on main and in all recent PRs.

The issue it flags and it suggestion:

https://github.com/image-rs/image/actions/runs/22436715116/job/64968316820?pr=2785

I don't think it's useful in any way so just suppress it.