### PR TITLE
Optimize GIF disposal further

### DIFF
--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -360,6 +360,10 @@ impl<R: Read> Iterator for GifFrameIterator<R> {
         // if `frame_buffer`'s frame exactly matches the entire image, then
         // use it directly, else create a new buffer to hold the composited
         // image.
+
+        // binding to variable makes it clear to the compiler that the value does not change in the loop,
+        // improves benchmarks by 10%
+        let disposal_method = frame.disposal_method;
         let image_buffer = if (frame.left, frame.top) == (0, 0)
             && (self.width, self.height) == frame_buffer.dimensions()
         {
@@ -367,7 +371,7 @@ impl<R: Read> Iterator for GifFrameIterator<R> {
                 .pixels_mut()
                 .zip(non_disposed_frame.pixels_mut())
             {
-                blend_and_dispose_pixel(frame.disposal_method, previous_pixel, pixel);
+                blend_and_dispose_pixel(disposal_method, previous_pixel, pixel);
             }
             frame_buffer
         } else {
@@ -382,7 +386,7 @@ impl<R: Read> Iterator for GifFrameIterator<R> {
 
                 if frame_x < frame_buffer.width() && frame_y < frame_buffer.height() {
                     let mut pixel = *frame_buffer.get_pixel(frame_x, frame_y);
-                    blend_and_dispose_pixel(frame.disposal_method, previous_pixel, &mut pixel);
+                    blend_and_dispose_pixel(disposal_method, previous_pixel, &mut pixel);
                     pixel
                 } else {
                     // out of bounds, return pixel from previous frame

--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -327,6 +327,7 @@ impl<R: Read> Iterator for GifFrameIterator<R> {
 
         // blend the current frame with the non-disposed frame, then update
         // the non-disposed frame according to the disposal method.
+        #[inline]
         fn blend_and_dispose_pixel(
             dispose: DisposalMethod,
             previous: &mut Rgba<u8>,


### PR DESCRIPTION
Speeds up GIF animation decoding with full-frame replacement by another 10% on top of #2914

I've also tried to write a fully unrolled version with explicit iteration over chunks of 128 bits, but it was only giving a 15% boost on top of #2914 and was very complex, so I chose to go with this instead.

Part of #2089