### PR TITLE
Add sigma threshold for `new_from_sigma`

### DIFF
--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -1207,9 +1207,9 @@ impl GaussianBlurParameters {
         /// precision.
         const IDENTITY_THRESHOLD: f32 = 0.16986436;
         if sigma < IDENTITY_THRESHOLD {
-            // Any kernel of size 1 is the identity, so sigma doesn't matter.
-            // However, we pick sigma=1 to avoid  potential issues with NaN,
-            // infinities, and subnormals.
+            // Any (normalized) kernel of size 1 is the identity, so sigma
+            // doesn't matter. However, we pick sigma=1 to avoid  potential
+            // issues with NaN, infinities, and subnormals.
             return GaussianBlurParameters {
                 x_axis_kernel_size: 1,
                 x_axis_sigma: 1.0,


### PR DESCRIPTION
As [I pointed out here](https://github.com/image-rs/image/issues/2842#issuecomment-4038951260), small sigmas quickly approach a blur kernel of `[0, 1, 0]`. This kernel performs no blurring and outputs the image unchanged. As such, we can define a sigma threshold below which we assume that the image is returned unchanged (i.e. no blurring).

To repeat the table of sigma values and resulting kernels:


| sigma | kernel |
| --- | --- |
| 0.5 | `0.10651 0.78699 0.10651` |
| 0.4 | `0.04039 0.91922 0.04039` |
| 0.3 | `0.00384 0.99233 0.00384` |
| 0.2 | `0.000004 0.999993 0.000004` |
| 0.15 | `2.2e-10 0.99999999956 2.2e-10` |
| 0.1 | `1.9e-22 1.0 1.9e-22` |
| 0.05 | `1.4e-87 1.0 1.4e-87` |

I selected sigma=0.2 as the threshold, because it's close enough to `0 1 0` that no blurring is performed on u16 images. If this isn't good enough for f32 images, we can lower it to 0.15.

Ideally, we could pick the threshold based on the precision of the image being blurred, but the API currently doesn't allow this. If we want to go this route, I believe this should be done in future PRs.

---

This PR is currently blocked by a bug that causes 1x1 kernels to be applied incorrectly. This bug should be fixed before this PR is merged. I'm currently working on a fix.