### PR TITLE
Clean up internal `Rect` methods

### DIFF
--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -41,13 +41,13 @@ pub use sample::{blur_advanced, GaussianBlurParameters};
 /// Return a mutable view into an image
 /// The coordinates set the position of the top left corner of the crop.
 pub fn crop_mut<I: GenericImageView>(image: &mut I, rect: Rect) -> SubImage<&mut I> {
-    SubImage::new(image, rect.crop_dimms(image))
+    SubImage::new(image, rect.shrink_to_bounds_of(image))
 }
 
 /// Return an immutable view into an image
 /// The coordinates set the position of the top left corner of the crop.
 pub fn crop<I: GenericImageView>(image: &I, rect: Rect) -> SubImage<&I> {
-    SubImage::new(image, rect.crop_dimms(image))
+    SubImage::new(image, rect.shrink_to_bounds_of(image))
 }
 
 /// Calculate the region that can be copied from top to bottom.

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -1025,8 +1025,8 @@ where
     /// assert_eq!(img.dimensions(), (16, 8));
     /// ```
     pub fn crop_in_place(&mut self, selection: Rect) {
-        let selection = selection.crop_dimms(self);
-        assert!(selection.test_in_bounds(self).is_ok());
+        let selection = selection.shrink_to_bounds_of(self);
+        assert!(selection.test_in_bounds_of(self).is_ok());
 
         fn copy_within<T: Copy>(data: &mut [T], src: usize, len: usize, dst: usize) {
             if src == dst || len == 0 {
@@ -1371,7 +1371,7 @@ where
     ) -> ImageResult<()> {
         let (width, height) = view.dimensions();
         let pix_stride = usize::from(<Self::Pixel as Pixel>::CHANNEL_COUNT);
-        Rect::from_image_at(&view, x, y).test_in_bounds(self)?;
+        Rect::from_image_at(&view, x, y).test_in_bounds_of(self)?;
 
         if width == 0 || height == 0 || pix_stride == 0 {
             return Ok(());

--- a/src/images/generic_image.rs
+++ b/src/images/generic_image.rs
@@ -95,7 +95,7 @@ pub trait GenericImageView {
     where
         Self: Sized,
     {
-        rect.test_in_bounds(self)?;
+        rect.test_in_bounds_of(self)?;
         Ok(SubImage::new(self, rect))
     }
 
@@ -225,7 +225,7 @@ pub trait GenericImage: GenericImageView {
 
         // Do bounds checking here so we can use the non-bounds-checking
         // functions to copy pixels.
-        Rect::from_image_at(other, x, y).test_in_bounds(self)?;
+        Rect::from_image_at(other, x, y).test_in_bounds_of(self)?;
 
         for k in 0..other.height() {
             for i in 0..other.width() {
@@ -246,7 +246,7 @@ pub trait GenericImage: GenericImageView {
     ) -> ImageResult<()> {
         // Even though the implementation is the same, do not just call `Self::copy_from` here to
         // avoid circular dependencies in careless implementations.
-        Rect::from_image_at(&samples, x, y).test_in_bounds(self)?;
+        Rect::from_image_at(&samples, x, y).test_in_bounds_of(self)?;
 
         for k in 0..samples.height() {
             for i in 0..samples.width() {

--- a/src/images/sub_image.rs
+++ b/src/images/sub_image.rs
@@ -232,7 +232,7 @@ where
     where
         O: GenericImageView<Pixel = Self::Pixel>,
     {
-        Rect::from_image_at(other, x, y).test_in_bounds(self)?;
+        Rect::from_image_at(other, x, y).test_in_bounds_of(self)?;
         // Dispatch the inner images `copy_from` method with adjusted offsets. this ensures its
         // potentially optimized implementation gets used.
         self.image

--- a/src/math/rect.rs
+++ b/src/math/rect.rs
@@ -65,13 +65,16 @@ impl Rect {
         }
     }
 
-    pub(crate) fn test_in_bounds(
+    fn is_in_bounds(&self, (width, height): (u32, u32)) -> bool {
+        u64::from(self.x) + u64::from(self.width) <= u64::from(width)
+            && u64::from(self.y) + u64::from(self.height) <= u64::from(height)
+    }
+
+    pub(crate) fn test_in_bounds_of(
         &self,
         image: &(impl GenericImageView + ?Sized),
     ) -> Result<(), error::ImageError> {
-        if image.width().checked_sub(self.width) >= Some(self.x)
-            && image.height().checked_sub(self.height) >= Some(self.y)
-        {
+        if self.is_in_bounds(image.dimensions()) {
             Ok(())
         } else {
             Err(error::ImageError::Parameter(
@@ -85,20 +88,15 @@ impl Rect {
     /// If exposed outside the library, add `#[inline]`.
     #[track_caller]
     pub(crate) fn assert_in_bounds_of(&self, image: &impl GenericImageView) {
-        let (width, height) = image.dimensions();
+        let dimensions = image.dimensions();
 
-        // Lots of ways to write this comparison..
-        if u64::from(self.x) + u64::from(self.width) <= u64::from(width)
-            && u64::from(self.y) + u64::from(self.height) <= u64::from(height)
-        {
-            return;
+        if !self.is_in_bounds(dimensions) {
+            panic_out_of_bounds(self, dimensions);
         }
-
-        panic_out_of_bounds(self, (width, height));
     }
 
     /// Return the part of the rectangle that is in-bounds of the image.
-    pub(crate) fn crop_dimms(&self, image: &impl GenericImageView) -> Rect {
+    pub(crate) fn shrink_to_bounds_of(&self, image: &impl GenericImageView) -> Rect {
         let (width, height) = image.dimensions();
 
         let x = cmp::min(self.x, width);


### PR DESCRIPTION
Changes:

- Renamed `crop_dimms` to `shrink_to_bounds_of`.
- Consistent naming for the 3 methods. They are now called `test_in_bounds_of`, `assert_in_bounds_of`, and `shrink_to_bounds_of`.
- Move condition for testing in-bounds-ness into its own function. (I also didn't like that one version of it relied on `None < Some(T)` for correctness. This is non-obvious to anyone not deep into Rust.)