### PR TITLE
Expose `ImageBuffer::subpixels*`

### DIFF
--- a/src/codecs/webp/encoder.rs
+++ b/src/codecs/webp/encoder.rs
@@ -137,7 +137,7 @@ mod tests {
         let mut output = Vec::new();
         super::WebPEncoder::new_lossless(&mut output)
             .write_image(
-                img.inner_pixels(),
+                img.subpixels(),
                 img.width(),
                 img.height(),
                 crate::ExtendedColorType::Rgba8,
@@ -162,7 +162,7 @@ mod tests {
             encoder.set_xmp_metadata(xmp.clone()).unwrap();
             encoder
                 .write_image(
-                    img.inner_pixels(),
+                    img.subpixels(),
                     img.width(),
                     img.height(),
                     crate::ExtendedColorType::Rgba8,

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -572,6 +572,7 @@ where
     /// Returns a slice of the subpixels of this image.
     ///
     /// This is guaranteed to contain exactly `width * height * channels` subpixels.
+    #[doc(alias = "channels")]
     pub fn subpixels(&self) -> &[P::Subpixel] {
         let len = Self::image_buffer_len(self.width, self.height).unwrap();
         &self.data[..len]

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -569,17 +569,21 @@ where
         self.height
     }
 
-    // TODO: choose name under which to expose.
-    pub(crate) fn inner_pixels(&self) -> &[P::Subpixel] {
+    /// Returns a slice of the subpixels of this image.
+    ///
+    /// This is guaranteed to contain exactly `width * height * channels` subpixels.
+    pub fn subpixels(&self) -> &[P::Subpixel] {
         let len = Self::image_buffer_len(self.width, self.height).unwrap();
         &self.data[..len]
     }
 
     /// Returns a slice for the pixels of this image.
     ///
-    /// The index order is x = 0 to width then y = 0 to height
+    /// The index order is x = 0 to width then y = 0 to height.
+    ///
+    /// This is guaranteed to contain exactly `width * height` subpixels.
     pub fn pixels(&self) -> &[P] {
-        let subpixels = self.inner_pixels();
+        let subpixels = self.subpixels();
         <P as Pixel>::pixels_from_channels(subpixels)
     }
 
@@ -743,15 +747,19 @@ where
     P: Pixel,
     Container: Deref<Target = [P::Subpixel]> + DerefMut,
 {
-    // TODO: choose name under which to expose.
-    pub(crate) fn inner_pixels_mut(&mut self) -> &mut [P::Subpixel] {
+    /// Returns a mutable slice of the subpixels of this image.
+    ///
+    /// This is guaranteed to contain exactly `width * height * channels` subpixels.
+    pub fn subpixels_mut(&mut self) -> &mut [P::Subpixel] {
         let len = Self::image_buffer_len(self.width, self.height).unwrap();
         &mut self.data[..len]
     }
 
     /// Returns a mutable slice of the pixels of this image.
+    ///
+    /// This is guaranteed to contain exactly `width * height` pixels.
     pub fn pixels_mut(&mut self) -> &mut [P] {
-        let subpixels = self.inner_pixels_mut();
+        let subpixels = self.subpixels_mut();
         <P as Pixel>::pixels_from_channels_mut(subpixels)
     }
 
@@ -972,7 +980,7 @@ where
     {
         save_buffer(
             path,
-            self.inner_pixels().as_bytes(),
+            self.subpixels().as_bytes(),
             self.width(),
             self.height(),
             <P as PixelWithColorType>::COLOR_TYPE,
@@ -999,7 +1007,7 @@ where
         // This is valid as the subpixel is u8.
         save_buffer_with_format(
             path,
-            self.inner_pixels().as_bytes(),
+            self.subpixels().as_bytes(),
             self.width(),
             self.height(),
             <P as PixelWithColorType>::COLOR_TYPE,
@@ -1026,7 +1034,7 @@ where
         // This is valid as the subpixel is u8.
         write_buffer_with_format(
             writer,
-            self.inner_pixels().as_bytes(),
+            self.subpixels().as_bytes(),
             self.width(),
             self.height(),
             <P as PixelWithColorType>::COLOR_TYPE,
@@ -1049,7 +1057,7 @@ where
     {
         // This is valid as the subpixel is u8.
         encoder.write_image(
-            self.inner_pixels().as_bytes(),
+            self.subpixels().as_bytes(),
             self.width(),
             self.height(),
             <P as PixelWithColorType>::COLOR_TYPE,
@@ -1234,7 +1242,7 @@ where
 
         let (sw, sh) = view.strides_wh();
         let view_samples: &[_] = view.samples();
-        let inner = self.inner_pixels_mut();
+        let inner = self.subpixels_mut();
 
         let img_pixel_indices_unchecked =
             |x: u32, y: u32| (y as usize * img_sh + x as usize) * pix_stride;
@@ -1400,7 +1408,7 @@ impl<P: Pixel> ImageBuffer<P, Vec<P::Subpixel>> {
     /// assert_eq!(img.into_vec().len(), 16 * 16 * 3);
     /// ```
     pub fn shrink_to_fit(&mut self) {
-        let need = self.inner_pixels().len();
+        let need = self.subpixels().len();
         self.data.truncate(need);
         self.data.shrink_to_fit();
     }
@@ -1633,7 +1641,7 @@ where
     {
         let vec = self
             .color
-            .cast_pixels::<SelfPixel, IntoPixel>(self.inner_pixels(), &|| [0.2126, 0.7152, 0.0722]);
+            .cast_pixels::<SelfPixel, IntoPixel>(self.subpixels(), &|| [0.2126, 0.7152, 0.0722]);
         let mut buffer = ImageBuffer::from_vec(self.width, self.height, vec)
             .expect("cast_pixels returned the right number of pixels");
         buffer.copy_color_space_from(self);
@@ -1671,8 +1679,8 @@ where
         let transform = options
             .as_transform_fn::<FromType, SelfPixel>(from.color_space(), self.color_space())?;
 
-        let from = from.inner_pixels();
-        let into = self.inner_pixels_mut();
+        let from = from.subpixels();
+        let into = self.subpixels_mut();
 
         debug_assert_eq!(
             from.len() / usize::from(FromType::CHANNEL_COUNT),
@@ -1706,8 +1714,8 @@ where
         let (width, height) = self.dimensions();
         let mut target = ImageBuffer::new(width, height);
 
-        let from = self.inner_pixels();
-        let into = target.inner_pixels_mut();
+        let from = self.subpixels();
+        let into = target.subpixels_mut();
 
         transform(from, into);
 

--- a/src/metadata/cicp.rs
+++ b/src/metadata/cicp.rs
@@ -778,62 +778,62 @@ impl CicpTransform {
             match rhs {
                 DynamicImage::ImageLuma8(buf) => {
                     CicpTransform::expand_luma_rgb(
-                        &buf.inner_pixels()[start_idx..end_idx],
+                        &buf.subpixels()[start_idx..end_idx],
                         &mut ibuffer[..3 * count],
                     );
                 }
                 DynamicImage::ImageLumaA8(buf) => {
                     CicpTransform::expand_luma_rgba(
-                        &buf.inner_pixels()[2 * start_idx..2 * end_idx],
+                        &buf.subpixels()[2 * start_idx..2 * end_idx],
                         &mut ibuffer[..4 * count],
                     );
                 }
                 DynamicImage::ImageRgb8(buf) => {
                     CicpTransform::expand_rgb(
-                        &buf.inner_pixels()[3 * start_idx..3 * end_idx],
+                        &buf.subpixels()[3 * start_idx..3 * end_idx],
                         &mut ibuffer[..3 * count],
                     );
                 }
                 DynamicImage::ImageRgba8(buf) => {
                     CicpTransform::expand_rgba(
-                        &buf.inner_pixels()[4 * start_idx..4 * end_idx],
+                        &buf.subpixels()[4 * start_idx..4 * end_idx],
                         &mut ibuffer[..4 * count],
                     );
                 }
                 DynamicImage::ImageLuma16(buf) => {
                     CicpTransform::expand_luma_rgb(
-                        &buf.inner_pixels()[start_idx..end_idx],
+                        &buf.subpixels()[start_idx..end_idx],
                         &mut ibuffer[..3 * count],
                     );
                 }
                 DynamicImage::ImageLumaA16(buf) => {
                     CicpTransform::expand_luma_rgba(
-                        &buf.inner_pixels()[2 * start_idx..2 * end_idx],
+                        &buf.subpixels()[2 * start_idx..2 * end_idx],
                         &mut ibuffer[..4 * count],
                     );
                 }
                 DynamicImage::ImageRgb16(buf) => {
                     CicpTransform::expand_rgb(
-                        &buf.inner_pixels()[3 * start_idx..3 * end_idx],
+                        &buf.subpixels()[3 * start_idx..3 * end_idx],
                         &mut ibuffer[..3 * count],
                     );
                 }
 
                 DynamicImage::ImageRgba16(buf) => {
                     CicpTransform::expand_rgba(
-                        &buf.inner_pixels()[4 * start_idx..4 * end_idx],
+                        &buf.subpixels()[4 * start_idx..4 * end_idx],
                         &mut ibuffer[..4 * count],
                     );
                 }
                 DynamicImage::ImageRgb32F(buf) => {
                     CicpTransform::expand_rgb(
-                        &buf.inner_pixels()[3 * start_idx..3 * end_idx],
+                        &buf.subpixels()[3 * start_idx..3 * end_idx],
                         &mut ibuffer[..3 * count],
                     );
                 }
                 DynamicImage::ImageRgba32F(buf) => {
                     CicpTransform::expand_rgba(
-                        &buf.inner_pixels()[4 * start_idx..4 * end_idx],
+                        &buf.subpixels()[4 * start_idx..4 * end_idx],
                         &mut ibuffer[..4 * count],
                     );
                 }
@@ -848,66 +848,66 @@ impl CicpTransform {
                 DynamicImage::ImageLuma8(buf) => {
                     CicpTransform::clamp_rgb_luma(
                         &obuffer[..3 * count],
-                        &mut buf.inner_pixels_mut()[start_idx..end_idx],
+                        &mut buf.subpixels_mut()[start_idx..end_idx],
                         self.output_coefs,
                     );
                 }
                 DynamicImage::ImageLumaA8(buf) => {
                     CicpTransform::clamp_rgba_luma(
                         &obuffer[..4 * count],
-                        &mut buf.inner_pixels_mut()[2 * start_idx..2 * end_idx],
+                        &mut buf.subpixels_mut()[2 * start_idx..2 * end_idx],
                         self.output_coefs,
                     );
                 }
                 DynamicImage::ImageRgb8(buf) => {
                     CicpTransform::clamp_rgb(
                         &obuffer[..3 * count],
-                        &mut buf.inner_pixels_mut()[3 * start_idx..3 * end_idx],
+                        &mut buf.subpixels_mut()[3 * start_idx..3 * end_idx],
                     );
                 }
                 DynamicImage::ImageRgba8(buf) => {
                     CicpTransform::clamp_rgba(
                         &obuffer[..4 * count],
-                        &mut buf.inner_pixels_mut()[4 * start_idx..4 * end_idx],
+                        &mut buf.subpixels_mut()[4 * start_idx..4 * end_idx],
                     );
                 }
                 DynamicImage::ImageLuma16(buf) => {
                     CicpTransform::clamp_rgb_luma(
                         &obuffer[..3 * count],
-                        &mut buf.inner_pixels_mut()[start_idx..end_idx],
+                        &mut buf.subpixels_mut()[start_idx..end_idx],
                         self.output_coefs,
                     );
                 }
                 DynamicImage::ImageLumaA16(buf) => {
                     CicpTransform::clamp_rgba_luma(
                         &obuffer[..4 * count],
-                        &mut buf.inner_pixels_mut()[2 * start_idx..2 * end_idx],
+                        &mut buf.subpixels_mut()[2 * start_idx..2 * end_idx],
                         self.output_coefs,
                     );
                 }
                 DynamicImage::ImageRgb16(buf) => {
                     CicpTransform::clamp_rgba(
                         &obuffer[..3 * count],
-                        &mut buf.inner_pixels_mut()[3 * start_idx..3 * end_idx],
+                        &mut buf.subpixels_mut()[3 * start_idx..3 * end_idx],
                     );
                 }
 
                 DynamicImage::ImageRgba16(buf) => {
                     CicpTransform::clamp_rgba(
                         &obuffer[..4 * count],
-                        &mut buf.inner_pixels_mut()[4 * start_idx..4 * end_idx],
+                        &mut buf.subpixels_mut()[4 * start_idx..4 * end_idx],
                     );
                 }
                 DynamicImage::ImageRgb32F(buf) => {
                     CicpTransform::clamp_rgb(
                         &obuffer[..3 * count],
-                        &mut buf.inner_pixels_mut()[3 * start_idx..3 * end_idx],
+                        &mut buf.subpixels_mut()[3 * start_idx..3 * end_idx],
                     );
                 }
                 DynamicImage::ImageRgba32F(buf) => {
                     CicpTransform::clamp_rgba(
                         &obuffer[..4 * count],
-                        &mut buf.inner_pixels_mut()[4 * start_idx..4 * end_idx],
+                        &mut buf.subpixels_mut()[4 * start_idx..4 * end_idx],
                     );
                 }
             }


### PR DESCRIPTION
Follow-up to #2938

### Changes

- Publicly expse `ImageBuffer::subpixels` and `ImageBuffer::subpixels_mut`. (Formerls `inner_pixels` and `inner_pixels_mut` respectively)
- Add documentation.

### Motivation

Before this PR, the most obvious and simple ways to get a slice of subpixels were `image.deref()` or `image.as_mut()` or `image.as_slice()` or `&*image` (depending on context). The problem is that these are all wrong. `ImageBuffer` derefs to the underlying container which is allowed to contain more subpixels than necessary for image. I.e. `image.len()` is required to be >= `w*h*c`, not equal. This makes it easy to create bugs since a lot of code assumes that ``image.as_slice()`` and co. have exactly `w*h*c` elements. To make things worse, not only was it easy to do the wrong, there was also no easy way to do the right thing.

This changes with `ImageBuffer::subpixels`. Now there at least is a function that gives a slice of subpixels that is guaranteed to be `w*h*c` subpixels long.