### PR TITLE
Fix links in documentations

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -42,7 +42,7 @@ impl<R: io::Read> ReadExt for R {
 /// Communicate the layout of an image.
 ///
 /// Describes a packed rectangular layout with given bit-depth in
-/// [`ImageDecoder::peek_layout`](crate::ImageDecoder::peek_layout). Standard layouts from `image`
+/// [`ImageDecoder::prepare_image`](crate::ImageDecoder::prepare_image). Standard layouts from `image`
 /// are row-major with no padding between rows and pixels packed by consecutive channels.
 ///
 /// For external crates constructing an instance, use [`ImageLayout::empty`] with the intended
@@ -90,7 +90,7 @@ impl ImageLayout {
 
     /// The total number of bytes in the described image.
     ///
-    /// See also [`DecodedLayout::total_bytes`].
+    /// See also [`DecoderPreparedImage::total_bytes`].
     pub fn total_bytes(&self) -> u64 {
         let ImageLayout { width, height, .. } = *self;
         let total_pixels = u64::from(width) * u64::from(height);

--- a/src/io/decoder.rs
+++ b/src/io/decoder.rs
@@ -6,7 +6,7 @@ use crate::Delay;
 /// The interface for `image` to utilize in reading image files.
 ///
 /// Please carefully consider consuming this interface directly and prefer interaction with an
-/// [`ImageReader`]. This is one directional of a protocol between `image` and format decoders. In
+/// [`ImageReader`](crate::ImageReader). This is one directional of a protocol between `image` and format decoders. In
 /// the general case, an implementation can expect calls to be made in the following order:
 ///
 /// ```text,bnf
@@ -171,9 +171,6 @@ pub trait ImageDecoder {
     }
 
     /// Consume the rest of the file, including any trailer.
-    ///
-    /// This method should ensure that metadata that used [`DecodedMetadataHint::AfterFinish`] has
-    /// all been ingested and can be retrieved.
     fn finish(&mut self) -> ImageResult<()> {
         Ok(())
     }

--- a/src/io/image_reader_type.rs
+++ b/src/io/image_reader_type.rs
@@ -814,7 +814,7 @@ impl<'stream> ImageReader<'stream> {
     /// The iterator will end (start returning `None`) when the decoder indicates that no more
     /// images are present in the stream by setting [`ImageDecoder::more_images`] to
     /// [`SequenceControl::None`]. Decoding can return
-    /// [`ParameterError`](`crate::error::ParameterError`) in [`ImageDecoder::peek_layout`] or
+    /// [`ParameterError`](`crate::error::ParameterError`) in [`ImageDecoder::prepare_image`] or
     /// [`ImageDecoder::read_image`] with kind set to [`None`](crate::io::SequenceControl::None),
     /// which is also treated as end of stream. This may be used by decoders which can not
     /// determine the number of images in advance.


### PR DESCRIPTION
All the renaming in #2672 caused some doc links to become stale. This PR fixes that.

I also removed one sentence from `finish` that *I think* no longer applies.

---

I thought we already had something like `RUSTDOCFLAGS="-D warnings" cargo doc` in CI, but apparently not. Should I add that?