### PR TITLE
pnm: reject images with missing PAM tupltype

### DIFF
--- a/src/codecs/pnm/decoder.rs
+++ b/src/codecs/pnm/decoder.rs
@@ -894,12 +894,15 @@ impl DecodableImageHeader for PixmapHeader {
 
 impl DecodableImageHeader for ArbitraryHeader {
     fn tuple_type(&self) -> ImageResult<TupleType> {
+        // Note: this strictly matches the (tupltype, depth, maxval) combinations
+        // documented in the PAM spec. The NetPBM format conversion programs are
+        // similarly strict, but other decoders are more lax:
+        // - GIMP interprets the data based on its depth and ignores the tupltype
+        // - ImageMagick interprets based on tupltype, ignores depth, and interprets
+        //   as 8-bit RGB if the tupltype is missing
+
         match self.tupltype {
             _ if self.maxval == 0 => Err(DecoderError::MaxvalZero.into()),
-            None if self.depth == 1 => Ok(TupleType::GrayU8),
-            None if self.depth == 2 => Ok(TupleType::GrayAlphaU8),
-            None if self.depth == 3 => Ok(TupleType::RGBU8),
-            None if self.depth == 4 => Ok(TupleType::RGBAlphaU8),
 
             Some(ArbitraryTuplType::BlackAndWhite) if self.maxval == 1 && self.depth == 1 => {
                 Ok(TupleType::BWBit)


### PR DESCRIPTION
Per the [PAM spec](https://netpbm.sourceforge.net/doc/pam.html), the optional tupltype is needed to interpret the data values:

> Though the basic format does not assign any meaning to the tuple values, it does include an optional string that describes that meaning.

The existing decoders of note are split in how they handle images with no tupltype:
* NetPBM programs that convert to other image types, like `pamtopng`, reject them. (The generic "array manipulation" programs like `pamstretch` ignore the tupltype.)
* ImageMagick blindly assumes the format is Rgb8, no matter what the depth or maxval is
* `image`'s PnmDecoder (and GIMP) interpret depth 1,2,3,4 images as GRAYSCALE, GRAYSCALE_ALPHA, RGB, RGB_ALPHA tupltypes in that order. However, PnmDecoder assumes 8 bit depth even when the maxval is > 255. The way GIMP handles mismatched tupltypes and depths suggests its behavior is accidental.

(See attached archive for how these decode PAM images with the same binary content and different headers: [conv.tar.gz](https://github.com/user-attachments/files/25814793/conv.tar.gz).)

I'm not aware of any program that creates images without a tupltype; these could exist, but PAM is already somewhat rare.

I generally prefer a strict approach to decoding ambiguous images, and to follow the reference implementation, precisely to avoid decoding inconsistencies as described above. But if preserving backwards compatibility for this class of invalid images is needed, I could also easily make PnmDecoder match GIMP's behavior in all cases when the tupltype is missing.



