### PR TITLE
Use `.pixels()` returning a slice to simply

### DIFF
--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -539,10 +539,6 @@ mod test {
 
         // the following is not a simple assert_eq, as in case of an error,
         // the whole image would be printed to the console, which takes forever
-        assert!(original
-            .pixels()
-            .iter()
-            .zip(cropped.pixels().iter())
-            .all(|(a, b)| a == b));
+        assert!(original.pixels() == cropped.pixels());
     }
 }

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -1342,9 +1342,7 @@ impl<P: Pixel> ImageBuffer<P, Vec<P::Subpixel>> {
     /// Panics when the resulting image is larger than the maximum size of a vector.
     pub fn from_pixel(width: u32, height: u32, pixel: P) -> ImageBuffer<P, Vec<P::Subpixel>> {
         let mut buf = ImageBuffer::new(width, height);
-        for p in buf.pixels_mut() {
-            *p = pixel;
-        }
+        buf.pixels_mut().fill(pixel);
         buf
     }
 


### PR DESCRIPTION
I found two cases where we can easily take advantage of the fact that `ImageBuffer::pixels*` now returns a slice.