### PR TITLE
Removed deprecated re-exports in `image::io`

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -13,18 +13,6 @@ pub(crate) mod free_functions;
 pub(crate) mod image_reader_type;
 pub(crate) mod limits;
 
-#[deprecated(note = "this type has been moved and renamed to image::ImageReader")]
-/// Deprecated re-export of `ImageReader` as `Reader`
-pub type Reader<R> = ImageReader<R>;
-#[deprecated(note = "this type has been moved to image::Limits")]
-/// Deprecated re-export of `Limits`
-pub type Limits = limits::Limits;
-#[deprecated(note = "this type has been moved to image::LimitSupport")]
-/// Deprecated re-export of `LimitSupport`
-pub type LimitSupport = limits::LimitSupport;
-
-pub(crate) use self::image_reader_type::ImageReader;
-
 /// Adds `read_exact_vec`
 pub(crate) trait ReadExt {
     fn read_exact_vec(&mut self, vec: &mut Vec<u8>, len: usize) -> io::Result<()>;


### PR DESCRIPTION
These type aliases are deprecated and unused internally. So I removed them for 1.0.