### PR TITLE
Use `.subpixels()` to access subpixels consistently

### DIFF
--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -353,7 +353,7 @@ mod test {
     fn write_rgb_image(write: impl Write + Seek, image: &Rgb32FImage) -> ImageResult<()> {
         write_buffer(
             write,
-            bytemuck::cast_slice(image.as_raw().as_slice()),
+            bytemuck::cast_slice(image.subpixels()),
             image.width(),
             image.height(),
             ExtendedColorType::Rgb32F,
@@ -366,7 +366,7 @@ mod test {
     fn write_rgba_image(write: impl Write + Seek, image: &Rgba32FImage) -> ImageResult<()> {
         write_buffer(
             write,
-            bytemuck::cast_slice(image.as_raw().as_slice()),
+            bytemuck::cast_slice(image.subpixels()),
             image.width(),
             image.height(),
             ExtendedColorType::Rgba32F,

--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -585,7 +585,7 @@ mod test {
         let mut image = ImageBuffer::from_raw(2, 2, vec![127, 127, 127, 127]).unwrap();
         let cmap = BiLevel;
         dither(&mut image, &cmap);
-        assert_eq!(&*image, &[0, 0xFF, 0xFF, 0]);
+        assert_eq!(image.subpixels(), &[0, 0xFF, 0xFF, 0]);
         assert_eq!(index_colors(&image, &cmap).into_raw(), vec![0, 1, 1, 0]);
     }
 

--- a/src/imageops/fast_blur.rs
+++ b/src/imageops/fast_blur.rs
@@ -35,7 +35,7 @@ pub fn fast_blur<P: Pixel>(
         return input_buffer.clone();
     }
 
-    let samples = input_buffer.as_flat_samples().samples;
+    let samples = input_buffer.subpixels();
 
     let destination_size = match (width as usize)
         .safe_mul(height as usize)

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -531,11 +531,9 @@ mod tests {
         let image_blurred_gauss = image
             .blur_advanced(GaussianBlurParameters::new_from_sigma(50.0))
             .to_rgb8();
-        let image_blurred_gauss_samples = image_blurred_gauss.as_flat_samples();
-        let image_blurred_gauss_bytes = image_blurred_gauss_samples.as_slice();
+        let image_blurred_gauss_bytes = image_blurred_gauss.subpixels();
         let image_blurred_fast = image.fast_blur(50.0).to_rgb8();
-        let image_blurred_fast_samples = image_blurred_fast.as_flat_samples();
-        let image_blurred_fast_bytes = image_blurred_fast_samples.as_slice();
+        let image_blurred_fast_bytes = image_blurred_fast.subpixels();
 
         let error = image_blurred_gauss_bytes
             .iter()

--- a/src/imageops/resize.rs
+++ b/src/imageops/resize.rs
@@ -37,43 +37,43 @@ pub(crate) fn resize_impl(
     use DynamicImage::*;
     let mut resized = match image {
         ImageLuma8(src) => {
-            let resized = resize_plane8(src.as_raw(), src_size, dst_size, alg)?;
+            let resized = resize_plane8(src.subpixels(), src_size, dst_size, alg)?;
             ImageLuma8(ImageBuffer::from_raw(dst_width, dst_height, resized).unwrap())
         }
         ImageLumaA8(src) => {
-            let resized = resize_plane8_with_alpha(src.as_raw(), src_size, dst_size, alg)?;
+            let resized = resize_plane8_with_alpha(src.subpixels(), src_size, dst_size, alg)?;
             ImageLumaA8(ImageBuffer::from_raw(dst_width, dst_height, resized).unwrap())
         }
         ImageRgb8(src) => {
-            let resized = resize_rgb8(src.as_raw(), src_size, dst_size, alg)?;
+            let resized = resize_rgb8(src.subpixels(), src_size, dst_size, alg)?;
             ImageRgb8(ImageBuffer::from_raw(dst_width, dst_height, resized).unwrap())
         }
         ImageRgba8(src) => {
-            let resized = resize_rgba8(src.as_raw(), src_size, dst_size, alg)?;
+            let resized = resize_rgba8(src.subpixels(), src_size, dst_size, alg)?;
             ImageRgba8(ImageBuffer::from_raw(dst_width, dst_height, resized).unwrap())
         }
         ImageLuma16(src) => {
-            let resized = resize_plane16(src.as_raw(), src_size, dst_size, 16, alg)?;
+            let resized = resize_plane16(src.subpixels(), src_size, dst_size, 16, alg)?;
             ImageLuma16(ImageBuffer::from_raw(dst_width, dst_height, resized).unwrap())
         }
         ImageLumaA16(src) => {
-            let resized = resize_plane16_with_alpha(src.as_raw(), src_size, dst_size, 16, alg)?;
+            let resized = resize_plane16_with_alpha(src.subpixels(), src_size, dst_size, 16, alg)?;
             ImageLumaA16(ImageBuffer::from_raw(dst_width, dst_height, resized).unwrap())
         }
         ImageRgb16(src) => {
-            let resized = resize_rgb16(src.as_raw(), src_size, dst_size, 16, alg)?;
+            let resized = resize_rgb16(src.subpixels(), src_size, dst_size, 16, alg)?;
             ImageRgb16(ImageBuffer::from_raw(dst_width, dst_height, resized).unwrap())
         }
         ImageRgba16(src) => {
-            let resized = resize_rgba16(src.as_raw(), src_size, dst_size, 16, alg)?;
+            let resized = resize_rgba16(src.subpixels(), src_size, dst_size, 16, alg)?;
             ImageRgba16(ImageBuffer::from_raw(dst_width, dst_height, resized).unwrap())
         }
         ImageRgb32F(src) => {
-            let resized = resize_rgb_f32(src.as_raw(), src_size, dst_size, alg)?;
+            let resized = resize_rgb_f32(src.subpixels(), src_size, dst_size, alg)?;
             ImageRgb32F(ImageBuffer::from_raw(dst_width, dst_height, resized).unwrap())
         }
         ImageRgba32F(src) => {
-            let resized = resize_rgba_f32(src.as_raw(), src_size, dst_size, alg)?;
+            let resized = resize_rgba_f32(src.subpixels(), src_size, dst_size, alg)?;
             ImageRgba32F(ImageBuffer::from_raw(dst_width, dst_height, resized).unwrap())
         }
     };
@@ -99,23 +99,23 @@ fn premultiply_alpha(image: &mut DynamicImage) {
     match image {
         DynamicImage::ImageLuma8(_) => (),
         DynamicImage::ImageLumaA8(buf) => {
-            premultiply_la8(buf.as_mut());
+            premultiply_la8(buf.subpixels_mut());
         }
         DynamicImage::ImageRgb8(_) => (),
         DynamicImage::ImageRgba8(buf) => {
-            premultiply_rgba8(buf.as_mut());
+            premultiply_rgba8(buf.subpixels_mut());
         }
         DynamicImage::ImageLuma16(_) => (),
         DynamicImage::ImageLumaA16(buf) => {
-            premultiply_la16(buf.as_mut(), 16);
+            premultiply_la16(buf.subpixels_mut(), 16);
         }
         DynamicImage::ImageRgb16(_) => (),
         DynamicImage::ImageRgba16(buf) => {
-            premultiply_rgba16(buf.as_mut(), 16);
+            premultiply_rgba16(buf.subpixels_mut(), 16);
         }
         DynamicImage::ImageRgb32F(_) => (),
         DynamicImage::ImageRgba32F(buf) => {
-            premultiply_rgba_f32(buf.as_mut());
+            premultiply_rgba_f32(buf.subpixels_mut());
         }
     }
 }
@@ -125,15 +125,15 @@ fn unpremultiply_alpha(image: &mut DynamicImage) {
     use pic_scale_safe::*;
     match image {
         DynamicImage::ImageLuma8(_) => (),
-        DynamicImage::ImageLumaA8(buf) => unpremultiply_la8(buf.as_mut()),
+        DynamicImage::ImageLumaA8(buf) => unpremultiply_la8(buf.subpixels_mut()),
         DynamicImage::ImageRgb8(_) => (),
-        DynamicImage::ImageRgba8(buf) => unpremultiply_rgba8(buf.as_mut()),
+        DynamicImage::ImageRgba8(buf) => unpremultiply_rgba8(buf.subpixels_mut()),
         DynamicImage::ImageLuma16(_) => (),
-        DynamicImage::ImageLumaA16(buf) => unpremultiply_la16(buf.as_mut(), 16),
+        DynamicImage::ImageLumaA16(buf) => unpremultiply_la16(buf.subpixels_mut(), 16),
         DynamicImage::ImageRgb16(_) => (),
-        DynamicImage::ImageRgba16(buf) => unpremultiply_rgba16(buf.as_mut(), 16),
+        DynamicImage::ImageRgba16(buf) => unpremultiply_rgba16(buf.subpixels_mut(), 16),
         DynamicImage::ImageRgb32F(_) => (),
-        DynamicImage::ImageRgba32F(buf) => unpremultiply_rgba_f32(buf),
+        DynamicImage::ImageRgba32F(buf) => unpremultiply_rgba_f32(buf.subpixels_mut()),
     }
 }
 

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -253,12 +253,12 @@ where
         vec_try_with_capacity(batch_size + 1).expect("capacity overflow in horizontal_sample");
 
     // Rgba32FImage per row
-    let src_raw = image.as_raw();
+    let src_raw = image.subpixels();
     let src_stride = width as usize * MAX_CHANNEL;
 
     let nchannels = P::CHANNEL_COUNT as usize;
     let out_stride = col_count * nchannels;
-    let out_raw = out.as_mut();
+    let out_raw = out.subpixels_mut();
 
     let mut batch_start = 0;
     while batch_start < col_count {
@@ -1284,9 +1284,9 @@ pub(crate) fn gaussian_blur_dyn_image(
 
     let mut target = match image {
         DynamicImage::ImageLuma8(img) => {
-            let mut dest_image = vec![0u8; img.len()];
+            let mut dest_image = vec![0u8; img.subpixels().len()];
             filter_2d_sep_plane(
-                img.as_raw(),
+                img.subpixels(),
                 &mut dest_image,
                 filter_image_size,
                 &x_axis_kernel,
@@ -1298,9 +1298,9 @@ pub(crate) fn gaussian_blur_dyn_image(
             )
         }
         DynamicImage::ImageLumaA8(img) => {
-            let mut dest_image = vec![0u8; img.len()];
+            let mut dest_image = vec![0u8; img.subpixels().len()];
             filter_2d_sep_la(
-                img.as_raw(),
+                img.subpixels(),
                 &mut dest_image,
                 filter_image_size,
                 &x_axis_kernel,
@@ -1312,9 +1312,9 @@ pub(crate) fn gaussian_blur_dyn_image(
             )
         }
         DynamicImage::ImageRgb8(img) => {
-            let mut dest_image = vec![0u8; img.len()];
+            let mut dest_image = vec![0u8; img.subpixels().len()];
             filter_2d_sep_rgb(
-                img.as_raw(),
+                img.subpixels(),
                 &mut dest_image,
                 filter_image_size,
                 &x_axis_kernel,
@@ -1326,9 +1326,9 @@ pub(crate) fn gaussian_blur_dyn_image(
             )
         }
         DynamicImage::ImageRgba8(img) => {
-            let mut dest_image = vec![0u8; img.len()];
+            let mut dest_image = vec![0u8; img.subpixels().len()];
             filter_2d_sep_rgba(
-                img.as_raw(),
+                img.subpixels(),
                 &mut dest_image,
                 filter_image_size,
                 &x_axis_kernel,
@@ -1340,9 +1340,9 @@ pub(crate) fn gaussian_blur_dyn_image(
             )
         }
         DynamicImage::ImageLuma16(img) => {
-            let mut dest_image = vec![0u16; img.len()];
+            let mut dest_image = vec![0u16; img.subpixels().len()];
             filter_2d_sep_plane_u16(
-                img.as_raw(),
+                img.subpixels(),
                 &mut dest_image,
                 filter_image_size,
                 &x_axis_kernel,
@@ -1354,9 +1354,9 @@ pub(crate) fn gaussian_blur_dyn_image(
             )
         }
         DynamicImage::ImageLumaA16(img) => {
-            let mut dest_image = vec![0u16; img.len()];
+            let mut dest_image = vec![0u16; img.subpixels().len()];
             filter_2d_sep_la_u16(
-                img.as_raw(),
+                img.subpixels(),
                 &mut dest_image,
                 filter_image_size,
                 &x_axis_kernel,
@@ -1368,9 +1368,9 @@ pub(crate) fn gaussian_blur_dyn_image(
             )
         }
         DynamicImage::ImageRgb16(img) => {
-            let mut dest_image = vec![0u16; img.len()];
+            let mut dest_image = vec![0u16; img.subpixels().len()];
             filter_2d_sep_rgb_u16(
-                img.as_raw(),
+                img.subpixels(),
                 &mut dest_image,
                 filter_image_size,
                 &x_axis_kernel,
@@ -1382,9 +1382,9 @@ pub(crate) fn gaussian_blur_dyn_image(
             )
         }
         DynamicImage::ImageRgba16(img) => {
-            let mut dest_image = vec![0u16; img.len()];
+            let mut dest_image = vec![0u16; img.subpixels().len()];
             filter_2d_sep_rgba_u16(
-                img.as_raw(),
+                img.subpixels(),
                 &mut dest_image,
                 filter_image_size,
                 &x_axis_kernel,
@@ -1396,9 +1396,9 @@ pub(crate) fn gaussian_blur_dyn_image(
             )
         }
         DynamicImage::ImageRgb32F(img) => {
-            let mut dest_image = vec![0f32; img.len()];
+            let mut dest_image = vec![0f32; img.subpixels().len()];
             filter_2d_sep_rgb_f32(
-                img.as_raw(),
+                img.subpixels(),
                 &mut dest_image,
                 filter_image_size,
                 &x_axis_kernel,
@@ -1410,9 +1410,9 @@ pub(crate) fn gaussian_blur_dyn_image(
             )
         }
         DynamicImage::ImageRgba32F(img) => {
-            let mut dest_image = vec![0f32; img.len()];
+            let mut dest_image = vec![0f32; img.subpixels().len()];
             filter_2d_sep_rgba_f32(
-                img.as_raw(),
+                img.subpixels(),
                 &mut dest_image,
                 filter_image_size,
                 &x_axis_kernel,

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -1497,7 +1497,6 @@ impl GrayImage {
         transparent_idx: Option<u8>,
     ) -> RgbaImage {
         let (width, height) = self.dimensions();
-        let len = width as usize * height as usize;
 
         let mut full_palette = vec![[0_u8; 4]; 256];
         let full_palette: &mut [[u8; 4]; 256] = full_palette.as_mut_slice().try_into().unwrap();
@@ -1508,7 +1507,8 @@ impl GrayImage {
             full_palette[palette_index as usize][3] = 0;
         }
 
-        let rgba_data: Vec<[u8; 4]> = self.as_raw()[..len]
+        let rgba_data: Vec<[u8; 4]> = self
+            .subpixels()
             .iter()
             .map(|&palette_index| full_palette[palette_index as usize])
             .collect();

--- a/src/images/dynimage.rs
+++ b/src/images/dynimage.rs
@@ -756,14 +756,25 @@ impl DynamicImage {
         dynamic_map!(self, ref mut p, p.shrink_to_fit());
     }
 
-    /// Return this image's pixels as a byte vector. If the `ImageBuffer`
-    /// container is `Vec<u8>`, this operation is free. Otherwise, a copy
-    /// is returned.
+    /// Return this image's pixels as a byte vector.
+    ///
+    /// If the `ImageBuffer` container is `Vec<u8>`, this operation is free.
+    /// Otherwise, a copy is returned.
+    ///
+    /// This is equivalent to `self.as_bytes().to_vec()`, but may be more efficient.
     #[must_use]
     pub fn into_bytes(self) -> Vec<u8> {
         // we can do this because every variant contains an `ImageBuffer<_, Vec<_>>`
         dynamic_map!(self, image_buffer, {
-            match bytemuck::allocation::try_cast_vec(image_buffer.into_raw()) {
+            // Truncate the underlying buffer to the actual length of the pixel data to be
+            // consistent with `as_bytes` and `as_mut_bytes`.
+            // Calling `.subpixels()` has the side effect of panicking if the buffer is too short.
+            // This ensures correctness and consistency.
+            let len = image_buffer.subpixels().len();
+            let mut raw = image_buffer.into_raw();
+            raw.truncate(len);
+
+            match bytemuck::allocation::try_cast_vec(raw) {
                 Ok(vec) => vec,
                 Err((_, vec)) => {
                     // Fallback: vector requires an exact alignment and size match

--- a/src/images/dynimage.rs
+++ b/src/images/dynimage.rs
@@ -720,7 +720,7 @@ impl DynamicImage {
         dynamic_map!(
             *self,
             ref image_buffer,
-            bytemuck::cast_slice(image_buffer.as_raw())
+            bytemuck::cast_slice(image_buffer.subpixels())
         )
     }
 


### PR DESCRIPTION
I looked at how the codebase accessed subpixels prior to #2940 and found multiple issues. They all follow the same pattern: the backing container is assumed to be sized exactly `w*h*c` when that is not guaranteed.

In this PR, I unified multiple different access patterns to always use `.subpixels()`. This should ensure consistency and correctness throughout the codebase.

---

One remaining bug is `DynamicImage::into_bytes`.