### PR TITLE
Fix `Format::reading_enabled` for AVIF

### DIFF
--- a/src/io/format.rs
+++ b/src/io/format.rs
@@ -317,7 +317,7 @@ impl ImageFormat {
             ImageFormat::OpenExr => cfg!(feature = "exr"),
             ImageFormat::Pnm => cfg!(feature = "pnm"),
             ImageFormat::Farbfeld => cfg!(feature = "ff"),
-            ImageFormat::Avif => cfg!(feature = "avif"),
+            ImageFormat::Avif => cfg!(feature = "avif-native"),
             ImageFormat::Qoi => cfg!(feature = "qoi"),
             #[allow(deprecated)]
             ImageFormat::Pcx => false,


### PR DESCRIPTION
AVIF is in the awkward position where it has one feature for writing `avif` and one for reading `avif-native`. Unfortunately, `Format::reading_enabled` used the `feature = "avif"`. This PR corrects that mistake. 

Hopefully, this feature divide won't persist for much longer (#2621).