### PR TITLE
GIF: Optimize alpha branch to allow for auto-vectorization

### DIFF
--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -40,7 +40,6 @@ use crate::error::{
     ParameterError, ParameterErrorKind, UnsupportedError, UnsupportedErrorKind,
 };
 use crate::metadata::LoopCount;
-use crate::traits::Pixel;
 use crate::{
     AnimationDecoder, ExtendedColorType, ImageBuffer, ImageDecoder, ImageEncoder, ImageFormat,
     Limits,
@@ -333,7 +332,11 @@ impl<R: Read> Iterator for GifFrameIterator<R> {
             previous: &mut Rgba<u8>,
             current: &mut Rgba<u8>,
         ) {
-            let pixel_alpha = current.channels()[3];
+            // Instead of only checking the alpha channel, use a bitmask to check
+            // the entire pixel and allow for better auto-vectorization.
+            // Makes it about 5% to 10% faster
+            const ALPHA_MASK: u32 = u32::from_ne_bytes([0, 0, 0, 255]);
+            let pixel_alpha = u32::from_ne_bytes(current.0) & ALPHA_MASK;
             if pixel_alpha == 0 {
                 *current = *previous;
             }


### PR DESCRIPTION
By masking out the RGB channels, we can compare against the whole pixel, which makes it easier to vectorize for the compiler. This gives a 5% speedup for the simple loop and 10% speedup for the offset rect loop.

<details><summary>Details</summary>

```
load-Gif/large-gif-anim-full-frame-replace.gif
                        time:   [1.7892 ms 1.7944 ms 1.8002 ms]
                        change: [-3.6680% -0.3734% +2.9110%] (p = 0.83 > 0.05)
                        No change in performance detected.
  5 (5.00%) high severe
load-Gif/Animation: large-gif-anim-full-frame-replace.gif
                        time:   [4.9648 ms 5.0004 ms 5.0554 ms]
                        change: [-8.5764% -7.3202% -6.1331%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  13 (13.00%) high mild
  2 (2.00%) high severe
load-Gif/large-gif-anim-combine.gif
                        time:   [2.5877 ms 2.6073 ms 2.6394 ms]
                        change: [-2.6560% -1.3064% +0.1235%] (p = 0.05 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe
load-Gif/Animation: large-gif-anim-combine.gif
                        time:   [8.5919 ms 8.6528 ms 8.7517 ms]
                        change: [-12.492% -11.374% -10.149%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe
```

</details> 

---

related to https://github.com/image-rs/image/issues/2089 and #2924