### PR TITLE
Support ICO decoding mid stream

### DIFF
--- a/src/codecs/ico/decoder.rs
+++ b/src/codecs/ico/decoder.rs
@@ -1,12 +1,12 @@
 use byteorder_lite::ReadBytesExt;
-use std::io::{BufRead, Read, Seek, SeekFrom};
+use std::io::{BufRead, Read, Seek};
 use std::{error, fmt};
 
 use crate::color::ColorType;
 use crate::error::{
     DecodingError, ImageError, ImageResult, UnsupportedError, UnsupportedErrorKind,
 };
-use crate::utils::OffsetReader;
+use crate::utils::seek_start_with_offset;
 use crate::{ImageDecoder, ImageFormat};
 
 use self::InnerDecoder::*;
@@ -108,12 +108,13 @@ impl From<IcoEntryImageFormat> for ImageFormat {
 /// An ico decoder
 pub struct IcoDecoder<R: BufRead + Seek> {
     selected_entry: DirEntry,
+    reader_offset: u64,
     inner_decoder: InnerDecoder<R>,
 }
 
 enum InnerDecoder<R: BufRead + Seek> {
-    Bmp(BmpDecoder<OffsetReader<R>>),
-    Png(Box<PngDecoder<OffsetReader<R>>>),
+    Bmp(BmpDecoder<R>),
+    Png(Box<PngDecoder<R>>),
 }
 
 #[derive(Clone, Copy, Default)]
@@ -143,18 +144,15 @@ struct DirEntry {
 
 impl<R: BufRead + Seek> IcoDecoder<R> {
     /// Create a new decoder that decodes from the stream ```r```
-    pub fn new(r: R) -> ImageResult<IcoDecoder<R>> {
-        // This decoder assumes that we start reading at stream_position() == 0,
-        // because the ICO format is offset based. The make that assumption true,
-        // we wrap the reader.
-        let mut r = OffsetReader::start_at_zero(r)?;
-
+    pub fn new(mut r: R) -> ImageResult<IcoDecoder<R>> {
+        let reader_offset = r.stream_position()?;
         let entries = read_entries(&mut r)?;
         let entry = best_entry(entries)?;
-        let decoder = entry.decoder(r)?;
+        let decoder = entry.decoder(r, reader_offset)?;
 
         Ok(IcoDecoder {
             selected_entry: entry,
+            reader_offset,
             inner_decoder: decoder,
         })
     }
@@ -236,13 +234,13 @@ impl DirEntry {
             && u32::from(self.real_height()) == height.min(256)
     }
 
-    fn seek_to_start<R: Read + Seek>(&self, r: &mut R) -> ImageResult<()> {
-        r.seek(SeekFrom::Start(u64::from(self.image_offset)))?;
+    fn seek_to_start<R: Read + Seek>(&self, r: &mut R, reader_offset: u64) -> ImageResult<()> {
+        seek_start_with_offset(r, reader_offset, u64::from(self.image_offset))?;
         Ok(())
     }
 
-    fn is_png<R: Read + Seek>(&self, r: &mut R) -> ImageResult<bool> {
-        self.seek_to_start(r)?;
+    fn is_png<R: Read + Seek>(&self, r: &mut R, reader_offset: u64) -> ImageResult<bool> {
+        self.seek_to_start(r, reader_offset)?;
 
         // Read the first 8 bytes to sniff the image.
         let mut signature = [0u8; 8];
@@ -251,9 +249,13 @@ impl DirEntry {
         Ok(signature == PNG_SIGNATURE)
     }
 
-    fn decoder<R: BufRead + Seek>(&self, mut r: OffsetReader<R>) -> ImageResult<InnerDecoder<R>> {
-        let is_png = self.is_png(&mut r)?;
-        self.seek_to_start(&mut r)?;
+    fn decoder<R: BufRead + Seek>(
+        &self,
+        mut r: R,
+        reader_offset: u64,
+    ) -> ImageResult<InnerDecoder<R>> {
+        let is_png = self.is_png(&mut r, reader_offset)?;
+        self.seek_to_start(&mut r, reader_offset)?;
 
         if is_png {
             let limits = crate::Limits {
@@ -341,7 +343,8 @@ impl<R: BufRead + Seek> ImageDecoder for IcoDecoder<R> {
 
                 let r = decoder.reader();
                 let image_end = r.stream_position()?;
-                let data_end = u64::from(self.selected_entry.image_offset)
+                let data_end = self.reader_offset
+                    + u64::from(self.selected_entry.image_offset)
                     + u64::from(self.selected_entry.image_length);
 
                 let mask_row_bytes = width.div_ceil(32) * 4;

--- a/src/codecs/ico/decoder.rs
+++ b/src/codecs/ico/decoder.rs
@@ -6,6 +6,7 @@ use crate::color::ColorType;
 use crate::error::{
     DecodingError, ImageError, ImageResult, UnsupportedError, UnsupportedErrorKind,
 };
+use crate::utils::OffsetReader;
 use crate::{ImageDecoder, ImageFormat};
 
 use self::InnerDecoder::*;
@@ -39,10 +40,6 @@ enum DecoderError {
         /// The dimensions of the image itself
         image: (u32, u32),
     },
-
-    /// The starting stream position of the reader is so large that the
-    /// positions of some bytes in the image data cannot be represented in a u64.
-    StreamPositionTooLarge,
 }
 
 impl fmt::Display for DecoderError {
@@ -69,9 +66,6 @@ impl fmt::Display for DecoderError {
             } => f.write_fmt(format_args!(
                 "Entry{entry:?} and {format}{image:?} dimensions do not match!"
             )),
-            DecoderError::StreamPositionTooLarge => f.write_str(
-                "The starting stream position of the reader is too large to be represented in a u64, which is required for seeking to the image data.",
-            ),
         }
     }
 }
@@ -118,8 +112,8 @@ pub struct IcoDecoder<R: BufRead + Seek> {
 }
 
 enum InnerDecoder<R: BufRead + Seek> {
-    Bmp(BmpDecoder<R>),
-    Png(Box<PngDecoder<R>>),
+    Bmp(BmpDecoder<OffsetReader<R>>),
+    Png(Box<PngDecoder<OffsetReader<R>>>),
 }
 
 #[derive(Clone, Copy, Default)]
@@ -144,13 +138,17 @@ struct DirEntry {
     bits_per_pixel: u16,
 
     image_length: u32,
-    // Offset is relative to the start of the stream, NOT the start of the ICO file.
-    image_offset: u64,
+    image_offset: u32,
 }
 
 impl<R: BufRead + Seek> IcoDecoder<R> {
     /// Create a new decoder that decodes from the stream ```r```
-    pub fn new(mut r: R) -> ImageResult<IcoDecoder<R>> {
+    pub fn new(r: R) -> ImageResult<IcoDecoder<R>> {
+        // This decoder assumes that we start reading at stream_position() == 0,
+        // because the ICO format is offset based. The make that assumption true,
+        // we wrap the reader.
+        let mut r = OffsetReader::start_at_zero(r)?;
+
         let entries = read_entries(&mut r)?;
         let entry = best_entry(entries)?;
         let decoder = entry.decoder(r)?;
@@ -162,17 +160,15 @@ impl<R: BufRead + Seek> IcoDecoder<R> {
     }
 }
 
-fn read_entries<R: Read + Seek>(r: &mut R) -> ImageResult<Vec<DirEntry>> {
-    let stream_start = r.stream_position()?;
-
+fn read_entries<R: Read>(r: &mut R) -> ImageResult<Vec<DirEntry>> {
     let mut header = [0u8; 6];
     r.read_exact(&mut header)?;
     // header[0..2] = reserved, header[2..4] = type, header[4..6] = count
     let count = u16::from_le_bytes(header[4..6].try_into().unwrap());
-    (0..count).map(|_| read_entry(r, stream_start)).collect()
+    (0..count).map(|_| read_entry(r)).collect()
 }
 
-fn read_entry<R: Read>(r: &mut R, stream_start: u64) -> ImageResult<DirEntry> {
+fn read_entry<R: Read>(r: &mut R) -> ImageResult<DirEntry> {
     let mut buf = [0u8; 16];
     r.read_exact(&mut buf)?;
 
@@ -189,18 +185,6 @@ fn read_entry<R: Read>(r: &mut R, stream_start: u64) -> ImageResult<DirEntry> {
         return Err(DecoderError::IcoEntryTooManyBitsPerPixelOrHotspot.into());
     }
 
-    let image_length = u32::from_le_bytes(buf[8..12].try_into().unwrap());
-    let image_offset = u32::from_le_bytes(buf[12..16].try_into().unwrap());
-
-    // translate from offsets within the ICO file to offsets within the stream
-    let Some(image_offset) = u64::from(image_offset).checked_add(stream_start) else {
-        return Err(DecoderError::StreamPositionTooLarge.into());
-    };
-    // verify that offset + length is within u64
-    if image_offset.checked_add(u64::from(image_length)).is_none() {
-        return Err(DecoderError::StreamPositionTooLarge.into());
-    }
-
     Ok(DirEntry {
         width: buf[0],
         height: buf[1],
@@ -208,8 +192,8 @@ fn read_entry<R: Read>(r: &mut R, stream_start: u64) -> ImageResult<DirEntry> {
         reserved: buf[3],
         num_color_planes,
         bits_per_pixel,
-        image_length,
-        image_offset,
+        image_length: u32::from_le_bytes(buf[8..12].try_into().unwrap()),
+        image_offset: u32::from_le_bytes(buf[12..16].try_into().unwrap()),
     })
 }
 
@@ -253,7 +237,7 @@ impl DirEntry {
     }
 
     fn seek_to_start<R: Read + Seek>(&self, r: &mut R) -> ImageResult<()> {
-        r.seek(SeekFrom::Start(self.image_offset))?;
+        r.seek(SeekFrom::Start(u64::from(self.image_offset)))?;
         Ok(())
     }
 
@@ -267,7 +251,7 @@ impl DirEntry {
         Ok(signature == PNG_SIGNATURE)
     }
 
-    fn decoder<R: BufRead + Seek>(&self, mut r: R) -> ImageResult<InnerDecoder<R>> {
+    fn decoder<R: BufRead + Seek>(&self, mut r: OffsetReader<R>) -> ImageResult<InnerDecoder<R>> {
         let is_png = self.is_png(&mut r)?;
         self.seek_to_start(&mut r)?;
 
@@ -357,8 +341,8 @@ impl<R: BufRead + Seek> ImageDecoder for IcoDecoder<R> {
 
                 let r = decoder.reader();
                 let image_end = r.stream_position()?;
-                let data_end =
-                    self.selected_entry.image_offset + u64::from(self.selected_entry.image_length);
+                let data_end = u64::from(self.selected_entry.image_offset)
+                    + u64::from(self.selected_entry.image_length);
 
                 let mask_row_bytes = width.div_ceil(32) * 4;
                 let mask_length = u64::from(mask_row_bytes) * u64::from(height);

--- a/src/codecs/ico/decoder.rs
+++ b/src/codecs/ico/decoder.rs
@@ -39,6 +39,10 @@ enum DecoderError {
         /// The dimensions of the image itself
         image: (u32, u32),
     },
+
+    /// The starting stream position of the reader is so large that the
+    /// positions of some bytes in the image data cannot be represented in a u64.
+    StreamPositionTooLarge,
 }
 
 impl fmt::Display for DecoderError {
@@ -65,6 +69,9 @@ impl fmt::Display for DecoderError {
             } => f.write_fmt(format_args!(
                 "Entry{entry:?} and {format}{image:?} dimensions do not match!"
             )),
+            DecoderError::StreamPositionTooLarge => f.write_str(
+                "The starting stream position of the reader is too large to be represented in a u64, which is required for seeking to the image data.",
+            ),
         }
     }
 }
@@ -137,7 +144,8 @@ struct DirEntry {
     bits_per_pixel: u16,
 
     image_length: u32,
-    image_offset: u32,
+    // Offset is relative to the start of the stream, NOT the start of the ICO file.
+    image_offset: u64,
 }
 
 impl<R: BufRead + Seek> IcoDecoder<R> {
@@ -154,15 +162,17 @@ impl<R: BufRead + Seek> IcoDecoder<R> {
     }
 }
 
-fn read_entries<R: Read>(r: &mut R) -> ImageResult<Vec<DirEntry>> {
+fn read_entries<R: Read + Seek>(r: &mut R) -> ImageResult<Vec<DirEntry>> {
+    let stream_start = r.stream_position()?;
+
     let mut header = [0u8; 6];
     r.read_exact(&mut header)?;
     // header[0..2] = reserved, header[2..4] = type, header[4..6] = count
     let count = u16::from_le_bytes(header[4..6].try_into().unwrap());
-    (0..count).map(|_| read_entry(r)).collect()
+    (0..count).map(|_| read_entry(r, stream_start)).collect()
 }
 
-fn read_entry<R: Read>(r: &mut R) -> ImageResult<DirEntry> {
+fn read_entry<R: Read>(r: &mut R, stream_start: u64) -> ImageResult<DirEntry> {
     let mut buf = [0u8; 16];
     r.read_exact(&mut buf)?;
 
@@ -179,6 +189,18 @@ fn read_entry<R: Read>(r: &mut R) -> ImageResult<DirEntry> {
         return Err(DecoderError::IcoEntryTooManyBitsPerPixelOrHotspot.into());
     }
 
+    let image_length = u32::from_le_bytes(buf[8..12].try_into().unwrap());
+    let image_offset = u32::from_le_bytes(buf[12..16].try_into().unwrap());
+
+    // translate from offsets within the ICO file to offsets within the stream
+    let Some(image_offset) = u64::from(image_offset).checked_add(stream_start) else {
+        return Err(DecoderError::StreamPositionTooLarge.into());
+    };
+    // verify that offset + length is within u64
+    if image_offset.checked_add(u64::from(image_length)).is_none() {
+        return Err(DecoderError::StreamPositionTooLarge.into());
+    }
+
     Ok(DirEntry {
         width: buf[0],
         height: buf[1],
@@ -186,8 +208,8 @@ fn read_entry<R: Read>(r: &mut R) -> ImageResult<DirEntry> {
         reserved: buf[3],
         num_color_planes,
         bits_per_pixel,
-        image_length: u32::from_le_bytes(buf[8..12].try_into().unwrap()),
-        image_offset: u32::from_le_bytes(buf[12..16].try_into().unwrap()),
+        image_length,
+        image_offset,
     })
 }
 
@@ -231,7 +253,7 @@ impl DirEntry {
     }
 
     fn seek_to_start<R: Read + Seek>(&self, r: &mut R) -> ImageResult<()> {
-        r.seek(SeekFrom::Start(u64::from(self.image_offset)))?;
+        r.seek(SeekFrom::Start(self.image_offset))?;
         Ok(())
     }
 
@@ -335,8 +357,8 @@ impl<R: BufRead + Seek> ImageDecoder for IcoDecoder<R> {
 
                 let r = decoder.reader();
                 let image_end = r.stream_position()?;
-                let data_end = u64::from(self.selected_entry.image_offset)
-                    + u64::from(self.selected_entry.image_length);
+                let data_end =
+                    self.selected_entry.image_offset + u64::from(self.selected_entry.image_length);
 
                 let mask_row_bytes = width.div_ceil(32) * 4;
                 let mask_length = u64::from(mask_row_bytes) * u64::from(height);

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,7 @@
 //!  Utilities
 
 use std::collections::TryReserveError;
+use std::io::{self, BufRead, Read, Seek};
 use std::iter::repeat;
 
 #[inline(always)]
@@ -154,6 +155,96 @@ pub(crate) fn is_integer<T: num_traits::NumCast + num_traits::Zero>() -> bool {
     // while types that can represent fractional values will return something
     // other than zero.
     <T as num_traits::NumCast>::from(0.5).unwrap().is_zero()
+}
+
+pub(crate) struct OffsetReader<R> {
+    inner: R,
+    offset: u64,
+}
+impl<R: Seek> OffsetReader<R> {
+    /// Creates a reader started at `stream_position() == 0`, no matter the
+    /// current stream position of the given reader.
+    pub(crate) fn start_at_zero(mut inner: R) -> io::Result<Self> {
+        let offset = inner.stream_position()?;
+        Ok(Self { inner, offset })
+    }
+}
+impl<R: Seek> Seek for OffsetReader<R> {
+    #[inline]
+    #[track_caller]
+    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
+        let inner_pos = match pos {
+            io::SeekFrom::Start(pos) => {
+                let Some(inner_pos) = pos.checked_add(self.offset) else {
+                    return Err(io::Error::new(
+                        io::ErrorKind::FileTooLarge,
+                        format!("SeekFrom::Start({pos}) is invalid, because it would cause an overflow when adding the offset (which is {}).", self.offset),
+                    ));
+                };
+                io::SeekFrom::Start(inner_pos)
+            }
+            _ => pos,
+        };
+
+        let stream_pos = self.inner.seek(inner_pos)?;
+
+        if stream_pos < self.offset {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("Seek to {pos:?} would seek before the start of the image data (which starts at {}).", self.offset),
+            ));
+        }
+
+        Ok(stream_pos - self.offset)
+    }
+    fn seek_relative(&mut self, offset: i64) -> io::Result<()> {
+        self.inner.seek_relative(offset)?;
+
+        debug_assert!(
+            self.inner.stream_position()? >= self.offset,
+            "Seek relative by {offset} would seek before the start of the image data (which starts at {}).",
+            self.offset
+        );
+
+        Ok(())
+    }
+    fn stream_position(&mut self) -> io::Result<u64> {
+        self.inner.stream_position().map(|pos| pos - self.offset)
+    }
+}
+impl<R: Read> Read for OffsetReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.inner.read(buf)
+    }
+    fn read_vectored(&mut self, bufs: &mut [io::IoSliceMut<'_>]) -> io::Result<usize> {
+        self.inner.read_vectored(bufs)
+    }
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        self.inner.read_to_end(buf)
+    }
+    fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
+        self.inner.read_to_string(buf)
+    }
+    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        self.inner.read_exact(buf)
+    }
+}
+impl<R: BufRead> BufRead for OffsetReader<R> {
+    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+        self.inner.fill_buf()
+    }
+    fn consume(&mut self, amt: usize) {
+        self.inner.consume(amt)
+    }
+    fn read_until(&mut self, byte: u8, buf: &mut Vec<u8>) -> io::Result<usize> {
+        self.inner.read_until(byte, buf)
+    }
+    fn skip_until(&mut self, byte: u8) -> io::Result<usize> {
+        self.inner.skip_until(byte)
+    }
+    fn read_line(&mut self, buf: &mut String) -> io::Result<usize> {
+        self.inner.read_line(buf)
+    }
 }
 
 #[cfg(test)]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,7 +1,6 @@
 //!  Utilities
 
 use std::collections::TryReserveError;
-use std::io::{self, BufRead, Read, Seek};
 use std::iter::repeat;
 
 #[inline(always)]
@@ -157,99 +156,20 @@ pub(crate) fn is_integer<T: num_traits::NumCast + num_traits::Zero>() -> bool {
     <T as num_traits::NumCast>::from(0.5).unwrap().is_zero()
 }
 
-pub(crate) struct OffsetReader<R> {
-    inner: R,
+/// This is equivalent to `r.seek(SeekFrom::Start(reader_offset + offset))`,
+/// but correctly handles the case where `reader_offset + offset` would overflow.
+pub(crate) fn seek_start_with_offset<R: std::io::Read + std::io::Seek>(
+    r: &mut R,
+    reader_offset: u64,
     offset: u64,
-}
-impl<R: Seek> OffsetReader<R> {
-    /// Creates a reader started at `stream_position() == 0`, no matter the
-    /// current stream position of the given reader.
-    pub(crate) fn start_at_zero(mut inner: R) -> io::Result<Self> {
-        let offset = inner.stream_position()?;
-        Ok(Self { inner, offset })
-    }
-}
-impl<R: Seek> Seek for OffsetReader<R> {
-    #[inline]
-    #[track_caller]
-    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
-        let inner_pos = match pos {
-            io::SeekFrom::Start(pos) => {
-                let Some(inner_pos) = pos.checked_add(self.offset) else {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        format!("SeekFrom::Start({pos}) is invalid, because it would cause an overflow when adding the offset (which is {}).", self.offset),
-                    ));
-                };
-                io::SeekFrom::Start(inner_pos)
-            }
-            _ => pos,
-        };
-
-        let stream_pos = self.inner.seek(inner_pos)?;
-
-        if stream_pos < self.offset {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("Seek to {pos:?} would seek before the start of the image data (which starts at {}).", self.offset),
-            ));
-        }
-
-        Ok(stream_pos - self.offset)
-    }
-    fn seek_relative(&mut self, offset: i64) -> io::Result<()> {
-        if self.offset == 0 || offset >= 0 {
-            // If self.offset is 0, then we can defer to the underlying reader
-            // without concern. Similarly, if the offset is positive, we seek
-            // to the right which is fine no matter the value of self.offset.
-            return self.inner.seek_relative(offset);
-        }
-
-        self.seek(io::SeekFrom::Current(offset))?;
-        Ok(())
-    }
-    fn stream_position(&mut self) -> io::Result<u64> {
-        let pos = self.inner.stream_position()?;
-        pos.checked_sub(self.offset).ok_or_else(|| {
-            io::Error::other(
-                format!("Stream position of the underlying reader is invalid. Expected position to be >= {} but found {pos}.", self.offset),
-            )
-        })
-    }
-}
-impl<R: Read> Read for OffsetReader<R> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.inner.read(buf)
-    }
-    fn read_vectored(&mut self, bufs: &mut [io::IoSliceMut<'_>]) -> io::Result<usize> {
-        self.inner.read_vectored(bufs)
-    }
-    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
-        self.inner.read_to_end(buf)
-    }
-    fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
-        self.inner.read_to_string(buf)
-    }
-    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
-        self.inner.read_exact(buf)
-    }
-}
-impl<R: BufRead> BufRead for OffsetReader<R> {
-    fn fill_buf(&mut self) -> io::Result<&[u8]> {
-        self.inner.fill_buf()
-    }
-    fn consume(&mut self, amt: usize) {
-        self.inner.consume(amt)
-    }
-    fn read_until(&mut self, byte: u8, buf: &mut Vec<u8>) -> io::Result<usize> {
-        self.inner.read_until(byte, buf)
-    }
-    fn skip_until(&mut self, byte: u8) -> io::Result<usize> {
-        self.inner.skip_until(byte)
-    }
-    fn read_line(&mut self, buf: &mut String) -> io::Result<usize> {
-        self.inner.read_line(buf)
-    }
+) -> std::io::Result<u64> {
+    let Some(offset) = reader_offset.checked_add(offset) else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "offset overflow",
+        ));
+    };
+    r.seek(std::io::SeekFrom::Start(offset))
 }
 
 #[cfg(test)]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -177,7 +177,7 @@ impl<R: Seek> Seek for OffsetReader<R> {
             io::SeekFrom::Start(pos) => {
                 let Some(inner_pos) = pos.checked_add(self.offset) else {
                     return Err(io::Error::new(
-                        io::ErrorKind::FileTooLarge,
+                        io::ErrorKind::InvalidInput,
                         format!("SeekFrom::Start({pos}) is invalid, because it would cause an overflow when adding the offset (which is {}).", self.offset),
                     ));
                 };
@@ -198,18 +198,23 @@ impl<R: Seek> Seek for OffsetReader<R> {
         Ok(stream_pos - self.offset)
     }
     fn seek_relative(&mut self, offset: i64) -> io::Result<()> {
-        self.inner.seek_relative(offset)?;
+        if self.offset == 0 || offset >= 0 {
+            // If self.offset is 0, then we can defer to the underlying reader
+            // without concern. Similarly, if the offset is positive, we seek
+            // to the right which is fine no matter the value of self.offset.
+            return self.inner.seek_relative(offset);
+        }
 
-        debug_assert!(
-            self.inner.stream_position()? >= self.offset,
-            "Seek relative by {offset} would seek before the start of the image data (which starts at {}).",
-            self.offset
-        );
-
+        self.seek(io::SeekFrom::Current(offset))?;
         Ok(())
     }
     fn stream_position(&mut self) -> io::Result<u64> {
-        self.inner.stream_position().map(|pos| pos - self.offset)
+        let pos = self.inner.stream_position()?;
+        pos.checked_sub(self.offset).ok_or_else(|| {
+            io::Error::other(
+                format!("Stream position of the underlying reader is invalid. Expected position to be >= {} but found {pos}.", self.offset),
+            )
+        })
     }
 }
 impl<R: Read> Read for OffsetReader<R> {


### PR DESCRIPTION
Based on [this comment](https://github.com/image-rs/image-extras/issues/41#issuecomment-4158901403), I investigated which decoders assume that they start reading the reader at stream position 0. I found that ICO, BMP, and TIFF make that assumption and fail to decode (or decode incorrectly) when the assumption is broken.

In this PR, I fixed ICO. I did this by adjusting the code to support arbitrary starting positions for the reader. 

However, I am not sure if this is the best approach. It adds non-trivial complexity. Looking at TIFF, the code making the assumption may not even be part of `image`. So I was also considering another approach: Make the assumption true. We could make a thin wrapper around the reader which offsets the stream position such that decoders start at *their* zero. This has the advantage that (almost) no code changes to decoders are necessary, which makes it trivial to support decoders implemented elsewhere.