### PR TITLE
Clean up around `ImageLayout::new`

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -44,10 +44,6 @@ impl<R: io::Read> ReadExt for R {
 /// Describes a packed rectangular layout with given bit-depth in
 /// [`ImageDecoder::peek_layout`](crate::ImageDecoder::peek_layout). Standard layouts from `image`
 /// are row-major with no padding between rows and pixels packed by consecutive channels.
-///
-/// For external crates constructing an instance, use [`ImageLayout::empty`] with the intended
-/// color type and then fill in all applicable fields. (It will become more convenient when Rust
-/// lets you use record update syntax but that won't work for now).
 #[non_exhaustive]
 pub struct ImageLayout {
     /// The color model of each pixel.
@@ -62,11 +58,21 @@ impl ImageLayout {
     /// A layout matching a [`DynamicImage`][`crate::DynamicImage`] of the given dimensions and
     /// color type.
     pub fn new(w: u32, h: u32, color: crate::ColorType) -> ImageLayout {
-        #[allow(deprecated)]
         ImageLayout {
+            color,
             width: w,
             height: h,
-            ..ImageLayout::empty(color)
+        }
+    }
+
+    /// A layout with no pixels, of the given [`ColorType`][`crate::ColorType`].
+    ///
+    /// This is equivalent to `ImageLayout::new(0, 0, color)`.
+    pub fn empty(color: crate::ColorType) -> Self {
+        ImageLayout {
+            color,
+            width: 0,
+            height: 0,
         }
     }
 
@@ -77,15 +83,6 @@ impl ImageLayout {
     /// indicated to be viewed in user facing applications by metadata.
     pub fn dimensions(&self) -> (u32, u32) {
         (self.width, self.height)
-    }
-
-    /// A layout with no pixels, of the given [`ColorType`][`crate::ColorType`].
-    pub fn empty(color: crate::ColorType) -> Self {
-        ImageLayout {
-            color,
-            width: 0,
-            height: 0,
-        }
     }
 
     /// The total number of bytes in the described image.


### PR DESCRIPTION
Changes:
- Remove outdated paragraph in documentation.
- Implement `::new` more succinctly.
- Move `::new` and `::empty` closer together.
- Add a note what "no pixels" means for `::empty`.