### PR TITLE
Fast path for `crop_in_place`

### DIFF
--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -1026,6 +1026,7 @@ where
     /// ```
     pub fn crop_in_place(&mut self, selection: Rect) {
         let selection = selection.crop_dimms(self);
+        assert!(selection.test_in_bounds(self).is_ok());
 
         fn copy_within<T: Copy>(data: &mut [T], src: usize, len: usize, dst: usize) {
             if src == dst || len == 0 {


### PR DESCRIPTION
`crop_in_place` did unnecessary copying for certain rectangles. For example, if the selection only shrinks the height of the image. Now it will check whether copying is necessary before calling `slice::copy_within`.

This won't make the average case faster, but the performance of certain edge cases is now close to optimal.

Note: I am making the assumption that `slice::copy_within` doesn't already perform this optimization. It doesn't seem to be, but I couldn't verify this conclusively.