### PR TITLE
Potentially more efficient default impl for `Pixel::alpha`

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -456,7 +456,7 @@ pub trait Pixel: Copy + Clone {
     #[inline]
     fn alpha(&self) -> Self::Subpixel {
         if Self::HAS_ALPHA {
-            *self.to_luma_alpha().channels().last().unwrap()
+            self.to_rgba().0[3]
         } else {
             Self::Subpixel::DEFAULT_MAX_VALUE
         }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -456,7 +456,7 @@ pub trait Pixel: Copy + Clone {
     #[inline]
     fn alpha(&self) -> Self::Subpixel {
         if Self::HAS_ALPHA {
-            self.to_rgba().0[3]
+            self.to_luma_alpha().0[1]
         } else {
             Self::Subpixel::DEFAULT_MAX_VALUE
         }


### PR DESCRIPTION
To quote the report in #2954:

> M14. `Pixel::alpha` default uses `to_luma_alpha()` (expensive + needless)
>
> The default forces an RGB→Luma matrix multiplication just to throw away the luma channel. Library-provided pixels override `alpha()`, so this only bites third-party `Pixel` implementors, but `Pixel` is a public trait.
> 
> **Fix:** `*self.channels().last().unwrap()` (assumes alpha is the last channel — which is what `HAS_ALPHA` already implies in this crate).

Firstly, the suggested fix is incorrect. We cannot assume that `HAS_ALPHA` implies that the last channel is alpha *in general*. So I would suggest `self.to_rgba().0[3]` as implemented in this PR. This is correct and also skips a potential luma conversion. However, it does assume that `to_rgba` is cheaper than `to_luma_alpha`.

Secondly, I'm not sure if this is worth it. The only penalty is worse performance, and any performance-conscious implementer would override these methods (I hope). If we deem the perf penalty too great, then I would suggest not providing a default.