### PR TITLE
Fix saving f32 images to PNG

### DIFF
--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -910,9 +910,9 @@ mod tests {
 
     #[test]
     fn encode_bad_color_type() {
-        // regression test for issue #1663
+        // regression test for issues #1663 and #2787
         let image = DynamicImage::new_rgb32f(1, 1);
         let mut target = Cursor::new(vec![]);
-        let _ = image.write_to(&mut target, ImageFormat::Png);
+        assert!(image.write_to(&mut target, ImageFormat::Png).is_ok());
     }
 }

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -822,6 +822,19 @@ impl<W: Write> ImageEncoder for PngEncoder<W> {
         self.exif_metadata = exif;
         Ok(())
     }
+
+    fn make_compatible_img(
+        &self,
+        _: crate::io::encoder::MethodSealedToImage,
+        img: &DynamicImage,
+    ) -> Option<DynamicImage> {
+        use ColorType::*;
+        match img.color() {
+            Rgb32F => Some(img.to_rgb16().into()),
+            Rgba32F => Some(img.to_rgba16().into()),
+            L8 | La8 | Rgb8 | Rgba8 | L16 | La16 | Rgb16 | Rgba16 => None,
+        }
+    }
 }
 
 impl ImageError {


### PR DESCRIPTION
Some APIs, such as `DynamicImage.save()`, transparently coerce the pixel layout to the one supported by the format in which the image is being saved.

We forgot to implement this coercion for PNG. This PNG fixes that.

This originally came up in https://github.com/Shnatsel/wondermagick/pull/91

Closes https://github.com/image-rs/image/issues/2787