### PR TITLE
Remove deprecated methods from `GenericImage`

### DIFF
--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -1342,10 +1342,6 @@ where
     P: Pixel,
     Container: Deref<Target = [P::Subpixel]> + DerefMut,
 {
-    fn get_pixel_mut(&mut self, x: u32, y: u32) -> &mut P {
-        self.get_pixel_mut(x, y)
-    }
-
     fn put_pixel(&mut self, x: u32, y: u32, pixel: P) {
         *self.get_pixel_mut(x, y) = pixel;
     }
@@ -1356,13 +1352,6 @@ where
         let indices = self.pixel_indices_unchecked(x, y);
         let p = <P as Pixel>::from_slice_mut(self.data.get_unchecked_mut(indices));
         *p = pixel;
-    }
-
-    /// Put a pixel at location (x, y), taking into account alpha channels
-    ///
-    /// DEPRECATED: This method will be removed. Blend the pixel directly instead.
-    fn blend_pixel(&mut self, x: u32, y: u32, p: P) {
-        self.get_pixel_mut(x, y).blend(&p);
     }
 
     fn copy_from_samples(

--- a/src/images/dynimage.rs
+++ b/src/images/dynimage.rs
@@ -1515,32 +1515,6 @@ impl GenericImage for DynamicImage {
             DynamicImage::ImageRgba32F(ref mut p) => p.put_pixel(x, y, pixel.into_color()),
         }
     }
-
-    fn blend_pixel(&mut self, x: u32, y: u32, pixel: color::Rgba<u8>) {
-        match *self {
-            DynamicImage::ImageLuma8(ref mut p) => p.blend_pixel(x, y, pixel.to_luma()),
-            DynamicImage::ImageLumaA8(ref mut p) => p.blend_pixel(x, y, pixel.to_luma_alpha()),
-            DynamicImage::ImageRgb8(ref mut p) => p.blend_pixel(x, y, pixel.to_rgb()),
-            DynamicImage::ImageRgba8(ref mut p) => p.blend_pixel(x, y, pixel),
-            DynamicImage::ImageLuma16(ref mut p) => {
-                p.blend_pixel(x, y, pixel.to_luma().into_color());
-            }
-            DynamicImage::ImageLumaA16(ref mut p) => {
-                p.blend_pixel(x, y, pixel.to_luma_alpha().into_color());
-            }
-            DynamicImage::ImageRgb16(ref mut p) => p.blend_pixel(x, y, pixel.to_rgb().into_color()),
-            DynamicImage::ImageRgba16(ref mut p) => p.blend_pixel(x, y, pixel.into_color()),
-            DynamicImage::ImageRgb32F(ref mut p) => {
-                p.blend_pixel(x, y, pixel.to_rgb().into_color());
-            }
-            DynamicImage::ImageRgba32F(ref mut p) => p.blend_pixel(x, y, pixel.into_color()),
-        }
-    }
-
-    /// Do not use is function: It is unimplemented!
-    fn get_pixel_mut(&mut self, _: u32, _: u32) -> &mut color::Rgba<u8> {
-        unimplemented!()
-    }
 }
 
 impl Default for DynamicImage {

--- a/src/images/flat.rs
+++ b/src/images/flat.rs
@@ -1497,7 +1497,7 @@ impl<Buffer, P: Pixel> GenericImage for ViewMut<Buffer, P>
 where
     Buffer: AsMut<[P::Subpixel]> + AsRef<[P::Subpixel]>,
 {
-    fn get_pixel_mut(&mut self, x: u32, y: u32) -> &mut Self::Pixel {
+    fn put_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel) {
         if !self.inner.in_bounds(0, x, y) {
             panic_pixel_out_of_bounds((x, y), self.dimensions())
         }
@@ -1505,17 +1505,7 @@ where
         let base_index = self.inner.in_bounds_index(0, x, y);
         let channel_count = <P as Pixel>::CHANNEL_COUNT as usize;
         let pixel_range = base_index..base_index + channel_count;
-        P::from_slice_mut(&mut self.inner.samples.as_mut()[pixel_range])
-    }
-
-    #[allow(deprecated)]
-    fn put_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel) {
-        *self.get_pixel_mut(x, y) = pixel;
-    }
-
-    #[allow(deprecated)]
-    fn blend_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel) {
-        self.get_pixel_mut(x, y).blend(&pixel);
+        *P::from_slice_mut(&mut self.inner.samples.as_mut()[pixel_range]) = pixel;
     }
 }
 
@@ -1666,9 +1656,8 @@ mod tests {
                 .as_view_mut::<LumaA<u16>>()
                 .expect("This should be a valid mutable buffer");
             assert_eq!(view.dimensions(), (3, 3));
-            #[allow(deprecated)]
             for i in 0..9 {
-                *view.get_pixel_mut(i % 3, i / 3) = LumaA([2 * i as u16, 2 * i as u16 + 1]);
+                view.put_pixel(i % 3, i / 3, LumaA([2 * i as u16, 2 * i as u16 + 1]));
             }
         }
 

--- a/src/images/generic_image.rs
+++ b/src/images/generic_image.rs
@@ -181,29 +181,6 @@ impl<I: ?Sized> Clone for Pixels<'_, I> {
 
 /// A trait for manipulating images.
 pub trait GenericImage: GenericImageView {
-    /// Gets a reference to the mutable pixel at location `(x, y)`. Indexed from top left.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `(x, y)` is out of bounds.
-    ///
-    /// Panics for dynamic images (this method is deprecated and will be removed).
-    ///
-    /// ## Known issues
-    ///
-    /// This requires the buffer to contain a unique set of continuous channels in the exact order
-    /// and byte representation that the pixel type requires. This is somewhat restrictive.
-    ///
-    /// TODO: Maybe use some kind of entry API? this would allow pixel type conversion on the fly
-    /// while still doing only one array lookup:
-    ///
-    /// ```ignore
-    /// let px = image.pixel_entry_at(x,y);
-    /// px.set_from_rgba(rgba)
-    /// ```
-    #[deprecated(since = "0.24.0", note = "Use `get_pixel` and `put_pixel` instead.")]
-    fn get_pixel_mut(&mut self, x: u32, y: u32) -> &mut Self::Pixel;
-
     /// Put a pixel at location (x, y). Indexed from top left.
     ///
     /// # Panics
@@ -222,13 +199,6 @@ pub trait GenericImage: GenericImageView {
     unsafe fn unsafe_put_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel) {
         self.put_pixel(x, y, pixel);
     }
-
-    /// Put a pixel at location (x, y), taking into account alpha channels
-    #[deprecated(
-        since = "0.24.0",
-        note = "Use iterator `pixels_mut` to blend the pixels directly"
-    )]
-    fn blend_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel);
 
     /// Copies all of the pixels from another image into this image.
     ///
@@ -356,23 +326,11 @@ mod tests {
     use crate::{GrayImage, ImageBuffer};
 
     #[test]
-    #[allow(deprecated)]
-    /// Test that alpha blending works as expected
-    fn test_image_alpha_blending() {
+    fn test_image_put_pixel() {
         let mut target = ImageBuffer::new(1, 1);
-        target.put_pixel(0, 0, Rgba([255u8, 0, 0, 255]));
-        assert_eq!(*target.get_pixel(0, 0), Rgba([255, 0, 0, 255]));
-        target.blend_pixel(0, 0, Rgba([0, 255, 0, 255]));
-        assert_eq!(*target.get_pixel(0, 0), Rgba([0, 255, 0, 255]));
-
-        // Blending an alpha channel onto a solid background
-        target.blend_pixel(0, 0, Rgba([255, 0, 0, 127]));
-        assert_eq!(*target.get_pixel(0, 0), Rgba([127, 128, 0, 255]));
-
-        // Blending two alpha channels
-        target.put_pixel(0, 0, Rgba([0, 255, 0, 127]));
-        target.blend_pixel(0, 0, Rgba([255, 0, 0, 127]));
-        assert_eq!(*target.get_pixel(0, 0), Rgba([170, 85, 0, 191]));
+        let pixel: Rgba<u8> = Rgba([255, 0, 0, 255]);
+        target.put_pixel(0, 0, pixel);
+        assert_eq!(*target.get_pixel(0, 0), pixel);
     }
 
     #[test]

--- a/src/images/sub_image.rs
+++ b/src/images/sub_image.rs
@@ -223,19 +223,9 @@ where
     I: DerefMut,
     I::Target: GenericImage + Sized,
 {
-    fn get_pixel_mut(&mut self, x: u32, y: u32) -> &mut Self::Pixel {
-        self.image.get_pixel_mut(x + self.xoffset, y + self.yoffset)
-    }
-
     fn put_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel) {
         self.image
             .put_pixel(x + self.xoffset, y + self.yoffset, pixel);
-    }
-
-    /// DEPRECATED: This method will be removed. Blend the pixel directly instead.
-    fn blend_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel) {
-        self.image
-            .blend_pixel(x + self.xoffset, y + self.yoffset, pixel);
     }
 
     fn copy_from<O>(&mut self, other: &O, x: u32, y: u32) -> Result<(), crate::ImageError>


### PR DESCRIPTION
`GenericImage::get_pixel_mut` and `GenericImage::blend_pixel` were deprecated some time ago. This PR removes them for v1.0.