### PR TITLE
Skip `winnow` in cargo-deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -46,4 +46,5 @@ skip = [
     { name = "hashbrown" },  # Some deps depend on 0.13.2 while others on 0.14.5
     { name = "zune-core" },  # Some deps depend on 0.4.12 while others on 0.5.0
     { name = "zune-jpeg" },  # Some deps depend on 0.4.21 while others on 0.5.1
+    { name = "winnow" },     # Some deps depend on 0.7.15 while others on 1.0.0
 ]


### PR DESCRIPTION
This fixes the recently broken CI by skipping `winnow` for cargo-deny.

<details><summary>Full previous error log</summary>

```
installed toolchains
--------------------
1.85.0-x86_64-unknown-linux-musl (active, default)

active toolchain
----------------
name: 1.85.0-x86_64-unknown-linux-musl
active because: it's the default toolchain
installed targets:
  x86_64-unknown-linux-musl
error[duplicate]: found 2 duplicate entries for crate 'winnow'
    ┌─ /github/workspace/Cargo.lock:165:1
    │  
165 │ ╭ winnow 0.7.15 registry+https://github.com/rust-lang/crates.io-index
166 │ │ winnow 1.0.0 registry+https://github.com/rust-lang/crates.io-index
    │ ╰──────────────────────────────────────────────────────────────────┘ lock entries
    │  
    ├ winnow v0.7.15
      └── toml v0.9.12+spec-1.1.0
          └── system-deps v7.0.7
              └── (build) dav1d-sys v0.8.3
                  └── dav1d v0.11.1
                      └── image v0.25.9
    ├ winnow v1.0.0
      └── toml_parser v1.0.10+spec-1.1.0
          └── toml v0.9.12+spec-1.1.0
              └── system-deps v7.0.7
                  └── (build) dav1d-sys v0.8.3
                      └── dav1d v0.11.1
                          └── image v0.25.9

warning[unnecessary-skip]: skip 'bitflags' applied to a crate with only one version
   ┌─ ./deny.toml:45:15
   │
45 │     { name = "bitflags" },   # Some deps depend on 1.3.2 while others on 2.6.0
   │               ━━━━━━━━ unnecessary skip configuration

warning[unnecessary-skip]: skip 'hashbrown' applied to a crate with only one version
   ┌─ ./deny.toml:46:15
   │
46 │     { name = "hashbrown" },  # Some deps depend on 0.13.2 while others on 0.14.5
   │               ━━━━━━━━━ unnecessary skip configuration

warning[unnecessary-skip]: skip 'zune-core' applied to a crate with only one version
   ┌─ ./deny.toml:47:15
   │
47 │     { name = "zune-core" },  # Some deps depend on 0.4.12 while others on 0.5.0
   │               ━━━━━━━━━ unnecessary skip configuration

warning[unnecessary-skip]: skip 'zune-jpeg' applied to a crate with only one version
   ┌─ ./deny.toml:48:15
   │
48 │     { name = "zune-jpeg" },  # Some deps depend on 0.4.21 while others on 0.5.1
   │               ━━━━━━━━━ unnecessary skip configuration

advisories ok, bans FAILED, licenses ok, sources ok
```


</details> 