### PR TITLE
Use `seek_relative` where possible

### DIFF
--- a/src/codecs/bmp/decoder.rs
+++ b/src/codecs/bmp/decoder.rs
@@ -1558,10 +1558,7 @@ impl<R: BufRead + Seek> BmpDecoder<R> {
         // Allocate 256 entries even if palette_size is smaller, to prevent corrupt files from
         // causing an out-of-bounds array access.
         match length.cmp(&max_length) {
-            Ordering::Greater => {
-                self.reader
-                    .seek(SeekFrom::Current((length - max_length) as i64))?;
-            }
+            Ordering::Greater => self.reader.seek_relative((length - max_length) as i64)?,
             Ordering::Less => buf.resize(max_length, 0),
             Ordering::Equal => (),
         }

--- a/src/codecs/farbfeld.rs
+++ b/src/codecs/farbfeld.rs
@@ -144,8 +144,7 @@ impl<R: Read + Seek> Seek for FarbfeldReader<R> {
                 )
             })?;
 
-        // TODO: convert to seek_relative() once that gets stabilised
-        self.inner.seek(SeekFrom::Current(offset_from_current))?;
+        self.inner.seek_relative(offset_from_current)?;
         self.current_offset = if offset_from_current < 0 {
             original_offset.checked_sub(offset_from_current.wrapping_neg() as u64)
         } else {


### PR DESCRIPTION
I found two occurrences of `.seek(Current(...))` and replaced them with `seek_relative`. Should be faster but I didn't measure.