### PR TITLE
Remove unnecessary 'static bounds

### DIFF
--- a/examples/concat/main.rs
+++ b/examples/concat/main.rs
@@ -20,8 +20,8 @@ fn main() {
 fn h_concat<I, P, S>(images: &[I]) -> ImageBuffer<P, Vec<S>>
 where
     I: GenericImageView<Pixel = P>,
-    P: Pixel<Subpixel = S> + 'static,
-    S: Primitive + 'static,
+    P: Pixel<Subpixel = S>,
+    S: Primitive,
 {
     // The final width is the sum of all images width.
     let img_width_out: u32 = images.iter().map(|im| im.width()).sum();

--- a/src/codecs/avif/encoder.rs
+++ b/src/codecs/avif/encoder.rs
@@ -154,7 +154,7 @@ impl<W: Write> AvifEncoder<W> {
         color: ExtendedColorType,
     ) -> ImageResult<RgbColor<'buf>> {
         // Error wrapping utility for color dependent buffer dimensions.
-        fn try_from_raw<P: Pixel + 'static>(
+        fn try_from_raw<P: Pixel>(
             data: &[P::Subpixel],
             width: u32,
             height: u32,
@@ -172,7 +172,7 @@ impl<W: Write> AvifEncoder<W> {
             image: ImageBuffer<P, &[P::Subpixel]>,
         ) -> Img<&'buf [RGBA8]>
         where
-            P: Pixel + 'static,
+            P: Pixel,
             Rgba<u8>: FromColor<P>,
         {
             let (width, height) = image.dimensions();

--- a/src/imageops/affine.rs
+++ b/src/imageops/affine.rs
@@ -7,10 +7,7 @@ use crate::{GenericImage, GenericImageView, ImageBuffer};
 /// Rotate an image 90 degrees clockwise.
 pub fn rotate90<I: GenericImageView>(
     image: &I,
-) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
-where
-    I::Pixel: 'static,
-{
+) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>> {
     let (width, height) = image.dimensions();
     let mut out = image.buffer_with_dimensions(height, width);
     let _ = rotate90_in(image, &mut out);
@@ -20,10 +17,7 @@ where
 /// Rotate an image 180 degrees clockwise.
 pub fn rotate180<I: GenericImageView>(
     image: &I,
-) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
-where
-    I::Pixel: 'static,
-{
+) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>> {
     let (width, height) = image.dimensions();
     let mut out = image.buffer_with_dimensions(width, height);
     let _ = rotate180_in(image, &mut out);
@@ -33,10 +27,7 @@ where
 /// Rotate an image 270 degrees clockwise.
 pub fn rotate270<I: GenericImageView>(
     image: &I,
-) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
-where
-    I::Pixel: 'static,
-{
+) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>> {
     let (width, height) = image.dimensions();
     let mut out = image.buffer_with_dimensions(height, width);
     let _ = rotate270_in(image, &mut out);
@@ -50,7 +41,6 @@ pub fn rotate90_in<I, Container>(
 ) -> crate::ImageResult<()>
 where
     I: GenericImageView,
-    I::Pixel: 'static,
     Container: std::ops::DerefMut<Target = [<I::Pixel as Pixel>::Subpixel]>,
 {
     let ((w0, h0), (w1, h1)) = (image.dimensions(), destination.dimensions());
@@ -76,7 +66,6 @@ pub fn rotate180_in<I, Container>(
 ) -> crate::ImageResult<()>
 where
     I: GenericImageView,
-    I::Pixel: 'static,
     Container: std::ops::DerefMut<Target = [<I::Pixel as Pixel>::Subpixel]>,
 {
     let ((w0, h0), (w1, h1)) = (image.dimensions(), destination.dimensions());
@@ -102,7 +91,6 @@ pub fn rotate270_in<I, Container>(
 ) -> crate::ImageResult<()>
 where
     I: GenericImageView,
-    I::Pixel: 'static,
     Container: std::ops::DerefMut<Target = [<I::Pixel as Pixel>::Subpixel]>,
 {
     let ((w0, h0), (w1, h1)) = (image.dimensions(), destination.dimensions());
@@ -124,10 +112,7 @@ where
 /// Flip an image horizontally
 pub fn flip_horizontal<I: GenericImageView>(
     image: &I,
-) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
-where
-    I::Pixel: 'static,
-{
+) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>> {
     let mut out = image.buffer_like();
     let _ = flip_horizontal_in(image, &mut out);
     out
@@ -136,10 +121,7 @@ where
 /// Flip an image vertically
 pub fn flip_vertical<I: GenericImageView>(
     image: &I,
-) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
-where
-    I::Pixel: 'static,
-{
+) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>> {
     let mut out = image.buffer_like();
     let _ = flip_vertical_in(image, &mut out);
     out
@@ -152,7 +134,6 @@ pub fn flip_horizontal_in<I, Container>(
 ) -> crate::ImageResult<()>
 where
     I: GenericImageView,
-    I::Pixel: 'static,
     Container: std::ops::DerefMut<Target = [<I::Pixel as Pixel>::Subpixel]>,
 {
     let ((w0, h0), (w1, h1)) = (image.dimensions(), destination.dimensions());
@@ -178,7 +159,6 @@ pub fn flip_vertical_in<I, Container>(
 ) -> crate::ImageResult<()>
 where
     I: GenericImageView,
-    I::Pixel: 'static,
     Container: std::ops::DerefMut<Target = [<I::Pixel as Pixel>::Subpixel]>,
 {
     let ((w0, h0), (w1, h1)) = (image.dimensions(), destination.dimensions());

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -90,8 +90,8 @@ pub fn invert<I: GenericImage>(image: &mut I) {
 pub fn contrast<I, P, S>(image: &I, contrast: f32) -> ImageBuffer<P, Vec<S>>
 where
     I: GenericImageView<Pixel = P>,
-    P: Pixel<Subpixel = S> + 'static,
-    S: Primitive + 'static,
+    P: Pixel<Subpixel = S>,
+    S: Primitive,
 {
     let mut out = image.buffer_like();
 
@@ -156,8 +156,8 @@ where
 pub fn brighten<I, P, S>(image: &I, value: i32) -> ImageBuffer<P, Vec<S>>
 where
     I: GenericImageView<Pixel = P>,
-    P: Pixel<Subpixel = S> + 'static,
-    S: Primitive + 'static,
+    P: Pixel<Subpixel = S>,
+    S: Primitive,
 {
     let mut out = image.buffer_like();
 
@@ -221,8 +221,8 @@ where
 pub fn huerotate<I, P, S>(image: &I, value: i32) -> ImageBuffer<P, Vec<S>>
 where
     I: GenericImageView<Pixel = P>,
-    P: Pixel<Subpixel = S> + 'static,
-    S: Primitive + 'static,
+    P: Pixel<Subpixel = S>,
+    S: Primitive,
 {
     let mut out = image.buffer_like();
 
@@ -480,7 +480,7 @@ macro_rules! do_dithering(
 pub fn dither<Pix, Map>(image: &mut ImageBuffer<Pix, Vec<u8>>, color_map: &Map)
 where
     Map: ColorMap<Color = Pix> + ?Sized,
-    Pix: Pixel<Subpixel = u8> + 'static,
+    Pix: Pixel<Subpixel = u8>,
 {
     let (width, height) = image.dimensions();
     let mut err: [i16; 3] = [0; 3];
@@ -521,7 +521,7 @@ pub fn index_colors<Pix, Map>(
 ) -> ImageBuffer<Luma<u8>, Vec<u8>>
 where
     Map: ColorMap<Color = Pix> + ?Sized,
-    Pix: Pixel<Subpixel = u8> + 'static,
+    Pix: Pixel<Subpixel = u8>,
 {
     // Special case, we do *not* want to copy the color space here.
     let mut indices = ImageBuffer::new(image.width(), image.height());

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -252,8 +252,8 @@ where
 pub fn vertical_gradient<S, P, I>(img: &mut I, start: &P, stop: &P)
 where
     I: GenericImage<Pixel = P>,
-    P: Pixel<Subpixel = S> + 'static,
-    S: Primitive + Lerp + 'static,
+    P: Pixel<Subpixel = S>,
+    S: Primitive + Lerp,
 {
     for y in 0..img.height() {
         let pixel = start.map2(stop, |a, b| {
@@ -285,8 +285,8 @@ where
 pub fn horizontal_gradient<S, P, I>(img: &mut I, start: &P, stop: &P)
 where
     I: GenericImage<Pixel = P>,
-    P: Pixel<Subpixel = S> + 'static,
-    S: Primitive + Lerp + 'static,
+    P: Pixel<Subpixel = S>,
+    S: Primitive + Lerp,
 {
     for x in 0..img.width() {
         let pixel = start.map2(stop, |a, b| {

--- a/src/imageops/resize.rs
+++ b/src/imageops/resize.rs
@@ -156,7 +156,7 @@ fn has_constant_alpha(image: &DynamicImage) -> bool {
 #[must_use]
 fn has_constant_alpha_integer<P, Container>(img: &ImageBuffer<P, Container>) -> bool
 where
-    P: Pixel + 'static,
+    P: Pixel,
     Container: std::ops::Deref<Target = [P::Subpixel]>,
     P::Subpixel:
         Copy + PartialEq + BitXor<P::Subpixel, Output = P::Subpixel> + AddAssign + Into<u64>,

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -247,8 +247,8 @@ fn horizontal_sample<P, S>(
     filter: &mut Filter,
 ) -> ImageBuffer<P, Vec<S>>
 where
-    P: Pixel<Subpixel = S> + 'static,
-    S: Primitive + 'static,
+    P: Pixel<Subpixel = S>,
+    S: Primitive,
 {
     let (width, height) = image.dimensions();
     // This is protection against a memory usage similar to #2340. See `vertical_sample`.
@@ -492,8 +492,8 @@ pub fn interpolate_bilinear<P: Pixel>(
 fn vertical_sample<I, P, S>(image: &I, new_height: u32, filter: &mut Filter) -> Rgba32FImage
 where
     I: GenericImageView<Pixel = P>,
-    P: Pixel<Subpixel = S> + 'static,
-    S: Primitive + 'static,
+    P: Pixel<Subpixel = S>,
+    S: Primitive,
 {
     let (width, height) = image.dimensions();
 
@@ -593,8 +593,8 @@ impl<S: Primitive + Enlargeable> ThumbnailSum<S> {
 pub fn thumbnail<I, P, S>(image: &I, new_width: u32, new_height: u32) -> ImageBuffer<P, Vec<S>>
 where
     I: GenericImageView<Pixel = P>,
-    P: Pixel<Subpixel = S> + 'static,
-    S: Primitive + Enlargeable + 'static,
+    P: Pixel<Subpixel = S>,
+    S: Primitive + Enlargeable,
 {
     // Maximum support channels for `ThumbnailSum`.
     assert!(P::CHANNEL_COUNT as usize <= MAX_CHANNEL);
@@ -866,8 +866,8 @@ where
 pub fn filter3x3<I, P, S>(image: &I, kernel: &[f32; 9]) -> ImageBuffer<P, Vec<S>>
 where
     I: GenericImageView<Pixel = P>,
-    P: Pixel<Subpixel = S> + 'static,
-    S: Primitive + 'static,
+    P: Pixel<Subpixel = S>,
+    S: Primitive,
 {
     // The kernel's input positions relative to the current pixel.
     let taps: &[(isize, isize)] = &[
@@ -941,11 +941,7 @@ pub fn resize<I: GenericImageView>(
     nwidth: u32,
     nheight: u32,
     filter: FilterType,
-) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
-where
-    I::Pixel: 'static,
-    <I::Pixel as Pixel>::Subpixel: 'static,
-{
+) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>> {
     // Check if there is nothing to sample from.
     let is_empty = {
         let (width, height) = image.dimensions();
@@ -1007,10 +1003,7 @@ where
 pub fn blur<I: GenericImageView>(
     image: &I,
     radius: f32,
-) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
-where
-    I::Pixel: 'static,
-{
+) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>> {
     gaussian_blur_indirect(image, GaussianBlurParameters::new_from_radius(radius))
 }
 
@@ -1026,10 +1019,7 @@ where
 pub fn blur_advanced<I: GenericImageView>(
     image: &I,
     parameters: GaussianBlurParameters,
-) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
-where
-    I::Pixel: 'static,
-{
+) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>> {
     gaussian_blur_indirect(image, parameters)
 }
 
@@ -1443,10 +1433,7 @@ pub(crate) fn gaussian_blur_dyn_image(
 fn gaussian_blur_indirect<I: GenericImageView>(
     image: &I,
     parameters: GaussianBlurParameters,
-) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
-where
-    I::Pixel: 'static,
-{
+) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>> {
     match I::Pixel::CHANNEL_COUNT {
         1 => gaussian_blur_indirect_impl::<I, 1>(image, parameters),
         2 => gaussian_blur_indirect_impl::<I, 2>(image, parameters),
@@ -1459,10 +1446,7 @@ where
 fn gaussian_blur_indirect_impl<I: GenericImageView, const CN: usize>(
     image: &I,
     parameters: GaussianBlurParameters,
-) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>>
-where
-    I::Pixel: 'static,
-{
+) -> ImageBuffer<I::Pixel, Vec<<I::Pixel as Pixel>::Subpixel>> {
     let mut transient = vec![0f32; image.width() as usize * image.height() as usize * CN];
     let transient_chunks = transient.as_chunks_mut::<CN>().0.iter_mut();
     for (pixel, dst) in image.pixels().zip(transient_chunks) {
@@ -1574,8 +1558,8 @@ where
 pub fn unsharpen<I, P, S>(image: &I, sigma: f32, threshold: i32) -> ImageBuffer<P, Vec<S>>
 where
     I: GenericImageView<Pixel = P>,
-    P: Pixel<Subpixel = S> + 'static,
-    S: Primitive + 'static,
+    P: Pixel<Subpixel = S>,
+    S: Primitive,
 {
     let mut tmp = blur_advanced(image, GaussianBlurParameters::new_from_sigma(sigma));
 

--- a/src/images/flat.rs
+++ b/src/images/flat.rs
@@ -789,8 +789,7 @@ impl<Buffer> FlatSamples<Buffer> {
     /// not release any allocation.
     pub fn try_into_buffer<P>(self) -> Result<ImageBuffer<P, Buffer>, (Error, Self)>
     where
-        P: Pixel + 'static,
-        P::Subpixel: 'static,
+        P: Pixel,
         Buffer: Deref<Target = [P::Subpixel]>,
     {
         if !self.is_normal(NormalForm::RowMajorPacked) {


### PR DESCRIPTION
A lot of functions generic over pixels had `'static` bounds for pixels and subpixels. Frankly, I have no idea why they had these bounds. Everything compiles without them. I also checked whether there was some `unsafe` code relying on static lifetimes, but there wasn't. The bounds seem completely unnecessary.

So I removed them all. I checked every `'static` bounds and removed the unnecessary ones.

If there is a reason why these bounds exist and should be kept, please tell me.