### PR TITLE
Cleanup ICO alpha mask application

### DIFF
--- a/src/codecs/ico/decoder.rs
+++ b/src/codecs/ico/decoder.rs
@@ -371,9 +371,15 @@ impl<R: BufRead + Seek> ImageDecoder for IcoDecoder<R> {
                 // the mask is not required. Unfortunately, Wikipedia does not have a citation
                 // for that claim, so we can't be sure which is correct.
                 if data_end >= image_end + mask_length {
+                    let rgba = buf.as_chunks_mut::<4>().0;
+                    let rows = rgba.chunks_exact_mut(width as usize);
+                    debug_assert_eq!(rows.len(), height as usize, "entry matches dimension");
+
                     // If there's an AND mask following the image, read and apply it.
-                    for y in 0..height {
+                    // This from the bottom up (in terms of our coordinates).
+                    for row in rows.rev() {
                         let mut x = 0;
+
                         for _ in 0..mask_row_bytes {
                             // Apply the bits of each byte until we reach the end of the row.
                             let mask_byte = r.read_u8()?;
@@ -381,10 +387,12 @@ impl<R: BufRead + Seek> ImageDecoder for IcoDecoder<R> {
                                 if x >= width {
                                     break;
                                 }
+
                                 if mask_byte & (1 << bit) != 0 {
                                     // Set alpha channel to transparent.
-                                    buf[((height - y - 1) * width + x) as usize * 4 + 3] = 0;
+                                    row[x as usize][3] = 0;
                                 }
+
                                 x += 1;
                             }
                         }

--- a/src/codecs/ico/decoder.rs
+++ b/src/codecs/ico/decoder.rs
@@ -371,9 +371,16 @@ impl<R: BufRead + Seek> ImageDecoder for IcoDecoder<R> {
                 // the mask is not required. Unfortunately, Wikipedia does not have a citation
                 // for that claim, so we can't be sure which is correct.
                 if data_end >= image_end + mask_length {
+                    if width == 0 {
+                        return Ok(DecodedImageAttributes::default());
+                    }
+
                     let rgba = buf.as_chunks_mut::<4>().0;
                     let rows = rgba.chunks_exact_mut(width as usize);
-                    debug_assert_eq!(rows.len(), height as usize, "entry matches dimension");
+
+                    if rows.len() != height as usize {
+                        return Err(DecoderError::InvalidDataSize.into());
+                    }
 
                     // If there's an AND mask following the image, read and apply it.
                     // This from the bottom up (in terms of our coordinates).


### PR DESCRIPTION
Addresses C7 of #2954 , although on hindsight the criticality maybe should have been even lower. It's a bad code smell that we were doing very manual indexing here (and we can probably do even less) but overall the bounds verification was already in the contract of the layout vs. the length of `buf` and verified further up in the function. The new implementation makes this much clearer though.