### PR TITLE
Improve perf of `DynamicImage::crop`

### DIFF
--- a/benches/imageops.rs
+++ b/benches/imageops.rs
@@ -4,7 +4,8 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use image::{
     buffer::ConvertBuffer,
     imageops::{self, FilterType},
-    GrayImage, ImageBuffer, Rgb,
+    math::Rect,
+    DynamicImage, GrayImage, ImageBuffer, Rgb,
 };
 
 pub fn bench_imageops(c: &mut Criterion) {
@@ -12,6 +13,8 @@ pub fn bench_imageops(c: &mut Criterion) {
         // "random" pixel values
         Rgb([x as u8, (y / 8) as u8, ((x * 13 + y) % 256) as u8])
     });
+
+    let src_dyn = DynamicImage::from(src.clone());
 
     c.bench_function("filter3x3", |b| {
         b.iter(|| imageops::filter3x3(&src, &[1.0, 1.0, 1.0, 1.0, -8.0, 1.0, 1.0, 1.0, 1.0]));
@@ -70,6 +73,17 @@ pub fn bench_imageops(c: &mut Criterion) {
 
     c.bench_function("unsharpen", |b| {
         b.iter(|| imageops::unsharpen(&src, 2.0, 0));
+    });
+
+    c.bench_function("dyn image crop", |b| {
+        b.iter(|| {
+            src_dyn.crop(Rect {
+                x: 13,
+                y: 45,
+                width: 1500,
+                height: 725,
+            })
+        });
     });
 }
 

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -14,6 +14,7 @@ use crate::flat::{FlatSamples, SampleLayout, ViewOfPixel};
 use crate::math::Rect;
 use crate::metadata::cicp::{CicpApplicable, CicpPixelCast, CicpRgb, ColorComponentForCicp};
 use crate::traits::{EncodableLayout, Pixel, PixelWithColorType};
+use crate::utils::vec_try_with_capacity;
 use crate::{
     metadata::{Cicp, CicpColorPrimaries, CicpTransferCharacteristics, CicpTransform},
     save_buffer, save_buffer_with_format, write_buffer_with_format, ImageError,
@@ -984,6 +985,27 @@ where
     #[track_caller]
     pub fn put_pixel(&mut self, x: u32, y: u32, pixel: P) {
         *self.get_pixel_mut(x, y) = pixel;
+    }
+
+    /// Same as `Self::crop_in_place` but not in place.
+    pub(crate) fn crop(&self, selection: Rect) -> ImageBuffer<P, Vec<P::Subpixel>> {
+        let selection = selection.shrink_to_bounds_of(self);
+        assert!(selection.test_in_bounds_of(self).is_ok());
+
+        let data_len = Self::image_buffer_len(selection.width, selection.height).unwrap();
+        let mut data = vec_try_with_capacity::<P::Subpixel>(data_len)
+            .expect("capacity overflow for cropped image");
+        let row_pitch = data_len / selection.height as usize;
+
+        for y in 0..selection.height {
+            let sy = selection.y + y;
+            let source = self.pixel_indices_unchecked(selection.x, sy).start;
+            data.extend_from_slice(&self.data[source..source + row_pitch]);
+        }
+
+        let mut out = ImageBuffer::from_raw(selection.width, selection.height, data).unwrap();
+        out.color = self.color;
+        out
     }
 
     /// Crop this image in place, removing pixels outside of the bounding rectangle.

--- a/src/images/dynimage.rs
+++ b/src/images/dynimage.rs
@@ -497,7 +497,7 @@ impl DynamicImage {
     /// Return a cut-out of this image delimited by the bounding rectangle.
     #[must_use]
     pub fn crop(&self, selection: Rect) -> DynamicImage {
-        dynamic_map!(*self, ref p => imageops::crop(p, selection).to_image())
+        dynamic_map!(*self, ref p => p.crop(selection))
     }
 
     /// Crop this image in place, removing pixels outside of the bounding rectangle.


### PR DESCRIPTION
Partial fix for #2295

I couldn't make `SubImage::to_image` faster, so I side-stepped the issue by implementing a new `ImageBuffer::crop` and deferring `DynamicImage::crop` to that. This makes the operation 3x faster on my machine.

I also added a benchmark for the operation.

<details><summary>Details</summary>

Before:

```
dyn image crop          time:   [2.1008 ms 2.1250 ms 2.1536 ms]
Found 16 outliers among 100 measurements (16.00%)
  5 (5.00%) high mild
  11 (11.00%) high severe
```

After:

```
dyn image crop          time:   [664.53 µs 708.05 µs 759.58 µs]
                        change: [-68.370% -66.769% -64.819%] (p = 0.00 < 0.05)
                        Performance has improved.
```

</p>
</details> 