### PR TITLE
Improve perf of `SubImage::to_image`

### DIFF
--- a/benches/imageops.rs
+++ b/benches/imageops.rs
@@ -4,7 +4,8 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use image::{
     buffer::ConvertBuffer,
     imageops::{self, FilterType},
-    GrayImage, ImageBuffer, Rgb,
+    math::Rect,
+    DynamicImage, GrayImage, ImageBuffer, Rgb,
 };
 
 pub fn bench_imageops(c: &mut Criterion) {
@@ -12,6 +13,8 @@ pub fn bench_imageops(c: &mut Criterion) {
         // "random" pixel values
         Rgb([x as u8, (y / 8) as u8, ((x * 13 + y) % 256) as u8])
     });
+
+    let src_dyn = DynamicImage::from(src.clone());
 
     c.bench_function("filter3x3", |b| {
         b.iter(|| imageops::filter3x3(&src, &[1.0, 1.0, 1.0, 1.0, -8.0, 1.0, 1.0, 1.0, 1.0]));
@@ -70,6 +73,17 @@ pub fn bench_imageops(c: &mut Criterion) {
 
     c.bench_function("unsharpen", |b| {
         b.iter(|| imageops::unsharpen(&src, 2.0, 0));
+    });
+
+    c.bench_function("dyn image crop", |b| {
+        b.iter(|| {
+            src_dyn.crop(Rect {
+                x: 13,
+                y: 45,
+                width: 1500,
+                height: 725,
+            })
+        });
     });
 }
 

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -272,6 +272,10 @@ impl<'a, P: Pixel + 'a> RowsMut<'a, P> {
             }
         }
     }
+
+    pub(crate) fn into_slices(self) -> ChunksExactMut<'a, P::Subpixel> {
+        self.pixels
+    }
 }
 
 impl<'a, P: Pixel + 'a> Iterator for RowsMut<'a, P>

--- a/src/images/flat.rs
+++ b/src/images/flat.rs
@@ -1260,6 +1260,10 @@ where
         let row_len = layout.width as usize * channels as usize;
         let row_stride = layout.height_stride;
 
+        // Note: We do **NOT** assume row_len <= row_stride. Rows may overlap
+        // (or even all be the same slice when row_stride == 0). So the usual
+        // iter().chunks() strategy does not work here.
+
         Some((0..layout.height as usize).map(move |y| {
             let start = y * row_stride;
             &data[start..start + row_len]

--- a/src/images/flat.rs
+++ b/src/images/flat.rs
@@ -1243,6 +1243,28 @@ where
             phantom: PhantomData,
         })
     }
+
+    /// If the underlying samples are in row-major form and packed pixels, return
+    /// an iterator over the rows of the image.
+    pub(crate) fn iter_rows(&self) -> Option<impl Iterator<Item = &[P::Subpixel]> + '_> {
+        let layout = self.flat().layout;
+        let channels = P::CHANNEL_COUNT;
+        if layout.channel_stride != 1
+            || layout.channels != channels
+            || layout.width_stride != channels as usize
+        {
+            return None;
+        }
+
+        let data = self.samples().as_ref();
+        let row_len = layout.width as usize * channels as usize;
+        let row_stride = layout.height_stride;
+
+        Some((0..layout.height as usize).map(move |y| {
+            let start = y * row_stride;
+            &data[start..start + row_len]
+        }))
+    }
 }
 
 impl<Buffer, P: Pixel> ViewMut<Buffer, P>

--- a/src/images/sub_image.rs
+++ b/src/images/sub_image.rs
@@ -88,12 +88,9 @@ impl<I> SubImage<I> {
         // fast path for row-major packed views
         if let Some(view) = self.to_pixel_view() {
             if let Some(row_iter) = view.iter_rows() {
-                let out_data = out.deref_mut();
-                let row_len = out_data.len() / h as usize;
-                for (y, row) in row_iter.enumerate() {
-                    out_data[y * row_len..(y + 1) * row_len].copy_from_slice(row);
+                for (row, out_row) in row_iter.zip(out.rows_mut().into_slices()) {
+                    out_row.copy_from_slice(row);
                 }
-
                 return out;
             }
         }

--- a/src/images/sub_image.rs
+++ b/src/images/sub_image.rs
@@ -80,11 +80,26 @@ impl<I> SubImage<I> {
         I: Deref,
         I::Target: GenericImageView + 'static,
     {
+        let w = self.inner.xstride;
+        let h = self.inner.ystride;
         let borrowed = &*self.inner.image;
-        let mut out = borrowed.buffer_with_dimensions(self.inner.xstride, self.inner.ystride);
+        let mut out = borrowed.buffer_with_dimensions(w, h);
 
-        for y in 0..self.inner.ystride {
-            for x in 0..self.inner.xstride {
+        // fast path for row-major packed views
+        if let Some(view) = self.to_pixel_view() {
+            if let Some(row_iter) = view.iter_rows() {
+                let out_data = out.deref_mut();
+                let row_len = out_data.len() / h as usize;
+                for (y, row) in row_iter.enumerate() {
+                    out_data[y * row_len..(y + 1) * row_len].copy_from_slice(row);
+                }
+
+                return out;
+            }
+        }
+
+        for y in 0..h {
+            for x in 0..w {
                 let p = borrowed.get_pixel(x + self.inner.xoffset, y + self.inner.yoffset);
                 out.put_pixel(x, y, p);
             }


### PR DESCRIPTION
Fixes https://github.com/image-rs/image/issues/2295

This PR implements @197g's idea for [a fast path](https://github.com/image-rs/image/pull/2928#pullrequestreview-4184934836) in `SubImage::to_image` using `to_pixel_view`. At the heart of this lies the new `View::iter_rows` method. This returns an iterator over all pixel rows in the flat buffer, if those rows are contiguous in memory and pixels within them are packed.

Just like in #2928, this makes `DynamicImage::crop` 3x faster. I also added the same benchmark as in #2928.

<details>

```
dyn image crop          time:   [676.30 µs 718.70 µs 769.05 µs]
                        change: [-67.332% -65.684% -63.447%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 19 outliers among 100 measurements (19.00%)
  3 (3.00%) high mild
  16 (16.00%) high severe
```

</details>

---

Aside: `iter_rows` could potentially be used to simplify the implementation of `ImageBuffer::copy_from_samples`. It also seems related to #2300.
