### PR TITLE
Update png dependency to 0.18.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ exr = { version = "1.74.0", default-features = false, optional = true }
 gif = { version = "0.14.1", optional = true }
 image-webp = { version = "0.2.0", optional = true }
 mp4parse = { version = "0.17.0", optional = true }
-png = { version = "0.18.0", optional = true }
+png = { version = "0.18.1", optional = true }
 qoi = { version = "0.4", optional = true }
 ravif = { version = "0.13", default-features = false, optional = true }
 rayon = { version = "1.7.0", optional = true }


### PR DESCRIPTION
Update png dependency to 0.18.1, which includes a fix required by Chromium. Chromium's dependency on image crate is currently based on main branch for BMP experiment (as we require all the changes for supporting resumable decoding). Now, we are starting work on rustification of ICO codec (preliminary work in https://skia-review.googlesource.com/c/skia/+/1165477) which requires enabling png feature, so we would need it including the latest fix from 0.18.1
