### PR TITLE
Omit LUT features from moxcms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,14 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 bytemuck = { version = "1.8.0", features = ["extern_crate_alloc"] } # includes cast_vec
 byteorder-lite = "0.1.0"
-moxcms = "0.8.0"
+moxcms = { version = "0.8.0", default-features = false, features = [
+    "avx_shaper_fixed_point_paths",
+    "avx_shaper_paths",
+    "neon_shaper_fixed_point_paths",
+    "neon_shaper_paths",
+    "sse_shaper_fixed_point_paths",
+    "sse_shaper_paths",
+] }
 num-traits = { version = "0.2.0" }
 
 # Optional dependencies


### PR DESCRIPTION
## Summary

Given:

```rust
use image::metadata::Cicp;
use image::{ImageBuffer, Rgb};

fn main() {
    let mut image = ImageBuffer::from_fn(1, 1, |_, _| Rgb([255u8, 0, 0]));
    image.set_rgb_primaries(Cicp::SRGB.primaries);
    image.set_transfer_function(Cicp::SRGB.transfer);
    image
        .apply_color_space(Cicp::DISPLAY_P3, Default::default())
        .unwrap();
    std::hint::black_box(image);
}
```

This PR reduces the binary size from 1,052,208 B to 831,152 B, by removing the unused LUT features.
