### PR TITLE
Faster and non-destructive `GrayImage::expand_palette`

### DIFF
--- a/benches/imageops.rs
+++ b/benches/imageops.rs
@@ -1,11 +1,11 @@
-use std::time::Duration;
+use std::{hint::black_box, time::Duration};
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use image::{
     buffer::ConvertBuffer,
     imageops::{self, FilterType},
     math::Rect,
-    DynamicImage, GrayImage, ImageBuffer, Rgb,
+    DynamicImage, GrayImage, ImageBuffer, Luma, Rgb,
 };
 
 pub fn bench_imageops(c: &mut Criterion) {
@@ -85,6 +85,41 @@ pub fn bench_imageops(c: &mut Criterion) {
             })
         });
     });
+
+    for size in [64, 256, 1024, 2048] {
+        let img_gray = GrayImage::from_fn(size, size, |x, y| {
+            // "random" pixel values
+            Luma([((x * 13 + y * 7 + x * x + y * y * y) % 256) as u8])
+        });
+        let palette = &[(1, 2, 3); 256];
+
+        c.bench_function(&format!("gray image expend_palette {size}"), |b| {
+            b.iter_batched(
+                || img_gray.clone(),
+                |img| img.expand_palette(black_box(palette), black_box(None)),
+                criterion::BatchSize::LargeInput,
+            );
+        });
+
+        c.bench_function(
+            &format!("gray image expend_palette {size} no realloc"),
+            |b| {
+                b.iter_batched(
+                    || {
+                        let mut data = img_gray.clone().into_raw();
+                        data.reserve_exact((size * size * 3) as usize);
+                        ImageBuffer::from_raw(size, size, data).unwrap()
+                    },
+                    |img| img.expand_palette(black_box(palette), black_box(None)),
+                    criterion::BatchSize::LargeInput,
+                );
+            },
+        );
+
+        c.bench_function(&format!("gray image expend_palette_2 {size}"), |b| {
+            b.iter(|| img_gray.expand_palette_2(black_box(palette), black_box(None)));
+        });
+    }
 }
 
 pub fn bench_resize(c: &mut Criterion) {

--- a/benches/imageops.rs
+++ b/benches/imageops.rs
@@ -5,7 +5,7 @@ use image::{
     buffer::ConvertBuffer,
     imageops::{self, FilterType},
     math::Rect,
-    DynamicImage, GrayImage, ImageBuffer, Luma, Rgb,
+    DynamicImage, GrayImage, ImageBuffer, Rgb,
 };
 
 pub fn bench_imageops(c: &mut Criterion) {
@@ -15,6 +15,7 @@ pub fn bench_imageops(c: &mut Criterion) {
     });
 
     let src_dyn = DynamicImage::from(src.clone());
+    let src_gray = src_dyn.to_luma8();
 
     c.bench_function("filter3x3", |b| {
         b.iter(|| imageops::filter3x3(&src, &[1.0, 1.0, 1.0, 1.0, -8.0, 1.0, 1.0, 1.0, 1.0]));
@@ -86,40 +87,10 @@ pub fn bench_imageops(c: &mut Criterion) {
         });
     });
 
-    for size in [64, 256, 1024, 2048] {
-        let img_gray = GrayImage::from_fn(size, size, |x, y| {
-            // "random" pixel values
-            Luma([((x * 13 + y * 7 + x * x + y * y * y) % 256) as u8])
-        });
+    c.bench_function("gray image expend_palette", |b| {
         let palette = &[(1, 2, 3); 256];
-
-        c.bench_function(&format!("gray image expend_palette {size}"), |b| {
-            b.iter_batched(
-                || img_gray.clone(),
-                |img| img.expand_palette(black_box(palette), black_box(None)),
-                criterion::BatchSize::LargeInput,
-            );
-        });
-
-        c.bench_function(
-            &format!("gray image expend_palette {size} no realloc"),
-            |b| {
-                b.iter_batched(
-                    || {
-                        let mut data = img_gray.clone().into_raw();
-                        data.reserve_exact((size * size * 3) as usize);
-                        ImageBuffer::from_raw(size, size, data).unwrap()
-                    },
-                    |img| img.expand_palette(black_box(palette), black_box(None)),
-                    criterion::BatchSize::LargeInput,
-                );
-            },
-        );
-
-        c.bench_function(&format!("gray image expend_palette_2 {size}"), |b| {
-            b.iter(|| img_gray.expand_palette_2(black_box(palette), black_box(None)));
-        });
-    }
+        b.iter(|| src_gray.expand_palette(black_box(palette), black_box(None)));
+    });
 }
 
 pub fn bench_resize(c: &mut Criterion) {

--- a/benches/imageops.rs
+++ b/benches/imageops.rs
@@ -87,7 +87,7 @@ pub fn bench_imageops(c: &mut Criterion) {
         });
     });
 
-    c.bench_function("gray image expend_palette", |b| {
+    c.bench_function("gray image expand_palette", |b| {
         let palette = &[(1, 2, 3); 256];
         b.iter(|| src_gray.expand_palette(black_box(palette), black_box(None)));
     });

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -1664,6 +1664,36 @@ impl GrayImage {
 
         buffer
     }
+
+    /// Expands a color palette into an RGBA image. Uses an optionally
+    /// transparent index to adjust its alpha value accordingly.
+    ///
+    /// Color indexes not in the palette are mapped to transparent black,
+    /// i.e. (0, 0, 0, 0).
+    #[must_use]
+    pub fn expand_palette_2(
+        &self,
+        palette: &[(u8, u8, u8)],
+        transparent_idx: Option<u8>,
+    ) -> RgbaImage {
+        let (width, height) = self.dimensions();
+        let len = width as usize * height as usize;
+
+        let mut full_palette = [[0_u8; 4]; 256];
+        for ((r, g, b), entry) in palette.iter().zip(full_palette.iter_mut()) {
+            *entry = [*r, *g, *b, 255];
+        }
+        if let Some(palette_index) = transparent_idx {
+            full_palette[palette_index as usize][3] = 0;
+        }
+
+        let rgba_data: Vec<[u8; 4]> = self.as_raw()[..len]
+            .iter()
+            .map(|&palette_index| full_palette[palette_index as usize])
+            .collect();
+
+        ImageBuffer::from_vec(width, height, rgba_data.into_flattened()).unwrap()
+    }
 }
 
 /// This copies the color space information but is somewhat wrong, in numeric terms this conversion

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -1631,47 +1631,13 @@ pub trait ConvertBuffer<T> {
 
 // concrete implementation Luma -> Rgba
 impl GrayImage {
-    /// Expands a color palette by re-using the existing buffer.
-    /// Assumes 8 bit per pixel. Uses an optionally transparent index to
-    /// adjust its alpha value accordingly.
-    #[must_use]
-    pub fn expand_palette(
-        self,
-        palette: &[(u8, u8, u8)],
-        transparent_idx: Option<u8>,
-    ) -> RgbaImage {
-        let (width, height) = self.dimensions();
-        let mut data = self.into_raw();
-        let entries = data.len();
-        data.resize(entries.checked_mul(4).unwrap(), 0);
-        let mut buffer = ImageBuffer::from_vec(width, height, data).unwrap();
-
-        let bytes = &mut *buffer;
-        for read_index in (0..entries).rev() {
-            let write_index = read_index * 4;
-
-            let palette_index = bytes[read_index];
-
-            let (r, g, b) = palette[palette_index as usize];
-            let a = if Some(palette_index) == transparent_idx {
-                0
-            } else {
-                255
-            };
-
-            bytes[write_index..][..4].copy_from_slice(&[r, g, b, a]);
-        }
-
-        buffer
-    }
-
     /// Expands a color palette into an RGBA image. Uses an optionally
     /// transparent index to adjust its alpha value accordingly.
     ///
     /// Color indexes not in the palette are mapped to transparent black,
     /// i.e. (0, 0, 0, 0).
     #[must_use]
-    pub fn expand_palette_2(
+    pub fn expand_palette(
         &self,
         palette: &[(u8, u8, u8)],
         transparent_idx: Option<u8>,

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -1645,7 +1645,8 @@ impl GrayImage {
         let (width, height) = self.dimensions();
         let len = width as usize * height as usize;
 
-        let mut full_palette = [[0_u8; 4]; 256];
+        let mut full_palette = vec![[0_u8; 4]; 256];
+        let full_palette: &mut [[u8; 4]; 256] = full_palette.as_mut_slice().try_into().unwrap();
         for ((r, g, b), entry) in palette.iter().zip(full_palette.iter_mut()) {
             *entry = [*r, *g, *b, 255];
         }


### PR DESCRIPTION
This implements a non-destructive version of `GrayImage::expand_palette` I suggested in #2920.

The implementation pulls a few tricks for speed:
- It uses an exact-size iterator, so collecting into a vec allocates only once and then initializes the memory with the yielded data.
- It creates a full 256-long palette to avoid bounds checking and the "branch" for `transparent_idx`.

In the first commit of this PR, you can see the benchmark code comparing the old function and the new one. I tested the old function in two scenarios: (1) the vec of the gray image is too small and requires a realloc, and (2) the vec of the gray image is exactly the right size for the RGBA image and no new memory needs to be allocated. Scenario 2 is the ideal scenario for the old implementation.

Results:

| Image Size | Old (1)   | Old (2)   | New       |
| ---------: | --------- | --------- | --------- |
|       64^2 | 6.3112 µs | 6.1838 µs | 1.7512 µs |
|      256^2 | 99.176 µs | 97.005 µs | 24.220 µs |
|     1024^2 | 2.1806 ms | 1.9472 ms | 1.1150 ms |
|     2048^2 | 8.6819 ms | 7.7218 ms | 4.4289 ms |

As we can see, the new implementation outperforms the old one by a significant margin.

---

I also fixed the bug that the old implementation assumed `data.len() == w * h`.