### PR TITLE
Update to moxcms 0.8.0 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 bytemuck = { version = "1.8.0", features = ["extern_crate_alloc"] } # includes cast_vec
 byteorder-lite = "0.1.0"
-moxcms = { version = ">=0.7.4, <0.9" }
+moxcms = "0.8.0"
 num-traits = { version = "0.2.0" }
 
 # Optional dependencies

--- a/src/metadata/cicp.rs
+++ b/src/metadata/cicp.rs
@@ -342,9 +342,6 @@ impl CicpTransform {
     /// This is used with [`ConvertColorOptions`][`crate::ConvertColorOptions`] in
     /// [`ImageBuffer::copy_from_color_space`][`crate::ImageBuffer::copy_from_color_space`],
     /// [`DynamicImage::copy_from_color_space`][`DynamicImage::copy_from_color_space`].
-    // `Arc::from` is needed for moxcms 0.7.x (returns Box) but is a no-op in 0.8.x (returns Arc
-    // directly); allow the lint so both versions compile cleanly under `-D warnings`.
-    #[allow(clippy::useless_conversion)]
     pub fn new(from: Cicp, into: Cicp) -> Option<Self> {
         if !from.qualify_stability() || !into.qualify_stability() {
             // To avoid regressions, we do not support all kinds of transforms from the start.
@@ -370,7 +367,6 @@ impl CicpTransform {
                 let (into, into_layout) = mox_into.map_layout(into_layout);
 
                 from.create_transform_f32(from_layout, into, into_layout, opt)
-                    .map(Arc::<dyn moxcms::TransformExecutor<f32> + Send + Sync>::from)
                     .ok()
             });
 
@@ -391,7 +387,6 @@ impl CicpTransform {
                     let (into, into_layout) = mox_into.map_layout(into_layout);
 
                     from.create_transform_8bit(from_layout, into, into_layout, opt)
-                        .map(Arc::<dyn moxcms::TransformExecutor<_> + Send + Sync>::from)
                         .ok()
                 }),
                 f32_fallback.clone(),
@@ -403,7 +398,6 @@ impl CicpTransform {
                     let (into, into_layout) = mox_into.map_layout(into_layout);
 
                     from.create_transform_16bit(from_layout, into, into_layout, opt)
-                        .map(Arc::<dyn moxcms::TransformExecutor<_> + Send + Sync>::from)
                         .ok()
                 }),
                 f32_fallback.clone(),


### PR DESCRIPTION
In Chromium we are also switch ICC parsing to use moxcms (WIP CL: https://chromium-review.googlesource.com/c/chromium/src/+/7588078). This requires some fix and struct exposure which are included in moxcms 0.8.0. However, this makes a dependency conflict as image crate depends on 0.7.4. This change is allowing both 0.7.4 and 0.8.x as at the moment there are no API changes. @awxkee , do you think it is ok to keep both as supported dependencies or better switch to 0.8.0?

Update: There is in fact some API change causing this clippy error when building. To support both we should tag with allow `clippy::useless_conversion` the callilng method 
```
error: useless conversion to the same type: `std::sync::Arc<dyn moxcms::TransformExecutor<f32> + std::marker::Send + std::marker::Sync>`
   --> src/metadata/cicp.rs:369:79
    |
369 |                    from.create_transform_f32(from_layout, into, into_layout, opt)
    |   _______________________________________________________________________________^
    |  |_______________________________________________________________________________|
370 | ||                     .map(Arc::<dyn moxcms::TransformExecutor<f32> + Send + Sync>::from)
    | ||_______________________________________________________________________________________^
371 | |                      .ok()
    | |_____________________- help: consider removing
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
    = note: `-D clippy::useless-conversion` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::useless_conversion)]`
```