### PR TITLE
perf: 5.5x faster `fast_blur` with u32 accumulators

### DIFF
--- a/src/imageops/fast_blur.rs
+++ b/src/imageops/fast_blur.rs
@@ -146,19 +146,53 @@ fn rounding_saturating_mul<T: Primitive>(v: f32, w: f32) -> T {
     T::clamp_nearest_from(v * w)
 }
 
+/// Precomputed reciprocal for fast integer division of u32 accumulators.
+///
+/// Replaces `(acc + ks/2) / ks` with a multiply-shift using the identity:
+///   `floor(n / d) == floor(n * ceil(2^32 / d) / 2^32)`
+/// which is exact for all `n` where `(d-1)*n < d * 2^32` (Granlund-Montgomery '94).
+/// For blur accumulators (`n <= kernel_size * 255`), this holds for all practical sizes.
+#[derive(Clone, Copy)]
+pub(crate) struct U8Weight {
+    reciprocal: u32, // ceil(2^32 / kernel_size)
+    rounding_bias: u32, // kernel_size / 2
+}
+
+impl U8Weight {
+    #[inline]
+    fn new(kernel_size: u32) -> Self {
+        debug_assert!(kernel_size >= 2);
+        Self {
+            // ceil(2^32 / ks) = floor((2^32 - 1) / ks) + 1 = (u32::MAX / ks) + 1
+            reciprocal: (u32::MAX / kernel_size) + 1,
+            rounding_bias: kernel_size / 2,
+        }
+    }
+
+    /// Compute `(acc + bias) / kernel_size` using reciprocal multiplication.
+    #[inline(always)]
+    fn apply(self, acc: u32) -> u8 {
+        let n = acc + self.rounding_bias;
+        ((n as u64 * self.reciprocal as u64) >> 32) as u8
+    }
+}
+
 /// Accumulator abstraction for box blur.
 /// `u8` uses `u32` integer accumulators; other types use `f32`.
 pub(crate) trait BlurAccum: Primitive + Sized {
     type Acc: Copy + Add<Output = Self::Acc> + AddAssign + Sub<Output = Self::Acc> + SubAssign;
+    type Weight: Copy;
 
     fn to_acc(self) -> Self::Acc;
     fn acc_zero() -> Self::Acc;
     fn acc_scale(acc: Self::Acc, count: usize) -> Self::Acc;
-    fn acc_to_store(acc: Self::Acc, kernel_size: usize) -> Self;
+    fn make_weight(kernel_size: usize) -> Self::Weight;
+    fn acc_to_store(acc: Self::Acc, weight: Self::Weight) -> Self;
 }
 
 impl BlurAccum for u8 {
     type Acc = u32;
+    type Weight = U8Weight;
     #[inline(always)]
     fn to_acc(self) -> u32 {
         self as u32
@@ -172,9 +206,12 @@ impl BlurAccum for u8 {
         acc * count as u32
     }
     #[inline(always)]
-    fn acc_to_store(acc: u32, kernel_size: usize) -> u8 {
-        let ks = kernel_size as u32;
-        ((acc + ks / 2) / ks) as u8
+    fn make_weight(kernel_size: usize) -> U8Weight {
+        U8Weight::new(kernel_size as u32)
+    }
+    #[inline(always)]
+    fn acc_to_store(acc: u32, weight: U8Weight) -> u8 {
+        weight.apply(acc)
     }
 }
 
@@ -182,6 +219,7 @@ macro_rules! impl_blur_accum_f32 {
     ($($t:ty),+) => { $(
         impl BlurAccum for $t {
             type Acc = f32;
+            type Weight = f32;
             #[inline(always)]
             fn to_acc(self) -> f32 {
                 self.to_f32().unwrap()
@@ -195,8 +233,12 @@ macro_rules! impl_blur_accum_f32 {
                 acc * count as f32
             }
             #[inline(always)]
-            fn acc_to_store(acc: f32, kernel_size: usize) -> Self {
-                rounding_saturating_mul(acc, 1.0 / kernel_size as f32)
+            fn make_weight(kernel_size: usize) -> f32 {
+                1.0 / kernel_size as f32
+            }
+            #[inline(always)]
+            fn acc_to_store(acc: f32, weight: f32) -> Self {
+                rounding_saturating_mul(acc, weight)
             }
         }
     )+ };
@@ -262,6 +304,7 @@ fn box_blur_horizontal_pass<P: BlurAccum, const CN: usize>(
     test_radius_size(width as usize, radius);
 
     let kernel_size = radius * 2 + 1;
+    let weight = P::make_weight(kernel_size);
     let edge_count = (kernel_size / 2) + 1;
     let half_kernel = kernel_size / 2;
     let width_bound = width as usize - 1;
@@ -299,7 +342,7 @@ fn box_blur_horizontal_pass<P: BlurAccum, const CN: usize>(
 
             let dst_chunk = &mut dst[x * CN..x * CN + CN];
             for c in 0..CN {
-                dst_chunk[c] = P::acc_to_store(sums[c], kernel_size);
+                dst_chunk[c] = P::acc_to_store(sums[c], weight);
             }
 
             let next_chunk = &src[next..next + CN];
@@ -330,7 +373,7 @@ fn box_blur_horizontal_pass<P: BlurAccum, const CN: usize>(
                 .zip(advanced_kernel_part_chunks)
             {
                 for c in 0..CN {
-                    dst_chunk[c] = P::acc_to_store(sums[c], kernel_size);
+                    dst_chunk[c] = P::acc_to_store(sums[c], weight);
                 }
                 for c in 0..CN {
                     sums[c] += src_next[c].to_acc();
@@ -347,7 +390,7 @@ fn box_blur_horizontal_pass<P: BlurAccum, const CN: usize>(
 
             let dst_chunk = &mut dst[x * CN..x * CN + CN];
             for c in 0..CN {
-                dst_chunk[c] = P::acc_to_store(sums[c], kernel_size);
+                dst_chunk[c] = P::acc_to_store(sums[c], weight);
             }
 
             let next_chunk = &src[next..next + CN];
@@ -376,6 +419,7 @@ fn box_blur_vertical_pass<P: BlurAccum>(
     test_radius_size(width as usize, radius);
 
     let kernel_size = radius * 2 + 1;
+    let weight = P::make_weight(kernel_size);
     let edge_count = (kernel_size / 2) + 1;
     let half_kernel = kernel_size / 2;
     let height_bound = height as usize - 1;
@@ -413,7 +457,7 @@ fn box_blur_vertical_pass<P: BlurAccum>(
             .zip(dst_row.iter_mut())
         {
             let acc = *buf;
-            *dst = P::acc_to_store(acc, kernel_size);
+            *dst = P::acc_to_store(acc, weight);
             *buf = acc + src_next.to_acc() - src_previous.to_acc();
         }
     }
@@ -504,6 +548,40 @@ mod tests {
                 }
                 _ => {}
             }
+        }
+    }
+
+    #[test]
+    fn test_u8_weight_exhaustive_small() {
+        use super::U8Weight;
+        // Exhaustive check for small kernel sizes
+        for ks in (3u32..=51).step_by(2) {
+            let w = U8Weight::new(ks);
+            let max_acc = ks * 255;
+            for acc in 0..=max_acc {
+                let expected = ((acc + ks / 2) / ks) as u8;
+                let got = w.apply(acc);
+                assert_eq!(got, expected, "ks={ks}, acc={acc}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_u8_weight_sampled_large() {
+        use super::U8Weight;
+        // Sampled check for larger kernel sizes
+        for ks in (53u32..=1025).step_by(2) {
+            let w = U8Weight::new(ks);
+            let max_acc = ks * 255;
+            let step = (max_acc / 10_000).max(1) as usize;
+            for acc in (0..=max_acc).step_by(step) {
+                let expected = ((acc + ks / 2) / ks) as u8;
+                let got = w.apply(acc);
+                assert_eq!(got, expected, "ks={ks}, acc={acc}");
+            }
+            // Always check boundaries
+            assert_eq!(w.apply(0), ((0 + ks / 2) / ks) as u8);
+            assert_eq!(w.apply(max_acc), ((max_acc + ks / 2) / ks) as u8);
         }
     }
 }

--- a/src/imageops/fast_blur.rs
+++ b/src/imageops/fast_blur.rs
@@ -1,4 +1,6 @@
-use num_traits::Bounded;
+use std::ops::{Add, AddAssign, Sub, SubAssign};
+
+use num_traits::{Bounded, ToPrimitive};
 
 use crate::imageops::filter_1d::{SafeAdd, SafeMul};
 use crate::{ImageBuffer, Pixel, Primitive};
@@ -18,10 +20,14 @@ use crate::{ImageBuffer, Pixel, Primitive};
 /// Source: Kovesi, P.:  Fast Almost-Gaussian Filtering The Australian Pattern
 /// Recognition Society Conference: DICTA 2010. December 2010. Sydney.
 #[must_use]
+#[expect(private_bounds)]
 pub fn fast_blur<P: Pixel>(
     input_buffer: &ImageBuffer<P, Vec<P::Subpixel>>,
     sigma: f32,
-) -> ImageBuffer<P, Vec<P::Subpixel>> {
+) -> ImageBuffer<P, Vec<P::Subpixel>>
+where
+    P::Subpixel: BlurAccum,
+{
     let (width, height) = input_buffer.dimensions();
 
     if width == 0 || height == 0 {
@@ -57,7 +63,7 @@ pub fn fast_blur<P: Pixel>(
     test_radius_size(width as usize, first_box);
     test_radius_size(height as usize, first_box);
 
-    box_blur_horizontal_pass_strategy::<P, P::Subpixel>(
+    box_blur_horizontal_pass_strategy::<P>(
         samples,
         stride,
         &mut transient,
@@ -66,7 +72,7 @@ pub fn fast_blur<P: Pixel>(
         first_box,
     );
 
-    box_blur_vertical_pass_strategy::<P, P::Subpixel>(
+    box_blur_vertical_pass_strategy::<P>(
         &transient, stride, &mut dst, stride, width, height, first_box,
     );
 
@@ -75,7 +81,7 @@ pub fn fast_blur<P: Pixel>(
         test_radius_size(width as usize, box_container);
         test_radius_size(height as usize, box_container);
 
-        box_blur_horizontal_pass_strategy::<P, P::Subpixel>(
+        box_blur_horizontal_pass_strategy::<P>(
             &dst,
             stride,
             &mut transient,
@@ -84,7 +90,7 @@ pub fn fast_blur<P: Pixel>(
             box_container,
         );
 
-        box_blur_vertical_pass_strategy::<P, P::Subpixel>(
+        box_blur_vertical_pass_strategy::<P>(
             &transient,
             stride,
             &mut dst,
@@ -140,39 +146,99 @@ fn rounding_saturating_mul<T: Primitive>(v: f32, w: f32) -> T {
     T::clamp_nearest_from(v * w)
 }
 
-fn box_blur_horizontal_pass_strategy<T, P: Primitive>(
-    src: &[P],
+/// Accumulator abstraction for box blur.
+/// `u8` uses `u32` integer accumulators; other types use `f32`.
+pub(crate) trait BlurAccum: Primitive + Sized {
+    type Acc: Copy + Add<Output = Self::Acc> + AddAssign + Sub<Output = Self::Acc> + SubAssign;
+
+    fn to_acc(self) -> Self::Acc;
+    fn acc_zero() -> Self::Acc;
+    fn acc_scale(acc: Self::Acc, count: usize) -> Self::Acc;
+    fn acc_to_store(acc: Self::Acc, kernel_size: usize) -> Self;
+}
+
+impl BlurAccum for u8 {
+    type Acc = u32;
+    #[inline(always)]
+    fn to_acc(self) -> u32 {
+        self as u32
+    }
+    #[inline(always)]
+    fn acc_zero() -> u32 {
+        0
+    }
+    #[inline(always)]
+    fn acc_scale(acc: u32, count: usize) -> u32 {
+        acc * count as u32
+    }
+    #[inline(always)]
+    fn acc_to_store(acc: u32, kernel_size: usize) -> u8 {
+        let ks = kernel_size as u32;
+        ((acc + ks / 2) / ks) as u8
+    }
+}
+
+macro_rules! impl_blur_accum_f32 {
+    ($($t:ty),+) => { $(
+        impl BlurAccum for $t {
+            type Acc = f32;
+            #[inline(always)]
+            fn to_acc(self) -> f32 {
+                self.to_f32().unwrap()
+            }
+            #[inline(always)]
+            fn acc_zero() -> f32 {
+                0.0
+            }
+            #[inline(always)]
+            fn acc_scale(acc: f32, count: usize) -> f32 {
+                acc * count as f32
+            }
+            #[inline(always)]
+            fn acc_to_store(acc: f32, kernel_size: usize) -> Self {
+                rounding_saturating_mul(acc, 1.0 / kernel_size as f32)
+            }
+        }
+    )+ };
+}
+
+impl_blur_accum_f32!(u16, f32, f64);
+
+fn box_blur_horizontal_pass_strategy<T: Pixel>(
+    src: &[T::Subpixel],
     src_stride: usize,
-    dst: &mut [P],
+    dst: &mut [T::Subpixel],
     dst_stride: usize,
     width: u32,
     radius: usize,
 ) where
-    T: Pixel,
+    T::Subpixel: BlurAccum,
 {
     if T::CHANNEL_COUNT == 1 {
-        box_blur_horizontal_pass_impl::<P, 1>(src, src_stride, dst, dst_stride, width, radius);
+        box_blur_horizontal_pass::<T::Subpixel, 1>(src, src_stride, dst, dst_stride, width, radius);
     } else if T::CHANNEL_COUNT == 2 {
-        box_blur_horizontal_pass_impl::<P, 2>(src, src_stride, dst, dst_stride, width, radius);
+        box_blur_horizontal_pass::<T::Subpixel, 2>(src, src_stride, dst, dst_stride, width, radius);
     } else if T::CHANNEL_COUNT == 3 {
-        box_blur_horizontal_pass_impl::<P, 3>(src, src_stride, dst, dst_stride, width, radius);
+        box_blur_horizontal_pass::<T::Subpixel, 3>(src, src_stride, dst, dst_stride, width, radius);
     } else if T::CHANNEL_COUNT == 4 {
-        box_blur_horizontal_pass_impl::<P, 4>(src, src_stride, dst, dst_stride, width, radius);
+        box_blur_horizontal_pass::<T::Subpixel, 4>(src, src_stride, dst, dst_stride, width, radius);
     } else {
         unimplemented!("More than 4 channels is not yet implemented");
     }
 }
 
-fn box_blur_vertical_pass_strategy<T: Pixel, P: Primitive>(
-    src: &[P],
+fn box_blur_vertical_pass_strategy<T: Pixel>(
+    src: &[T::Subpixel],
     src_stride: usize,
-    dst: &mut [P],
+    dst: &mut [T::Subpixel],
     dst_stride: usize,
     width: u32,
     height: u32,
     radius: usize,
-) {
-    box_blur_vertical_pass_impl::<P>(
+) where
+    T::Subpixel: BlurAccum,
+{
+    box_blur_vertical_pass::<T::Subpixel>(
         src,
         src_stride,
         dst,
@@ -184,25 +250,20 @@ fn box_blur_vertical_pass_strategy<T: Pixel, P: Primitive>(
     );
 }
 
-fn box_blur_horizontal_pass_impl<T, const CN: usize>(
-    src: &[T],
+fn box_blur_horizontal_pass<P: BlurAccum, const CN: usize>(
+    src: &[P],
     src_stride: usize,
-    dst: &mut [T],
+    dst: &mut [P],
     dst_stride: usize,
     width: u32,
     radius: usize,
-) where
-    T: Primitive,
-{
+) {
     assert!(width > 0, "Width must be sanitized before this method");
     test_radius_size(width as usize, radius);
 
     let kernel_size = radius * 2 + 1;
-    let edge_count = ((kernel_size / 2) + 1) as f32;
+    let edge_count = (kernel_size / 2) + 1;
     let half_kernel = kernel_size / 2;
-
-    let weight = 1f32 / (radius * 2 + 1) as f32;
-
     let width_bound = width as usize - 1;
 
     // Horizontal blurring consists from 4 phases
@@ -215,36 +276,20 @@ fn box_blur_horizontal_pass_impl<T, const CN: usize>(
         .chunks_exact_mut(dst_stride)
         .zip(src.chunks_exact(src_stride))
     {
-        let mut weight1: f32 = 0.;
-        let mut weight2: f32 = 0.;
-        let mut weight3: f32 = 0.;
+        let mut sums = [P::acc_zero(); CN];
 
         let chunk0 = &src[..CN];
 
         // replicate edge
-        let mut weight0 = chunk0[0].to_f32().unwrap() * edge_count;
-        if CN > 1 {
-            weight1 = chunk0[1].to_f32().unwrap() * edge_count;
-        }
-        if CN > 2 {
-            weight2 = chunk0[2].to_f32().unwrap() * edge_count;
-        }
-        if CN == 4 {
-            weight3 = chunk0[3].to_f32().unwrap() * edge_count;
+        for c in 0..CN {
+            sums[c] = P::acc_scale(chunk0[c].to_acc(), edge_count);
         }
 
         for x in 1..=half_kernel {
             let px = x.min(width_bound) * CN;
-            let chunk0 = &src[px..px + CN];
-            weight0 += chunk0[0].to_f32().unwrap();
-            if CN > 1 {
-                weight1 += chunk0[1].to_f32().unwrap();
-            }
-            if CN > 2 {
-                weight2 += chunk0[2].to_f32().unwrap();
-            }
-            if CN == 4 {
-                weight3 += chunk0[3].to_f32().unwrap();
+            let chunk = &src[px..px + CN];
+            for c in 0..CN {
+                sums[c] += chunk[c].to_acc();
             }
         }
 
@@ -253,40 +298,15 @@ fn box_blur_horizontal_pass_impl<T, const CN: usize>(
             let previous = (x as i64 - half_kernel as i64).max(0) as usize * CN;
 
             let dst_chunk = &mut dst[x * CN..x * CN + CN];
-            dst_chunk[0] = rounding_saturating_mul(weight0, weight);
-            if CN > 1 {
-                dst_chunk[1] = rounding_saturating_mul(weight1, weight);
-            }
-            if CN > 2 {
-                dst_chunk[2] = rounding_saturating_mul(weight2, weight);
-            }
-            if CN == 4 {
-                dst_chunk[3] = rounding_saturating_mul(weight3, weight);
+            for c in 0..CN {
+                dst_chunk[c] = P::acc_to_store(sums[c], kernel_size);
             }
 
             let next_chunk = &src[next..next + CN];
             let previous_chunk = &src[previous..previous + CN];
-
-            weight0 += next_chunk[0].to_f32().unwrap();
-            if CN > 1 {
-                weight1 += next_chunk[1].to_f32().unwrap();
-            }
-            if CN > 2 {
-                weight2 += next_chunk[2].to_f32().unwrap();
-            }
-            if CN == 4 {
-                weight3 += next_chunk[3].to_f32().unwrap();
-            }
-
-            weight0 -= previous_chunk[0].to_f32().unwrap();
-            if CN > 1 {
-                weight1 -= previous_chunk[1].to_f32().unwrap();
-            }
-            if CN > 2 {
-                weight2 -= previous_chunk[2].to_f32().unwrap();
-            }
-            if CN == 4 {
-                weight3 -= previous_chunk[3].to_f32().unwrap();
+            for c in 0..CN {
+                sums[c] += next_chunk[c].to_acc();
+                sums[c] -= previous_chunk[c].to_acc();
             }
         }
 
@@ -309,37 +329,12 @@ fn box_blur_horizontal_pass_impl<T, const CN: usize>(
                 .zip(data_section_chunks)
                 .zip(advanced_kernel_part_chunks)
             {
-                dst_chunk[0] = rounding_saturating_mul(weight0, weight);
-                if CN > 1 {
-                    dst_chunk[1] = rounding_saturating_mul(weight1, weight);
+                for c in 0..CN {
+                    dst_chunk[c] = P::acc_to_store(sums[c], kernel_size);
                 }
-                if CN > 2 {
-                    dst_chunk[2] = rounding_saturating_mul(weight2, weight);
-                }
-                if CN == 4 {
-                    dst_chunk[3] = rounding_saturating_mul(weight3, weight);
-                }
-
-                weight0 += src_next[0].to_f32().unwrap();
-                if CN > 1 {
-                    weight1 += src_next[1].to_f32().unwrap();
-                }
-                if CN > 2 {
-                    weight2 += src_next[2].to_f32().unwrap();
-                }
-                if CN == 4 {
-                    weight3 += src_next[3].to_f32().unwrap();
-                }
-
-                weight0 -= src_previous[0].to_f32().unwrap();
-                if CN > 1 {
-                    weight1 -= src_previous[1].to_f32().unwrap();
-                }
-                if CN > 2 {
-                    weight2 -= src_previous[2].to_f32().unwrap();
-                }
-                if CN == 4 {
-                    weight3 -= src_previous[3].to_f32().unwrap();
+                for c in 0..CN {
+                    sums[c] += src_next[c].to_acc();
+                    sums[c] -= src_previous[c].to_acc();
                 }
             }
 
@@ -349,51 +344,27 @@ fn box_blur_horizontal_pass_impl<T, const CN: usize>(
         for x in last_processed_item..width as usize {
             let next = (x + half_kernel + 1).min(width_bound) * CN;
             let previous = (x as i64 - half_kernel as i64).max(0) as usize * CN;
+
             let dst_chunk = &mut dst[x * CN..x * CN + CN];
-            dst_chunk[0] = rounding_saturating_mul(weight0, weight);
-            if CN > 1 {
-                dst_chunk[1] = rounding_saturating_mul(weight1, weight);
-            }
-            if CN > 2 {
-                dst_chunk[2] = rounding_saturating_mul(weight2, weight);
-            }
-            if CN == 4 {
-                dst_chunk[3] = rounding_saturating_mul(weight3, weight);
+            for c in 0..CN {
+                dst_chunk[c] = P::acc_to_store(sums[c], kernel_size);
             }
 
             let next_chunk = &src[next..next + CN];
             let previous_chunk = &src[previous..previous + CN];
-
-            weight0 += next_chunk[0].to_f32().unwrap();
-            if CN > 1 {
-                weight1 += next_chunk[1].to_f32().unwrap();
-            }
-            if CN > 2 {
-                weight2 += next_chunk[2].to_f32().unwrap();
-            }
-            if CN == 4 {
-                weight3 += next_chunk[3].to_f32().unwrap();
-            }
-
-            weight0 -= previous_chunk[0].to_f32().unwrap();
-            if CN > 1 {
-                weight1 -= previous_chunk[1].to_f32().unwrap();
-            }
-            if CN > 2 {
-                weight2 -= previous_chunk[2].to_f32().unwrap();
-            }
-            if CN == 4 {
-                weight3 -= previous_chunk[3].to_f32().unwrap();
+            for c in 0..CN {
+                sums[c] += next_chunk[c].to_acc();
+                sums[c] -= previous_chunk[c].to_acc();
             }
         }
     }
 }
 
 #[allow(clippy::too_many_arguments)]
-fn box_blur_vertical_pass_impl<T: Primitive>(
-    src: &[T],
+fn box_blur_vertical_pass<P: BlurAccum>(
+    src: &[P],
     src_stride: usize,
-    dst: &mut [T],
+    dst: &mut [P],
     dst_stride: usize,
     width: u32,
     height: u32,
@@ -405,17 +376,11 @@ fn box_blur_vertical_pass_impl<T: Primitive>(
     test_radius_size(width as usize, radius);
 
     let kernel_size = radius * 2 + 1;
-
-    let edge_count = ((kernel_size / 2) + 1) as f32;
+    let edge_count = (kernel_size / 2) + 1;
     let half_kernel = kernel_size / 2;
-
-    let weight = 1f32 / (radius * 2 + 1) as f32;
+    let height_bound = height as usize - 1;
 
     let buf_size = width as usize * n;
-
-    let buf_cap = buf_size;
-
-    let height_bound = height as usize - 1;
 
     // Instead of summing each column separately we use here transient buffer that
     // averages columns in row manner.
@@ -423,38 +388,33 @@ fn box_blur_vertical_pass_impl<T: Primitive>(
     // and then doing blur by averaging the whole row ( which is in buffer )
     // and subtracting and adding next and previous rows in horizontal manner.
 
-    let mut buffer = vec![0f32; buf_cap];
+    let mut buffer = vec![P::acc_zero(); buf_size];
 
-    for (x, (v, bf)) in src.iter().zip(buffer.iter_mut()).enumerate() {
-        let mut w = v.to_f32().unwrap() * edge_count;
+    for (x, bf) in buffer.iter_mut().enumerate() {
+        let mut w = P::acc_scale(src[x].to_acc(), edge_count);
         for y in 1..=half_kernel {
             let y_src_shift = y.min(height_bound) * src_stride;
-            w += src[y_src_shift + x].to_f32().unwrap();
+            w += src[y_src_shift + x].to_acc();
         }
         *bf = w;
     }
 
-    for (dst, y) in dst.chunks_exact_mut(dst_stride).zip(0..height as usize) {
+    for (dst_row, y) in dst.chunks_exact_mut(dst_stride).zip(0..height as usize) {
         let next = (y + half_kernel + 1).min(height_bound) * src_stride;
         let previous = (y as i64 - half_kernel as i64).max(0) as usize * src_stride;
 
-        let next_row = &src[next..next + width as usize * n];
-        let previous_row = &src[previous..previous + width as usize * n];
+        let next_row = &src[next..next + buf_size];
+        let previous_row = &src[previous..previous + buf_size];
 
-        for (((src_next, src_previous), buffer), dst) in next_row
+        for (((src_next, src_previous), buf), dst) in next_row
             .iter()
             .zip(previous_row.iter())
             .zip(buffer.iter_mut())
-            .zip(dst.iter_mut())
+            .zip(dst_row.iter_mut())
         {
-            let mut weight0 = *buffer;
-
-            *dst = rounding_saturating_mul(weight0, weight);
-
-            weight0 += src_next.to_f32().unwrap();
-            weight0 -= src_previous.to_f32().unwrap();
-
-            *buffer = weight0;
+            let acc = *buf;
+            *dst = P::acc_to_store(acc, kernel_size);
+            *buf = acc + src_next.to_acc() - src_previous.to_acc();
         }
     }
 }

--- a/src/imageops/fast_blur.rs
+++ b/src/imageops/fast_blur.rs
@@ -135,7 +135,6 @@ fn ceil_to_odd(x: usize) -> usize {
     }
 }
 
-#[inline]
 fn box_blur_horizontal_pass_strategy<T: Pixel>(
     src: &[T::Subpixel],
     src_stride: usize,
@@ -205,7 +204,7 @@ fn box_blur_horizontal_pass<P: Primitive, const CN: usize>(
         .chunks_exact_mut(dst_stride)
         .zip(src.chunks_exact(src_stride))
     {
-        let mut sums = [P::ZERO; CN];
+        let mut sums = [P::EMPTY_ACCUMULATOR; CN];
 
         let chunk0 = &src[..CN];
 
@@ -318,7 +317,7 @@ fn box_blur_vertical_pass<P: Primitive>(
     // and then doing blur by averaging the whole row ( which is in buffer )
     // and subtracting and adding next and previous rows in horizontal manner.
 
-    let mut buffer = vec![P::ZERO; buf_size];
+    let mut buffer = vec![P::EMPTY_ACCUMULATOR; buf_size];
 
     for (x, bf) in buffer.iter_mut().enumerate() {
         let mut w = P::scale(src[x].to_acc(), edge_count);

--- a/src/imageops/fast_blur.rs
+++ b/src/imageops/fast_blur.rs
@@ -1,7 +1,101 @@
+use std::ops::{Add, AddAssign, Sub, SubAssign};
+
 use num_traits::Bounded;
 
 use crate::imageops::filter_1d::{SafeAdd, SafeMul};
+use crate::primitive_sealed::WithBlurAcc;
 use crate::{ImageBuffer, Pixel, Primitive};
+
+/// Accumulator type for box blur of subpixel type `T`.
+pub(crate) trait BlurAccumulator<T>:
+    Copy + Sized + Add<Output = Self> + AddAssign + Sub<Output = Self> + SubAssign
+{
+    type Weight: Copy;
+
+    const ZERO: Self;
+
+    /// Lift a single source sample into the accumulator type.
+    fn from_primitive(value: T) -> Self;
+    /// Multiply an accumulator by an integer count (used for edge replication).
+    fn scale(self, count: usize) -> Self;
+    /// Precompute the per-kernel-size weight applied at every store.
+    fn create_weight(kernel_size: usize) -> Self::Weight;
+    /// Apply the weight and convert back to the source primitive.
+    fn to_store(self, weight: Self::Weight) -> T;
+}
+
+/// Precomputed reciprocal for fast integer division of u32 accumulators.
+///
+/// Replaces `(acc + ks/2) / ks` with a multiply-shift using the identity:
+///   `floor(n / d) == floor(n * ceil(2^32 / d) / 2^32)`
+/// which is exact for all `n` where `(d-1)*n < d * 2^32` (Granlund-Montgomery '94).
+/// For blur accumulators (`n <= kernel_size * 255`), this holds for all practical sizes.
+#[derive(Clone, Copy)]
+pub(crate) struct U8Weight {
+    reciprocal: u32,    // ceil(2^32 / kernel_size)
+    rounding_bias: u32, // kernel_size / 2
+}
+
+impl U8Weight {
+    #[inline]
+    fn new(kernel_size: u32) -> Self {
+        debug_assert!(kernel_size >= 2);
+        Self {
+            // ceil(2^32 / ks) = floor((2^32 - 1) / ks) + 1 = (u32::MAX / ks) + 1
+            reciprocal: (u32::MAX / kernel_size) + 1,
+            rounding_bias: kernel_size / 2,
+        }
+    }
+
+    /// Compute `(acc + bias) / kernel_size` using reciprocal multiplication.
+    #[inline(always)]
+    fn apply(self, acc: u32) -> u8 {
+        let n = acc + self.rounding_bias;
+        ((n as u64 * self.reciprocal as u64) >> 32) as u8
+    }
+}
+
+impl BlurAccumulator<u8> for u32 {
+    type Weight = U8Weight;
+    const ZERO: u32 = 0;
+    #[inline(always)]
+    fn from_primitive(value: u8) -> u32 {
+        value as u32
+    }
+    #[inline(always)]
+    fn scale(self, count: usize) -> u32 {
+        self * count as u32
+    }
+    #[inline(always)]
+    fn create_weight(kernel_size: usize) -> U8Weight {
+        U8Weight::new(kernel_size as u32)
+    }
+    #[inline(always)]
+    fn to_store(self, weight: U8Weight) -> u8 {
+        weight.apply(self)
+    }
+}
+
+impl<T: Primitive> BlurAccumulator<T> for f32 {
+    type Weight = f32;
+    const ZERO: f32 = 0.0;
+    #[inline(always)]
+    fn from_primitive(value: T) -> f32 {
+        value.to_f32().unwrap()
+    }
+    #[inline(always)]
+    fn scale(self, count: usize) -> f32 {
+        self * count as f32
+    }
+    #[inline(always)]
+    fn create_weight(kernel_size: usize) -> f32 {
+        1.0 / kernel_size as f32
+    }
+    #[inline(always)]
+    fn to_store(self, weight: f32) -> T {
+        T::clamp_nearest_from(self * weight)
+    }
+}
 
 /// Approximation of Gaussian blur.
 ///
@@ -188,8 +282,8 @@ fn box_blur_horizontal_pass<P: Primitive, const CN: usize>(
     assert!(width > 0, "Width must be sanitized before this method");
     test_radius_size(width as usize, radius);
 
+    type Acc<P> = <P as WithBlurAcc>::BlurAcc;
     let kernel_size = radius * 2 + 1;
-    let weight = P::make_weight(kernel_size);
     let edge_count = (kernel_size / 2) + 1;
     let half_kernel = kernel_size / 2;
     let width_bound = width as usize - 1;
@@ -204,20 +298,20 @@ fn box_blur_horizontal_pass<P: Primitive, const CN: usize>(
         .chunks_exact_mut(dst_stride)
         .zip(src.chunks_exact(src_stride))
     {
-        let mut sums = [P::EMPTY_ACCUMULATOR; CN];
+        let mut sums = [Acc::<P>::ZERO; CN];
 
         let chunk0 = &src[..CN];
 
         // replicate edge
         for c in 0..CN {
-            sums[c] = P::scale(chunk0[c].to_acc(), edge_count);
+            sums[c] = Acc::<P>::from_primitive(chunk0[c]).scale(edge_count);
         }
 
         for x in 1..=half_kernel {
             let px = x.min(width_bound) * CN;
             let chunk = &src[px..px + CN];
             for c in 0..CN {
-                sums[c] += chunk[c].to_acc();
+                sums[c] += Acc::<P>::from_primitive(chunk[c]);
             }
         }
 
@@ -227,14 +321,14 @@ fn box_blur_horizontal_pass<P: Primitive, const CN: usize>(
 
             let dst_chunk = &mut dst[x * CN..x * CN + CN];
             for c in 0..CN {
-                dst_chunk[c] = P::to_store(sums[c], weight);
+                dst_chunk[c] = sums[c].to_store(Acc::<P>::create_weight(kernel_size));
             }
 
             let next_chunk = &src[next..next + CN];
             let previous_chunk = &src[previous..previous + CN];
             for c in 0..CN {
-                sums[c] += next_chunk[c].to_acc();
-                sums[c] -= previous_chunk[c].to_acc();
+                sums[c] += Acc::<P>::from_primitive(next_chunk[c]);
+                sums[c] -= Acc::<P>::from_primitive(previous_chunk[c]);
             }
         }
 
@@ -258,11 +352,11 @@ fn box_blur_horizontal_pass<P: Primitive, const CN: usize>(
                 .zip(advanced_kernel_part_chunks)
             {
                 for c in 0..CN {
-                    dst_chunk[c] = P::to_store(sums[c], weight);
+                    dst_chunk[c] = sums[c].to_store(Acc::<P>::create_weight(kernel_size));
                 }
                 for c in 0..CN {
-                    sums[c] += src_next[c].to_acc();
-                    sums[c] -= src_previous[c].to_acc();
+                    sums[c] += Acc::<P>::from_primitive(src_next[c]);
+                    sums[c] -= Acc::<P>::from_primitive(src_previous[c]);
                 }
             }
 
@@ -275,14 +369,14 @@ fn box_blur_horizontal_pass<P: Primitive, const CN: usize>(
 
             let dst_chunk = &mut dst[x * CN..x * CN + CN];
             for c in 0..CN {
-                dst_chunk[c] = P::to_store(sums[c], weight);
+                dst_chunk[c] = sums[c].to_store(Acc::<P>::create_weight(kernel_size));
             }
 
             let next_chunk = &src[next..next + CN];
             let previous_chunk = &src[previous..previous + CN];
             for c in 0..CN {
-                sums[c] += next_chunk[c].to_acc();
-                sums[c] -= previous_chunk[c].to_acc();
+                sums[c] += Acc::<P>::from_primitive(next_chunk[c]);
+                sums[c] -= Acc::<P>::from_primitive(previous_chunk[c]);
             }
         }
     }
@@ -303,8 +397,8 @@ fn box_blur_vertical_pass<P: Primitive>(
     assert!(height > 0, "Height must be sanitized before this method");
     test_radius_size(width as usize, radius);
 
+    type Acc<P> = <P as WithBlurAcc>::BlurAcc;
     let kernel_size = radius * 2 + 1;
-    let weight = P::make_weight(kernel_size);
     let edge_count = (kernel_size / 2) + 1;
     let half_kernel = kernel_size / 2;
     let height_bound = height as usize - 1;
@@ -317,13 +411,13 @@ fn box_blur_vertical_pass<P: Primitive>(
     // and then doing blur by averaging the whole row ( which is in buffer )
     // and subtracting and adding next and previous rows in horizontal manner.
 
-    let mut buffer = vec![P::EMPTY_ACCUMULATOR; buf_size];
+    let mut buffer = vec![Acc::<P>::ZERO; buf_size];
 
     for (x, bf) in buffer.iter_mut().enumerate() {
-        let mut w = P::scale(src[x].to_acc(), edge_count);
+        let mut w = Acc::<P>::from_primitive(src[x]).scale(edge_count);
         for y in 1..=half_kernel {
             let y_src_shift = y.min(height_bound) * src_stride;
-            w += src[y_src_shift + x].to_acc();
+            w += Acc::<P>::from_primitive(src[y_src_shift + x]);
         }
         *bf = w;
     }
@@ -342,15 +436,47 @@ fn box_blur_vertical_pass<P: Primitive>(
             .zip(dst_row.iter_mut())
         {
             let acc = *buf;
-            *dst = P::to_store(acc, weight);
-            *buf = acc + src_next.to_acc() - src_previous.to_acc();
+            *dst = acc.to_store(Acc::<P>::create_weight(kernel_size));
+            *buf =
+                acc + Acc::<P>::from_primitive(*src_next) - Acc::<P>::from_primitive(*src_previous);
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::U8Weight;
     use crate::{DynamicImage, GrayAlphaImage, GrayImage, RgbImage, RgbaImage};
+
+    #[test]
+    fn u8_weight_exhaustive_small() {
+        for ks in (3u32..=51).step_by(2) {
+            let w = U8Weight::new(ks);
+            let max_acc = ks * 255;
+            for acc in 0..=max_acc {
+                let expected = ((acc + ks / 2) / ks) as u8;
+                let got = w.apply(acc);
+                assert_eq!(got, expected, "ks={ks}, acc={acc}");
+            }
+        }
+    }
+
+    #[test]
+    fn u8_weight_sampled_large() {
+        for ks in (53u32..=1025).step_by(2) {
+            let w = U8Weight::new(ks);
+            let max_acc = ks * 255;
+            let step = (max_acc / 10_000).max(1) as usize;
+            for acc in (0..=max_acc).step_by(step) {
+                let expected = ((acc + ks / 2) / ks) as u8;
+                let got = w.apply(acc);
+                assert_eq!(got, expected, "ks={ks}, acc={acc}");
+            }
+            assert_eq!(w.apply(0), ((ks / 2) / ks) as u8);
+            assert_eq!(w.apply(max_acc), ((max_acc + ks / 2) / ks) as u8);
+        }
+    }
+
     use std::time::{SystemTime, UNIX_EPOCH};
 
     struct Rng {

--- a/src/imageops/fast_blur.rs
+++ b/src/imageops/fast_blur.rs
@@ -14,6 +14,9 @@ pub(crate) trait BlurAccumulator<T>:
 
     const ZERO: Self;
 
+    /// Largest kernel size for which this accumulator is exact.
+    const MAX_KERNEL_SIZE: usize;
+
     /// Lift a single source sample into the accumulator type.
     fn from_primitive(value: T) -> Self;
     /// Multiply an accumulator by an integer count (used for edge replication).
@@ -39,6 +42,9 @@ pub(crate) struct U8Weight {
 impl BlurAccumulator<u8> for u32 {
     type Weight = U8Weight;
     const ZERO: u32 = 0;
+    // u32 stays exact while sum_max = kernel_size * u8::MAX fits in u32.
+    // 2^24 * 255 < 2^32 - 2^24 (also leaves headroom for the rounding bias add).
+    const MAX_KERNEL_SIZE: usize = 1 << 24;
     #[inline(always)]
     fn from_primitive(value: u8) -> u32 {
         value as u32
@@ -67,6 +73,8 @@ impl BlurAccumulator<u8> for u32 {
 impl<T: Primitive> BlurAccumulator<T> for f32 {
     type Weight = f32;
     const ZERO: f32 = 0.0;
+    // No hard overflow
+    const MAX_KERNEL_SIZE: usize = usize::MAX;
     #[inline(always)]
     fn from_primitive(value: T) -> f32 {
         value.to_f32().unwrap()
@@ -225,14 +233,44 @@ fn box_blur_horizontal_pass_strategy<T: Pixel>(
     width: u32,
     radius: usize,
 ) {
+    type Acc<P> = <P as WithBlurAcc>::BlurAcc;
+    let kernel_size = radius * 2 + 1;
+    if kernel_size <= Acc::<T::Subpixel>::MAX_KERNEL_SIZE {
+        box_blur_horizontal_pass_dispatch_cn::<T, Acc<T::Subpixel>>(
+            src, src_stride, dst, dst_stride, width, radius,
+        );
+    } else {
+        // fall back to f32, which has no overflow ceiling
+        box_blur_horizontal_pass_dispatch_cn::<T, f32>(
+            src, src_stride, dst, dst_stride, width, radius,
+        );
+    }
+}
+
+fn box_blur_horizontal_pass_dispatch_cn<T: Pixel, A: BlurAccumulator<T::Subpixel>>(
+    src: &[T::Subpixel],
+    src_stride: usize,
+    dst: &mut [T::Subpixel],
+    dst_stride: usize,
+    width: u32,
+    radius: usize,
+) {
     if T::CHANNEL_COUNT == 1 {
-        box_blur_horizontal_pass::<T::Subpixel, 1>(src, src_stride, dst, dst_stride, width, radius);
+        box_blur_horizontal_pass::<T::Subpixel, A, 1>(
+            src, src_stride, dst, dst_stride, width, radius,
+        );
     } else if T::CHANNEL_COUNT == 2 {
-        box_blur_horizontal_pass::<T::Subpixel, 2>(src, src_stride, dst, dst_stride, width, radius);
+        box_blur_horizontal_pass::<T::Subpixel, A, 2>(
+            src, src_stride, dst, dst_stride, width, radius,
+        );
     } else if T::CHANNEL_COUNT == 3 {
-        box_blur_horizontal_pass::<T::Subpixel, 3>(src, src_stride, dst, dst_stride, width, radius);
+        box_blur_horizontal_pass::<T::Subpixel, A, 3>(
+            src, src_stride, dst, dst_stride, width, radius,
+        );
     } else if T::CHANNEL_COUNT == 4 {
-        box_blur_horizontal_pass::<T::Subpixel, 4>(src, src_stride, dst, dst_stride, width, radius);
+        box_blur_horizontal_pass::<T::Subpixel, A, 4>(
+            src, src_stride, dst, dst_stride, width, radius,
+        );
     } else {
         unimplemented!("More than 4 channels is not yet implemented");
     }
@@ -247,19 +285,22 @@ fn box_blur_vertical_pass_strategy<T: Pixel>(
     height: u32,
     radius: usize,
 ) {
-    box_blur_vertical_pass::<T::Subpixel>(
-        src,
-        src_stride,
-        dst,
-        dst_stride,
-        width,
-        height,
-        radius,
-        T::CHANNEL_COUNT as usize,
-    );
+    type Acc<P> = <P as WithBlurAcc>::BlurAcc;
+    let kernel_size = radius * 2 + 1;
+    let n = T::CHANNEL_COUNT as usize;
+    if kernel_size <= Acc::<T::Subpixel>::MAX_KERNEL_SIZE {
+        box_blur_vertical_pass::<T::Subpixel, Acc<T::Subpixel>>(
+            src, src_stride, dst, dst_stride, width, height, radius, n,
+        );
+    } else {
+        // fall back to f32, which has no overflow ceiling
+        box_blur_vertical_pass::<T::Subpixel, f32>(
+            src, src_stride, dst, dst_stride, width, height, radius, n,
+        );
+    }
 }
 
-fn box_blur_horizontal_pass<P: Primitive, const CN: usize>(
+fn box_blur_horizontal_pass<P: Primitive, A: BlurAccumulator<P>, const CN: usize>(
     src: &[P],
     src_stride: usize,
     dst: &mut [P],
@@ -270,7 +311,6 @@ fn box_blur_horizontal_pass<P: Primitive, const CN: usize>(
     assert!(width > 0, "Width must be sanitized before this method");
     test_radius_size(width as usize, radius);
 
-    type Acc<P> = <P as WithBlurAcc>::BlurAcc;
     let kernel_size = radius * 2 + 1;
     let edge_count = (kernel_size / 2) + 1;
     let half_kernel = kernel_size / 2;
@@ -286,20 +326,20 @@ fn box_blur_horizontal_pass<P: Primitive, const CN: usize>(
         .chunks_exact_mut(dst_stride)
         .zip(src.chunks_exact(src_stride))
     {
-        let mut sums = [Acc::<P>::ZERO; CN];
+        let mut sums = [A::ZERO; CN];
 
         let chunk0 = &src[..CN];
 
         // replicate edge
         for c in 0..CN {
-            sums[c] = Acc::<P>::from_primitive(chunk0[c]).scale(edge_count);
+            sums[c] = A::from_primitive(chunk0[c]).scale(edge_count);
         }
 
         for x in 1..=half_kernel {
             let px = x.min(width_bound) * CN;
             let chunk = &src[px..px + CN];
             for c in 0..CN {
-                sums[c] += Acc::<P>::from_primitive(chunk[c]);
+                sums[c] += A::from_primitive(chunk[c]);
             }
         }
 
@@ -309,14 +349,14 @@ fn box_blur_horizontal_pass<P: Primitive, const CN: usize>(
 
             let dst_chunk = &mut dst[x * CN..x * CN + CN];
             for c in 0..CN {
-                dst_chunk[c] = sums[c].to_store(Acc::<P>::create_weight(kernel_size));
+                dst_chunk[c] = sums[c].to_store(A::create_weight(kernel_size));
             }
 
             let next_chunk = &src[next..next + CN];
             let previous_chunk = &src[previous..previous + CN];
             for c in 0..CN {
-                sums[c] += Acc::<P>::from_primitive(next_chunk[c]);
-                sums[c] -= Acc::<P>::from_primitive(previous_chunk[c]);
+                sums[c] += A::from_primitive(next_chunk[c]);
+                sums[c] -= A::from_primitive(previous_chunk[c]);
             }
         }
 
@@ -340,11 +380,11 @@ fn box_blur_horizontal_pass<P: Primitive, const CN: usize>(
                 .zip(advanced_kernel_part_chunks)
             {
                 for c in 0..CN {
-                    dst_chunk[c] = sums[c].to_store(Acc::<P>::create_weight(kernel_size));
+                    dst_chunk[c] = sums[c].to_store(A::create_weight(kernel_size));
                 }
                 for c in 0..CN {
-                    sums[c] += Acc::<P>::from_primitive(src_next[c]);
-                    sums[c] -= Acc::<P>::from_primitive(src_previous[c]);
+                    sums[c] += A::from_primitive(src_next[c]);
+                    sums[c] -= A::from_primitive(src_previous[c]);
                 }
             }
 
@@ -357,21 +397,21 @@ fn box_blur_horizontal_pass<P: Primitive, const CN: usize>(
 
             let dst_chunk = &mut dst[x * CN..x * CN + CN];
             for c in 0..CN {
-                dst_chunk[c] = sums[c].to_store(Acc::<P>::create_weight(kernel_size));
+                dst_chunk[c] = sums[c].to_store(A::create_weight(kernel_size));
             }
 
             let next_chunk = &src[next..next + CN];
             let previous_chunk = &src[previous..previous + CN];
             for c in 0..CN {
-                sums[c] += Acc::<P>::from_primitive(next_chunk[c]);
-                sums[c] -= Acc::<P>::from_primitive(previous_chunk[c]);
+                sums[c] += A::from_primitive(next_chunk[c]);
+                sums[c] -= A::from_primitive(previous_chunk[c]);
             }
         }
     }
 }
 
 #[allow(clippy::too_many_arguments)]
-fn box_blur_vertical_pass<P: Primitive>(
+fn box_blur_vertical_pass<P: Primitive, A: BlurAccumulator<P>>(
     src: &[P],
     src_stride: usize,
     dst: &mut [P],
@@ -385,7 +425,6 @@ fn box_blur_vertical_pass<P: Primitive>(
     assert!(height > 0, "Height must be sanitized before this method");
     test_radius_size(width as usize, radius);
 
-    type Acc<P> = <P as WithBlurAcc>::BlurAcc;
     let kernel_size = radius * 2 + 1;
     let edge_count = (kernel_size / 2) + 1;
     let half_kernel = kernel_size / 2;
@@ -399,13 +438,13 @@ fn box_blur_vertical_pass<P: Primitive>(
     // and then doing blur by averaging the whole row ( which is in buffer )
     // and subtracting and adding next and previous rows in horizontal manner.
 
-    let mut buffer = vec![Acc::<P>::ZERO; buf_size];
+    let mut buffer = vec![A::ZERO; buf_size];
 
     for (x, bf) in buffer.iter_mut().enumerate() {
-        let mut w = Acc::<P>::from_primitive(src[x]).scale(edge_count);
+        let mut w = A::from_primitive(src[x]).scale(edge_count);
         for y in 1..=half_kernel {
             let y_src_shift = y.min(height_bound) * src_stride;
-            w += Acc::<P>::from_primitive(src[y_src_shift + x]);
+            w += A::from_primitive(src[y_src_shift + x]);
         }
         *bf = w;
     }
@@ -424,9 +463,8 @@ fn box_blur_vertical_pass<P: Primitive>(
             .zip(dst_row.iter_mut())
         {
             let acc = *buf;
-            *dst = acc.to_store(Acc::<P>::create_weight(kernel_size));
-            *buf =
-                acc + Acc::<P>::from_primitive(*src_next) - Acc::<P>::from_primitive(*src_previous);
+            *dst = acc.to_store(A::create_weight(kernel_size));
+            *buf = acc + A::from_primitive(*src_next) - A::from_primitive(*src_previous);
         }
     }
 }

--- a/src/imageops/fast_blur.rs
+++ b/src/imageops/fast_blur.rs
@@ -21,8 +21,7 @@ use crate::{ImageBuffer, Pixel, Primitive};
 pub fn fast_blur<P: Pixel>(
     input_buffer: &ImageBuffer<P, Vec<P::Subpixel>>,
     sigma: f32,
-) -> ImageBuffer<P, Vec<P::Subpixel>>
-{
+) -> ImageBuffer<P, Vec<P::Subpixel>> {
     let (width, height) = input_buffer.dimensions();
 
     if width == 0 || height == 0 {
@@ -437,5 +436,4 @@ mod tests {
             }
         }
     }
-
 }

--- a/src/imageops/fast_blur.rs
+++ b/src/imageops/fast_blur.rs
@@ -36,25 +36,6 @@ pub(crate) struct U8Weight {
     rounding_bias: u32, // kernel_size / 2
 }
 
-impl U8Weight {
-    #[inline]
-    fn new(kernel_size: u32) -> Self {
-        debug_assert!(kernel_size >= 2);
-        Self {
-            // ceil(2^32 / ks) = floor((2^32 - 1) / ks) + 1 = (u32::MAX / ks) + 1
-            reciprocal: (u32::MAX / kernel_size) + 1,
-            rounding_bias: kernel_size / 2,
-        }
-    }
-
-    /// Compute `(acc + bias) / kernel_size` using reciprocal multiplication.
-    #[inline(always)]
-    fn apply(self, acc: u32) -> u8 {
-        let n = acc + self.rounding_bias;
-        ((n as u64 * self.reciprocal as u64) >> 32) as u8
-    }
-}
-
 impl BlurAccumulator<u8> for u32 {
     type Weight = U8Weight;
     const ZERO: u32 = 0;
@@ -68,11 +49,18 @@ impl BlurAccumulator<u8> for u32 {
     }
     #[inline(always)]
     fn create_weight(kernel_size: usize) -> U8Weight {
-        U8Weight::new(kernel_size as u32)
+        let ks = kernel_size as u32;
+        debug_assert!(ks >= 2);
+        U8Weight {
+            // ceil(2^32 / ks) = floor((2^32 - 1) / ks) + 1 = (u32::MAX / ks) + 1
+            reciprocal: (u32::MAX / ks) + 1,
+            rounding_bias: ks / 2,
+        }
     }
     #[inline(always)]
     fn to_store(self, weight: U8Weight) -> u8 {
-        weight.apply(self)
+        let n = self + weight.rounding_bias;
+        ((n as u64 * weight.reciprocal as u64) >> 32) as u8
     }
 }
 
@@ -445,17 +433,17 @@ fn box_blur_vertical_pass<P: Primitive>(
 
 #[cfg(test)]
 mod tests {
-    use super::U8Weight;
+    use super::BlurAccumulator;
     use crate::{DynamicImage, GrayAlphaImage, GrayImage, RgbImage, RgbaImage};
 
     #[test]
     fn u8_weight_exhaustive_small() {
         for ks in (3u32..=51).step_by(2) {
-            let w = U8Weight::new(ks);
+            let w = <u32 as BlurAccumulator<u8>>::create_weight(ks as usize);
             let max_acc = ks * 255;
             for acc in 0..=max_acc {
                 let expected = ((acc + ks / 2) / ks) as u8;
-                let got = w.apply(acc);
+                let got = acc.to_store(w);
                 assert_eq!(got, expected, "ks={ks}, acc={acc}");
             }
         }
@@ -464,16 +452,16 @@ mod tests {
     #[test]
     fn u8_weight_sampled_large() {
         for ks in (53u32..=1025).step_by(2) {
-            let w = U8Weight::new(ks);
+            let w = <u32 as BlurAccumulator<u8>>::create_weight(ks as usize);
             let max_acc = ks * 255;
             let step = (max_acc / 10_000).max(1) as usize;
             for acc in (0..=max_acc).step_by(step) {
                 let expected = ((acc + ks / 2) / ks) as u8;
-                let got = w.apply(acc);
+                let got = acc.to_store(w);
                 assert_eq!(got, expected, "ks={ks}, acc={acc}");
             }
-            assert_eq!(w.apply(0), ((ks / 2) / ks) as u8);
-            assert_eq!(w.apply(max_acc), ((max_acc + ks / 2) / ks) as u8);
+            assert_eq!(0u32.to_store(w), ((ks / 2) / ks) as u8);
+            assert_eq!(max_acc.to_store(w), ((max_acc + ks / 2) / ks) as u8);
         }
     }
 

--- a/src/imageops/fast_blur.rs
+++ b/src/imageops/fast_blur.rs
@@ -1,6 +1,4 @@
-use std::ops::{Add, AddAssign, Sub, SubAssign};
-
-use num_traits::{Bounded, ToPrimitive};
+use num_traits::Bounded;
 
 use crate::imageops::filter_1d::{SafeAdd, SafeMul};
 use crate::{ImageBuffer, Pixel, Primitive};
@@ -20,13 +18,10 @@ use crate::{ImageBuffer, Pixel, Primitive};
 /// Source: Kovesi, P.:  Fast Almost-Gaussian Filtering The Australian Pattern
 /// Recognition Society Conference: DICTA 2010. December 2010. Sydney.
 #[must_use]
-#[expect(private_bounds)]
 pub fn fast_blur<P: Pixel>(
     input_buffer: &ImageBuffer<P, Vec<P::Subpixel>>,
     sigma: f32,
 ) -> ImageBuffer<P, Vec<P::Subpixel>>
-where
-    P::Subpixel: BlurAccum,
 {
     let (width, height) = input_buffer.dimensions();
 
@@ -142,110 +137,6 @@ fn ceil_to_odd(x: usize) -> usize {
 }
 
 #[inline]
-fn rounding_saturating_mul<T: Primitive>(v: f32, w: f32) -> T {
-    T::clamp_nearest_from(v * w)
-}
-
-/// Precomputed reciprocal for fast integer division of u32 accumulators.
-///
-/// Replaces `(acc + ks/2) / ks` with a multiply-shift using the identity:
-///   `floor(n / d) == floor(n * ceil(2^32 / d) / 2^32)`
-/// which is exact for all `n` where `(d-1)*n < d * 2^32` (Granlund-Montgomery '94).
-/// For blur accumulators (`n <= kernel_size * 255`), this holds for all practical sizes.
-#[derive(Clone, Copy)]
-pub(crate) struct U8Weight {
-    reciprocal: u32, // ceil(2^32 / kernel_size)
-    rounding_bias: u32, // kernel_size / 2
-}
-
-impl U8Weight {
-    #[inline]
-    fn new(kernel_size: u32) -> Self {
-        debug_assert!(kernel_size >= 2);
-        Self {
-            // ceil(2^32 / ks) = floor((2^32 - 1) / ks) + 1 = (u32::MAX / ks) + 1
-            reciprocal: (u32::MAX / kernel_size) + 1,
-            rounding_bias: kernel_size / 2,
-        }
-    }
-
-    /// Compute `(acc + bias) / kernel_size` using reciprocal multiplication.
-    #[inline(always)]
-    fn apply(self, acc: u32) -> u8 {
-        let n = acc + self.rounding_bias;
-        ((n as u64 * self.reciprocal as u64) >> 32) as u8
-    }
-}
-
-/// Accumulator abstraction for box blur.
-/// `u8` uses `u32` integer accumulators; other types use `f32`.
-pub(crate) trait BlurAccum: Primitive + Sized {
-    type Acc: Copy + Add<Output = Self::Acc> + AddAssign + Sub<Output = Self::Acc> + SubAssign;
-    type Weight: Copy;
-
-    fn to_acc(self) -> Self::Acc;
-    fn acc_zero() -> Self::Acc;
-    fn acc_scale(acc: Self::Acc, count: usize) -> Self::Acc;
-    fn make_weight(kernel_size: usize) -> Self::Weight;
-    fn acc_to_store(acc: Self::Acc, weight: Self::Weight) -> Self;
-}
-
-impl BlurAccum for u8 {
-    type Acc = u32;
-    type Weight = U8Weight;
-    #[inline(always)]
-    fn to_acc(self) -> u32 {
-        self as u32
-    }
-    #[inline(always)]
-    fn acc_zero() -> u32 {
-        0
-    }
-    #[inline(always)]
-    fn acc_scale(acc: u32, count: usize) -> u32 {
-        acc * count as u32
-    }
-    #[inline(always)]
-    fn make_weight(kernel_size: usize) -> U8Weight {
-        U8Weight::new(kernel_size as u32)
-    }
-    #[inline(always)]
-    fn acc_to_store(acc: u32, weight: U8Weight) -> u8 {
-        weight.apply(acc)
-    }
-}
-
-macro_rules! impl_blur_accum_f32 {
-    ($($t:ty),+) => { $(
-        impl BlurAccum for $t {
-            type Acc = f32;
-            type Weight = f32;
-            #[inline(always)]
-            fn to_acc(self) -> f32 {
-                self.to_f32().unwrap()
-            }
-            #[inline(always)]
-            fn acc_zero() -> f32 {
-                0.0
-            }
-            #[inline(always)]
-            fn acc_scale(acc: f32, count: usize) -> f32 {
-                acc * count as f32
-            }
-            #[inline(always)]
-            fn make_weight(kernel_size: usize) -> f32 {
-                1.0 / kernel_size as f32
-            }
-            #[inline(always)]
-            fn acc_to_store(acc: f32, weight: f32) -> Self {
-                rounding_saturating_mul(acc, weight)
-            }
-        }
-    )+ };
-}
-
-impl_blur_accum_f32!(u16, f32, f64);
-
 fn box_blur_horizontal_pass_strategy<T: Pixel>(
     src: &[T::Subpixel],
     src_stride: usize,
@@ -253,9 +144,7 @@ fn box_blur_horizontal_pass_strategy<T: Pixel>(
     dst_stride: usize,
     width: u32,
     radius: usize,
-) where
-    T::Subpixel: BlurAccum,
-{
+) {
     if T::CHANNEL_COUNT == 1 {
         box_blur_horizontal_pass::<T::Subpixel, 1>(src, src_stride, dst, dst_stride, width, radius);
     } else if T::CHANNEL_COUNT == 2 {
@@ -277,9 +166,7 @@ fn box_blur_vertical_pass_strategy<T: Pixel>(
     width: u32,
     height: u32,
     radius: usize,
-) where
-    T::Subpixel: BlurAccum,
-{
+) {
     box_blur_vertical_pass::<T::Subpixel>(
         src,
         src_stride,
@@ -292,7 +179,7 @@ fn box_blur_vertical_pass_strategy<T: Pixel>(
     );
 }
 
-fn box_blur_horizontal_pass<P: BlurAccum, const CN: usize>(
+fn box_blur_horizontal_pass<P: Primitive, const CN: usize>(
     src: &[P],
     src_stride: usize,
     dst: &mut [P],
@@ -319,13 +206,13 @@ fn box_blur_horizontal_pass<P: BlurAccum, const CN: usize>(
         .chunks_exact_mut(dst_stride)
         .zip(src.chunks_exact(src_stride))
     {
-        let mut sums = [P::acc_zero(); CN];
+        let mut sums = [P::ZERO; CN];
 
         let chunk0 = &src[..CN];
 
         // replicate edge
         for c in 0..CN {
-            sums[c] = P::acc_scale(chunk0[c].to_acc(), edge_count);
+            sums[c] = P::scale(chunk0[c].to_acc(), edge_count);
         }
 
         for x in 1..=half_kernel {
@@ -342,7 +229,7 @@ fn box_blur_horizontal_pass<P: BlurAccum, const CN: usize>(
 
             let dst_chunk = &mut dst[x * CN..x * CN + CN];
             for c in 0..CN {
-                dst_chunk[c] = P::acc_to_store(sums[c], weight);
+                dst_chunk[c] = P::to_store(sums[c], weight);
             }
 
             let next_chunk = &src[next..next + CN];
@@ -373,7 +260,7 @@ fn box_blur_horizontal_pass<P: BlurAccum, const CN: usize>(
                 .zip(advanced_kernel_part_chunks)
             {
                 for c in 0..CN {
-                    dst_chunk[c] = P::acc_to_store(sums[c], weight);
+                    dst_chunk[c] = P::to_store(sums[c], weight);
                 }
                 for c in 0..CN {
                     sums[c] += src_next[c].to_acc();
@@ -390,7 +277,7 @@ fn box_blur_horizontal_pass<P: BlurAccum, const CN: usize>(
 
             let dst_chunk = &mut dst[x * CN..x * CN + CN];
             for c in 0..CN {
-                dst_chunk[c] = P::acc_to_store(sums[c], weight);
+                dst_chunk[c] = P::to_store(sums[c], weight);
             }
 
             let next_chunk = &src[next..next + CN];
@@ -404,7 +291,7 @@ fn box_blur_horizontal_pass<P: BlurAccum, const CN: usize>(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn box_blur_vertical_pass<P: BlurAccum>(
+fn box_blur_vertical_pass<P: Primitive>(
     src: &[P],
     src_stride: usize,
     dst: &mut [P],
@@ -432,10 +319,10 @@ fn box_blur_vertical_pass<P: BlurAccum>(
     // and then doing blur by averaging the whole row ( which is in buffer )
     // and subtracting and adding next and previous rows in horizontal manner.
 
-    let mut buffer = vec![P::acc_zero(); buf_size];
+    let mut buffer = vec![P::ZERO; buf_size];
 
     for (x, bf) in buffer.iter_mut().enumerate() {
-        let mut w = P::acc_scale(src[x].to_acc(), edge_count);
+        let mut w = P::scale(src[x].to_acc(), edge_count);
         for y in 1..=half_kernel {
             let y_src_shift = y.min(height_bound) * src_stride;
             w += src[y_src_shift + x].to_acc();
@@ -457,7 +344,7 @@ fn box_blur_vertical_pass<P: BlurAccum>(
             .zip(dst_row.iter_mut())
         {
             let acc = *buf;
-            *dst = P::acc_to_store(acc, weight);
+            *dst = P::to_store(acc, weight);
             *buf = acc + src_next.to_acc() - src_previous.to_acc();
         }
     }
@@ -551,37 +438,4 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_u8_weight_exhaustive_small() {
-        use super::U8Weight;
-        // Exhaustive check for small kernel sizes
-        for ks in (3u32..=51).step_by(2) {
-            let w = U8Weight::new(ks);
-            let max_acc = ks * 255;
-            for acc in 0..=max_acc {
-                let expected = ((acc + ks / 2) / ks) as u8;
-                let got = w.apply(acc);
-                assert_eq!(got, expected, "ks={ks}, acc={acc}");
-            }
-        }
-    }
-
-    #[test]
-    fn test_u8_weight_sampled_large() {
-        use super::U8Weight;
-        // Sampled check for larger kernel sizes
-        for ks in (53u32..=1025).step_by(2) {
-            let w = U8Weight::new(ks);
-            let max_acc = ks * 255;
-            let step = (max_acc / 10_000).max(1) as usize;
-            for acc in (0..=max_acc).step_by(step) {
-                let expected = ((acc + ks / 2) / ks) as u8;
-                let got = w.apply(acc);
-                assert_eq!(got, expected, "ks={ks}, acc={acc}");
-            }
-            // Always check boundaries
-            assert_eq!(w.apply(0), ((0 + ks / 2) / ks) as u8);
-            assert_eq!(w.apply(max_acc), ((max_acc + ks / 2) / ks) as u8);
-        }
-    }
 }

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -27,7 +27,7 @@ pub use self::colorops::{
 
 mod affine;
 mod colorops;
-mod fast_blur;
+pub(crate) mod fast_blur;
 mod filter_1d;
 pub(crate) mod resize;
 mod sample;

--- a/src/primitive_sealed.rs
+++ b/src/primitive_sealed.rs
@@ -160,7 +160,7 @@ pub trait BlurAccum: Copy + Sized {
     type Acc: Copy + Add<Output = Self::Acc> + AddAssign + Sub<Output = Self::Acc> + SubAssign;
     type Weight: Copy;
 
-    const ZERO: Self::Acc;
+    const EMPTY_ACCUMULATOR: Self::Acc;
 
     fn to_acc(self) -> Self::Acc;
     fn scale(acc: Self::Acc, count: usize) -> Self::Acc;
@@ -171,7 +171,7 @@ pub trait BlurAccum: Copy + Sized {
 impl BlurAccum for u8 {
     type Acc = u32;
     type Weight = U8Weight;
-    const ZERO: u32 = 0;
+    const EMPTY_ACCUMULATOR: u32 = 0;
     #[inline(always)]
     fn to_acc(self) -> u32 {
         self as u32
@@ -195,7 +195,7 @@ macro_rules! impl_blur_accum_f32 {
         impl BlurAccum for $t {
             type Acc = f32;
             type Weight = f32;
-            const ZERO: f32 = 0.0;
+            const EMPTY_ACCUMULATOR: f32 = 0.0;
             #[inline(always)]
             fn to_acc(self) -> f32 {
                 self.to_f32().unwrap()

--- a/src/primitive_sealed.rs
+++ b/src/primitive_sealed.rs
@@ -1,8 +1,6 @@
 //! Module for crate-private traits implemented for all primitive types.
 
-use std::ops::{Add, AddAssign, Sub, SubAssign};
-
-use num_traits::ToPrimitive;
+use crate::imageops::fast_blur::BlurAccumulator;
 
 /// Crate-private trait to seal the [`Primitive`](crate::Primitive) trait.
 ///
@@ -118,136 +116,26 @@ macro_rules! impl_nearest_from_f32_for_ints {
 }
 impl_nearest_from_f32_for_ints!(u32, u64, usize, i8, i16, i32, i64, isize);
 
-/// Precomputed reciprocal for fast integer division of u32 accumulators.
+/// Crate-private companion to [`Primitive`] that picks the box-blur
+/// accumulator type for each primitive.
 ///
-/// Replaces `(acc + ks/2) / ks` with a multiply-shift using the identity:
-///   `floor(n / d) == floor(n * ceil(2^32 / d) / 2^32)`
-/// which is exact for all `n` where `(d-1)*n < d * 2^32` (Granlund-Montgomery '94).
-/// For blur accumulators (`n <= kernel_size * 255`), this holds for all practical sizes.
-#[derive(Clone, Copy)]
-pub struct U8Weight {
-    reciprocal: u32,    // ceil(2^32 / kernel_size)
-    rounding_bias: u32, // kernel_size / 2
+/// `u8` uses an integer (`u32`) accumulator for speed; everything else goes
+/// through `f32`.
+#[allow(private_bounds)]
+pub trait WithBlurAcc: Sized {
+    type BlurAcc: BlurAccumulator<Self>;
 }
 
-impl U8Weight {
-    #[inline]
-    fn new(kernel_size: u32) -> Self {
-        debug_assert!(kernel_size >= 2);
-        Self {
-            // ceil(2^32 / ks) = floor((2^32 - 1) / ks) + 1 = (u32::MAX / ks) + 1
-            reciprocal: (u32::MAX / kernel_size) + 1,
-            rounding_bias: kernel_size / 2,
-        }
-    }
-
-    /// Compute `(acc + bias) / kernel_size` using reciprocal multiplication.
-    #[inline(always)]
-    fn apply(self, acc: u32) -> u8 {
-        let n = acc + self.rounding_bias;
-        ((n as u64 * self.reciprocal as u64) >> 32) as u8
-    }
+impl WithBlurAcc for u8 {
+    type BlurAcc = u32;
 }
 
-#[inline]
-fn rounding_saturating_mul<T: crate::Primitive>(v: f32, w: f32) -> T {
-    T::clamp_nearest_from(v * w)
-}
-
-/// Accumulator abstraction for box blur.
-/// `u8` uses `u32` integer accumulators; other types use `f32`.
-pub trait BlurAccum: Copy + Sized {
-    type Acc: Copy + Add<Output = Self::Acc> + AddAssign + Sub<Output = Self::Acc> + SubAssign;
-    type Weight: Copy;
-
-    const EMPTY_ACCUMULATOR: Self::Acc;
-
-    fn to_acc(self) -> Self::Acc;
-    fn scale(acc: Self::Acc, count: usize) -> Self::Acc;
-    fn make_weight(kernel_size: usize) -> Self::Weight;
-    fn to_store(acc: Self::Acc, weight: Self::Weight) -> Self;
-}
-
-impl BlurAccum for u8 {
-    type Acc = u32;
-    type Weight = U8Weight;
-    const EMPTY_ACCUMULATOR: u32 = 0;
-    #[inline(always)]
-    fn to_acc(self) -> u32 {
-        self as u32
-    }
-    #[inline(always)]
-    fn scale(acc: u32, count: usize) -> u32 {
-        acc * count as u32
-    }
-    #[inline(always)]
-    fn make_weight(kernel_size: usize) -> U8Weight {
-        U8Weight::new(kernel_size as u32)
-    }
-    #[inline(always)]
-    fn to_store(acc: u32, weight: U8Weight) -> u8 {
-        weight.apply(acc)
-    }
-}
-
-macro_rules! impl_blur_accum_f32 {
+macro_rules! impl_with_blur_acc_f32 {
     ($($t:ty),+) => { $(
-        impl BlurAccum for $t {
-            type Acc = f32;
-            type Weight = f32;
-            const EMPTY_ACCUMULATOR: f32 = 0.0;
-            #[inline(always)]
-            fn to_acc(self) -> f32 {
-                self.to_f32().unwrap()
-            }
-            #[inline(always)]
-            fn scale(acc: f32, count: usize) -> f32 {
-                acc * count as f32
-            }
-            #[inline(always)]
-            fn make_weight(kernel_size: usize) -> f32 {
-                1.0 / kernel_size as f32
-            }
-            #[inline(always)]
-            fn to_store(acc: f32, weight: f32) -> Self {
-                rounding_saturating_mul(acc, weight)
-            }
+        impl WithBlurAcc for $t {
+            type BlurAcc = f32;
         }
     )+ };
 }
 
-impl_blur_accum_f32!(u16, u32, u64, usize, i8, i16, i32, i64, isize, f32, f64);
-
-#[cfg(test)]
-mod tests {
-    use super::U8Weight;
-
-    #[test]
-    fn u8_weight_exhaustive_small() {
-        for ks in (3u32..=51).step_by(2) {
-            let w = U8Weight::new(ks);
-            let max_acc = ks * 255;
-            for acc in 0..=max_acc {
-                let expected = ((acc + ks / 2) / ks) as u8;
-                let got = w.apply(acc);
-                assert_eq!(got, expected, "ks={ks}, acc={acc}");
-            }
-        }
-    }
-
-    #[test]
-    fn u8_weight_sampled_large() {
-        for ks in (53u32..=1025).step_by(2) {
-            let w = U8Weight::new(ks);
-            let max_acc = ks * 255;
-            let step = (max_acc / 10_000).max(1) as usize;
-            for acc in (0..=max_acc).step_by(step) {
-                let expected = ((acc + ks / 2) / ks) as u8;
-                let got = w.apply(acc);
-                assert_eq!(got, expected, "ks={ks}, acc={acc}");
-            }
-            assert_eq!(w.apply(0), ((ks / 2) / ks) as u8);
-            assert_eq!(w.apply(max_acc), ((max_acc + ks / 2) / ks) as u8);
-        }
-    }
-}
+impl_with_blur_acc_f32!(u16, u32, u64, usize, i8, i16, i32, i64, isize, f32, f64);

--- a/src/primitive_sealed.rs
+++ b/src/primitive_sealed.rs
@@ -126,7 +126,7 @@ impl_nearest_from_f32_for_ints!(u32, u64, usize, i8, i16, i32, i64, isize);
 /// For blur accumulators (`n <= kernel_size * 255`), this holds for all practical sizes.
 #[derive(Clone, Copy)]
 pub struct U8Weight {
-    reciprocal: u32, // ceil(2^32 / kernel_size)
+    reciprocal: u32,    // ceil(2^32 / kernel_size)
     rounding_bias: u32, // kernel_size / 2
 }
 
@@ -246,7 +246,7 @@ mod tests {
                 let got = w.apply(acc);
                 assert_eq!(got, expected, "ks={ks}, acc={acc}");
             }
-            assert_eq!(w.apply(0), ((0 + ks / 2) / ks) as u8);
+            assert_eq!(w.apply(0), ((ks / 2) / ks) as u8);
             assert_eq!(w.apply(max_acc), ((max_acc + ks / 2) / ks) as u8);
         }
     }

--- a/src/primitive_sealed.rs
+++ b/src/primitive_sealed.rs
@@ -1,5 +1,9 @@
 //! Module for crate-private traits implemented for all primitive types.
 
+use std::ops::{Add, AddAssign, Sub, SubAssign};
+
+use num_traits::ToPrimitive;
+
 /// Crate-private trait to seal the [`Primitive`](crate::Primitive) trait.
 ///
 /// This trait is `pub` but not exported, so it cannot be implemented outside
@@ -113,3 +117,137 @@ macro_rules! impl_nearest_from_f32_for_ints {
     )+ };
 }
 impl_nearest_from_f32_for_ints!(u32, u64, usize, i8, i16, i32, i64, isize);
+
+/// Precomputed reciprocal for fast integer division of u32 accumulators.
+///
+/// Replaces `(acc + ks/2) / ks` with a multiply-shift using the identity:
+///   `floor(n / d) == floor(n * ceil(2^32 / d) / 2^32)`
+/// which is exact for all `n` where `(d-1)*n < d * 2^32` (Granlund-Montgomery '94).
+/// For blur accumulators (`n <= kernel_size * 255`), this holds for all practical sizes.
+#[derive(Clone, Copy)]
+pub struct U8Weight {
+    reciprocal: u32, // ceil(2^32 / kernel_size)
+    rounding_bias: u32, // kernel_size / 2
+}
+
+impl U8Weight {
+    #[inline]
+    fn new(kernel_size: u32) -> Self {
+        debug_assert!(kernel_size >= 2);
+        Self {
+            // ceil(2^32 / ks) = floor((2^32 - 1) / ks) + 1 = (u32::MAX / ks) + 1
+            reciprocal: (u32::MAX / kernel_size) + 1,
+            rounding_bias: kernel_size / 2,
+        }
+    }
+
+    /// Compute `(acc + bias) / kernel_size` using reciprocal multiplication.
+    #[inline(always)]
+    fn apply(self, acc: u32) -> u8 {
+        let n = acc + self.rounding_bias;
+        ((n as u64 * self.reciprocal as u64) >> 32) as u8
+    }
+}
+
+#[inline]
+fn rounding_saturating_mul<T: crate::Primitive>(v: f32, w: f32) -> T {
+    T::clamp_nearest_from(v * w)
+}
+
+/// Accumulator abstraction for box blur.
+/// `u8` uses `u32` integer accumulators; other types use `f32`.
+pub trait BlurAccum: Copy + Sized {
+    type Acc: Copy + Add<Output = Self::Acc> + AddAssign + Sub<Output = Self::Acc> + SubAssign;
+    type Weight: Copy;
+
+    const ZERO: Self::Acc;
+
+    fn to_acc(self) -> Self::Acc;
+    fn scale(acc: Self::Acc, count: usize) -> Self::Acc;
+    fn make_weight(kernel_size: usize) -> Self::Weight;
+    fn to_store(acc: Self::Acc, weight: Self::Weight) -> Self;
+}
+
+impl BlurAccum for u8 {
+    type Acc = u32;
+    type Weight = U8Weight;
+    const ZERO: u32 = 0;
+    #[inline(always)]
+    fn to_acc(self) -> u32 {
+        self as u32
+    }
+    #[inline(always)]
+    fn scale(acc: u32, count: usize) -> u32 {
+        acc * count as u32
+    }
+    #[inline(always)]
+    fn make_weight(kernel_size: usize) -> U8Weight {
+        U8Weight::new(kernel_size as u32)
+    }
+    #[inline(always)]
+    fn to_store(acc: u32, weight: U8Weight) -> u8 {
+        weight.apply(acc)
+    }
+}
+
+macro_rules! impl_blur_accum_f32 {
+    ($($t:ty),+) => { $(
+        impl BlurAccum for $t {
+            type Acc = f32;
+            type Weight = f32;
+            const ZERO: f32 = 0.0;
+            #[inline(always)]
+            fn to_acc(self) -> f32 {
+                self.to_f32().unwrap()
+            }
+            #[inline(always)]
+            fn scale(acc: f32, count: usize) -> f32 {
+                acc * count as f32
+            }
+            #[inline(always)]
+            fn make_weight(kernel_size: usize) -> f32 {
+                1.0 / kernel_size as f32
+            }
+            #[inline(always)]
+            fn to_store(acc: f32, weight: f32) -> Self {
+                rounding_saturating_mul(acc, weight)
+            }
+        }
+    )+ };
+}
+
+impl_blur_accum_f32!(u16, u32, u64, usize, i8, i16, i32, i64, isize, f32, f64);
+
+#[cfg(test)]
+mod tests {
+    use super::U8Weight;
+
+    #[test]
+    fn u8_weight_exhaustive_small() {
+        for ks in (3u32..=51).step_by(2) {
+            let w = U8Weight::new(ks);
+            let max_acc = ks * 255;
+            for acc in 0..=max_acc {
+                let expected = ((acc + ks / 2) / ks) as u8;
+                let got = w.apply(acc);
+                assert_eq!(got, expected, "ks={ks}, acc={acc}");
+            }
+        }
+    }
+
+    #[test]
+    fn u8_weight_sampled_large() {
+        for ks in (53u32..=1025).step_by(2) {
+            let w = U8Weight::new(ks);
+            let max_acc = ks * 255;
+            let step = (max_acc / 10_000).max(1) as usize;
+            for acc in (0..=max_acc).step_by(step) {
+                let expected = ((acc + ks / 2) / ks) as u8;
+                let got = w.apply(acc);
+                assert_eq!(got, expected, "ks={ks}, acc={acc}");
+            }
+            assert_eq!(w.apply(0), ((0 + ks / 2) / ks) as u8);
+            assert_eq!(w.apply(max_acc), ((max_acc + ks / 2) / ks) as u8);
+        }
+    }
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -6,7 +6,7 @@ use num_traits::{Bounded, Num, NumCast};
 use std::ops::AddAssign;
 
 use crate::color::{Luma, LumaA, Rgb, Rgba};
-use crate::primitive_sealed::{BlurAccum, PrimitiveSealed};
+use crate::primitive_sealed::{PrimitiveSealed, WithBlurAcc};
 use crate::ExtendedColorType;
 
 /// Types which are safe to treat as an immutable byte slice in a pixel layout
@@ -37,7 +37,7 @@ impl EncodableLayout for [f32] {
 /// The type of each channel in a pixel. For example, this can be `u8`, `u16`, `f32`.
 // TODO rename to `PixelComponent`? Split up into separate traits? Seal?
 pub trait Primitive:
-    Copy + NumCast + Num + PartialOrd<Self> + Clone + Bounded + PrimitiveSealed + BlurAccum
+    Copy + NumCast + Num + PartialOrd<Self> + Clone + Bounded + PrimitiveSealed + WithBlurAcc
 {
     /// The maximum value for this type of primitive within the context of color.
     /// For floats, the maximum is `1.0`, whereas the integer types inherit their usual maximum values.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -6,7 +6,7 @@ use num_traits::{Bounded, Num, NumCast};
 use std::ops::AddAssign;
 
 use crate::color::{Luma, LumaA, Rgb, Rgba};
-use crate::primitive_sealed::PrimitiveSealed;
+use crate::primitive_sealed::{BlurAccum, PrimitiveSealed};
 use crate::ExtendedColorType;
 
 /// Types which are safe to treat as an immutable byte slice in a pixel layout
@@ -37,7 +37,7 @@ impl EncodableLayout for [f32] {
 /// The type of each channel in a pixel. For example, this can be `u8`, `u16`, `f32`.
 // TODO rename to `PixelComponent`? Split up into separate traits? Seal?
 pub trait Primitive:
-    Copy + NumCast + Num + PartialOrd<Self> + Clone + Bounded + PrimitiveSealed
+    Copy + NumCast + Num + PartialOrd<Self> + Clone + Bounded + PrimitiveSealed + BlurAccum
 {
     /// The maximum value for this type of primitive within the context of color.
     /// For floats, the maximum is `1.0`, whereas the integer types inherit their usual maximum values.


### PR DESCRIPTION
Following #2809 
This was already reviewed a bit [here](https://github.com/art049/image-rs/pull/2)

## Changes
- **Use u32 integer accumulators for u8 fast blur** — The box blur hot path used f32 accumulators for all pixel types. For u8 images (the dominant case), every pixel went through to_f32/from_f32 conversions and software roundf. Replaced with u32 integer arithmetic.
- ~Replace roundf with fast truncation in FloatNearest::to_u8/to_u16 for non optimized architectures~

## Results

Walltime on x86 on a build without sse4.1
Simulation results from CodSpeed

### Walltime

| Benchmark | Baseline | Optimized | Speedup |
|-----------|----------|-----------|---------|
| fast blur: sigma 3.0 | 41.8 ms | 7.7 ms | **×5.5** |
| fast blur: sigma 7.0 | 42.1 ms | 7.7 ms | **×5.4** |
| fast blur: sigma 50.0 | 42.5 ms | 8.4 ms | **×5.0** |
| fast_blur | 41.9 ms | 8.5 ms | **×4.9** |

### Simulation

| Benchmark | Baseline | Optimized | Speedup |
|-----------|----------|-----------|---------|
| fast blur: sigma 3.0 | 254.3 ms | 45.3 ms | **×5.6** |
| fast blur: sigma 7.0 | 254.8 ms | 45.6 ms | **×5.6** |
| fast blur: sigma 50.0 | 260.6 ms | 50.3 ms | **×5.2** |
| fast_blur | 260.6 ms | 50.3 ms | **×5.2** |

