### PR TITLE
Don't use `f32::round` for Cicp

### DIFF
--- a/src/metadata/cicp.rs
+++ b/src/metadata/cicp.rs
@@ -1352,8 +1352,12 @@ impl ColorComponentForCicp for u8 {
 
     #[inline]
     fn clamp_from_f32(val: f32) -> Self {
-        // Note: saturating conversion does the clamp for us
-        (val * Self::MAX as f32).round() as u8
+        // Standard trick to convert f32 (0.0-1.0) to u8 (0-255) with rounding
+        // to nearest. `as u8` saturates, so it will clamp values outside the
+        // range [0.0, 1.0] to 0 or 255 (NaN is mapped to 0). `as u8` also
+        // truncates towards zero, so adding a bias of 0.5 before the truncation
+        // achieves rounding to the nearest integer.
+        (val * Self::MAX as f32 + 0.5) as u8
     }
 }
 
@@ -1365,8 +1369,8 @@ impl ColorComponentForCicp for u16 {
 
     #[inline]
     fn clamp_from_f32(val: f32) -> Self {
-        // Note: saturating conversion does the clamp for us
-        (val * Self::MAX as f32).round() as u16
+        // Same as for u8.
+        (val * Self::MAX as f32 + 0.5) as u16
     }
 }
 


### PR DESCRIPTION
Found another 2 uses of `f32::round` for f32 -> u8/u16 conversion. Just like in #2834, I replaced them with a `+ 0.5` to make them faster on x86. How much faster I don't know, since we don't have benchmarks for color space conversions. But since `clamp_from_f32` is often used in tight loops, I suspect that those loops are probably at least 2x faster now.