### PR TITLE
Add benchmark for imageops

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,11 @@ path = "benches/convert.rs"
 name = "convert"
 harness = false
 
+[[bench]]
+path = "benches/imageops.rs"
+name = "imageops"
+harness = false
+
 [[test]]
 path = "tests/reference_images.rs"
 name = "reference_images"

--- a/benches/imageops.rs
+++ b/benches/imageops.rs
@@ -1,0 +1,108 @@
+use std::time::Duration;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use image::{
+    buffer::ConvertBuffer,
+    imageops::{self, FilterType},
+    GrayImage, ImageBuffer, Rgb,
+};
+
+pub fn bench_imageops(c: &mut Criterion) {
+    let src = ImageBuffer::from_fn(1920, 1080, |x, y| {
+        // "random" pixel values
+        Rgb([x as u8, (y / 8) as u8, ((x * 13 + y) % 256) as u8])
+    });
+
+    c.bench_function("filter3x3", |b| {
+        b.iter(|| imageops::filter3x3(&src, &[1.0, 1.0, 1.0, 1.0, -8.0, 1.0, 1.0, 1.0, 1.0]));
+    });
+
+    c.bench_function("brighten", |b| {
+        b.iter(|| imageops::brighten(&src, 100));
+    });
+
+    c.bench_function("contrast", |b| {
+        b.iter(|| imageops::contrast(&src, 5.0));
+    });
+
+    c.bench_function("dither", |b| {
+        let luma: GrayImage = src.convert();
+        b.iter(|| {
+            let mut luma = luma.clone();
+            imageops::dither(&mut luma, &imageops::BiLevel)
+        });
+    });
+
+    c.bench_function("flip_horizontal", |b| {
+        b.iter(|| imageops::flip_horizontal(&src));
+    });
+    c.bench_function("flip_vertical", |b| {
+        b.iter(|| imageops::flip_vertical(&src));
+    });
+
+    c.bench_function("grayscale", |b| {
+        b.iter(|| imageops::grayscale(&src));
+    });
+    c.bench_function("grayscale_alpha", |b| {
+        b.iter(|| imageops::grayscale_alpha(&src));
+    });
+
+    c.bench_function("huerotate", |b| {
+        b.iter(|| imageops::huerotate(&src, 180));
+    });
+
+    c.bench_function("invert", |b| {
+        b.iter(|| {
+            let mut src = src.clone();
+            imageops::invert(&mut src)
+        });
+    });
+
+    c.bench_function("rotate90", |b| {
+        b.iter(|| imageops::rotate90(&src));
+    });
+    c.bench_function("rotate180", |b| {
+        b.iter(|| imageops::rotate180(&src));
+    });
+    c.bench_function("rotate270", |b| {
+        b.iter(|| imageops::rotate270(&src));
+    });
+
+    c.bench_function("unsharpen", |b| {
+        b.iter(|| imageops::unsharpen(&src, 2.0, 0));
+    });
+}
+
+pub fn bench_resize(c: &mut Criterion) {
+    let src = ImageBuffer::from_fn(1920, 1080, |x, y| {
+        // "random" pixel values
+        Rgb([x as u8, (y / 8) as u8, ((x * 13 + y) % 256) as u8])
+    });
+
+    let filters = [
+        FilterType::Nearest,
+        FilterType::Triangle,
+        FilterType::CatmullRom,
+        FilterType::Gaussian,
+        FilterType::Lanczos3,
+    ];
+
+    for filter in filters {
+        c.bench_function(&format!("resize 400x300 {:?}", filter), |b| {
+            b.iter(|| imageops::resize(&src, 400, 300, filter));
+        });
+    }
+
+    // resizing with large dimensions is slower, so take fewer samples
+    let mut group = c.benchmark_group("large");
+    let c = group.warm_up_time(Duration::from_secs(1)).sample_size(10);
+
+    for filter in filters {
+        c.bench_function(format!("resize 2000x2000 {:?}", filter), |b| {
+            b.iter(|| imageops::resize(&src, 2000, 2000, filter));
+        });
+    }
+}
+
+criterion_group!(benches, bench_imageops, bench_resize);
+criterion_main!(benches);


### PR DESCRIPTION
I added benchmarks for most image operations.



Here are current benchmark times on my Intel i7-8700K:

```
filter3x3                          time:   [42.946 ms 43.168 ms 43.487 ms]
brighten                           time:   [6.8451 ms 6.8946 ms 6.9601 ms]
contrast                           time:   [20.375 ms 20.479 ms 20.627 ms]
dither                             time:   [10.813 ms 10.896 ms 11.006 ms]
flip_horizontal                    time:   [4.1840 ms 4.2105 ms 4.2511 ms]
flip_vertical                      time:   [3.9517 ms 3.9796 ms 4.0161 ms]
grayscale                          time:   [4.1077 ms 4.1356 ms 4.1781 ms]
grayscale_alpha                    time:   [4.8491 ms 4.8833 ms 4.9338 ms]
huerotate                          time:   [15.462 ms 15.551 ms 15.669 ms]
invert                             time:   [4.2286 ms 4.2638 ms 4.3090 ms]
rotate90                           time:   [4.7771 ms 4.8037 ms 4.8366 ms]
rotate180                          time:   [4.5799 ms 4.6114 ms 4.6580 ms]
rotate270                          time:   [6.0641 ms 6.1083 ms 6.1676 ms]
unsharpen                          time:   [114.44 ms 117.48 ms 120.60 ms]

resize 400x300 Nearest             time:   [10.868 ms 11.140 ms 11.435 ms]
resize 400x300 Triangle            time:   [17.416 ms 17.603 ms 17.812 ms]
resize 400x300 CatmullRom          time:   [25.427 ms 25.661 ms 25.960 ms]
resize 400x300 Gaussian            time:   [34.811 ms 35.042 ms 35.334 ms]
resize 400x300 Lanczos3            time:   [35.635 ms 35.968 ms 36.361 ms]

large/resize 2000x2000 Nearest     time:   [212.22 ms 218.18 ms 224.78 ms]
large/resize 2000x2000 Triangle    time:   [253.28 ms 264.13 ms 275.62 ms]
large/resize 2000x2000 CatmullRom  time:   [344.37 ms 358.05 ms 375.18 ms]
large/resize 2000x2000 Gaussian    time:   [358.06 ms 365.74 ms 375.32 ms]
large/resize 2000x2000 Lanczos3    time:   [354.13 ms 360.72 ms 369.06 ms]
```