### PR TITLE
BMP: Implement lenient decoding for missing final byte on last row

### DIFF
--- a/src/codecs/bmp/decoder.rs
+++ b/src/codecs/bmp/decoder.rs
@@ -564,8 +564,8 @@ fn allocate_row_buffer(size: usize) -> ImageResult<Vec<u8>> {
 /// last one, it performs a normal read. Otherwise, the special case applies:
 /// Apparently many BMPs are missing the final byte at the end of the file.
 /// This function checks if the stream is exactly one byte short of the
-/// required final scanline length. If so, it reads the available bytes, leaving
-/// the missing trailing byte as zero. Otherwise, it performs a normal `read_exact`.
+/// required final scanline length. If so, it reads the available bytes and
+/// explicitly zeroes the missing trailing byte. Otherwise, it performs a normal `read_exact`.
 fn read_scanline(
     reader: &mut (impl io::Read + Seek),
     buf: &mut [u8],
@@ -580,10 +580,15 @@ fn read_scanline(
         let current_pos = reader.stream_position()?;
         let end_pos = reader.seek(SeekFrom::End(0))?;
         reader.seek(SeekFrom::Start(current_pos))?;
-        let remaining = (end_pos - current_pos) as usize;
 
-        if buf.len() == remaining + 1 {
-            reader.read_exact(&mut buf[..remaining])?;
+        let Some((last, head)) = buf.split_last_mut() else {
+            // Empty row, nothing to read.
+            return Ok(());
+        };
+
+        if Ok(head.len()) == usize::try_from(end_pos - current_pos) {
+            reader.read_exact(head)?;
+            *last = b'\0';
             return Ok(());
         }
     }

--- a/src/codecs/bmp/decoder.rs
+++ b/src/codecs/bmp/decoder.rs
@@ -562,9 +562,12 @@ fn allocate_row_buffer(size: usize) -> ImageResult<Vec<u8>> {
 
 /// Apparently many BMPs are missing the final byte at the end of the file.
 /// This function checks if the stream is exactly one byte short of the
-/// required scanline length. If so, it reads the available bytes and pads the final
-/// byte with zero. Otherwise, it performs a normal `read_exact`.
-fn read_last_scanline_lenient(reader: &mut (impl io::Read + Seek), buf: &mut [u8]) -> io::Result<()> {
+/// required final scanline length. If so, it reads the available bytes, leaving
+/// the missing trailing byte as zero. Otherwise, it performs a normal `read_exact`.
+fn read_last_scanline_lenient(
+    reader: &mut (impl io::Read + Seek),
+    buf: &mut [u8],
+) -> io::Result<()> {
     let current_pos = reader.stream_position()?;
     let end_pos = reader.seek(SeekFrom::End(0))?;
     reader.seek(SeekFrom::Start(current_pos))?;

--- a/src/codecs/bmp/decoder.rs
+++ b/src/codecs/bmp/decoder.rs
@@ -560,6 +560,24 @@ fn allocate_row_buffer(size: usize) -> ImageResult<Vec<u8>> {
     Ok(buffer)
 }
 
+/// Apparently many BMPs are missing the final byte at the end of the file.
+/// This function checks if the stream is exactly one byte short of the
+/// required scanline length. If so, it reads the available bytes and pads the final
+/// byte with zero. Otherwise, it performs a normal `read_exact`.
+fn read_last_scanline_lenient(reader: &mut (impl io::Read + Seek), buf: &mut [u8]) -> io::Result<()> {
+    let current_pos = reader.stream_position()?;
+    let end_pos = reader.seek(SeekFrom::End(0))?;
+    reader.seek(SeekFrom::Start(current_pos))?;
+    let remaining = (end_pos - current_pos) as usize;
+
+    if buf.len() == remaining + 1 {
+        reader.read_exact(&mut buf[..remaining])?;
+        Ok(())
+    } else {
+        reader.read_exact(buf)
+    }
+}
+
 /// Convenience function to check if the combination of width, length and number of
 /// channels would result in a buffer that would overflow.
 fn check_for_overflow(width: i32, length: i32, channels: usize) -> ImageResult<()> {
@@ -1633,6 +1651,9 @@ impl<R: BufRead + Seek> BmpDecoder<R> {
                 .for_each(|c| c[3] = ALPHA_OPAQUE);
         }
 
+        let spec_strictness = self.spec_strictness;
+        let last_row: u32 = (self.height - 1).try_into().unwrap();
+        let mut current_file_row = start_row;
         let reader = &mut self.reader;
         let result = with_rows_resumable(
             buf,
@@ -1642,7 +1663,13 @@ impl<R: BufRead + Seek> BmpDecoder<R> {
             top_down,
             start_row,
             |row| {
-                reader.read_exact(&mut indices)?;
+                let is_last_row = current_file_row == last_row;
+                current_file_row += 1;
+                if is_last_row && spec_strictness == SpecCompliance::Lenient {
+                    read_last_scanline_lenient(reader, &mut indices)?;
+                } else {
+                    reader.read_exact(&mut indices)?;
+                }
                 if skip_palette {
                     row.clone_from_slice(&indices[0..width]);
                 } else {
@@ -1696,6 +1723,9 @@ impl<R: BufRead + Seek> BmpDecoder<R> {
 
         let mut row_buffer = allocate_row_buffer(total_row_len)?;
 
+        let spec_strictness = self.spec_strictness;
+        let last_row: u32 = (height - 1).try_into().unwrap();
+        let mut current_file_row = start_row;
         let reader = &mut self.reader;
         let result = with_rows_resumable(
             buf,
@@ -1705,7 +1735,13 @@ impl<R: BufRead + Seek> BmpDecoder<R> {
             top_down,
             start_row,
             |row| {
-                reader.read_exact(&mut row_buffer)?;
+                let is_last_row = current_file_row == last_row;
+                current_file_row += 1;
+                if is_last_row && spec_strictness == SpecCompliance::Lenient {
+                    read_last_scanline_lenient(reader, &mut row_buffer)?;
+                } else {
+                    reader.read_exact(&mut row_buffer)?;
+                }
                 let row_buffer_chunks = row_buffer.as_chunks::<2>().0.iter();
                 for (&row_data, pixel) in row_buffer_chunks.zip(row.chunks_exact_mut(num_channels))
                 {
@@ -1746,6 +1782,9 @@ impl<R: BufRead + Seek> BmpDecoder<R> {
 
         let mut row_buffer = allocate_row_buffer(row_data_len)?;
 
+        let spec_strictness = self.spec_strictness;
+        let last_row: u32 = (height - 1).try_into().unwrap();
+        let mut current_file_row = start_row;
         let reader = &mut self.reader;
         let result = with_rows_resumable(
             buf,
@@ -1755,7 +1794,13 @@ impl<R: BufRead + Seek> BmpDecoder<R> {
             top_down,
             start_row,
             |row| {
-                reader.read_exact(&mut row_buffer)?;
+                let is_last_row = current_file_row == last_row;
+                current_file_row += 1;
+                if is_last_row && spec_strictness == SpecCompliance::Lenient {
+                    read_last_scanline_lenient(reader, &mut row_buffer)?;
+                } else {
+                    reader.read_exact(&mut row_buffer)?;
+                }
                 let row_buffer_chunks = row_buffer.as_chunks::<4>().0.iter();
                 for (&row_data, pixel) in row_buffer_chunks.zip(row.chunks_exact_mut(num_channels))
                 {
@@ -1807,6 +1852,9 @@ impl<R: BufRead + Seek> BmpDecoder<R> {
 
         let mut row_buffer = allocate_row_buffer(total_row_len)?;
 
+        let spec_strictness = self.spec_strictness;
+        let last_row: u32 = (height - 1).try_into().unwrap();
+        let mut current_file_row = start_row;
         let reader = &mut self.reader;
         let result = with_rows_resumable(
             buf,
@@ -1816,7 +1864,13 @@ impl<R: BufRead + Seek> BmpDecoder<R> {
             top_down,
             start_row,
             |row| {
-                reader.read_exact(&mut row_buffer)?;
+                let is_last_row = current_file_row == last_row;
+                current_file_row += 1;
+                if is_last_row && spec_strictness == SpecCompliance::Lenient {
+                    read_last_scanline_lenient(reader, &mut row_buffer)?;
+                } else {
+                    reader.read_exact(&mut row_buffer)?;
+                }
 
                 for (i, pixel) in row.chunks_mut(num_channels).enumerate() {
                     let offset = match *format {
@@ -2792,5 +2846,37 @@ mod test {
         let mut buffer = vec![0u8; decoder.total_bytes() as usize];
         let result = decoder.read_image(&mut buffer);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_decode_truncated_bmp() {
+        use std::io::Cursor;
+
+        let data = vec![
+            0x42, 0x4D, 0x3A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x36, 0x00, 0x00, 0x00,
+            0x28, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00,
+            0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0x00,
+            0x00,
+        ];
+
+        // Test Lenient mode
+        let decoder = BmpDecoder::new(Cursor::new(data.clone())).unwrap();
+        let mut buffer = vec![0u8; decoder.total_bytes() as usize];
+        let result = decoder.read_image(&mut buffer);
+        assert!(
+            result.is_ok(),
+            "Expected Ok in lenient mode for truncated file"
+        );
+
+        // Test Strict mode
+        let strict_decoder =
+            BmpDecoder::new_with_spec_compliance(Cursor::new(data), SpecCompliance::Strict)
+                .unwrap();
+        let result = strict_decoder.read_image(&mut buffer);
+        assert!(
+            result.is_err(),
+            "Expected error in strict mode for truncated file"
+        );
     }
 }

--- a/src/codecs/bmp/decoder.rs
+++ b/src/codecs/bmp/decoder.rs
@@ -560,25 +560,35 @@ fn allocate_row_buffer(size: usize) -> ImageResult<Vec<u8>> {
     Ok(buffer)
 }
 
+/// Checks if the current scanline is the last one or not. If it is not the
+/// last one, it performs a normal read. Otherwise, the special case applies:
 /// Apparently many BMPs are missing the final byte at the end of the file.
 /// This function checks if the stream is exactly one byte short of the
 /// required final scanline length. If so, it reads the available bytes, leaving
 /// the missing trailing byte as zero. Otherwise, it performs a normal `read_exact`.
-fn read_last_scanline_lenient(
+fn read_scanline(
     reader: &mut (impl io::Read + Seek),
     buf: &mut [u8],
+    current_file_row: &mut u32,
+    last_row: u32,
+    spec_strictness: SpecCompliance,
 ) -> io::Result<()> {
-    let current_pos = reader.stream_position()?;
-    let end_pos = reader.seek(SeekFrom::End(0))?;
-    reader.seek(SeekFrom::Start(current_pos))?;
-    let remaining = (end_pos - current_pos) as usize;
+    let is_last_row = *current_file_row == last_row;
+    *current_file_row += 1;
 
-    if buf.len() == remaining + 1 {
-        reader.read_exact(&mut buf[..remaining])?;
-        Ok(())
-    } else {
-        reader.read_exact(buf)
+    if is_last_row && spec_strictness == SpecCompliance::Lenient {
+        let current_pos = reader.stream_position()?;
+        let end_pos = reader.seek(SeekFrom::End(0))?;
+        reader.seek(SeekFrom::Start(current_pos))?;
+        let remaining = (end_pos - current_pos) as usize;
+
+        if buf.len() == remaining + 1 {
+            reader.read_exact(&mut buf[..remaining])?;
+            return Ok(());
+        }
     }
+
+    reader.read_exact(buf)
 }
 
 /// Convenience function to check if the combination of width, length and number of
@@ -1666,13 +1676,13 @@ impl<R: BufRead + Seek> BmpDecoder<R> {
             top_down,
             start_row,
             |row| {
-                let is_last_row = current_file_row == last_row;
-                current_file_row += 1;
-                if is_last_row && spec_strictness == SpecCompliance::Lenient {
-                    read_last_scanline_lenient(reader, &mut indices)?;
-                } else {
-                    reader.read_exact(&mut indices)?;
-                }
+                read_scanline(
+                    reader,
+                    &mut indices,
+                    &mut current_file_row,
+                    last_row,
+                    spec_strictness,
+                )?;
                 if skip_palette {
                     row.clone_from_slice(&indices[0..width]);
                 } else {
@@ -1738,13 +1748,13 @@ impl<R: BufRead + Seek> BmpDecoder<R> {
             top_down,
             start_row,
             |row| {
-                let is_last_row = current_file_row == last_row;
-                current_file_row += 1;
-                if is_last_row && spec_strictness == SpecCompliance::Lenient {
-                    read_last_scanline_lenient(reader, &mut row_buffer)?;
-                } else {
-                    reader.read_exact(&mut row_buffer)?;
-                }
+                read_scanline(
+                    reader,
+                    &mut row_buffer,
+                    &mut current_file_row,
+                    last_row,
+                    spec_strictness,
+                )?;
                 let row_buffer_chunks = row_buffer.as_chunks::<2>().0.iter();
                 for (&row_data, pixel) in row_buffer_chunks.zip(row.chunks_exact_mut(num_channels))
                 {
@@ -1797,13 +1807,13 @@ impl<R: BufRead + Seek> BmpDecoder<R> {
             top_down,
             start_row,
             |row| {
-                let is_last_row = current_file_row == last_row;
-                current_file_row += 1;
-                if is_last_row && spec_strictness == SpecCompliance::Lenient {
-                    read_last_scanline_lenient(reader, &mut row_buffer)?;
-                } else {
-                    reader.read_exact(&mut row_buffer)?;
-                }
+                read_scanline(
+                    reader,
+                    &mut row_buffer,
+                    &mut current_file_row,
+                    last_row,
+                    spec_strictness,
+                )?;
                 let row_buffer_chunks = row_buffer.as_chunks::<4>().0.iter();
                 for (&row_data, pixel) in row_buffer_chunks.zip(row.chunks_exact_mut(num_channels))
                 {
@@ -1867,13 +1877,13 @@ impl<R: BufRead + Seek> BmpDecoder<R> {
             top_down,
             start_row,
             |row| {
-                let is_last_row = current_file_row == last_row;
-                current_file_row += 1;
-                if is_last_row && spec_strictness == SpecCompliance::Lenient {
-                    read_last_scanline_lenient(reader, &mut row_buffer)?;
-                } else {
-                    reader.read_exact(&mut row_buffer)?;
-                }
+                read_scanline(
+                    reader,
+                    &mut row_buffer,
+                    &mut current_file_row,
+                    last_row,
+                    spec_strictness,
+                )?;
 
                 for (i, pixel) in row.chunks_mut(num_channels).enumerate() {
                     let offset = match *format {


### PR DESCRIPTION
This PR implements lenient handling for BMP files that are truncated by exactly one byte at the end of the file. This is an issue with some legacy BMP encoders that omit the trailing padding byte on the final scanline. The image is fine otherwise.