### PR TITLE
Remove more unnecessary `#[allow(deprecated)]`

### DIFF
--- a/src/codecs/ico/mod.rs
+++ b/src/codecs/ico/mod.rs
@@ -7,7 +7,6 @@
 //!  * <https://en.wikipedia.org/wiki/ICO_%28file_format%29>
 
 pub use self::decoder::IcoDecoder;
-#[allow(deprecated)]
 pub use self::encoder::{IcoEncoder, IcoFrame};
 
 mod decoder;

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -86,14 +86,11 @@ fn gif() {
     // no tests for allocation limits because the caller is responsible for allocating the buffer in this case
 
     // Custom constructor on GifDecoder
-    #[allow(deprecated)]
-    {
-        assert!(GifDecoder::new(Cursor::new(&image))
-            .unwrap()
-            .set_limits(width_height_limits())
-            .is_err());
-        // no tests for allocation limits because the caller is responsible for allocating the buffer in this case
-    }
+    assert!(GifDecoder::new(Cursor::new(&image))
+        .unwrap()
+        .set_limits(width_height_limits())
+        .is_err());
+    // no tests for allocation limits because the caller is responsible for allocating the buffer in this case
 }
 
 #[test]


### PR DESCRIPTION
I found 2 more unnecessary `#[allow(deprecated)]`. 

The only one left in the whole codebase is necessary.