### PR TITLE
Farbfeld: Simpler decoder

### DIFF
--- a/src/codecs/farbfeld.rs
+++ b/src/codecs/farbfeld.rs
@@ -16,7 +16,7 @@
 //! # Related Links
 //! * <https://tools.suckless.org/farbfeld/> - the farbfeld specification
 
-use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::io::{self, Read, Write};
 
 use crate::color::ExtendedColorType;
 use crate::error::{
@@ -24,178 +24,70 @@ use crate::error::{
 };
 use crate::{ColorType, ImageDecoder, ImageEncoder, ImageFormat};
 
-/// farbfeld Reader
-pub struct FarbfeldReader<R: Read> {
-    width: u32,
-    height: u32,
-    inner: R,
-    /// Relative to the start of the pixel data
-    current_offset: u64,
-    cached_byte: Option<u8>,
-}
+const MAGIC: &[u8] = b"farbfeld";
+fn parse_header(r: &mut dyn Read) -> ImageResult<(u32, u32)> {
+    let mut header = [0_u8; 16];
+    r.read_exact(&mut header)?;
 
-impl<R: Read> FarbfeldReader<R> {
-    fn new(mut buffered_read: R) -> ImageResult<FarbfeldReader<R>> {
-        fn read_dimm<R: Read>(from: &mut R) -> ImageResult<u32> {
-            let mut buf = [0u8; 4];
-            from.read_exact(&mut buf).map_err(|err| {
-                ImageError::Decoding(DecodingError::new(ImageFormat::Farbfeld.into(), err))
-            })?;
-            Ok(u32::from_be_bytes(buf))
-        }
+    let magic = &header[..8];
+    if magic != MAGIC {
+        return Err(ImageError::Decoding(DecodingError::new(
+            ImageFormat::Farbfeld.into(),
+            format!("Invalid magic: {magic:02x?}"),
+        )));
+    }
 
-        let mut magic = [0u8; 8];
-        buffered_read.read_exact(&mut magic).map_err(|err| {
-            ImageError::Decoding(DecodingError::new(ImageFormat::Farbfeld.into(), err))
-        })?;
-        if &magic != b"farbfeld" {
-            return Err(ImageError::Decoding(DecodingError::new(
+    let width = u32::from_be_bytes(header[8..12].try_into().unwrap());
+    let height = u32::from_be_bytes(header[12..16].try_into().unwrap());
+
+    if crate::utils::check_dimension_overflow(
+        width, height, 8, // ExtendedColorType is always rgba16
+    ) {
+        return Err(ImageError::Unsupported(
+            UnsupportedError::from_format_and_kind(
                 ImageFormat::Farbfeld.into(),
-                format!("Invalid magic: {magic:02x?}"),
-            )));
-        }
-
-        let reader = FarbfeldReader {
-            width: read_dimm(&mut buffered_read)?,
-            height: read_dimm(&mut buffered_read)?,
-            inner: buffered_read,
-            current_offset: 0,
-            cached_byte: None,
-        };
-
-        if crate::utils::check_dimension_overflow(
-            reader.width,
-            reader.height,
-            // ExtendedColorType is always rgba16
-            8,
-        ) {
-            return Err(ImageError::Unsupported(
-                UnsupportedError::from_format_and_kind(
-                    ImageFormat::Farbfeld.into(),
-                    UnsupportedErrorKind::GenericFeature(format!(
-                        "Image dimensions ({}x{}) are too large",
-                        reader.width, reader.height
-                    )),
-                ),
-            ));
-        }
-
-        Ok(reader)
+                UnsupportedErrorKind::GenericFeature(format!(
+                    "Image dimensions ({width}x{height}) are too large"
+                )),
+            ),
+        ));
     }
+
+    Ok((width, height))
 }
 
-impl<R: Read> Read for FarbfeldReader<R> {
-    fn read(&mut self, mut buf: &mut [u8]) -> io::Result<usize> {
-        let mut bytes_written = 0;
-        if let Some(byte) = self.cached_byte.take() {
-            buf[0] = byte;
-            buf = &mut buf[1..];
-            bytes_written = 1;
-            self.current_offset += 1;
+fn u16_be_to_ne(data: &mut [u8]) {
+    #[cfg(target_endian = "little")]
+    {
+        for [low, high] in data.as_chunks_mut::<2>().0 {
+            std::mem::swap(low, high);
         }
-
-        if buf.len() == 1 {
-            buf[0] = cache_byte(&mut self.inner, &mut self.cached_byte)?;
-            bytes_written += 1;
-            self.current_offset += 1;
-        } else {
-            for channel_out in buf.as_chunks_mut::<2>().0 {
-                consume_channel(&mut self.inner, channel_out)?;
-                bytes_written += 2;
-                self.current_offset += 2;
-            }
-        }
-
-        Ok(bytes_written)
     }
-}
-
-impl<R: Read + Seek> Seek for FarbfeldReader<R> {
-    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
-        fn parse_offset(original_offset: u64, end_offset: u64, pos: SeekFrom) -> Option<i64> {
-            match pos {
-                SeekFrom::Start(off) => i64::try_from(off)
-                    .ok()?
-                    .checked_sub(i64::try_from(original_offset).ok()?),
-                SeekFrom::End(off) => {
-                    if off < i64::try_from(end_offset).unwrap_or(i64::MAX) {
-                        None
-                    } else {
-                        Some(i64::try_from(end_offset.checked_sub(original_offset)?).ok()? + off)
-                    }
-                }
-                SeekFrom::Current(off) => {
-                    if off < i64::try_from(original_offset).unwrap_or(i64::MAX) {
-                        None
-                    } else {
-                        Some(off)
-                    }
-                }
-            }
-        }
-
-        let original_offset = self.current_offset;
-        let end_offset = u64::from(self.width) * u64::from(self.height) * 2;
-        let offset_from_current =
-            parse_offset(original_offset, end_offset, pos).ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    "invalid seek to a negative or overflowing position",
-                )
-            })?;
-
-        self.inner.seek_relative(offset_from_current)?;
-        self.current_offset = if offset_from_current < 0 {
-            original_offset.checked_sub(offset_from_current.wrapping_neg() as u64)
-        } else {
-            original_offset.checked_add(offset_from_current as u64)
-        }
-        .expect("This should've been checked above");
-
-        if self.current_offset < end_offset && self.current_offset % 2 == 1 {
-            let curr = self.inner.seek(SeekFrom::Current(-1))?;
-            cache_byte(&mut self.inner, &mut self.cached_byte)?;
-            self.inner.seek(SeekFrom::Start(curr))?;
-        } else {
-            self.cached_byte = None;
-        }
-
-        Ok(original_offset)
-    }
-}
-
-fn consume_channel<R: Read>(from: &mut R, to: &mut [u8; 2]) -> io::Result<()> {
-    let mut ibuf = [0u8; 2];
-    from.read_exact(&mut ibuf)?;
-    to.copy_from_slice(&u16::from_be_bytes(ibuf).to_ne_bytes());
-
-    Ok(())
-}
-
-fn cache_byte<R: Read>(from: &mut R, cached_byte: &mut Option<u8>) -> io::Result<u8> {
-    let mut obuf = [0u8; 2];
-    consume_channel(from, &mut obuf)?;
-    *cached_byte = Some(obuf[1]);
-    Ok(obuf[0])
 }
 
 /// farbfeld decoder
 pub struct FarbfeldDecoder<R: Read> {
-    reader: FarbfeldReader<R>,
+    width: u32,
+    height: u32,
+    reader: R,
 }
 
 impl<R: Read> FarbfeldDecoder<R> {
     /// Creates a new decoder that decodes from the stream ```r```
-    pub fn new(buffered_read: R) -> ImageResult<FarbfeldDecoder<R>> {
+    pub fn new(mut r: R) -> ImageResult<Self> {
+        let (width, height) = parse_header(&mut r)?;
+
         Ok(FarbfeldDecoder {
-            reader: FarbfeldReader::new(buffered_read)?,
+            width,
+            height,
+            reader: r,
         })
     }
 }
 
 impl<R: Read> ImageDecoder for FarbfeldDecoder<R> {
     fn dimensions(&self) -> (u32, u32) {
-        (self.reader.width, self.reader.height)
+        (self.width, self.height)
     }
 
     fn color_type(&self) -> ColorType {
@@ -205,6 +97,7 @@ impl<R: Read> ImageDecoder for FarbfeldDecoder<R> {
     fn read_image(mut self, buf: &mut [u8]) -> ImageResult<()> {
         assert_eq!(u64::try_from(buf.len()), Ok(self.total_bytes()));
         self.reader.read_exact(buf)?;
+        u16_be_to_ne(buf);
         Ok(())
     }
 
@@ -243,7 +136,7 @@ impl<W: Write> FarbfeldEncoder<W> {
     }
 
     fn encode_impl(mut self, data: &[u8], width: u32, height: u32) -> io::Result<()> {
-        self.w.write_all(b"farbfeld")?;
+        self.w.write_all(MAGIC)?;
 
         self.w.write_all(&width.to_be_bytes())?;
         self.w.write_all(&height.to_be_bytes())?;


### PR DESCRIPTION
Changes:
- Remove `FarbfeldReader`.
- Read the entire image at once and swap endianness on LE.

---

Frankly, I have no idea why `FarbfeldReader` existed in the first place. I read through the discussion on the PRs touching it (#1171, #1173) and nobody seems to have raised any objections. Reading pixel data channel by channel and swapping the endianness while reading is about as inefficient as it gets. We make 4 calls to the underlying reader *per pixel*. There was also a bug in `FarbfeldReader::read` that could cause a panic.

So I just ripped it out. Now the decoder reads the entire image with one call to the underlying reader total (ignoring header parsing) and then swaps endianness on LE. The compiler is going to love vectorizing the swapping function, so this is FAST.

I've also written `FarbfeldDecoder` such that generic instances of it are basically free in terms of code size and compile times. The actual parsing/decoding logic is in non-generic functions now.