### PR TITLE
Avif EXIF and bump ravif dav1d versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,14 +42,14 @@ num-traits = { version = "0.2.0" }
 
 # Optional dependencies
 color_quant = { version = "1.1", optional = true }
-dav1d = { version = "0.10.3", optional = true }
+dav1d = { version = "0.11.0", optional = true }
 exr = { version = "1.74.0", default-features = false, optional = true }
 gif = { version = "0.14.0", optional = true }
 image-webp = { version = "0.2.0", optional = true }
 mp4parse = { version = "0.17.0", optional = true }
 png = { version = "0.18.0", optional = true }
 qoi = { version = "0.4", optional = true }
-ravif = { version = "0.12", default-features = false, optional = true }
+ravif = { version = "0.13", default-features = false, optional = true }
 rayon = { version = "1.7.0", optional = true }
 rgb = { version = "0.8.48", default-features = false, optional = true }
 tiff = { version = "0.11.2", optional = true }

--- a/src/codecs/avif/encoder.rs
+++ b/src/codecs/avif/encoder.rs
@@ -26,7 +26,7 @@ use rgb::AsPixels;
 /// Writes one image into the chosen output.
 pub struct AvifEncoder<W> {
     inner: W,
-    encoder: Encoder,
+    encoder: Encoder<'static>,
 }
 
 /// An enumeration over supported AVIF color spaces
@@ -128,6 +128,12 @@ impl<W: Write> ImageEncoder for AvifEncoder<W> {
             ImageError::Encoding(EncodingError::new(ImageFormat::Avif.into(), err))
         })?;
         self.inner.write_all(&data.avif_file)?;
+        Ok(())
+    }
+
+    fn set_exif_metadata(&mut self, exif: Vec<u8>) -> Result<(), UnsupportedError> {
+        let encoder = core::mem::replace(&mut self.encoder, Encoder::new());
+        self.encoder = encoder.with_exif(exif);
         Ok(())
     }
 }


### PR DESCRIPTION
Bump `dav1d` and `ravif` dependencies, use new `with_tiff` capability.