### PR TITLE
Don't use `f32::round` for filter 1D

### DIFF
--- a/src/imageops/filter_1d.rs
+++ b/src/imageops/filter_1d.rs
@@ -194,7 +194,7 @@ impl ToStorage<u16> for u32 {
 impl ToStorage<u16> for f32 {
     #[inline(always)]
     fn to_(self) -> u16 {
-        self.round().min(u16::MAX as f32) as u16
+        (self.min(u16::MAX as f32) + 0.5) as u16
     }
 }
 


### PR DESCRIPTION
Same as #2837. I removed `f32::round` and replaced it with `+ 0.5` for better perf on x86..

The `self.min(u16::MAX as f32)` might be unnecessary too. I left it in for now, because it maps NaN to `u16::MAX` instead of 0 (by the `as` cast). If NaN isn't a concern for filter 1D, then it can be removed too. Just let me know.