### PR TITLE
Add L32F and La32F to `ExtendedColorType`

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -150,6 +150,10 @@ pub enum ExtendedColorType {
     Bgra8,
 
     // TODO f16 types?
+    /// Pixel is 32-bit float luminance
+    L32F,
+    /// Pixel is 32-bit float luminance with an alpha channel
+    La32F,
     /// Pixel is 32-bit float RGB
     Rgb32F,
     /// Pixel is 32-bit float RGBA
@@ -180,12 +184,14 @@ impl ExtendedColorType {
             | ExtendedColorType::L4
             | ExtendedColorType::L8
             | ExtendedColorType::L16
+            | ExtendedColorType::L32F
             | ExtendedColorType::Unknown(_) => 1,
             ExtendedColorType::La1
             | ExtendedColorType::La2
             | ExtendedColorType::La4
             | ExtendedColorType::La8
-            | ExtendedColorType::La16 => 2,
+            | ExtendedColorType::La16
+            | ExtendedColorType::La32F => 2,
             ExtendedColorType::Rgb1
             | ExtendedColorType::Rgb2
             | ExtendedColorType::Rgb4
@@ -232,6 +238,8 @@ impl ExtendedColorType {
             ExtendedColorType::La16 => 32,
             ExtendedColorType::Rgb16 => 48,
             ExtendedColorType::Rgba16 => 64,
+            ExtendedColorType::L32F => 32,
+            ExtendedColorType::La32F => 64,
             ExtendedColorType::Rgb32F => 96,
             ExtendedColorType::Rgba32F => 128,
             ExtendedColorType::Bgr8 => 24,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -224,11 +224,18 @@ impl PixelWithColorType for Luma<u8> {
 impl PixelWithColorType for Luma<u16> {
     const COLOR_TYPE: ExtendedColorType = ExtendedColorType::L16;
 }
+impl PixelWithColorType for Luma<f32> {
+    const COLOR_TYPE: ExtendedColorType = ExtendedColorType::L32F;
+}
+
 impl PixelWithColorType for LumaA<u8> {
     const COLOR_TYPE: ExtendedColorType = ExtendedColorType::La8;
 }
 impl PixelWithColorType for LumaA<u16> {
     const COLOR_TYPE: ExtendedColorType = ExtendedColorType::La16;
+}
+impl PixelWithColorType for LumaA<f32> {
+    const COLOR_TYPE: ExtendedColorType = ExtendedColorType::La32F;
 }
 
 /// Prevents down-stream users from implementing the `Primitive` trait


### PR DESCRIPTION
Related to #1940

This PR adds variants to `ExtendedColorType` for representing single-channel and dual-channel float32 colors: `L32F` and `La32F` respectively. These color types are not uncommon and should at least be representable in `image`. Adding them to `ColorType` would be nice too, but likely much more complex due to the symmetry with `DynamicImage`. I added them `ExtendedColorType` because this type seems more open to change and enables additional functionality (such as saving images).

This addition also closes some gaps in existing APIs. Since `ExtendedColorType` can now represent the pixel types `Luma<f32>` and `LumaA<f32>`, the `PixelWithColorType` trait can be implemented for all color x primitive combinations. Because of this, `ImageBuffer<Luma<f32>, _>` and `ImageBuffer<LumaA<f32>, _>` can now use the `save*` and `write*` methods.

Of course, no encoder currently supports L32F or La32F, but this can easily be added in follow-up PRs. In particular, supporting L32F in TIFF and HDR should be relatively easy. And of course, I want to support L32F for DDS too.