### PR TITLE
Remove `ConvertBuffer` trait

### DIFF
--- a/benches/imageops.rs
+++ b/benches/imageops.rs
@@ -2,7 +2,6 @@ use std::{hint::black_box, time::Duration};
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use image::{
-    buffer::ConvertBuffer,
     imageops::{self, FilterType},
     math::Rect,
     DynamicImage, GrayImage, ImageBuffer, Rgb,

--- a/src/codecs/avif/encoder.rs
+++ b/src/codecs/avif/encoder.rs
@@ -8,7 +8,6 @@ use std::cmp::min;
 use std::io::Write;
 use std::mem::size_of;
 
-use crate::buffer::ConvertBuffer;
 use crate::color::{FromColor, Luma, LumaA, Rgb, Rgba};
 use crate::error::{
     EncodingError, ParameterError, ParameterErrorKind, UnsupportedError, UnsupportedErrorKind,

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -2407,7 +2407,7 @@ mod test {
 #[cfg(test)]
 #[cfg(feature = "benchmarks")]
 mod benchmarks {
-    use super::{ConvertBuffer, GrayImage, ImageBuffer, Pixel, RgbImage};
+    use super::{GrayImage, ImageBuffer, Pixel, RgbImage};
 
     #[bench]
     fn conversion(b: &mut test::Bencher) {

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -1442,16 +1442,6 @@ where
     }
 }
 
-/// Provides color conversions for whole image buffers.
-pub trait ConvertBuffer<T> {
-    /// Converts `self` to a buffer of type T
-    ///
-    /// A generic implementation is provided to convert any image buffer to a image buffer
-    /// based on a `Vec<T>`.
-    fn convert(&self) -> T;
-}
-
-// concrete implementation Luma -> Rgba
 impl GrayImage {
     /// Expands a color palette into an RGBA image. Uses an optionally
     /// transparent index to adjust its alpha value accordingly.
@@ -1485,23 +1475,23 @@ impl GrayImage {
     }
 }
 
-/// This copies the color space information but is somewhat wrong, in numeric terms this conversion
-/// fails to actually convert rgb/luma with consistent treatment. But this trait impl is too
-/// generic to handle it correctly (missing any CICP related parameter for the coefficients) so the
-/// best effort here is to copy the metadata and have slighly incorrect color. May you've only been
-/// adding an alpha channel or converting sample types, which is fine.
-///
-/// It will very likely be deprecated in a future release.
-impl<Container, FromType: Pixel, ToType: Pixel>
-    ConvertBuffer<ImageBuffer<ToType, Vec<ToType::Subpixel>>> for ImageBuffer<FromType, Container>
+impl<P: Pixel, Container> ImageBuffer<P, Container>
 where
-    Container: Deref<Target = [FromType::Subpixel]>,
-    ToType: FromColor<FromType>,
+    Container: Deref<Target = [P::Subpixel]>,
 {
+    /// Convert this image buffer to another pixel type, copying the color space information.
+    ///
+    /// The conversion uses [`FromColor`] and ignores color space information. The resulting image
+    /// will have the same color space as the original, which may lead to incorrect colors if the
+    /// source and target pixel types have different color types, e.g. `Rgb` and `Luma`.
+    /// In that case, the conversion is a best effort and may be inaccurate.
+    /// Conversions between alpha and non-alpha variants of Pixels are correct regarding the color space.
+    ///
     /// # Examples
+    ///
     /// Convert RGB image to gray image.
+    ///
     /// ```no_run
-    /// use image::buffer::ConvertBuffer;
     /// use image::GrayImage;
     ///
     /// let image_path = "examples/fractal.png";
@@ -1511,7 +1501,10 @@ where
     ///
     /// let gray_image: GrayImage = image.convert();
     /// ```
-    fn convert(&self) -> ImageBuffer<ToType, Vec<ToType::Subpixel>> {
+    pub fn convert<ToType>(&self) -> ImageBuffer<ToType, Vec<ToType::Subpixel>>
+    where
+        ToType: Pixel + FromColor<P>,
+    {
         let mut buffer: ImageBuffer<ToType, Vec<ToType::Subpixel>> =
             ImageBuffer::new(self.width, self.height);
         buffer.copy_color_space_from(self);

--- a/src/images/dynimage.rs
+++ b/src/images/dynimage.rs
@@ -7,8 +7,8 @@ use crate::error::{ImageError, ImageResult, ParameterError, ParameterErrorKind};
 use crate::flat::FlatSamples;
 use crate::imageops::{gaussian_blur_dyn_image, GaussianBlurParameters};
 use crate::images::buffer::{
-    ConvertBuffer, Gray16Image, GrayAlpha16Image, GrayAlphaImage, GrayImage, ImageBuffer,
-    Rgb16Image, Rgb32FImage, RgbImage, Rgba16Image, Rgba32FImage, RgbaImage,
+    Gray16Image, GrayAlpha16Image, GrayAlphaImage, GrayImage, ImageBuffer, Rgb16Image, Rgb32FImage,
+    RgbImage, Rgba16Image, Rgba32FImage, RgbaImage,
 };
 use crate::io::encoder::ImageEncoderBoxed;
 use crate::io::free_functions::{self, encoder_for_format};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,8 +181,7 @@ pub mod error;
 pub mod buffer {
     // Only those not exported at the top-level
     pub use crate::images::buffer::{
-        ConvertBuffer, EnumeratePixels, EnumeratePixelsMut, EnumerateRows, EnumerateRowsMut, Rows,
-        RowsMut,
+        EnumeratePixels, EnumeratePixelsMut, EnumerateRows, EnumerateRowsMut, Rows, RowsMut,
     };
 
     #[cfg(feature = "rayon")]

--- a/tests/conversions.rs
+++ b/tests/conversions.rs
@@ -1,4 +1,3 @@
-use image::buffer::ConvertBuffer;
 use image::{ImageBuffer, Rgb, Rgba};
 
 use std::fs;


### PR DESCRIPTION
I removed the `ConvertBuffer` trait and made `convert` a simple method on `ImageBuffer`.

I did this for a few reasons:

1. The trait is only implemented by `ImageBuffer` and nothing else. So it does not abstract over different implementations within `image`.
2. It is never used as a trait bound. So even if third-party implementations were made, they wouldn't enable anything within `image`.
3. The trait cannot respect color space information due to its API.
4. It adds complexity. Since the trait isn't really used as a trait, it just gates the `convert` method. So why have a trait when a method suffices?