### PR TITLE
Make `WithBlurAcc` super of `PrimitiveSealed`

### DIFF
--- a/src/primitive_sealed.rs
+++ b/src/primitive_sealed.rs
@@ -7,7 +7,7 @@ use crate::imageops::fast_blur::BlurAccumulator;
 /// This trait is `pub` but not exported, so it cannot be implemented outside
 /// this crate.
 #[allow(private_bounds)]
-pub trait PrimitiveSealed: Sized + NearestFrom<f32> {}
+pub trait PrimitiveSealed: Sized + NearestFrom<f32> + WithBlurAcc {}
 
 impl PrimitiveSealed for usize {}
 impl PrimitiveSealed for u8 {}
@@ -121,8 +121,7 @@ impl_nearest_from_f32_for_ints!(u32, u64, usize, i8, i16, i32, i64, isize);
 ///
 /// `u8` uses an integer (`u32`) accumulator for speed; everything else goes
 /// through `f32`.
-#[allow(private_bounds)]
-pub trait WithBlurAcc: Sized {
+pub(crate) trait WithBlurAcc: Sized {
     type BlurAcc: BlurAccumulator<Self>;
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -6,7 +6,7 @@ use num_traits::{Bounded, Num, NumCast};
 use std::ops::AddAssign;
 
 use crate::color::{Luma, LumaA, Rgb, Rgba};
-use crate::primitive_sealed::{PrimitiveSealed, WithBlurAcc};
+use crate::primitive_sealed::PrimitiveSealed;
 use crate::ExtendedColorType;
 
 /// Types which are safe to treat as an immutable byte slice in a pixel layout
@@ -37,7 +37,7 @@ impl EncodableLayout for [f32] {
 /// The type of each channel in a pixel. For example, this can be `u8`, `u16`, `f32`.
 // TODO rename to `PixelComponent`? Split up into separate traits? Seal?
 pub trait Primitive:
-    Copy + NumCast + Num + PartialOrd<Self> + Clone + Bounded + PrimitiveSealed + WithBlurAcc
+    Copy + NumCast + Num + PartialOrd<Self> + Clone + Bounded + PrimitiveSealed
 {
     /// The maximum value for this type of primitive within the context of color.
     /// For floats, the maximum is `1.0`, whereas the integer types inherit their usual maximum values.


### PR DESCRIPTION
After it was merged, I noticed that #2846 had a small issue: it used `PrimitiveSealed` incorrectly. 

`PrimitiveSealed` is supposed to be *the* trait all internal traits attach themselves to. So `WithBlurAcc` (being internal) should be super of `PrimitiveSealed`, not `Primitive`. Boring bookkeeping that doesn't affect functionality, but I like to keep things tidy.