### PR TITLE
Return exit code to collect test coverage

### DIFF
--- a/tests/reference_images.rs
+++ b/tests/reference_images.rs
@@ -15,7 +15,7 @@ use image::{DynamicImage, ImageFormat};
 use libtest_mimic::{Arguments, Failed, Trial};
 use walkdir::WalkDir;
 
-fn main() {
+fn main() -> std::process::ExitCode {
     let mut trials = Vec::new();
 
     let image_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -187,7 +187,7 @@ fn main() {
     }
 
     let args = Arguments::from_args();
-    libtest_mimic::run(&args, trials).exit_if_failed();
+    libtest_mimic::run(&args, trials).exit_code()
 }
 
 /// Describes a single test case of `check_references`.


### PR DESCRIPTION
`cargo-llvm-cov` cannot write coverage data on Windows when using `.exit()`. See https://github.com/LukasKalbertodt/libtest-mimic/issues/39.

In this PR, I changed it to `.exit_if_failed()`. This allows LLVM cov to report coverage, fixing the issue.