### PR TITLE
Fixed `GrayImage::expand_palette` at pixel 0,0

### DIFF
--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -1629,7 +1629,7 @@ pub trait ConvertBuffer<T> {
 impl GrayImage {
     /// Expands a color palette by re-using the existing buffer.
     /// Assumes 8 bit per pixel. Uses an optionally transparent index to
-    /// adjust it's alpha value accordingly.
+    /// adjust its alpha value accordingly.
     #[must_use]
     pub fn expand_palette(
         self,
@@ -1647,22 +1647,15 @@ impl GrayImage {
             let write_index = read_index * 4;
 
             let palette_index = bytes[read_index];
-            let pixel = &mut bytes[write_index..write_index + 4];
 
             let (r, g, b) = palette[palette_index as usize];
-            let a = if let Some(t_idx) = transparent_idx {
-                if t_idx == palette_index {
-                    0
-                } else {
-                    255
-                }
+            let a = if Some(palette_index) == transparent_idx {
+                0
             } else {
                 255
             };
-            pixel[0] = r;
-            pixel[1] = g;
-            pixel[2] = b;
-            pixel[3] = a;
+
+            bytes[write_index..][..4].copy_from_slice(&[r, g, b, a]);
         }
 
         buffer

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -1643,8 +1643,7 @@ impl GrayImage {
         let mut buffer = ImageBuffer::from_vec(width, height, data).unwrap();
 
         let bytes = &mut *buffer;
-        for i in 0..entries {
-            let read_index = entries - 1 - i;
+        for read_index in (0..entries).rev() {
             let write_index = read_index * 4;
 
             let palette_index = bytes[read_index];

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -14,7 +14,6 @@ use crate::flat::{FlatSamples, SampleLayout, ViewOfPixel};
 use crate::math::Rect;
 use crate::metadata::cicp::{CicpApplicable, CicpPixelCast, CicpRgb, ColorComponentForCicp};
 use crate::traits::{EncodableLayout, Pixel, PixelWithColorType};
-use crate::utils::expand_packed;
 use crate::{
     metadata::{Cicp, CicpColorPrimaries, CicpTransferCharacteristics, CicpTransform},
     save_buffer, save_buffer_with_format, write_buffer_with_format, ImageError,
@@ -1642,10 +1641,18 @@ impl GrayImage {
         let entries = data.len();
         data.resize(entries.checked_mul(4).unwrap(), 0);
         let mut buffer = ImageBuffer::from_vec(width, height, data).unwrap();
-        expand_packed(&mut buffer, 4, 8, |idx, pixel| {
-            let (r, g, b) = palette[idx as usize];
+
+        let bytes = &mut *buffer;
+        for i in 0..entries {
+            let read_index = entries - 1 - i;
+            let write_index = read_index * 4;
+
+            let palette_index = bytes[read_index];
+            let pixel = &mut bytes[write_index..write_index + 4];
+
+            let (r, g, b) = palette[palette_index as usize];
             let a = if let Some(t_idx) = transparent_idx {
-                if t_idx == idx {
+                if t_idx == palette_index {
                     0
                 } else {
                     255
@@ -1657,7 +1664,8 @@ impl GrayImage {
             pixel[1] = g;
             pixel[2] = b;
             pixel[3] = a;
-        });
+        }
+
         buffer
     }
 }
@@ -2574,6 +2582,25 @@ mod test {
             target.iter().copied().map(usize::from).sum::<usize>(),
             255 + 9 + 8
         );
+    }
+
+    #[test]
+    fn expend_palette() {
+        let gray = GrayImage::from_fn(3, 1, |x, _| Luma([x as u8]));
+        let expanded = gray.expand_palette(&[(255, 0, 0), (1, 2, 3), (255, 255, 255)], None);
+
+        assert_eq!(expanded.get_pixel(0, 0), &Rgba([255, 0, 0, 255]));
+        assert_eq!(expanded.get_pixel(1, 0), &Rgba([1, 2, 3, 255]));
+        assert_eq!(expanded.get_pixel(2, 0), &Rgba([255, 255, 255, 255]));
+
+        // issue #2918
+        let indexes = GrayImage::from_pixel(2, 2, Luma([0]));
+        let expanded = indexes.expand_palette(&[(255, 255, 255)], None);
+
+        assert_eq!(expanded.get_pixel(1, 0), &Rgba([255, 255, 255, 255]));
+        assert_eq!(expanded.get_pixel(0, 1), &Rgba([255, 255, 255, 255]));
+        assert_eq!(expanded.get_pixel(1, 1), &Rgba([255, 255, 255, 255]));
+        assert_eq!(expanded.get_pixel(0, 0), &Rgba([255, 255, 255, 255]));
     }
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,35 +1,6 @@
 //!  Utilities
 
 use std::collections::TryReserveError;
-use std::iter::repeat;
-
-#[inline(always)]
-pub(crate) fn expand_packed<F>(buf: &mut [u8], channels: usize, bit_depth: u8, mut func: F)
-where
-    F: FnMut(u8, &mut [u8]),
-{
-    let pixels = buf.len() / channels * bit_depth as usize;
-    let extra = pixels % 8;
-    let entries = pixels / 8
-        + match extra {
-            0 => 0,
-            _ => 1,
-        };
-    let mask = ((1u16 << bit_depth) - 1) as u8;
-    let i = (0..entries)
-        .rev() // Reverse iterator
-        .flat_map(|idx|
-            // This has to be reversed to
-            (0..8/bit_depth).map(|i| i*bit_depth).zip(repeat(idx)))
-        .skip(extra);
-    let buf_len = buf.len();
-    let j_inv = (channels..buf_len).step_by(channels);
-    for ((shift, i), j_inv) in i.zip(j_inv) {
-        let j = buf_len - j_inv;
-        let pixel = (buf[i] & (mask << shift)) >> shift;
-        func(pixel, &mut buf[j..(j + channels)]);
-    }
-}
 
 /// Expand a buffer of packed 1, 2, or 4 bits integers into u8's. Assumes that
 /// every `row_size` entries there are padding bits up to the next byte boundary.


### PR DESCRIPTION
Fixes #2918.

The bug was in `expand_packed` in this line:

```rs
    let buf_len = buf.len();
    let j_inv = (channels..buf_len).step_by(channels); // <---
    for ((shift, i), j_inv) in i.zip(j_inv) {
        let j = buf_len - j_inv;
        let pixel = (buf[i] & (mask << shift)) >> shift;
        func(pixel, &mut buf[j..(j + channels)]);
```

The range in `j_inv` goes to `buf_len` *exclusive*, so `j` is never zero. That `..` should have been `..=`.

However, that's not how I fixed it. I removed `expand_packed`. The function is much more general than necessary for `GrayImage::expand_palette` (the only caller of that function), and all it does is a loop. So I just moved the simple loop inside `GrayImage::expand_palette` and removed `expand_packed`. Should be faster too.

I added a test too.

---

Unrelated: `GrayImage::expand_palette` seems like a very limited API to me. I also don't get why `expand_palette` performs everything inplace. The commit that did that said it was for performance, but `data.resize` most likely re-allocs anyway, so it seems more efficient to me to alloc a new vec and initializing it the indexed colors directly (e.g. via `Vec::from_iter`). This would also enable a more expressive API.