### PR TITLE
Add slice casting to `Pixel`

### DIFF
--- a/src/codecs/avif/encoder.rs
+++ b/src/codecs/avif/encoder.rs
@@ -223,7 +223,7 @@ impl<W: Write> AvifEncoder<W> {
                 let img = try_from_raw::<Rgb<u8>>(data, width, height)?;
                 // Now, internally ravif uses u32 but it takes usize. We could do some checked
                 // conversion but instead we use that a non-empty image must be addressable.
-                if img.pixels().len() == 0 {
+                if img.pixels().is_empty() {
                     return Err(ImageError::Parameter(ParameterError::from_kind(
                         ParameterErrorKind::DimensionMismatch,
                     )));
@@ -240,7 +240,7 @@ impl<W: Write> AvifEncoder<W> {
                 let img = try_from_raw::<Rgba<u8>>(data, width, height)?;
                 // Now, internally ravif uses u32 but it takes usize. We could do some checked
                 // conversion but instead we use that a non-empty image must be addressable.
-                if img.pixels().len() == 0 {
+                if img.pixels().is_empty() {
                     return Err(ImageError::Parameter(ParameterError::from_kind(
                         ParameterErrorKind::DimensionMismatch,
                     )));

--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -373,7 +373,8 @@ impl<R: Read> Iterator for GifFrameIterator<R> {
         {
             for (pixel, previous_pixel) in frame_buffer
                 .pixels_mut()
-                .zip(non_disposed_frame.pixels_mut())
+                .iter_mut()
+                .zip(non_disposed_frame.pixels_mut().iter_mut())
             {
                 blend_and_dispose_pixel(disposal_method, previous_pixel, pixel);
             }

--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -436,7 +436,7 @@ mod test {
             let exr_pixels: Rgb32FImage = read_as_rgb_image_from_file(exr_path).unwrap();
             assert_eq!(exr_pixels.dimensions(), hdr.dimensions());
 
-            for (expected, found) in hdr.pixels().zip(exr_pixels.pixels()) {
+            for (expected, found) in hdr.pixels().iter().zip(exr_pixels.pixels().iter()) {
                 for (expected, found) in expected.0.iter().zip(found.0.iter()) {
                     // the large tolerance seems to be caused by
                     // the RGBE u8x4 pixel quantization of the hdr image format
@@ -497,7 +497,7 @@ mod test {
 
         assert_eq!(rgba.dimensions(), rgb.dimensions());
 
-        for (Rgb(rgb), Rgba(rgba)) in rgb.pixels().zip(rgba.pixels()) {
+        for (Rgb(rgb), Rgba(rgba)) in rgb.pixels().iter().zip(rgba.pixels().iter()) {
             assert_eq!(rgb, &rgba[..3]);
         }
     }
@@ -539,6 +539,10 @@ mod test {
 
         // the following is not a simple assert_eq, as in case of an error,
         // the whole image would be printed to the console, which takes forever
-        assert!(original.pixels().zip(cropped.pixels()).all(|(a, b)| a == b));
+        assert!(original
+            .pixels()
+            .iter()
+            .zip(cropped.pixels().iter())
+            .all(|(a, b)| a == b));
     }
 }

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -426,7 +426,7 @@ impl<R: BufRead + Seek> ApngDecoder<R> {
                     }
                 } else {
                     // The first frame is always a background frame.
-                    current.pixels_mut().for_each(|pixel| {
+                    current.pixels_mut().iter_mut().for_each(|pixel| {
                         *pixel = Rgba::from([0, 0, 0, 0]);
                     });
                 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -395,6 +395,16 @@ impl<T: $($bound+)*> Pixel for $ident<T> {
         unsafe { std::slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut $ident<T>, len) }
     }
 
+    fn pixels_as_channels(slice: &[$ident<T>]) -> &[T] {
+        let len = slice.len() * $channels;
+        unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const T, len) }
+    }
+
+    fn pixels_as_channels_mut(slice: &mut [$ident<T>]) -> &mut [T] {
+        let len = slice.len() * $channels;
+        unsafe { std::slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut T, len) }
+    }
+
     fn broadcast(val: T) -> $ident<T> {
         $ident([val; $channels])
     }

--- a/src/color.rs
+++ b/src/color.rs
@@ -401,16 +401,6 @@ impl<T: $($bound+)*> Pixel for $ident<T> {
         unsafe { std::slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut $ident<T>, len) }
     }
 
-    fn to_subpixel_slice(slice: &[$ident<T>]) -> &[T] {
-        let len = slice.len() * $channels;
-        unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const T, len) }
-    }
-
-    fn to_subpixel_slice_mut(slice: &mut [$ident<T>]) -> &mut [T] {
-        let len = slice.len() * $channels;
-        unsafe { std::slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut T, len) }
-    }
-
     fn broadcast(val: T) -> $ident<T> {
         $ident([val; $channels])
     }

--- a/src/color.rs
+++ b/src/color.rs
@@ -385,6 +385,28 @@ impl<T: $($bound+)*> Pixel for $ident<T> {
         unsafe { &mut *(slice.as_mut_ptr() as *mut $ident<T>) }
     }
 
+    #[track_caller]
+    #[allow(clippy::modulo_one)]
+    fn slice_from_slice(slice: &[T]) -> &[ $ident<T>] {
+        assert_eq!(slice.len() % $channels, 0);
+        unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const $ident<T>, slice.len() / $channels) }
+    }
+
+    #[track_caller]
+    #[allow(clippy::modulo_one)]
+    fn slice_from_slice_mut(slice: &mut [T]) -> &mut [ $ident<T>] {
+        assert_eq!(slice.len() % $channels, 0);
+        unsafe { std::slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut $ident<T>, slice.len() / $channels) }
+    }
+
+    fn to_subpixel_slice(slice: &[$ident<T>]) -> &[T] {
+        unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const T, slice.len() * $channels) }
+    }
+
+    fn to_subpixel_slice_mut(slice: &mut [$ident<T>]) -> &mut [T] {
+        unsafe { std::slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut T, slice.len() * $channels) }
+    }
+
     fn broadcast(val: T) -> $ident<T> {
         $ident([val; $channels])
     }

--- a/src/color.rs
+++ b/src/color.rs
@@ -385,12 +385,12 @@ impl<T: $($bound+)*> Pixel for $ident<T> {
         unsafe { &mut *(slice.as_mut_ptr() as *mut $ident<T>) }
     }
 
-    fn slice_from_slice(slice: &[T]) -> &[ $ident<T>] {
+    fn pixels_from_channels(slice: &[T]) -> &[ $ident<T>] {
         let len = slice.len() / $channels;
         unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const $ident<T>, len) }
     }
 
-    fn slice_from_slice_mut(slice: &mut [T]) -> &mut [ $ident<T>] {
+    fn pixels_from_channels_mut(slice: &mut [T]) -> &mut [ $ident<T>] {
         let len = slice.len() / $channels;
         unsafe { std::slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut $ident<T>, len) }
     }

--- a/src/color.rs
+++ b/src/color.rs
@@ -389,22 +389,26 @@ impl<T: $($bound+)*> Pixel for $ident<T> {
     #[allow(clippy::modulo_one)]
     fn slice_from_slice(slice: &[T]) -> &[ $ident<T>] {
         assert_eq!(slice.len() % $channels, 0);
-        unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const $ident<T>, slice.len() / $channels) }
+        let len = slice.len() / $channels;
+        unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const $ident<T>, len) }
     }
 
     #[track_caller]
     #[allow(clippy::modulo_one)]
     fn slice_from_slice_mut(slice: &mut [T]) -> &mut [ $ident<T>] {
         assert_eq!(slice.len() % $channels, 0);
-        unsafe { std::slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut $ident<T>, slice.len() / $channels) }
+        let len = slice.len() / $channels;
+        unsafe { std::slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut $ident<T>, len) }
     }
 
     fn to_subpixel_slice(slice: &[$ident<T>]) -> &[T] {
-        unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const T, slice.len() * $channels) }
+        let len = slice.len() * $channels;
+        unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const T, len) }
     }
 
     fn to_subpixel_slice_mut(slice: &mut [$ident<T>]) -> &mut [T] {
-        unsafe { std::slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut T, slice.len() * $channels) }
+        let len = slice.len() * $channels;
+        unsafe { std::slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut T, len) }
     }
 
     fn broadcast(val: T) -> $ident<T> {

--- a/src/color.rs
+++ b/src/color.rs
@@ -385,18 +385,12 @@ impl<T: $($bound+)*> Pixel for $ident<T> {
         unsafe { &mut *(slice.as_mut_ptr() as *mut $ident<T>) }
     }
 
-    #[track_caller]
-    #[allow(clippy::modulo_one)]
     fn slice_from_slice(slice: &[T]) -> &[ $ident<T>] {
-        assert_eq!(slice.len() % $channels, 0);
         let len = slice.len() / $channels;
         unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const $ident<T>, len) }
     }
 
-    #[track_caller]
-    #[allow(clippy::modulo_one)]
     fn slice_from_slice_mut(slice: &mut [T]) -> &mut [ $ident<T>] {
-        assert_eq!(slice.len() % $channels, 0);
         let len = slice.len() / $channels;
         unsafe { std::slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut $ident<T>, len) }
     }

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -537,7 +537,7 @@ where
     let mut indices = ImageBuffer::new(image.width(), image.height());
     indices.set_rgb_primaries(CicpColorPrimaries::Unspecified);
     indices.set_transfer_function(CicpTransferCharacteristics::Unspecified);
-    for (pixel, idx) in image.pixels().zip(indices.pixels_mut()) {
+    for (pixel, idx) in image.pixels().iter().zip(indices.pixels_mut().iter_mut()) {
         *idx = Luma([color_map.index_of(pixel) as u8]);
     }
     indices

--- a/src/imageops/resize.rs
+++ b/src/imageops/resize.rs
@@ -161,7 +161,7 @@ where
     P::Subpixel:
         Copy + PartialEq + BitXor<P::Subpixel, Output = P::Subpixel> + AddAssign + Into<u64>,
 {
-    let first_pixel_alpha = *match img.pixels().next() {
+    let first_pixel_alpha = *match img.pixels().first() {
         Some(pixel) => pixel.channels().last().unwrap(), // there doesn't seem to be a better way to retrieve the alpha channel
         None => return true,                             // empty input image
     };
@@ -173,7 +173,7 @@ where
     // and only compare the sum of divergences on every row, which should be 0
     let mut sum_of_diffs: u64 = 0;
     for row in img.rows() {
-        row.for_each(|pixel| {
+        row.iter().for_each(|pixel| {
             let alpha = pixel.alpha();
             sum_of_diffs += alpha.bitxor(first_pixel_alpha).into();
         });
@@ -187,11 +187,12 @@ where
 #[must_use]
 fn has_constant_alpha_f32(img: &ImageBuffer<crate::Rgba<f32>, Vec<f32>>) -> bool {
     // Optimizing correctly in presence of NaNs and infinities is tricky, so just do the naive thing for now
-    let first_pixel_alpha = match img.pixels().next() {
+    let first_pixel_alpha = match img.pixels().first() {
         Some(pixel) => pixel.alpha(),
         None => return true, // empty input image
     };
     img.pixels()
+        .iter()
         .map(|pixel| pixel.channels().last().unwrap())
         .all(|alpha| *alpha == first_pixel_alpha)
 }

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -1536,7 +1536,7 @@ fn gaussian_blur_indirect_impl<I: GenericImageView, const CN: usize>(
 
     let mut out = image.buffer_like();
     let transient_dst_chunks = transient_dst.as_chunks_mut::<CN>().0.iter_mut();
-    for (dst, src) in out.pixels_mut().zip(transient_dst_chunks) {
+    for (dst, src) in out.pixels_mut().iter_mut().zip(transient_dst_chunks) {
         let pix = src.map(NearestFrom::<f32>::nearest_from);
         *dst = *Pixel::from_slice(&pix);
     }

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -580,7 +580,7 @@ where
     /// The index order is x = 0 to width then y = 0 to height
     pub fn pixels(&self) -> &[P] {
         let subpixels = self.inner_pixels();
-        <P as Pixel>::slice_from_slice(subpixels)
+        <P as Pixel>::pixels_from_channels(subpixels)
     }
 
     /// Returns an iterator over the rows of this image.
@@ -752,7 +752,7 @@ where
     /// Returns a mutable slice of the pixels of this image.
     pub fn pixels_mut(&mut self) -> &mut [P] {
         let subpixels = self.inner_pixels_mut();
-        <P as Pixel>::slice_from_slice_mut(subpixels)
+        <P as Pixel>::pixels_from_channels_mut(subpixels)
     }
 
     /// Returns an iterator over the mutable rows of this image.

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -575,8 +575,9 @@ where
         &self.data[..len]
     }
 
-    /// Returns an iterator over the pixels of this image.
-    /// The iteration order is x = 0 to width then y = 0 to height
+    /// Returns a slice for the pixels of this image.
+    ///
+    /// The index order is x = 0 to width then y = 0 to height
     pub fn pixels(&self) -> &[P] {
         let subpixels = self.inner_pixels();
         <P as Pixel>::slice_from_slice(subpixels)
@@ -748,7 +749,7 @@ where
         &mut self.data[..len]
     }
 
-    /// Returns an iterator over the mutable pixels of this image.
+    /// Returns a mutable slice of the pixels of this image.
     pub fn pixels_mut(&mut self) -> &mut [P] {
         let subpixels = self.inner_pixels_mut();
         <P as Pixel>::slice_from_slice_mut(subpixels)

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -20,157 +20,31 @@ use crate::{
 };
 use crate::{DynamicImage, GenericImage, GenericImageView, ImageEncoder, ImageFormat};
 
-/// Iterate over pixel refs.
-pub struct Pixels<'a, P: Pixel + 'a>
-where
-    P::Subpixel: 'a,
-{
-    chunks: ChunksExact<'a, P::Subpixel>,
-}
-
-impl<'a, P: Pixel + 'a> Iterator for Pixels<'a, P>
-where
-    P::Subpixel: 'a,
-{
-    type Item = &'a P;
-
-    #[inline(always)]
-    fn next(&mut self) -> Option<&'a P> {
-        self.chunks.next().map(|v| <P as Pixel>::from_slice(v))
-    }
-
-    #[inline(always)]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.len();
-        (len, Some(len))
-    }
-}
-
-impl<'a, P: Pixel + 'a> ExactSizeIterator for Pixels<'a, P>
-where
-    P::Subpixel: 'a,
-{
-    fn len(&self) -> usize {
-        self.chunks.len()
-    }
-}
-
-impl<'a, P: Pixel + 'a> DoubleEndedIterator for Pixels<'a, P>
-where
-    P::Subpixel: 'a,
-{
-    #[inline(always)]
-    fn next_back(&mut self) -> Option<&'a P> {
-        self.chunks.next_back().map(|v| <P as Pixel>::from_slice(v))
-    }
-}
-
-impl<P: Pixel> Clone for Pixels<'_, P> {
-    fn clone(&self) -> Self {
-        Pixels {
-            chunks: self.chunks.clone(),
-        }
-    }
-}
-
-impl<P: Pixel> fmt::Debug for Pixels<'_, P>
-where
-    P::Subpixel: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Pixels")
-            .field("chunks", &self.chunks)
-            .finish()
-    }
-}
-
-/// Iterate over mutable pixel refs.
-pub struct PixelsMut<'a, P: Pixel + 'a>
-where
-    P::Subpixel: 'a,
-{
-    chunks: ChunksExactMut<'a, P::Subpixel>,
-}
-
-impl<'a, P: Pixel + 'a> Iterator for PixelsMut<'a, P>
-where
-    P::Subpixel: 'a,
-{
-    type Item = &'a mut P;
-
-    #[inline(always)]
-    fn next(&mut self) -> Option<&'a mut P> {
-        self.chunks.next().map(|v| <P as Pixel>::from_slice_mut(v))
-    }
-
-    #[inline(always)]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.len();
-        (len, Some(len))
-    }
-}
-
-impl<'a, P: Pixel + 'a> ExactSizeIterator for PixelsMut<'a, P>
-where
-    P::Subpixel: 'a,
-{
-    fn len(&self) -> usize {
-        self.chunks.len()
-    }
-}
-
-impl<'a, P: Pixel + 'a> DoubleEndedIterator for PixelsMut<'a, P>
-where
-    P::Subpixel: 'a,
-{
-    #[inline(always)]
-    fn next_back(&mut self) -> Option<&'a mut P> {
-        self.chunks
-            .next_back()
-            .map(|v| <P as Pixel>::from_slice_mut(v))
-    }
-}
-
-impl<P: Pixel> fmt::Debug for PixelsMut<'_, P>
-where
-    P::Subpixel: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("PixelsMut")
-            .field("chunks", &self.chunks)
-            .finish()
-    }
-}
-
 /// Iterate over rows of an image
 ///
 /// This iterator is created with [`ImageBuffer::rows`]. See its document for details.
 ///
 /// [`ImageBuffer::rows`]: ../struct.ImageBuffer.html#method.rows
-pub struct Rows<'a, P: Pixel + 'a>
-where
-    <P as Pixel>::Subpixel: 'a,
-{
-    pixels: ChunksExact<'a, P::Subpixel>,
+pub struct Rows<'a, P: Pixel + 'a> {
+    pixels: ChunksExact<'a, P>,
 }
 
 impl<'a, P: Pixel + 'a> Rows<'a, P> {
     /// Construct the iterator from image pixels. This is not public since it has a (hidden) panic
     /// condition. The `pixels` slice must be large enough so that all pixels are addressable.
-    fn with_image(pixels: &'a [P::Subpixel], width: u32, height: u32) -> Self {
-        let row_len = (width as usize) * usize::from(<P as Pixel>::CHANNEL_COUNT);
-        if row_len == 0 {
+    fn with_image(pixels: &'a [P], width: u32, height: u32) -> Self {
+        assert_eq!(
+            Some(pixels.len()),
+            (width as usize).checked_mul(height as usize)
+        );
+
+        if width == 0 {
             Rows {
                 pixels: [].chunks_exact(1),
             }
         } else {
-            let pixels = pixels
-                .get(..row_len * height as usize)
-                .expect("Pixel buffer has too few subpixels");
-            // Rows are physically present. In particular, height is smaller than `usize::MAX` as
-            // all subpixels can be indexed.
             Rows {
-                pixels: pixels.chunks_exact(row_len),
+                pixels: pixels.chunks_exact(width as usize),
             }
         }
     }
@@ -180,15 +54,11 @@ impl<'a, P: Pixel + 'a> Iterator for Rows<'a, P>
 where
     P::Subpixel: 'a,
 {
-    type Item = Pixels<'a, P>;
+    type Item = &'a [P];
 
     #[inline(always)]
-    fn next(&mut self) -> Option<Pixels<'a, P>> {
-        let row = self.pixels.next()?;
-        Some(Pixels {
-            // Note: this is not reached when CHANNEL_COUNT is 0.
-            chunks: row.chunks_exact(<P as Pixel>::CHANNEL_COUNT as usize),
-        })
+    fn next(&mut self) -> Option<&'a [P]> {
+        self.pixels.next()
     }
 
     #[inline(always)]
@@ -212,12 +82,8 @@ where
     P::Subpixel: 'a,
 {
     #[inline(always)]
-    fn next_back(&mut self) -> Option<Pixels<'a, P>> {
-        let row = self.pixels.next_back()?;
-        Some(Pixels {
-            // Note: this is not reached when CHANNEL_COUNT is 0.
-            chunks: row.chunks_exact(<P as Pixel>::CHANNEL_COUNT as usize),
-        })
+    fn next_back(&mut self) -> Option<&'a [P]> {
+        self.pixels.next_back()
     }
 }
 
@@ -231,7 +97,7 @@ impl<P: Pixel> Clone for Rows<'_, P> {
 
 impl<P: Pixel> fmt::Debug for Rows<'_, P>
 where
-    P::Subpixel: fmt::Debug,
+    P: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Rows")
@@ -245,36 +111,28 @@ where
 /// This iterator is created with [`ImageBuffer::rows_mut`]. See its document for details.
 ///
 /// [`ImageBuffer::rows_mut`]: ../struct.ImageBuffer.html#method.rows_mut
-pub struct RowsMut<'a, P: Pixel + 'a>
-where
-    <P as Pixel>::Subpixel: 'a,
-{
-    pixels: ChunksExactMut<'a, P::Subpixel>,
+pub struct RowsMut<'a, P: Pixel + 'a> {
+    pixels: ChunksExactMut<'a, P>,
 }
 
 impl<'a, P: Pixel + 'a> RowsMut<'a, P> {
     /// Construct the iterator from image pixels. This is not public since it has a (hidden) panic
     /// condition. The `pixels` slice must be large enough so that all pixels are addressable.
-    fn with_image(pixels: &'a mut [P::Subpixel], width: u32, height: u32) -> Self {
-        let row_len = (width as usize) * usize::from(<P as Pixel>::CHANNEL_COUNT);
-        if row_len == 0 {
+    fn with_image(pixels: &'a mut [P], width: u32, height: u32) -> Self {
+        assert_eq!(
+            Some(pixels.len()),
+            (width as usize).checked_mul(height as usize)
+        );
+
+        if width == 0 {
             RowsMut {
                 pixels: [].chunks_exact_mut(1),
             }
         } else {
-            let pixels = pixels
-                .get_mut(..row_len * height as usize)
-                .expect("Pixel buffer has too few subpixels");
-            // Rows are physically present. In particular, height is smaller than `usize::MAX` as
-            // all subpixels can be indexed.
             RowsMut {
-                pixels: pixels.chunks_exact_mut(row_len),
+                pixels: pixels.chunks_exact_mut(width as usize),
             }
         }
-    }
-
-    pub(crate) fn into_slices(self) -> ChunksExactMut<'a, P::Subpixel> {
-        self.pixels
     }
 }
 
@@ -282,15 +140,11 @@ impl<'a, P: Pixel + 'a> Iterator for RowsMut<'a, P>
 where
     P::Subpixel: 'a,
 {
-    type Item = PixelsMut<'a, P>;
+    type Item = &'a mut [P];
 
     #[inline(always)]
-    fn next(&mut self) -> Option<PixelsMut<'a, P>> {
-        let row = self.pixels.next()?;
-        Some(PixelsMut {
-            // Note: this is not reached when CHANNEL_COUNT is 0.
-            chunks: row.chunks_exact_mut(<P as Pixel>::CHANNEL_COUNT as usize),
-        })
+    fn next(&mut self) -> Option<&'a mut [P]> {
+        self.pixels.next()
     }
 
     #[inline(always)]
@@ -314,18 +168,14 @@ where
     P::Subpixel: 'a,
 {
     #[inline(always)]
-    fn next_back(&mut self) -> Option<PixelsMut<'a, P>> {
-        let row = self.pixels.next_back()?;
-        Some(PixelsMut {
-            // Note: this is not reached when CHANNEL_COUNT is 0.
-            chunks: row.chunks_exact_mut(<P as Pixel>::CHANNEL_COUNT as usize),
-        })
+    fn next_back(&mut self) -> Option<&'a mut [P]> {
+        self.pixels.next_back()
     }
 }
 
 impl<P: Pixel> fmt::Debug for RowsMut<'_, P>
 where
-    P::Subpixel: fmt::Debug,
+    P: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("RowsMut")
@@ -339,7 +189,7 @@ pub struct EnumeratePixels<'a, P: Pixel + 'a>
 where
     <P as Pixel>::Subpixel: 'a,
 {
-    pixels: Pixels<'a, P>,
+    pixels: std::slice::Iter<'a, P>,
     x: u32,
     y: u32,
     width: u32,
@@ -389,7 +239,7 @@ impl<P: Pixel> Clone for EnumeratePixels<'_, P> {
 
 impl<P: Pixel> fmt::Debug for EnumeratePixels<'_, P>
 where
-    P::Subpixel: fmt::Debug,
+    P: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("EnumeratePixels")
@@ -428,7 +278,7 @@ where
                     x: 0,
                     y,
                     width: self.width,
-                    pixels: r,
+                    pixels: r.iter(),
                 },
             )
         })
@@ -461,7 +311,7 @@ impl<P: Pixel> Clone for EnumerateRows<'_, P> {
 
 impl<P: Pixel> fmt::Debug for EnumerateRows<'_, P>
 where
-    P::Subpixel: fmt::Debug,
+    P: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("EnumerateRows")
@@ -477,7 +327,7 @@ pub struct EnumeratePixelsMut<'a, P: Pixel + 'a>
 where
     <P as Pixel>::Subpixel: 'a,
 {
-    pixels: PixelsMut<'a, P>,
+    pixels: std::slice::IterMut<'a, P>,
     x: u32,
     y: u32,
     width: u32,
@@ -518,7 +368,7 @@ where
 
 impl<P: Pixel> fmt::Debug for EnumeratePixelsMut<'_, P>
 where
-    P::Subpixel: fmt::Debug,
+    P: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("EnumeratePixelsMut")
@@ -557,7 +407,7 @@ where
                     x: 0,
                     y,
                     width: self.width,
-                    pixels: r,
+                    pixels: r.iter_mut(),
                 },
             )
         })
@@ -581,7 +431,7 @@ where
 
 impl<P: Pixel> fmt::Debug for EnumerateRowsMut<'_, P>
 where
-    P::Subpixel: fmt::Debug,
+    P: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("EnumerateRowsMut")
@@ -727,12 +577,9 @@ where
 
     /// Returns an iterator over the pixels of this image.
     /// The iteration order is x = 0 to width then y = 0 to height
-    pub fn pixels(&self) -> Pixels<'_, P> {
-        Pixels {
-            chunks: self
-                .inner_pixels()
-                .chunks_exact(<P as Pixel>::CHANNEL_COUNT as usize),
-        }
+    pub fn pixels(&self) -> &[P] {
+        let subpixels = self.inner_pixels();
+        <P as Pixel>::slice_from_slice(subpixels)
     }
 
     /// Returns an iterator over the rows of this image.
@@ -741,7 +588,7 @@ where
     /// yield any item when the width of the image is `0` or a pixel type without any channels is
     /// used. This ensures that its length can always be represented by `usize`.
     pub fn rows(&self) -> Rows<'_, P> {
-        Rows::with_image(&self.data, self.width, self.height)
+        Rows::with_image(self.pixels(), self.width, self.height)
     }
 
     /// Enumerates over the pixels of the image.
@@ -751,7 +598,7 @@ where
     /// Starting from the top left.
     pub fn enumerate_pixels(&self) -> EnumeratePixels<'_, P> {
         EnumeratePixels {
-            pixels: self.pixels(),
+            pixels: self.pixels().iter(),
             x: 0,
             y: 0,
             width: self.width,
@@ -902,12 +749,9 @@ where
     }
 
     /// Returns an iterator over the mutable pixels of this image.
-    pub fn pixels_mut(&mut self) -> PixelsMut<'_, P> {
-        PixelsMut {
-            chunks: self
-                .inner_pixels_mut()
-                .chunks_exact_mut(<P as Pixel>::CHANNEL_COUNT as usize),
-        }
+    pub fn pixels_mut(&mut self) -> &mut [P] {
+        let subpixels = self.inner_pixels_mut();
+        <P as Pixel>::slice_from_slice_mut(subpixels)
     }
 
     /// Returns an iterator over the mutable rows of this image.
@@ -916,7 +760,9 @@ where
     /// yield any item when the width of the image is `0` or a pixel type without any channels is
     /// used. This ensures that its length can always be represented by `usize`.
     pub fn rows_mut(&mut self) -> RowsMut<'_, P> {
-        RowsMut::with_image(&mut self.data, self.width, self.height)
+        let width = self.width;
+        let height = self.height;
+        RowsMut::with_image(self.pixels_mut(), width, height)
     }
 
     /// Enumerates over the pixels of the image.
@@ -925,7 +771,7 @@ where
     pub fn enumerate_pixels_mut(&mut self) -> EnumeratePixelsMut<'_, P> {
         let width = self.width;
         EnumeratePixelsMut {
-            pixels: self.pixels_mut(),
+            pixels: self.pixels_mut().iter_mut(),
             x: 0,
             y: 0,
             width,
@@ -1693,7 +1539,7 @@ where
         let mut buffer: ImageBuffer<ToType, Vec<ToType::Subpixel>> =
             ImageBuffer::new(self.width, self.height);
         buffer.copy_color_space_from(self);
-        for (to, from) in buffer.pixels_mut().zip(self.pixels()) {
+        for (to, from) in buffer.pixels_mut().iter_mut().zip(self.pixels().iter()) {
             to.from_color(from);
         }
         buffer
@@ -2056,7 +1902,7 @@ mod test {
     fn mut_iter() {
         let mut a: RgbImage = ImageBuffer::new(10, 10);
         {
-            let val = a.pixels_mut().next().unwrap();
+            let val = a.pixels_mut().first_mut().unwrap();
             *val = Rgb([42, 0, 0]);
         }
         assert_eq!(a.data[0], 42);
@@ -2067,9 +1913,9 @@ mod test {
         let mut image = RgbImage::new(0, 0);
 
         assert_eq!(image.rows_mut().count(), 0);
-        assert_eq!(image.pixels_mut().count(), 0);
+        assert_eq!(image.pixels_mut().len(), 0);
         assert_eq!(image.rows().count(), 0);
-        assert_eq!(image.pixels().count(), 0);
+        assert_eq!(image.pixels().len(), 0);
     }
 
     #[test]
@@ -2077,9 +1923,9 @@ mod test {
         let mut image = RgbImage::new(0, 2);
 
         assert_eq!(image.rows_mut().count(), 0);
-        assert_eq!(image.pixels_mut().count(), 0);
+        assert_eq!(image.pixels_mut().len(), 0);
         assert_eq!(image.rows().count(), 0);
-        assert_eq!(image.pixels().count(), 0);
+        assert_eq!(image.pixels().len(), 0);
     }
 
     #[test]
@@ -2087,18 +1933,18 @@ mod test {
         let mut image = RgbImage::new(2, 0);
 
         assert_eq!(image.rows_mut().count(), 0);
-        assert_eq!(image.pixels_mut().count(), 0);
+        assert_eq!(image.pixels_mut().len(), 0);
         assert_eq!(image.rows().count(), 0);
-        assert_eq!(image.pixels().count(), 0);
+        assert_eq!(image.pixels().len(), 0);
     }
 
     #[test]
     fn pixels_on_large_buffer() {
         let mut image = RgbImage::from_raw(1, 1, vec![0; 6]).unwrap();
 
-        assert_eq!(image.pixels().count(), 1);
+        assert_eq!(image.pixels().len(), 1);
         assert_eq!(image.enumerate_pixels().count(), 1);
-        assert_eq!(image.pixels_mut().count(), 1);
+        assert_eq!(image.pixels_mut().len(), 1);
         assert_eq!(image.enumerate_pixels_mut().count(), 1);
 
         assert_eq!(image.rows().count(), 1);
@@ -2216,14 +2062,6 @@ mod test {
 
         let mut image = RgbImage::from_raw(N, N, vec![0; (N * N * 3) as usize]).unwrap();
 
-        let iter = image.pixels();
-        let exact_len = ExactSizeIterator::len(&iter);
-        assert_eq!(iter.size_hint(), (exact_len, Some(exact_len)));
-
-        let iter = image.pixels_mut();
-        let exact_len = ExactSizeIterator::len(&iter);
-        assert_eq!(iter.size_hint(), (exact_len, Some(exact_len)));
-
         let iter = image.rows();
         let exact_len = ExactSizeIterator::len(&iter);
         assert_eq!(iter.size_hint(), (exact_len, Some(exact_len)));
@@ -2311,7 +2149,7 @@ mod test {
             .apply_color_space(Cicp::DISPLAY_P3, Default::default())
             .expect("supported transform");
 
-        buffer.pixels().for_each(|&p| {
+        buffer.pixels().iter().for_each(|&p| {
             assert_eq!(p, Rgb([234u8, 51, 35]));
         });
     }

--- a/src/images/buffer_par.rs
+++ b/src/images/buffer_par.rs
@@ -445,11 +445,11 @@ mod test {
             image2.par_enumerate_pixels().collect::<Vec<_>>()
         );
         assert_eq!(
-            image1.pixels_mut().collect::<Vec<_>>(),
+            image1.pixels_mut().iter().collect::<Vec<_>>(),
             image2.par_pixels_mut().collect::<Vec<_>>()
         );
         assert_eq!(
-            image1.pixels().collect::<Vec<_>>(),
+            image1.pixels().iter().collect::<Vec<_>>(),
             image2.par_pixels().collect::<Vec<_>>()
         );
     }

--- a/src/images/buffer_par.rs
+++ b/src/images/buffer_par.rs
@@ -1,140 +1,11 @@
-use rayon::iter::plumbing::*;
+use rayon::iter::{plumbing::*, IntoParallelRefIterator, IntoParallelRefMutIterator};
 use rayon::iter::{IndexedParallelIterator, ParallelIterator};
-use rayon::slice::{ChunksExact, ChunksExactMut, ParallelSlice, ParallelSliceMut};
+use rayon::slice::{Iter, IterMut};
 use std::fmt;
 use std::ops::{Deref, DerefMut};
 
 use crate::traits::Pixel;
 use crate::ImageBuffer;
-
-/// Parallel iterator over pixel refs.
-#[derive(Clone)]
-pub struct PixelsPar<'a, P>
-where
-    P: Pixel + Sync + 'a,
-    P::Subpixel: Sync + 'a,
-{
-    chunks: ChunksExact<'a, P::Subpixel>,
-}
-
-impl<'a, P> ParallelIterator for PixelsPar<'a, P>
-where
-    P: Pixel + Sync + 'a,
-    P::Subpixel: Sync + 'a,
-{
-    type Item = &'a P;
-
-    fn drive_unindexed<C>(self, consumer: C) -> C::Result
-    where
-        C: UnindexedConsumer<Self::Item>,
-    {
-        self.chunks
-            .map(|v| <P as Pixel>::from_slice(v))
-            .drive_unindexed(consumer)
-    }
-
-    fn opt_len(&self) -> Option<usize> {
-        Some(self.len())
-    }
-}
-
-impl<'a, P> IndexedParallelIterator for PixelsPar<'a, P>
-where
-    P: Pixel + Sync + 'a,
-    P::Subpixel: Sync + 'a,
-{
-    fn drive<C: Consumer<Self::Item>>(self, consumer: C) -> C::Result {
-        self.chunks
-            .map(|v| <P as Pixel>::from_slice(v))
-            .drive(consumer)
-    }
-
-    fn len(&self) -> usize {
-        self.chunks.len()
-    }
-
-    fn with_producer<CB: ProducerCallback<Self::Item>>(self, callback: CB) -> CB::Output {
-        self.chunks
-            .map(|v| <P as Pixel>::from_slice(v))
-            .with_producer(callback)
-    }
-}
-
-impl<P> fmt::Debug for PixelsPar<'_, P>
-where
-    P: Pixel + Sync,
-    P::Subpixel: Sync + fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("PixelsPar")
-            .field("chunks", &self.chunks)
-            .finish()
-    }
-}
-
-/// Parallel iterator over mutable pixel refs.
-pub struct PixelsMutPar<'a, P>
-where
-    P: Pixel + Send + Sync + 'a,
-    P::Subpixel: Send + Sync + 'a,
-{
-    chunks: ChunksExactMut<'a, P::Subpixel>,
-}
-
-impl<'a, P> ParallelIterator for PixelsMutPar<'a, P>
-where
-    P: Pixel + Send + Sync + 'a,
-    P::Subpixel: Send + Sync + 'a,
-{
-    type Item = &'a mut P;
-
-    fn drive_unindexed<C>(self, consumer: C) -> C::Result
-    where
-        C: UnindexedConsumer<Self::Item>,
-    {
-        self.chunks
-            .map(|v| <P as Pixel>::from_slice_mut(v))
-            .drive_unindexed(consumer)
-    }
-
-    fn opt_len(&self) -> Option<usize> {
-        Some(self.len())
-    }
-}
-
-impl<'a, P> IndexedParallelIterator for PixelsMutPar<'a, P>
-where
-    P: Pixel + Send + Sync + 'a,
-    P::Subpixel: Send + Sync + 'a,
-{
-    fn drive<C: Consumer<Self::Item>>(self, consumer: C) -> C::Result {
-        self.chunks
-            .map(|v| <P as Pixel>::from_slice_mut(v))
-            .drive(consumer)
-    }
-
-    fn len(&self) -> usize {
-        self.chunks.len()
-    }
-
-    fn with_producer<CB: ProducerCallback<Self::Item>>(self, callback: CB) -> CB::Output {
-        self.chunks
-            .map(|v| <P as Pixel>::from_slice_mut(v))
-            .with_producer(callback)
-    }
-}
-
-impl<P> fmt::Debug for PixelsMutPar<'_, P>
-where
-    P: Pixel + Send + Sync,
-    P::Subpixel: Send + Sync + fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("PixelsMutPar")
-            .field("chunks", &self.chunks)
-            .finish()
-    }
-}
 
 /// Parallel iterator over pixel refs and their coordinates.
 #[derive(Clone)]
@@ -143,7 +14,7 @@ where
     P: Pixel + Sync + 'a,
     P::Subpixel: Sync + 'a,
 {
-    pixels: PixelsPar<'a, P>,
+    pixels: Iter<'a, P>,
     width: u32,
 }
 
@@ -213,8 +84,8 @@ where
 
 impl<P> fmt::Debug for EnumeratePixelsPar<'_, P>
 where
-    P: Pixel + Sync,
-    P::Subpixel: Sync + fmt::Debug,
+    P: Pixel + Sync + fmt::Debug,
+    P::Subpixel: Sync,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("EnumeratePixelsPar")
@@ -230,7 +101,7 @@ where
     P: Pixel + Send + Sync + 'a,
     P::Subpixel: Send + Sync + 'a,
 {
-    pixels: PixelsMutPar<'a, P>,
+    pixels: IterMut<'a, P>,
     width: u32,
 }
 
@@ -300,8 +171,8 @@ where
 
 impl<P> fmt::Debug for EnumeratePixelsMutPar<'_, P>
 where
-    P: Pixel + Send + Sync,
-    P::Subpixel: Send + Sync + fmt::Debug,
+    P: Pixel + Send + Sync + fmt::Debug,
+    P::Subpixel: Send + Sync,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("EnumeratePixelsMutPar")
@@ -317,25 +188,13 @@ where
     P::Subpixel: Sync,
     Container: Deref<Target = [P::Subpixel]>,
 {
-    /// Returns a parallel iterator over the pixels of this image, usable with `rayon`.
-    /// See [`pixels`] for more information.
-    ///
-    /// [`pixels`]: #method.pixels
-    pub fn par_pixels(&self) -> PixelsPar<'_, P> {
-        PixelsPar {
-            chunks: self
-                .inner_pixels()
-                .par_chunks_exact(<P as Pixel>::CHANNEL_COUNT as usize),
-        }
-    }
-
     /// Returns a parallel iterator over the pixels of this image and their coordinates, usable with `rayon`.
     /// See [`enumerate_pixels`] for more information.
     ///
     /// [`enumerate_pixels`]: #method.enumerate_pixels
     pub fn par_enumerate_pixels(&self) -> EnumeratePixelsPar<'_, P> {
         EnumeratePixelsPar {
-            pixels: self.par_pixels(),
+            pixels: self.pixels().par_iter(),
             width: self.width(),
         }
     }
@@ -347,18 +206,6 @@ where
     P::Subpixel: Send + Sync,
     Container: Deref<Target = [P::Subpixel]> + DerefMut,
 {
-    /// Returns a parallel iterator over the mutable pixels of this image, usable with `rayon`.
-    /// See [`pixels_mut`] for more information.
-    ///
-    /// [`pixels_mut`]: #method.pixels_mut
-    pub fn par_pixels_mut(&mut self) -> PixelsMutPar<'_, P> {
-        PixelsMutPar {
-            chunks: self
-                .inner_pixels_mut()
-                .par_chunks_exact_mut(<P as Pixel>::CHANNEL_COUNT as usize),
-        }
-    }
-
     /// Returns a parallel iterator over the mutable pixels of this image and their coordinates, usable with `rayon`.
     /// See [`enumerate_pixels_mut`] for more information.
     ///
@@ -366,7 +213,7 @@ where
     pub fn par_enumerate_pixels_mut(&mut self) -> EnumeratePixelsMutPar<'_, P> {
         let width = self.width();
         EnumeratePixelsMutPar {
-            pixels: self.par_pixels_mut(),
+            pixels: self.pixels_mut().par_iter_mut(),
             width,
         }
     }
@@ -408,8 +255,8 @@ mod test {
 
         assert_eq!(image.par_enumerate_pixels_mut().len(), len);
         assert_eq!(image.par_enumerate_pixels().len(), len);
-        assert_eq!(image.par_pixels_mut().len(), len);
-        assert_eq!(image.par_pixels().len(), len);
+        assert_eq!(image.pixels_mut().len(), len);
+        assert_eq!(image.pixels().len(), len);
     }
 
     #[test]
@@ -443,14 +290,6 @@ mod test {
         assert_eq!(
             image1.enumerate_pixels().collect::<Vec<_>>(),
             image2.par_enumerate_pixels().collect::<Vec<_>>()
-        );
-        assert_eq!(
-            image1.pixels_mut().iter().collect::<Vec<_>>(),
-            image2.par_pixels_mut().collect::<Vec<_>>()
-        );
-        assert_eq!(
-            image1.pixels().iter().collect::<Vec<_>>(),
-            image2.par_pixels().collect::<Vec<_>>()
         );
     }
 }

--- a/src/images/flat.rs
+++ b/src/images/flat.rs
@@ -1246,7 +1246,7 @@ where
 
     /// If the underlying samples are in row-major form and packed pixels, return
     /// an iterator over the rows of the image.
-    pub(crate) fn iter_rows(&self) -> Option<impl Iterator<Item = &[P::Subpixel]> + '_> {
+    pub(crate) fn iter_rows(&self) -> Option<impl Iterator<Item = &[P]> + '_> {
         let layout = self.flat().layout;
         let channels = P::CHANNEL_COUNT;
         if layout.channel_stride != 1
@@ -1266,7 +1266,7 @@ where
 
         Some((0..layout.height as usize).map(move |y| {
             let start = y * row_stride;
-            &data[start..start + row_len]
+            P::slice_from_slice(&data[start..start + row_len])
         }))
     }
 }

--- a/src/images/flat.rs
+++ b/src/images/flat.rs
@@ -1246,7 +1246,7 @@ where
 
     /// If the underlying samples are in row-major form and packed pixels, return
     /// an iterator over the rows of the image.
-    pub(crate) fn iter_rows(&self) -> Option<impl Iterator<Item = &[P]> + '_> {
+    pub(crate) fn iter_rows(&self) -> Option<impl Iterator<Item = &[P::Subpixel]> + '_> {
         let layout = self.flat().layout;
         let channels = P::CHANNEL_COUNT;
         if layout.channel_stride != 1
@@ -1266,7 +1266,7 @@ where
 
         Some((0..layout.height as usize).map(move |y| {
             let start = y * row_stride;
-            P::slice_from_slice(&data[start..start + row_len])
+            &data[start..start + row_len]
         }))
     }
 }

--- a/src/images/sub_image.rs
+++ b/src/images/sub_image.rs
@@ -88,8 +88,8 @@ impl<I> SubImage<I> {
         // fast path for row-major packed views
         if let Some(view) = self.to_pixel_view() {
             if let Some(row_iter) = view.iter_rows() {
-                for (row, out_row) in row_iter.zip(out.pixels_mut().chunks_exact_mut(w as usize)) {
-                    Pixel::to_subpixel_slice_mut(out_row).copy_from_slice(row);
+                for (row, out_row) in row_iter.zip(out.rows_mut()) {
+                    out_row.copy_from_slice(row);
                 }
                 return out;
             }

--- a/src/images/sub_image.rs
+++ b/src/images/sub_image.rs
@@ -88,10 +88,8 @@ impl<I> SubImage<I> {
         // fast path for row-major packed views
         if let Some(view) = self.to_pixel_view() {
             if let Some(row_iter) = view.iter_rows() {
-                let row_len = (w as usize) * <DerefPixel<I> as Pixel>::CHANNEL_COUNT as usize;
-                for (row, out_row) in row_iter.zip(out.inner_pixels_mut().chunks_exact_mut(row_len))
-                {
-                    out_row.copy_from_slice(row);
+                for (row, out_row) in row_iter.zip(out.rows_mut()) {
+                    Pixel::pixels_as_channels_mut(out_row).copy_from_slice(row);
                 }
                 return out;
             }

--- a/src/images/sub_image.rs
+++ b/src/images/sub_image.rs
@@ -88,7 +88,9 @@ impl<I> SubImage<I> {
         // fast path for row-major packed views
         if let Some(view) = self.to_pixel_view() {
             if let Some(row_iter) = view.iter_rows() {
-                for (row, out_row) in row_iter.zip(out.rows_mut()) {
+                let row_len = (w as usize) * <DerefPixel<I> as Pixel>::CHANNEL_COUNT as usize;
+                for (row, out_row) in row_iter.zip(out.inner_pixels_mut().chunks_exact_mut(row_len))
+                {
                     out_row.copy_from_slice(row);
                 }
                 return out;

--- a/src/images/sub_image.rs
+++ b/src/images/sub_image.rs
@@ -88,8 +88,8 @@ impl<I> SubImage<I> {
         // fast path for row-major packed views
         if let Some(view) = self.to_pixel_view() {
             if let Some(row_iter) = view.iter_rows() {
-                for (row, out_row) in row_iter.zip(out.rows_mut().into_slices()) {
-                    out_row.copy_from_slice(row);
+                for (row, out_row) in row_iter.zip(out.pixels_mut().chunks_exact_mut(w as usize)) {
+                    Pixel::to_subpixel_slice_mut(out_row).copy_from_slice(row);
                 }
                 return out;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,8 +178,8 @@ pub mod error;
 pub mod buffer {
     // Only those not exported at the top-level
     pub use crate::images::buffer::{
-        ConvertBuffer, EnumeratePixels, EnumeratePixelsMut, EnumerateRows, EnumerateRowsMut,
-        Pixels, PixelsMut, Rows, RowsMut,
+        ConvertBuffer, EnumeratePixels, EnumeratePixelsMut, EnumerateRows, EnumerateRowsMut, Rows,
+        RowsMut,
     };
 
     #[cfg(feature = "rayon")]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -484,6 +484,12 @@ pub trait Pixel: Copy + Clone {
     /// If `slice.len()` is not a multiple of `CHANNEL_COUNT`, the longest prefix of whole pixels is returned.
     fn pixels_from_channels_mut(slice: &mut [Self::Subpixel]) -> &mut [Self];
 
+    /// Returns a slice of subpixels from a slice of pixels.
+    fn pixels_as_channels(slice: &[Self]) -> &[Self::Subpixel];
+
+    /// Returns a mutable slice of subpixels from a mutable slice of pixels.
+    fn pixels_as_channels_mut(slice: &mut [Self]) -> &mut [Self::Subpixel];
+
     /// Create a pixel from setting all channels to the same value.
     fn broadcast(_: Self::Subpixel) -> Self;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -476,16 +476,12 @@ pub trait Pixel: Copy + Clone {
 
     /// Returns a slice of pixels from a slice of subpixels.
     ///
-    /// ## Panics
-    ///
-    /// Panics if `slice.len()` is not a multiple of `CHANNEL_COUNT`.
+    /// If `slice.len()` is not a multiple of `CHANNEL_COUNT`, the longest prefix of whole pixels is returned.
     fn slice_from_slice(slice: &[Self::Subpixel]) -> &[Self];
 
     /// Returns a mutable slice of pixels from a mutable slice of subpixels.
     ///
-    /// ## Panics
-    ///
-    /// Panics if `slice.len()` is not a multiple of `CHANNEL_COUNT`.
+    /// If `slice.len()` is not a multiple of `CHANNEL_COUNT`, the longest prefix of whole pixels is returned.
     fn slice_from_slice_mut(slice: &mut [Self::Subpixel]) -> &mut [Self];
 
     /// Create a pixel from setting all channels to the same value.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -474,6 +474,15 @@ pub trait Pixel: Copy + Clone {
     /// that the slice is long enough to prevent panics if the pixel is used later on.
     fn from_slice_mut(slice: &mut [Self::Subpixel]) -> &mut Self;
 
+    /// Returns a view into a slice.
+    fn slice_from_slice(slice: &[Self::Subpixel]) -> &[Self];
+
+    /// Returns mutable view into a mutable slice.
+    fn slice_from_slice_mut(slice: &mut [Self::Subpixel]) -> &mut [Self];
+
+    fn to_subpixel_slice(slice: &[Self]) -> &[Self::Subpixel];
+    fn to_subpixel_slice_mut(slice: &mut [Self]) -> &mut [Self::Subpixel];
+
     /// Create a pixel from setting all channels to the same value.
     fn broadcast(_: Self::Subpixel) -> Self;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -477,12 +477,12 @@ pub trait Pixel: Copy + Clone {
     /// Returns a slice of pixels from a slice of subpixels.
     ///
     /// If `slice.len()` is not a multiple of `CHANNEL_COUNT`, the longest prefix of whole pixels is returned.
-    fn slice_from_slice(slice: &[Self::Subpixel]) -> &[Self];
+    fn pixels_from_channels(slice: &[Self::Subpixel]) -> &[Self];
 
     /// Returns a mutable slice of pixels from a mutable slice of subpixels.
     ///
     /// If `slice.len()` is not a multiple of `CHANNEL_COUNT`, the longest prefix of whole pixels is returned.
-    fn slice_from_slice_mut(slice: &mut [Self::Subpixel]) -> &mut [Self];
+    fn pixels_from_channels_mut(slice: &mut [Self::Subpixel]) -> &mut [Self];
 
     /// Create a pixel from setting all channels to the same value.
     fn broadcast(_: Self::Subpixel) -> Self;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -480,17 +480,13 @@ pub trait Pixel: Copy + Clone {
     ///
     /// Panics if `slice.len()` is not a multiple of `CHANNEL_COUNT`.
     fn slice_from_slice(slice: &[Self::Subpixel]) -> &[Self];
+
     /// Returns a mutable slice of pixels from a mutable slice of subpixels.
     ///
     /// ## Panics
     ///
     /// Panics if `slice.len()` is not a multiple of `CHANNEL_COUNT`.
     fn slice_from_slice_mut(slice: &mut [Self::Subpixel]) -> &mut [Self];
-
-    /// Returns a slice of subpixels from a slice of pixels.
-    fn to_subpixel_slice(slice: &[Self]) -> &[Self::Subpixel];
-    /// Returns a mutable slice of subpixels from a mutable slice of pixels.
-    fn to_subpixel_slice_mut(slice: &mut [Self]) -> &mut [Self::Subpixel];
 
     /// Create a pixel from setting all channels to the same value.
     fn broadcast(_: Self::Subpixel) -> Self;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -474,13 +474,22 @@ pub trait Pixel: Copy + Clone {
     /// that the slice is long enough to prevent panics if the pixel is used later on.
     fn from_slice_mut(slice: &mut [Self::Subpixel]) -> &mut Self;
 
-    /// Returns a view into a slice.
+    /// Returns a slice of pixels from a slice of subpixels.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if `slice.len()` is not a multiple of `CHANNEL_COUNT`.
     fn slice_from_slice(slice: &[Self::Subpixel]) -> &[Self];
-
-    /// Returns mutable view into a mutable slice.
+    /// Returns a mutable slice of pixels from a mutable slice of subpixels.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if `slice.len()` is not a multiple of `CHANNEL_COUNT`.
     fn slice_from_slice_mut(slice: &mut [Self::Subpixel]) -> &mut [Self];
 
+    /// Returns a slice of subpixels from a slice of pixels.
     fn to_subpixel_slice(slice: &[Self]) -> &[Self::Subpixel];
+    /// Returns a mutable slice of subpixels from a mutable slice of pixels.
     fn to_subpixel_slice_mut(slice: &mut [Self]) -> &mut [Self::Subpixel];
 
     /// Create a pixel from setting all channels to the same value.


### PR DESCRIPTION
This PR implements my proposal #2936. For motivation, see the proposal. (The main point is that slices are strictly more powerful than iterators.)

API changes:
- Add `fn Pixel::slice_from_slice(slice: &[Self::Subpixel]) -> &[Self]` and `fn Pixel::slice_from_slice_mut(slice: &mut [Self::Subpixel]) -> &mut [Self]` to cast a slice of subpixels to a slice of pixels.
- Change `ImageBuffer::pixels()` and `ImageBuffer::pixels_mut()` to return pixel slices inside of iterators.
- Change `Rows` and `RowsMut` iterators to yield pixel slices.
- Remove `Pixels`, `PixelsMut`, `PixelsPar`, and `PixelsMutPar` iterators.

Notes:
- I removed `Pixels` and `PixelsPar` because they are now unnecessary. Use `image.pixels().iter()` and `image.pixels().par_iter()` instead. Same for the mut variants.
- I ran all benchmarks and found no perf regressions.
- This unfortunately adds 2 new `unsafe` to implement slice casting.

### Future work

- `Rows` and `RowsMut` are now wrappers around `ChunksExact{,Mut}` and don't implement any real logic. They could be removed as well.
- We could expose `ImageBuffer::inner_pixels() -> &[P::Subpixel]` under the name `ImageBuffer::subpixels()`. This would create a nice symmetry with `ImageBuffer::pixels() -> &[P]`. Same for mut, of course.