### PR TITLE
Export 16-bit image type aliases

### DIFF
--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -1759,13 +1759,13 @@ pub type GrayImage = ImageBuffer<Luma<u8>, Vec<u8>>;
 /// Sendable grayscale + alpha channel image buffer
 pub type GrayAlphaImage = ImageBuffer<LumaA<u8>, Vec<u8>>;
 /// Sendable 16-bit Rgb image buffer
-pub(crate) type Rgb16Image = ImageBuffer<Rgb<u16>, Vec<u16>>;
+pub type Rgb16Image = ImageBuffer<Rgb<u16>, Vec<u16>>;
 /// Sendable 16-bit Rgb + alpha channel image buffer
-pub(crate) type Rgba16Image = ImageBuffer<Rgba<u16>, Vec<u16>>;
+pub type Rgba16Image = ImageBuffer<Rgba<u16>, Vec<u16>>;
 /// Sendable 16-bit grayscale image buffer
-pub(crate) type Gray16Image = ImageBuffer<Luma<u16>, Vec<u16>>;
+pub type Gray16Image = ImageBuffer<Luma<u16>, Vec<u16>>;
 /// Sendable 16-bit grayscale + alpha channel image buffer
-pub(crate) type GrayAlpha16Image = ImageBuffer<LumaA<u16>, Vec<u16>>;
+pub type GrayAlpha16Image = ImageBuffer<LumaA<u16>, Vec<u16>>;
 
 /// An image buffer for 32-bit float RGB pixels,
 /// where the backing container is a flattened vector of floats.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,12 +138,16 @@ pub use crate::images::sub_image::SubImage;
 
 pub use crate::images::buffer::{
     ConvertColorOptions,
+    Gray16Image,
+    GrayAlpha16Image,
     GrayAlphaImage,
     GrayImage,
     // Image types
     ImageBuffer,
+    Rgb16Image,
     Rgb32FImage,
     RgbImage,
+    Rgba16Image,
     Rgba32FImage,
     RgbaImage,
 };


### PR DESCRIPTION
Resolves #1384

This PR makes the type aliases for 16-bit image types publically accessible.

Why?
- Consistency. The aliases of the types of other `DynamicImage` variants are already exposed.
- Easy of use. Users could define their own types, but not having access to them is just a little stumbling block users have to navigate. (Something I ran into myself, when I first used this library.)