### PR TITLE
Add support for writing XMP metadata

### DIFF
--- a/src/codecs/jpeg/encoder.rs
+++ b/src/codecs/jpeg/encoder.rs
@@ -275,6 +275,23 @@ impl<W: Write> ImageEncoder for JpegEncoder<W> {
         Ok(())
     }
 
+    fn set_xmp_metadata(&mut self, xmp: Vec<u8>) -> Result<(), UnsupportedError> {
+        // XMP is stored in an APP1 segment with namespace prefix "http://ns.adobe.com/xap/1.0/\0"
+        const XMP_NAMESPACE_PREFIX: &[u8] = b"http://ns.adobe.com/xap/1.0/\0";
+
+        let mut data = Vec::with_capacity(XMP_NAMESPACE_PREFIX.len() + xmp.len());
+        data.extend_from_slice(XMP_NAMESPACE_PREFIX);
+        data.extend_from_slice(&xmp);
+
+        self.encoder.add_app_segment(1, data).map_err(|_| {
+            UnsupportedError::from_format_and_kind(
+                ImageFormat::Jpeg.into(),
+                UnsupportedErrorKind::GenericFeature("XMP metadata too large".to_string()),
+            )
+        })?;
+        Ok(())
+    }
+
     fn make_compatible_img(
         &self,
         _: crate::io::encoder::MethodSealedToImage,
@@ -399,6 +416,30 @@ mod tests {
             .expect("Error decoding ICC")
             .expect("ICC is empty");
         assert_eq!(icc, decoded_icc);
+    }
+
+    #[test]
+    fn roundtrip_xmp() {
+        let img = [255u8, 0, 0, 255];
+
+        let xmp = b"<x:xmpmeta xmlns:x=\"adobe:ns:meta/\"><rdf:RDF></rdf:RDF></x:xmpmeta>".to_vec();
+
+        let mut encoded_img = Vec::new();
+        {
+            let mut encoder = JpegEncoder::new_with_quality(&mut encoded_img, 100);
+            encoder.set_xmp_metadata(xmp.clone()).unwrap();
+            encoder
+                .write_image(&img[..], 2, 2, ExtendedColorType::L8)
+                .expect("Could not encode image");
+        }
+
+        let mut decoder =
+            JpegDecoder::new(Cursor::new(encoded_img)).expect("Could not decode image");
+        let decoded_xmp = decoder
+            .xmp_metadata()
+            .expect("Error decoding XMP")
+            .expect("XMP is empty");
+        assert_eq!(xmp, decoded_xmp);
     }
 
     #[test]

--- a/src/codecs/jpeg/encoder.rs
+++ b/src/codecs/jpeg/encoder.rs
@@ -275,15 +275,14 @@ impl<W: Write> ImageEncoder for JpegEncoder<W> {
         Ok(())
     }
 
-    fn set_xmp_metadata(&mut self, xmp: Vec<u8>) -> Result<(), UnsupportedError> {
+    fn set_xmp_metadata(&mut self, mut xmp: Vec<u8>) -> Result<(), UnsupportedError> {
         // XMP is stored in an APP1 segment with namespace prefix "http://ns.adobe.com/xap/1.0/\0"
         const XMP_NAMESPACE_PREFIX: &[u8] = b"http://ns.adobe.com/xap/1.0/\0";
 
-        let mut data = Vec::with_capacity(XMP_NAMESPACE_PREFIX.len() + xmp.len());
-        data.extend_from_slice(XMP_NAMESPACE_PREFIX);
-        data.extend_from_slice(&xmp);
+        xmp.extend_from_slice(XMP_NAMESPACE_PREFIX);
+        xmp.rotate_right(XMP_NAMESPACE_PREFIX.len());
 
-        self.encoder.add_app_segment(1, data).map_err(|_| {
+        self.encoder.add_app_segment(1, xmp).map_err(|_| {
             UnsupportedError::from_format_and_kind(
                 ImageFormat::Jpeg.into(),
                 UnsupportedErrorKind::GenericFeature("XMP metadata too large".to_string()),

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -596,6 +596,7 @@ pub struct PngEncoder<W: Write> {
     filter: FilterType,
     icc_profile: Vec<u8>,
     exif_metadata: Vec<u8>,
+    xmp_metadata: Vec<u8>,
 }
 
 /// DEFLATE compression level of a PNG encoder. The default setting is `Fast`.
@@ -649,6 +650,7 @@ impl<W: Write> PngEncoder<W> {
             filter: FilterType::default(),
             icc_profile: Vec::new(),
             exif_metadata: Vec::new(),
+            xmp_metadata: Vec::new(),
         }
     }
 
@@ -675,6 +677,7 @@ impl<W: Write> PngEncoder<W> {
             filter,
             icc_profile: Vec::new(),
             exif_metadata: Vec::new(),
+            xmp_metadata: Vec::new(),
         }
     }
 
@@ -740,6 +743,15 @@ impl<W: Write> PngEncoder<W> {
 
         let mut encoder =
             png::Encoder::with_info(self.w, info).map_err(|e| ImageError::IoError(e.into()))?;
+
+        if !self.xmp_metadata.is_empty() {
+            let xmp_text = String::from_utf8(self.xmp_metadata).map_err(|e| {
+                ImageError::IoError(std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+            })?;
+            encoder
+                .add_itxt_chunk(XMP_KEY.to_string(), xmp_text)
+                .map_err(|e| ImageError::IoError(e.into()))?;
+        }
 
         encoder.set_color(ct);
         encoder.set_depth(bits);
@@ -820,6 +832,11 @@ impl<W: Write> ImageEncoder for PngEncoder<W> {
 
     fn set_exif_metadata(&mut self, exif: Vec<u8>) -> Result<(), UnsupportedError> {
         self.exif_metadata = exif;
+        Ok(())
+    }
+
+    fn set_xmp_metadata(&mut self, xmp: Vec<u8>) -> Result<(), UnsupportedError> {
+        self.xmp_metadata = xmp;
         Ok(())
     }
 
@@ -914,5 +931,27 @@ mod tests {
         let image = DynamicImage::new_rgb32f(1, 1);
         let mut target = Cursor::new(vec![]);
         assert!(image.write_to(&mut target, ImageFormat::Png).is_ok());
+    }
+
+    #[test]
+    fn roundtrip_xmp() {
+        let img = [255u8, 0, 0, 0, 255, 0, 0, 0, 255];
+        let xmp = b"<x:xmpmeta xmlns:x=\"adobe:ns:meta/\"><rdf:RDF></rdf:RDF></x:xmpmeta>".to_vec();
+
+        let mut encoded = Vec::new();
+        {
+            let mut encoder = PngEncoder::new(&mut encoded);
+            encoder.set_xmp_metadata(xmp.clone()).unwrap();
+            encoder
+                .write_image(&img, 3, 1, ExtendedColorType::Rgb8)
+                .expect("Could not encode image");
+        }
+
+        let mut decoder = PngDecoder::new(Cursor::new(&encoded)).expect("Could not decode image");
+        let decoded_xmp = decoder
+            .xmp_metadata()
+            .expect("Error decoding XMP")
+            .expect("XMP is empty");
+        assert_eq!(xmp, decoded_xmp);
     }
 }

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -596,7 +596,7 @@ pub struct PngEncoder<W: Write> {
     filter: FilterType,
     icc_profile: Vec<u8>,
     exif_metadata: Vec<u8>,
-    xmp_metadata: Vec<u8>,
+    xmp_metadata: Option<String>,
 }
 
 /// DEFLATE compression level of a PNG encoder. The default setting is `Fast`.
@@ -650,7 +650,7 @@ impl<W: Write> PngEncoder<W> {
             filter: FilterType::default(),
             icc_profile: Vec::new(),
             exif_metadata: Vec::new(),
-            xmp_metadata: Vec::new(),
+            xmp_metadata: None,
         }
     }
 
@@ -677,7 +677,7 @@ impl<W: Write> PngEncoder<W> {
             filter,
             icc_profile: Vec::new(),
             exif_metadata: Vec::new(),
-            xmp_metadata: Vec::new(),
+            xmp_metadata: None,
         }
     }
 
@@ -744,10 +744,7 @@ impl<W: Write> PngEncoder<W> {
         let mut encoder =
             png::Encoder::with_info(self.w, info).map_err(|e| ImageError::IoError(e.into()))?;
 
-        if !self.xmp_metadata.is_empty() {
-            let xmp_text = String::from_utf8(self.xmp_metadata).map_err(|e| {
-                ImageError::IoError(std::io::Error::new(std::io::ErrorKind::InvalidData, e))
-            })?;
+        if let Some(xmp_text) = self.xmp_metadata {
             encoder
                 .add_itxt_chunk(XMP_KEY.to_string(), xmp_text)
                 .map_err(|e| ImageError::IoError(e.into()))?;
@@ -836,7 +833,12 @@ impl<W: Write> ImageEncoder for PngEncoder<W> {
     }
 
     fn set_xmp_metadata(&mut self, xmp: Vec<u8>) -> Result<(), UnsupportedError> {
-        self.xmp_metadata = xmp;
+        self.xmp_metadata = Some(String::from_utf8(xmp).map_err(|_| {
+            UnsupportedError::from_format_and_kind(
+                ImageFormat::Png.into(),
+                UnsupportedErrorKind::GenericFeature("XMP metadata is not valid UTF-8".to_string()),
+            )
+        })?);
         Ok(())
     }
 

--- a/src/codecs/tiff.rs
+++ b/src/codecs/tiff.rs
@@ -530,6 +530,7 @@ impl<R: BufRead + Seek> ImageDecoder for TiffDecoder<R> {
 pub struct TiffEncoder<W> {
     w: W,
     icc: Option<Vec<u8>>,
+    xmp: Option<Vec<u8>>,
 }
 
 fn ycbcr_to_rgb8(ycbcr: &[[u8; 3]], lr: f32, lg: f32, lb: f32, out: &mut [[u8; 3]]) {
@@ -611,7 +612,11 @@ fn u8_slice_as_pod<P: bytemuck::Pod>(buf: &[u8]) -> ImageResult<std::borrow::Cow
 impl<W: Write + Seek> TiffEncoder<W> {
     /// Create a new encoder that writes its output to `w`
     pub fn new(w: W) -> TiffEncoder<W> {
-        TiffEncoder { w, icc: None }
+        TiffEncoder {
+            w,
+            icc: None,
+            xmp: None,
+        }
     }
 
     /// Private wrapper function to encode the image with a generic color type. This is used to reduce code duplication in the public `write_image` function.
@@ -630,16 +635,18 @@ impl<W: Write + Seek> TiffEncoder<W> {
         let mut img_encoder = encoder
             .new_image::<C>(width, height)
             .map_err(ImageError::from_tiff_encode)?;
-        if let Some(icc_profile) = self.icc {
-            // An ICC device profile is embedded, in its entirety, as a single TIFF field or Image File Directory (IFD) entry in
-            // the IFD containing the corresponding image data. An IFD should contain no more than one embedded profile.
-            // A TIFF file may contain more than one image, and so, more than one IFD. Each IFD may have its own
-            // embedded profile.
-            // -- Specification ICC.1:2004-10 (Profile version 4.2.0.0), https://www.color.org/icc1V42.pdf
-            let ifd_encoder = img_encoder.encoder(); // low-level TIFF directory encoder
-            ifd_encoder
-                .write_tag(Tag::IccProfile, icc_profile.as_slice())
-                .map_err(ImageError::from_tiff_encode)?;
+        if self.icc.is_some() || self.xmp.is_some() {
+            let ifd_encoder = img_encoder.encoder();
+            if let Some(icc_profile) = self.icc {
+                ifd_encoder
+                    .write_tag(Tag::IccProfile, icc_profile.as_slice())
+                    .map_err(ImageError::from_tiff_encode)?;
+            }
+            if let Some(xmp) = self.xmp {
+                ifd_encoder
+                    .write_tag(TAG_XML_PACKET, xmp.as_slice())
+                    .map_err(ImageError::from_tiff_encode)?;
+            }
         }
         img_encoder
             .write_data(&data)
@@ -694,5 +701,41 @@ impl<W: Write + Seek> ImageEncoder for TiffEncoder<W> {
     fn set_icc_profile(&mut self, icc_profile: Vec<u8>) -> Result<(), UnsupportedError> {
         self.icc = Some(icc_profile);
         Ok(())
+    }
+
+    fn set_xmp_metadata(&mut self, xmp: Vec<u8>) -> Result<(), UnsupportedError> {
+        self.xmp = Some(xmp);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use crate::{ExtendedColorType, ImageDecoder as _, ImageEncoder};
+
+    use super::{TiffDecoder, TiffEncoder};
+
+    #[test]
+    fn roundtrip_xmp() {
+        let img = [255u8, 0, 0, 0, 255, 0, 0, 0, 255];
+        let xmp = b"<x:xmpmeta xmlns:x=\"adobe:ns:meta/\"><rdf:RDF></rdf:RDF></x:xmpmeta>".to_vec();
+
+        let mut encoded = Vec::new();
+        {
+            let mut encoder = TiffEncoder::new(Cursor::new(&mut encoded));
+            encoder.set_xmp_metadata(xmp.clone()).unwrap();
+            encoder
+                .write_image(&img, 3, 1, ExtendedColorType::Rgb8)
+                .expect("Could not encode image");
+        }
+
+        let mut decoder = TiffDecoder::new(Cursor::new(&encoded)).expect("Could not decode image");
+        let decoded_xmp = decoder
+            .xmp_metadata()
+            .expect("Error decoding XMP")
+            .expect("XMP is empty");
+        assert_eq!(xmp, decoded_xmp);
     }
 }

--- a/src/codecs/webp/encoder.rs
+++ b/src/codecs/webp/encoder.rs
@@ -103,6 +103,11 @@ impl<W: Write> ImageEncoder for WebPEncoder<W> {
         Ok(())
     }
 
+    fn set_xmp_metadata(&mut self, xmp: Vec<u8>) -> Result<(), UnsupportedError> {
+        self.inner.set_xmp_metadata(xmp);
+        Ok(())
+    }
+
     fn make_compatible_img(
         &self,
         _: crate::io::encoder::MethodSealedToImage,
@@ -123,7 +128,7 @@ impl ImageError {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ImageEncoder, RgbaImage};
+    use crate::{ImageDecoder as _, ImageEncoder, RgbaImage};
 
     #[test]
     fn write_webp() {
@@ -144,5 +149,33 @@ mod tests {
             .to_rgba8();
 
         assert_eq!(img, img2);
+    }
+
+    #[test]
+    fn roundtrip_xmp() {
+        let img = RgbaImage::from_raw(10, 6, (0..240).collect()).unwrap();
+        let xmp = b"<x:xmpmeta xmlns:x=\"adobe:ns:meta/\"><rdf:RDF></rdf:RDF></x:xmpmeta>".to_vec();
+
+        let mut output = Vec::new();
+        {
+            let mut encoder = super::WebPEncoder::new_lossless(&mut output);
+            encoder.set_xmp_metadata(xmp.clone()).unwrap();
+            encoder
+                .write_image(
+                    img.inner_pixels(),
+                    img.width(),
+                    img.height(),
+                    crate::ExtendedColorType::Rgba8,
+                )
+                .unwrap();
+        }
+
+        let mut decoder = crate::codecs::webp::WebPDecoder::new(std::io::Cursor::new(&output))
+            .expect("Could not decode image");
+        let decoded_xmp = decoder
+            .xmp_metadata()
+            .expect("Error decoding XMP")
+            .expect("XMP is empty");
+        assert_eq!(xmp, decoded_xmp);
     }
 }

--- a/src/io/encoder.rs
+++ b/src/io/encoder.rs
@@ -80,6 +80,26 @@ pub trait ImageEncoder {
         ))
     }
 
+    /// Set the XMP metadata to use for the image.
+    ///
+    /// This function is a no-op for formats that don't support XMP metadata.
+    /// For formats that do support XMP metadata, the metadata will be embedded
+    /// in the image when it is saved.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if the format does not support XMP metadata or if the
+    /// encoder doesn't implement saving XMP metadata yet.
+    fn set_xmp_metadata(&mut self, xmp: Vec<u8>) -> Result<(), UnsupportedError> {
+        let _ = xmp;
+        Err(UnsupportedError::from_format_and_kind(
+            ImageFormatHint::Unknown,
+            UnsupportedErrorKind::GenericFeature(
+                "XMP metadata is not supported for this format".into(),
+            ),
+        ))
+    }
+
     /// Convert the image to a compatible format for the encoder. This is used by the encoding
     /// methods on `DynamicImage`.
     ///


### PR DESCRIPTION
Changes in this PR:

- Add a method for writing XMP metadata to the `ImageEncoder` trait
- Implement it for JPEG, PNG, TIFF and WebP
- Add a roundtrip test for each format to verify correctness

Motivation: wondermagick.

Out of scope of this PR:

- Writing XMP to GIF files. I don't understand GIF format well enough to implement that.
- Writing extended XMP to JPEG. As of this PR we can read it but not write it.
- Better error propagation - some formats impose constraints on metadata, e.g. Exif size in JPEG, UTF-8 validity in `png` crate for itxt chunk and therefore XMP; returning `InvalidData` from the metadata function would make sense. This is not specific to XMP but may be worth addressing before 1.0 ships.