### PR TITLE
Extract out hue rotate logic

### DIFF
--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -246,7 +246,7 @@ where
 
     let mut out = image.buffer_like();
 
-    let rotation = HueRotation::new(value as f32);
+    let rotation = HueRotation::new(value as f64);
 
     for (x, y, outpixel) in out.enumerate_pixels_mut() {
         let pixel = image.get_pixel(x, y);
@@ -270,7 +270,7 @@ where
 
     let (width, height) = image.dimensions();
 
-    let rotation = HueRotation::new(value as f32);
+    let rotation = HueRotation::new(value as f64);
 
     // TODO find a way to use pixels?
     for y in 0..height {
@@ -282,14 +282,14 @@ where
 }
 
 struct HueRotation {
-    matrix: [f32; 9],
+    matrix: [f64; 9],
 }
 impl HueRotation {
-    fn new(angle: f32) -> Self {
+    fn new(angle: f64) -> Self {
         let cosv = angle.to_radians().cos();
         let sinv = angle.to_radians().sin();
 
-        let matrix: [f32; 9] = [
+        let matrix: [f64; 9] = [
             // Reds
             0.213 + cosv * 0.787 - sinv * 0.213,
             0.715 - cosv * 0.715 - sinv * 0.715,
@@ -308,14 +308,14 @@ impl HueRotation {
     }
     fn apply<P: Pixel>(&self, mut pixel: P) -> P {
         let channels = pixel.channels_mut();
-        let r = channels[0].to_f32().unwrap();
-        let g = channels[1].to_f32().unwrap();
-        let b = channels[2].to_f32().unwrap();
+        let r = channels[0].to_f64().unwrap();
+        let g = channels[1].to_f64().unwrap();
+        let b = channels[2].to_f64().unwrap();
 
         let new_r = self.matrix[0] * r + self.matrix[1] * g + self.matrix[2] * b;
         let new_g = self.matrix[3] * r + self.matrix[4] * g + self.matrix[5] * b;
         let new_b = self.matrix[6] * r + self.matrix[7] * g + self.matrix[8] * b;
-        let max = 255f32;
+        let max = 255f64;
 
         channels[0] = NumCast::from(clamp(new_r, 0.0, max)).unwrap();
         channels[1] = NumCast::from(clamp(new_g, 0.0, max)).unwrap();


### PR DESCRIPTION
Changes:
- Extract shared hue rotation logic into new `HueRotation` type.
- ~~Switch from f64 to f32 for better performance.~~ Edit: Undid that.