### PR TITLE
Make `huerotate` support any number of channels

### DIFF
--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -213,11 +213,24 @@ where
 }
 
 /// Hue rotate the supplied image.
-/// `value` is the degrees to rotate each pixel by.
-/// 0 and 360 do nothing, the rest rotates by the given degree value.
-/// just like the css webkit filter hue-rotate(180)
 ///
-/// *[See also `huerotate_in_place`.][huerotate_in_place]*
+/// `value` is the angle in degrees to rotate the hue of each pixel by. 0 and 360
+/// do nothing. -15 is the same as 360-15 = 345. This behaves the same as the CSS
+/// filter [`hue-rotate()`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/filter-function/hue-rotate).
+///
+/// # Notes
+///
+/// This method operates on pixel channel values directly without taking into
+/// account color space data. The HSV color space is dependent on the current
+/// color space primaries.
+///
+/// The first 3 channels are interpreted as RGB and the hue rotation is applied
+/// to those channels. Any additional channels (e.g. alpha) are left unchanged.
+/// Images with fewer than 3 channels are not modified.
+///
+/// # See also
+///
+/// * [`huerotate_in_place`] for an in-place version of this function.
 pub fn huerotate<I, P, S>(image: &I, value: i32) -> ImageBuffer<P, Vec<S>>
 where
     I: GenericImageView<Pixel = P>,

--- a/src/images/dynimage.rs
+++ b/src/images/dynimage.rs
@@ -1070,12 +1070,24 @@ impl DynamicImage {
     }
 
     /// Hue rotate the supplied image.
-    /// `value` is the degrees to rotate each pixel by.
-    /// 0 and 360 do nothing, the rest rotates by the given degree value.
-    /// just like the css webkit filter hue-rotate(180)
     ///
-    /// This method operates on pixel channel values directly without taking into account color
-    /// space data. The HSV color space is dependent on the current color space primaries.
+    /// `value` is the angle in degrees to rotate the hue of each pixel by. 0 and 360
+    /// do nothing. -15 is the same as 360-15 = 345. This behaves the same as the CSS
+    /// filter [`hue-rotate()`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/filter-function/hue-rotate).
+    ///
+    /// # Notes
+    ///
+    /// This method operates on pixel channel values directly without taking into
+    /// account color space data. The HSV color space is dependent on the current
+    /// color space primaries.
+    ///
+    /// The first 3 channels are interpreted as RGB and the hue rotation is applied
+    /// to those channels. Any additional channels (e.g. alpha) are left unchanged.
+    /// Images with fewer than 3 channels are not modified.
+    ///
+    /// # See also
+    ///
+    /// * [`imageops::huerotate`] for a generic version of this function.
     #[must_use]
     pub fn huerotate(&self, value: i32) -> DynamicImage {
         dynamic_map!(*self, ref p => imageops::huerotate(p, value))


### PR DESCRIPTION
Fixes #2859

I changed the implementations of `huerotate` and `huerotate_in_place` to be a noop for pixels with less than 3 channels. Both will now assume that the first 3 channels are R,G,B (like before) and leave all others untouched (not quite like before). This is done by directly modifying the the first 3 channels of the original pixel, instead of trying to create a new pixel, which previously only supported up to 4 channels.

