### PR TITLE
Make JpegDecoder not read the whole stream to memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ rayon = { version = "1.7.0", optional = true }
 rgb = { version = "0.8.48", default-features = false, optional = true }
 tiff = { version = "0.11.2", optional = true }
 zune-core = { version = "0.5.0", default-features = false, optional = true }
-zune-jpeg = { version = "0.5.5", optional = true }
+zune-jpeg = { version = "0.5.15", optional = true }
 jpeg-encoder = { version = "0.7.0", optional = true, features = ["simd"] }
 serde = { version = "1.0.214", optional = true, features = ["derive"] }
 pic-scale-safe = "0.1.5"

--- a/src/codecs/bmp/decoder.rs
+++ b/src/codecs/bmp/decoder.rs
@@ -1143,7 +1143,7 @@ impl<R: BufRead + Seek> BmpDecoder<R> {
     }
 
     /// Create a new decoder with the given spec compliance mode.
-    pub(crate) fn new_with_spec_compliance(
+    pub(crate) fn with_spec_compliance(
         reader: R,
         spec: SpecCompliance,
     ) -> ImageResult<BmpDecoder<R>> {
@@ -3024,7 +3024,7 @@ mod test {
 
             // Strict mode: these files should be rejected
             assert!(
-                BmpDecoder::new_with_spec_compliance(Cursor::new(&data), SpecCompliance::Strict)
+                BmpDecoder::with_spec_compliance(Cursor::new(&data), SpecCompliance::Strict)
                     .is_err(),
                 "{description}: expected error in strict mode, but got Ok"
             );
@@ -3083,7 +3083,7 @@ mod test {
 
             // Strict mode must fail on these images during full decode
             let strict_result =
-                BmpDecoder::new_with_spec_compliance(Cursor::new(&data), SpecCompliance::Strict)
+                BmpDecoder::with_spec_compliance(Cursor::new(&data), SpecCompliance::Strict)
                     .and_then(|mut d| {
                         let len = d.prepare_image()?.total_bytes();
                         let mut buf = vec![0u8; len as usize];
@@ -3141,8 +3141,7 @@ mod test {
 
         // Test Strict mode
         let strict_decoder =
-            BmpDecoder::new_with_spec_compliance(Cursor::new(data), SpecCompliance::Strict)
-                .unwrap();
+            BmpDecoder::with_spec_compliance(Cursor::new(data), SpecCompliance::Strict).unwrap();
         let mut decoder = crate::ImageReader::from_decoder(Box::new(strict_decoder));
         let result = decoder.decode();
 

--- a/src/codecs/hdr/decoder.rs
+++ b/src/codecs/hdr/decoder.rs
@@ -193,13 +193,13 @@ impl<R: Read> HdrDecoder<R> {
     }
 
     /// Allows reading old Radiance HDR images
-    #[deprecated(note = "Use `new_with_spec_compliance(reader, SpecCompliance::Lenient)` instead")]
+    #[deprecated(note = "Use `with_spec_compliance(reader, SpecCompliance::Lenient)` instead")]
     pub fn new_nonstrict(reader: R) -> ImageResult<Self> {
         Self::with_strictness(reader, false)
     }
 
     /// Create a new decoder with the given spec compliance mode.
-    pub(crate) fn new_with_spec_compliance(reader: R, spec: SpecCompliance) -> ImageResult<Self> {
+    pub(crate) fn with_spec_compliance(reader: R, spec: SpecCompliance) -> ImageResult<Self> {
         Self::with_strictness(reader, spec == SpecCompliance::Strict)
     }
 
@@ -795,8 +795,7 @@ mod tests {
 
         assert!(HdrDecoder::new(Cursor::new(data)).is_err());
         assert!(
-            HdrDecoder::new_with_spec_compliance(Cursor::new(data), SpecCompliance::Lenient)
-                .is_err()
+            HdrDecoder::with_spec_compliance(Cursor::new(data), SpecCompliance::Lenient).is_err()
         );
     }
 }

--- a/src/codecs/jpeg/decoder.rs
+++ b/src/codecs/jpeg/decoder.rs
@@ -14,15 +14,19 @@ type ZuneColorSpace = zune_core::colorspace::ColorSpace;
 
 /// JPEG decoder
 pub struct JpegDecoder<R> {
-    input: zune_jpeg::JpegDecoder<R>,
-    orig_color_space: ZuneColorSpace,
+    decoder: zune_jpeg::JpegDecoder<R>,
     spec_compliance: SpecCompliance,
-    width: u16,
-    height: u16,
     limits: Limits,
+    header: Option<HeaderData>,
     // For API compatibility with the previous jpeg_decoder wrapper.
     // Can be removed later, which would be an API break.
     phantom: PhantomData<R>,
+}
+
+struct HeaderData {
+    orig_color_space: ZuneColorSpace,
+    width: u16,
+    height: u16,
 }
 
 impl<R: BufRead + Seek> JpegDecoder<R> {
@@ -33,39 +37,14 @@ impl<R: BufRead + Seek> JpegDecoder<R> {
             .set_max_width(usize::MAX)
             .set_max_height(usize::MAX);
 
-        let mut decoder = zune_jpeg::JpegDecoder::new_with_options(r, options);
-        // Adjust ensure_headers if we do not run this in the constructor!
-        decoder.decode_headers().map_err(ImageError::from_jpeg)?;
-        // now that we've decoded the headers we can `.unwrap()`
-        // all these functions that only fail if called before decoding the headers
-        let (width, height) = decoder.dimensions().unwrap();
-        // JPEG can only express dimensions up to 65535x65535, so this conversion cannot fail
-        let width: u16 = width.try_into().unwrap();
-        let height: u16 = height.try_into().unwrap();
-        let orig_color_space = decoder.input_colorspace().expect("headers were decoded");
-
-        // Now configure the decoder color output.
-        decoder.set_options({
-            let requested_color = match orig_color_space {
-                ZuneColorSpace::RGB
-                | ZuneColorSpace::RGBA
-                | ZuneColorSpace::Luma
-                | ZuneColorSpace::LumaA => orig_color_space,
-                // Late failure
-                _ => ZuneColorSpace::RGB,
-            };
-
-            decoder.options().jpeg_set_out_colorspace(requested_color)
-        });
-
+        let decoder = zune_jpeg::JpegDecoder::new_with_options(r, options);
         // Limits are disabled by default in the constructor for all decoders
         let limits = Limits::no_limits();
+
         Ok(JpegDecoder {
-            input: decoder,
-            orig_color_space,
+            decoder,
+            header: None,
             spec_compliance: SpecCompliance::default(),
-            width,
-            height,
             limits,
             phantom: PhantomData,
         })
@@ -76,20 +55,66 @@ impl<R: BufRead + Seek> JpegDecoder<R> {
         r: R,
         spec: SpecCompliance,
     ) -> ImageResult<JpegDecoder<R>> {
-        let mut decoder = Self::new(r)?;
-        decoder.spec_compliance = spec;
-        decoder.input.set_options({
-            decoder
-                .input
+        let mut this = Self::new(r)?;
+        this.spec_compliance = spec;
+        this.decoder.set_options({
+            this.decoder
                 .options()
                 .set_strict_mode(matches!(spec, SpecCompliance::Strict))
         });
-        Ok(decoder)
+
+        Ok(this)
     }
 
-    fn ensure_headers(&mut self) -> ImageResult<&mut zune_jpeg::JpegDecoder<R>> {
+    fn ensure_headers(&mut self) -> ImageResult<(&mut zune_jpeg::JpegDecoder<R>, &HeaderData)> {
+        if self.header.is_none() {
+            // Adjust ensure_headers if we do not run this in the constructor!
+            self.decoder
+                .decode_headers()
+                .map_err(ImageError::from_jpeg)?;
+
+            // now that we've decoded the headers we can `.unwrap()`
+            // all these functions that only fail if called before decoding the headers
+            let (width, height) = self.decoder.dimensions().unwrap();
+            // JPEG can only express dimensions up to 65535x65535, so this conversion cannot fail
+            let width: u16 = width.try_into().unwrap();
+            let height: u16 = height.try_into().unwrap();
+
+            let orig_color_space = self
+                .decoder
+                .input_colorspace()
+                .expect("headers were decoded");
+
+            // configure the decoder color output based on the header information. By default it
+            // would do its own color space defaults and we want to setup those that are compatible
+            // with our wish of sRGB outputs.
+            self.decoder.set_options({
+                let requested_color = match orig_color_space {
+                    ZuneColorSpace::RGB
+                    | ZuneColorSpace::RGBA
+                    | ZuneColorSpace::Luma
+                    | ZuneColorSpace::LumaA => orig_color_space,
+                    // Late failure
+                    _ => ZuneColorSpace::RGB,
+                };
+
+                self.decoder
+                    .options()
+                    .jpeg_set_out_colorspace(requested_color)
+            });
+
+            self.header = Some(HeaderData {
+                orig_color_space,
+                width,
+                height,
+            });
+        }
+
+        // `unwrap` instead of match is used here due to lifetime overlaps in the codeflow
+        // otherwise, we could not quick return anyways.
+        let header = self.header.as_ref().unwrap();
         // Headers are already decoded in `new()` right now, so this is a no-op.
-        Ok(&mut self.input)
+        Ok((&mut self.decoder, header))
     }
 }
 
@@ -108,30 +133,31 @@ impl<R: BufRead + Seek> ImageDecoder for JpegDecoder<R> {
     }
 
     fn prepare_image(&mut self) -> ImageResult<DecoderPreparedImage> {
+        let (_, header) = self.ensure_headers()?;
         Ok(DecoderPreparedImage::new(
-            self.width.into(),
-            self.height.into(),
-            ColorType::from_jpeg(self.orig_color_space),
+            header.width.into(),
+            header.height.into(),
+            ColorType::from_jpeg(header.orig_color_space),
         ))
     }
 
     fn icc_profile(&mut self) -> ImageResult<Option<Vec<u8>>> {
-        let decoder = self.ensure_headers()?;
+        let (decoder, _) = self.ensure_headers()?;
         Ok(decoder.icc_profile())
     }
 
     fn exif_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {
-        let decoder = self.ensure_headers()?;
+        let (decoder, _) = self.ensure_headers()?;
         Ok(decoder.exif().cloned())
     }
 
     fn xmp_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {
-        let decoder = self.ensure_headers()?;
+        let (decoder, _) = self.ensure_headers()?;
         Ok(decoder.xmp().cloned())
     }
 
     fn iptc_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {
-        let decoder = self.ensure_headers()?;
+        let (decoder, _) = self.ensure_headers()?;
         Ok(decoder.iptc().cloned())
     }
 
@@ -152,7 +178,7 @@ impl<R: BufRead + Seek> ImageDecoder for JpegDecoder<R> {
             )));
         }
 
-        let decoder = self.ensure_headers()?;
+        let (decoder, _) = self.ensure_headers()?;
         decoder.decode_into(buf).map_err(|err| {
             ImageError::Decoding(DecodingError::new(ImageFormat::Jpeg.into(), err))
         })?;

--- a/src/codecs/jpeg/decoder.rs
+++ b/src/codecs/jpeg/decoder.rs
@@ -1,5 +1,4 @@
 use std::io::{BufRead, Seek};
-use std::marker::PhantomData;
 
 use crate::color::ColorType;
 use crate::error::{
@@ -15,12 +14,8 @@ type ZuneColorSpace = zune_core::colorspace::ColorSpace;
 /// JPEG decoder
 pub struct JpegDecoder<R> {
     decoder: zune_jpeg::JpegDecoder<R>,
-    spec_compliance: SpecCompliance,
     limits: Limits,
     header: Option<HeaderData>,
-    // For API compatibility with the previous jpeg_decoder wrapper.
-    // Can be removed later, which would be an API break.
-    phantom: PhantomData<R>,
 }
 
 struct HeaderData {
@@ -30,10 +25,15 @@ struct HeaderData {
 }
 
 impl<R: BufRead + Seek> JpegDecoder<R> {
-    /// Create a new decoder that decodes from the stream ```r```
+    /// Create a new decoder that decodes from the stream `r`
     pub fn new(r: R) -> JpegDecoder<R> {
+        Self::with_spec_compliance(r, SpecCompliance::default())
+    }
+
+    /// Create a new decoder with the given spec compliance mode.
+    pub(crate) fn with_spec_compliance(r: R, spec: SpecCompliance) -> JpegDecoder<R> {
         let options = zune_core::options::DecoderOptions::default()
-            .set_strict_mode(false)
+            .set_strict_mode(matches!(spec, SpecCompliance::Strict))
             .set_max_width(usize::MAX)
             .set_max_height(usize::MAX);
 
@@ -44,24 +44,8 @@ impl<R: BufRead + Seek> JpegDecoder<R> {
         JpegDecoder {
             decoder,
             header: None,
-            spec_compliance: SpecCompliance::default(),
             limits,
-            phantom: PhantomData,
         }
-    }
-
-    /// Create a new decoder with the given spec compliance mode.
-    pub(crate) fn new_with_spec_compliance(r: R, spec: SpecCompliance) -> JpegDecoder<R> {
-        let mut this = Self::new(r);
-
-        this.spec_compliance = spec;
-        this.decoder.set_options({
-            this.decoder
-                .options()
-                .set_strict_mode(matches!(spec, SpecCompliance::Strict))
-        });
-
-        this
     }
 
     fn ensure_headers(&mut self) -> ImageResult<(&mut zune_jpeg::JpegDecoder<R>, &HeaderData)> {
@@ -270,7 +254,7 @@ mod tests {
 
         // Strict mode: truncated image should be rejected
         let mut decoder =
-            JpegDecoder::new_with_spec_compliance(Cursor::new(&image), SpecCompliance::Strict);
+            JpegDecoder::with_spec_compliance(Cursor::new(&image), SpecCompliance::Strict);
         let layout = decoder.prepare_image().unwrap();
         let mut buffer = vec![0u8; layout.total_bytes() as usize];
         assert!(decoder.read_image(&mut buffer).is_err());

--- a/src/codecs/jpeg/decoder.rs
+++ b/src/codecs/jpeg/decoder.rs
@@ -31,7 +31,7 @@ struct HeaderData {
 
 impl<R: BufRead + Seek> JpegDecoder<R> {
     /// Create a new decoder that decodes from the stream ```r```
-    pub fn new(r: R) -> ImageResult<JpegDecoder<R>> {
+    pub fn new(r: R) -> JpegDecoder<R> {
         let options = zune_core::options::DecoderOptions::default()
             .set_strict_mode(false)
             .set_max_width(usize::MAX)
@@ -41,21 +41,19 @@ impl<R: BufRead + Seek> JpegDecoder<R> {
         // Limits are disabled by default in the constructor for all decoders
         let limits = Limits::no_limits();
 
-        Ok(JpegDecoder {
+        JpegDecoder {
             decoder,
             header: None,
             spec_compliance: SpecCompliance::default(),
             limits,
             phantom: PhantomData,
-        })
+        }
     }
 
     /// Create a new decoder with the given spec compliance mode.
-    pub(crate) fn new_with_spec_compliance(
-        r: R,
-        spec: SpecCompliance,
-    ) -> ImageResult<JpegDecoder<R>> {
-        let mut this = Self::new(r)?;
+    pub(crate) fn new_with_spec_compliance(r: R, spec: SpecCompliance) -> JpegDecoder<R> {
+        let mut this = Self::new(r);
+
         this.spec_compliance = spec;
         this.decoder.set_options({
             this.decoder
@@ -63,7 +61,7 @@ impl<R: BufRead + Seek> JpegDecoder<R> {
                 .set_strict_mode(matches!(spec, SpecCompliance::Strict))
         });
 
-        Ok(this)
+        this
     }
 
     fn ensure_headers(&mut self) -> ImageResult<(&mut zune_jpeg::JpegDecoder<R>, &HeaderData)> {
@@ -247,7 +245,7 @@ mod tests {
     #[test]
     fn test_exif_orientation() {
         let data = fs::read("tests/images/jpg/portrait_2.jpg").unwrap();
-        let decoder = JpegDecoder::new(Cursor::new(data)).unwrap();
+        let decoder = JpegDecoder::new(Cursor::new(data));
 
         let mut image = crate::DynamicImage::new_luma8(0, 0);
         let mut reader = crate::ImageReader::from_decoder(Box::new(decoder));
@@ -265,15 +263,14 @@ mod tests {
         image.truncate(image.len() - 1000); // simulate a truncated image
 
         // Default (lenient) mode: truncated image should be accepted
-        let mut decoder = JpegDecoder::new(Cursor::new(&image)).unwrap();
+        let mut decoder = JpegDecoder::new(Cursor::new(&image));
         let layout = decoder.prepare_image().unwrap();
         let mut buffer = vec![0u8; layout.total_bytes() as usize];
         assert!(decoder.read_image(&mut buffer).is_ok());
 
         // Strict mode: truncated image should be rejected
         let mut decoder =
-            JpegDecoder::new_with_spec_compliance(Cursor::new(&image), SpecCompliance::Strict)
-                .unwrap();
+            JpegDecoder::new_with_spec_compliance(Cursor::new(&image), SpecCompliance::Strict);
         let layout = decoder.prepare_image().unwrap();
         let mut buffer = vec![0u8; layout.total_bytes() as usize];
         assert!(decoder.read_image(&mut buffer).is_err());

--- a/src/codecs/jpeg/decoder.rs
+++ b/src/codecs/jpeg/decoder.rs
@@ -1,8 +1,6 @@
 use std::io::{BufRead, Seek};
 use std::marker::PhantomData;
 
-use zune_core::bytestream::ZCursor;
-
 use crate::color::ColorType;
 use crate::error::{
     DecodingError, ImageError, ImageResult, LimitError, UnsupportedError, UnsupportedErrorKind,
@@ -16,7 +14,7 @@ type ZuneColorSpace = zune_core::colorspace::ColorSpace;
 
 /// JPEG decoder
 pub struct JpegDecoder<R> {
-    input: Vec<u8>,
+    input: zune_jpeg::JpegDecoder<R>,
     orig_color_space: ZuneColorSpace,
     spec_compliance: SpecCompliance,
     width: u16,
@@ -30,15 +28,13 @@ pub struct JpegDecoder<R> {
 impl<R: BufRead + Seek> JpegDecoder<R> {
     /// Create a new decoder that decodes from the stream ```r```
     pub fn new(r: R) -> ImageResult<JpegDecoder<R>> {
-        let mut input = Vec::new();
-        let mut r = r;
-        r.read_to_end(&mut input)?;
         let options = zune_core::options::DecoderOptions::default()
             .set_strict_mode(false)
             .set_max_width(usize::MAX)
             .set_max_height(usize::MAX);
-        let mut decoder =
-            zune_jpeg::JpegDecoder::new_with_options(ZCursor::new(input.as_slice()), options);
+
+        let mut decoder = zune_jpeg::JpegDecoder::new_with_options(r, options);
+        // Adjust ensure_headers if we do not run this in the constructor!
         decoder.decode_headers().map_err(ImageError::from_jpeg)?;
         // now that we've decoded the headers we can `.unwrap()`
         // all these functions that only fail if called before decoding the headers
@@ -65,7 +61,7 @@ impl<R: BufRead + Seek> JpegDecoder<R> {
         // Limits are disabled by default in the constructor for all decoders
         let limits = Limits::no_limits();
         Ok(JpegDecoder {
-            input,
+            input: decoder,
             orig_color_space,
             spec_compliance: SpecCompliance::default(),
             width,
@@ -82,7 +78,18 @@ impl<R: BufRead + Seek> JpegDecoder<R> {
     ) -> ImageResult<JpegDecoder<R>> {
         let mut decoder = Self::new(r)?;
         decoder.spec_compliance = spec;
+        decoder.input.set_options({
+            decoder
+                .input
+                .options()
+                .set_strict_mode(matches!(spec, SpecCompliance::Strict))
+        });
         Ok(decoder)
+    }
+
+    fn ensure_headers(&mut self) -> ImageResult<&mut zune_jpeg::JpegDecoder<R>> {
+        // Headers are already decoded in `new()` right now, so this is a no-op.
+        Ok(&mut self.input)
     }
 }
 
@@ -109,58 +116,22 @@ impl<R: BufRead + Seek> ImageDecoder for JpegDecoder<R> {
     }
 
     fn icc_profile(&mut self) -> ImageResult<Option<Vec<u8>>> {
-        // If this is changed to operate on a file, ensure all headers are done here and we have
-        // reached the MCU/RST portion of the stream.
-        let options = zune_core::options::DecoderOptions::default()
-            .set_strict_mode(self.spec_compliance == SpecCompliance::Strict)
-            .set_max_width(usize::MAX)
-            .set_max_height(usize::MAX);
-        let mut decoder =
-            zune_jpeg::JpegDecoder::new_with_options(ZCursor::new(&self.input), options);
-        decoder.decode_headers().map_err(ImageError::from_jpeg)?;
+        let decoder = self.ensure_headers()?;
         Ok(decoder.icc_profile())
     }
 
     fn exif_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {
-        // If this is changed to operate on a file, ensure all headers are done here and we have
-        // reached the MCU/RST portion of the stream.
-        let options = zune_core::options::DecoderOptions::default()
-            .set_strict_mode(self.spec_compliance == SpecCompliance::Strict)
-            .set_max_width(usize::MAX)
-            .set_max_height(usize::MAX);
-        let mut decoder =
-            zune_jpeg::JpegDecoder::new_with_options(ZCursor::new(&self.input), options);
-        decoder.decode_headers().map_err(ImageError::from_jpeg)?;
-        let exif = decoder.exif().cloned();
-
-        Ok(exif)
+        let decoder = self.ensure_headers()?;
+        Ok(decoder.exif().cloned())
     }
 
     fn xmp_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {
-        // If this is changed to operate on a file, ensure all headers are done here and we have
-        // reached the MCU/RST portion of the stream.
-        let options = zune_core::options::DecoderOptions::default()
-            .set_strict_mode(self.spec_compliance == SpecCompliance::Strict)
-            .set_max_width(usize::MAX)
-            .set_max_height(usize::MAX);
-        let mut decoder =
-            zune_jpeg::JpegDecoder::new_with_options(ZCursor::new(&self.input), options);
-        decoder.decode_headers().map_err(ImageError::from_jpeg)?;
-
+        let decoder = self.ensure_headers()?;
         Ok(decoder.xmp().cloned())
     }
 
     fn iptc_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {
-        // If this is changed to operate on a file, ensure all headers are done here and we have
-        // reached the MCU/RST portion of the stream.
-        let options = zune_core::options::DecoderOptions::default()
-            .set_strict_mode(self.spec_compliance == SpecCompliance::Strict)
-            .set_max_width(usize::MAX)
-            .set_max_height(usize::MAX);
-        let mut decoder =
-            zune_jpeg::JpegDecoder::new_with_options(ZCursor::new(&self.input), options);
-        decoder.decode_headers().map_err(ImageError::from_jpeg)?;
-
+        let decoder = self.ensure_headers()?;
         Ok(decoder.iptc().cloned())
     }
 
@@ -181,14 +152,10 @@ impl<R: BufRead + Seek> ImageDecoder for JpegDecoder<R> {
             )));
         }
 
-        let mut decoder = new_zune_decoder(
-            &self.input,
-            self.orig_color_space,
-            self.spec_compliance == SpecCompliance::Strict,
-            &self.limits,
-        );
-
-        decoder.decode_into(buf).map_err(ImageError::from_jpeg)?;
+        let decoder = self.ensure_headers()?;
+        decoder.decode_into(buf).map_err(|err| {
+            ImageError::Decoding(DecodingError::new(ImageFormat::Jpeg.into(), err))
+        })?;
 
         Ok(DecodedImageAttributes {
             ..DecodedImageAttributes::default()
@@ -228,27 +195,6 @@ fn to_supported_color_space(orig: ZuneColorSpace) -> ZuneColorSpace {
         // the rest is not supported by `image` so it will be converted to RGB during decoding
         _ => RGB,
     }
-}
-
-fn new_zune_decoder<'input>(
-    input: &'input [u8],
-    orig_color_space: ZuneColorSpace,
-    strict_mode: bool,
-    limits: &Limits,
-) -> zune_jpeg::JpegDecoder<ZCursor<&'input [u8]>> {
-    let target_color_space = to_supported_color_space(orig_color_space);
-    let mut options = zune_core::options::DecoderOptions::default()
-        .jpeg_set_out_colorspace(target_color_space)
-        .set_strict_mode(strict_mode);
-    options = options.set_max_width(match limits.max_image_width {
-        Some(max_width) => max_width as usize, // u32 to usize never truncates
-        None => usize::MAX,
-    });
-    options = options.set_max_height(match limits.max_image_height {
-        Some(max_height) => max_height as usize, // u32 to usize never truncates
-        None => usize::MAX,
-    });
-    zune_jpeg::JpegDecoder::new_with_options(ZCursor::new(input), options)
 }
 
 impl ImageError {

--- a/src/codecs/jpeg/encoder.rs
+++ b/src/codecs/jpeg/encoder.rs
@@ -320,7 +320,7 @@ mod tests {
     use super::super::{JpegDecoder, JpegEncoder};
 
     fn decode(encoded: &[u8]) -> Vec<u8> {
-        let mut decoder = JpegDecoder::new(Cursor::new(encoded)).expect("Could not decode image");
+        let mut decoder = JpegDecoder::new(Cursor::new(encoded));
         let layout = decoder.prepare_image().unwrap();
         let mut decoded = vec![0; layout.total_bytes() as usize];
         decoder
@@ -403,8 +403,7 @@ mod tests {
                 .expect("Could not encode image");
         }
 
-        let mut decoder =
-            JpegDecoder::new(Cursor::new(encoded_img)).expect("Could not decode image");
+        let mut decoder = JpegDecoder::new(Cursor::new(encoded_img));
         let decoded_exif = decoder
             .exif_metadata()
             .expect("Error decoding Exif")
@@ -432,8 +431,7 @@ mod tests {
                 .expect("Could not encode image");
         }
 
-        let mut decoder =
-            JpegDecoder::new(Cursor::new(encoded_img)).expect("Could not decode image");
+        let mut decoder = JpegDecoder::new(Cursor::new(encoded_img));
         let decoded_xmp = decoder
             .xmp_metadata()
             .expect("Error decoding XMP")

--- a/src/io/image_reader_type.rs
+++ b/src/io/image_reader_type.rs
@@ -204,7 +204,7 @@ impl<'a, R: 'a + BufRead + Seek> ImageReaderOptions<R> {
             #[cfg(feature = "gif")]
             ImageFormat::Gif => Box::new(gif::GifDecoder::new(reader)?),
             #[cfg(feature = "jpeg")]
-            ImageFormat::Jpeg => Box::new(jpeg::JpegDecoder::new_with_spec_compliance(
+            ImageFormat::Jpeg => Box::new(jpeg::JpegDecoder::with_spec_compliance(
                 reader,
                 spec_compliance,
             )),

--- a/src/io/image_reader_type.rs
+++ b/src/io/image_reader_type.rs
@@ -215,14 +215,14 @@ impl<'a, R: 'a + BufRead + Seek> ImageReaderOptions<R> {
             #[cfg(feature = "tga")]
             ImageFormat::Tga => Box::new(tga::TgaDecoder::new(reader)?),
             #[cfg(feature = "bmp")]
-            ImageFormat::Bmp => Box::new(bmp::BmpDecoder::new_with_spec_compliance(
+            ImageFormat::Bmp => Box::new(bmp::BmpDecoder::with_spec_compliance(
                 reader,
                 spec_compliance,
             )?),
             #[cfg(feature = "ico")]
             ImageFormat::Ico => Box::new(ico::IcoDecoder::new(reader)?),
             #[cfg(feature = "hdr")]
-            ImageFormat::Hdr => Box::new(hdr::HdrDecoder::new_with_spec_compliance(
+            ImageFormat::Hdr => Box::new(hdr::HdrDecoder::with_spec_compliance(
                 reader,
                 spec_compliance,
             )?),

--- a/src/io/image_reader_type.rs
+++ b/src/io/image_reader_type.rs
@@ -207,7 +207,7 @@ impl<'a, R: 'a + BufRead + Seek> ImageReaderOptions<R> {
             ImageFormat::Jpeg => Box::new(jpeg::JpegDecoder::new_with_spec_compliance(
                 reader,
                 spec_compliance,
-            )?),
+            )),
             #[cfg(feature = "webp")]
             ImageFormat::WebP => Box::new(webp::WebPDecoder::new(reader)?),
             #[cfg(feature = "tiff")]

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -196,7 +196,7 @@ mod tests {
     #[test] // This attribute marks the function as a test function.
     fn test_extraction_and_clearing() {
         let reader = Cursor::new(TEST_IMAGE);
-        let mut decoder = JpegDecoder::new(reader).expect("Failed to decode test image");
+        let mut decoder = JpegDecoder::new(reader);
         let mut exif_chunk = decoder
             .exif_metadata()
             .expect("Failed to extract Exif chunk")

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -117,7 +117,7 @@ fn jpeg() {
     assert!(load_through_reader(&image, ImageFormat::Jpeg, allocation_limits()).is_err());
 
     // JpegDecoder
-    let mut decoder = JpegDecoder::new(Cursor::new(&image)).unwrap();
+    let mut decoder = JpegDecoder::new(Cursor::new(&image));
     assert!(decoder.set_limits(width_height_limits()).is_err());
     // No tests for allocation limits because the caller is responsible for allocating the buffer in this case.
 }

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -92,7 +92,7 @@ fn test_read_iptc_jpeg() -> Result<(), image::ImageError> {
     let img_path = PathBuf::from_str(IPTC_JPG_PATH).unwrap();
 
     let data = fs::read(img_path)?;
-    let mut jpeg_decoder = JpegDecoder::new(std::io::Cursor::new(data))?;
+    let mut jpeg_decoder = JpegDecoder::new(std::io::Cursor::new(data));
     let metadata = jpeg_decoder.iptc_metadata()?;
     assert!(metadata.is_some());
     assert_eq!(EXPECTED_METADATA, metadata.unwrap());
@@ -137,7 +137,7 @@ fn test_read_xmp_jpeg() -> Result<(), image::ImageError> {
     let img_path = PathBuf::from_str(IMG_PATH).unwrap();
 
     let data = fs::read(img_path)?;
-    let mut tiff_decoder = JpegDecoder::new(std::io::Cursor::new(data))?;
+    let mut tiff_decoder = JpegDecoder::new(std::io::Cursor::new(data));
     let metadata = tiff_decoder.xmp_metadata()?;
     assert!(metadata.is_some());
     assert_eq!(EXPECTED_METADATA, &metadata.unwrap());


### PR DESCRIPTION
With the decoder trait changed to take a mutable reference as well as `zune-jpeg` providing an IO-based cursor we can now implement this trait in terms of iteration over a file; instead of buffering the whole stream into memory once at the start.