### PR TITLE
Remove deprecated `Format::Pcx`

### DIFF
--- a/src/io/format.rs
+++ b/src/io/format.rs
@@ -50,11 +50,6 @@ pub enum ImageFormat {
 
     /// An Image in QOI Format
     Qoi,
-
-    /// An Image in PCX Format
-    #[cfg_attr(not(feature = "serde"), deprecated)]
-    #[doc(hidden)]
-    Pcx,
 }
 
 impl ImageFormat {
@@ -212,8 +207,6 @@ impl ImageFormat {
             ImageFormat::Qoi => "image/x-qoi",
             // farbfeld's MIME type taken from https://www.wikidata.org/wiki/Q28206109
             ImageFormat::Farbfeld => "application/octet-stream",
-            #[allow(deprecated)]
-            ImageFormat::Pcx => "image/vnd.zbrush.pcx",
         }
     }
 
@@ -237,8 +230,6 @@ impl ImageFormat {
             ImageFormat::Farbfeld => true,
             ImageFormat::Avif => true,
             ImageFormat::Qoi => true,
-            #[allow(deprecated)]
-            ImageFormat::Pcx => false,
         }
     }
 
@@ -262,8 +253,6 @@ impl ImageFormat {
             ImageFormat::Hdr => true,
             ImageFormat::OpenExr => true,
             ImageFormat::Qoi => true,
-            #[allow(deprecated)]
-            ImageFormat::Pcx => false,
         }
     }
 
@@ -295,8 +284,6 @@ impl ImageFormat {
             // According to: https://aomediacodec.github.io/av1-avif/#mime-registration
             ImageFormat::Avif => &["avif"],
             ImageFormat::Qoi => &["qoi"],
-            #[allow(deprecated)]
-            ImageFormat::Pcx => &["pcx"],
         }
     }
 
@@ -319,8 +306,6 @@ impl ImageFormat {
             ImageFormat::Farbfeld => cfg!(feature = "ff"),
             ImageFormat::Avif => cfg!(feature = "avif"),
             ImageFormat::Qoi => cfg!(feature = "qoi"),
-            #[allow(deprecated)]
-            ImageFormat::Pcx => false,
         }
     }
 
@@ -343,8 +328,6 @@ impl ImageFormat {
             ImageFormat::OpenExr => cfg!(feature = "exr"),
             ImageFormat::Qoi => cfg!(feature = "qoi"),
             ImageFormat::Hdr => cfg!(feature = "hdr"),
-            #[allow(deprecated)]
-            ImageFormat::Pcx => false,
         }
     }
 
@@ -365,8 +348,6 @@ impl ImageFormat {
             ImageFormat::OpenExr,
             ImageFormat::Qoi,
             ImageFormat::Hdr,
-            #[allow(deprecated)]
-            ImageFormat::Pcx,
         ]
         .iter()
         .copied()

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -90,6 +90,7 @@ pub(crate) fn encoder_for_format<'a, W: Write + Seek>(
         ImageFormat::WebP => Box::new(webp::WebPEncoder::new_lossless(buffered_write)),
         #[cfg(feature = "hdr")]
         ImageFormat::Hdr => Box::new(hdr::HdrEncoder::new(buffered_write)),
+        #[allow(unreachable_patterns)] // unreachable if all formats are enabled
         _ => {
             return Err(ImageError::Unsupported(
                 UnsupportedError::from_format_and_kind(


### PR DESCRIPTION
`Format::Pcx` has been deprecated for a while now, and PCX support itself has been added to `image-extras`. Removing it is part of #2245, so I see no reason for it to linger.

### Additional considerations

With `Format::Pcx` gone, `Format::can_{read,write}` now always return `true`. Maybe they could be removed? Frankly, I don't see `image` adding formats not supporting both reading and writing again. The hooks API and `image-extras` exist now.