### PR TITLE
Add GenericImage::to_pixel_view_mut and copy performance

### DIFF
--- a/benches/copy_from.rs
+++ b/benches/copy_from.rs
@@ -3,6 +3,7 @@ use image::{GenericImage, ImageBuffer, Rgba};
 
 pub fn bench_copy_from(c: &mut Criterion) {
     let at = image::math::Rect::from_xy_ranges(256..1280, 256..1280);
+    let mut c = c.benchmark_group("target: ImageBuffer");
 
     let mut target = ImageBuffer::from_pixel(2048, 2048, Rgba([0u8, 0, 0, 255]));
     let src = ImageBuffer::from_pixel(2048, 2048, Rgba([255u8, 0, 0, 255]));
@@ -45,6 +46,7 @@ pub fn bench_copy_from(c: &mut Criterion) {
 pub fn bench_copy_subimage_from(c: &mut Criterion) {
     let viewport = image::math::Rect::from_xy_ranges(256..1280, 256..1280);
     let at = image::math::Rect::from_xy_ranges(128..512, 128..512);
+    let mut c = c.benchmark_group("target: SubImage");
 
     let mut target = ImageBuffer::from_pixel(2048, 2048, Rgba([0u8, 0, 0, 255]));
     let mut target = target.sub_image(viewport);
@@ -85,5 +87,56 @@ pub fn bench_copy_subimage_from(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_copy_from, bench_copy_subimage_from);
+pub fn bench_view_copy_from(c: &mut Criterion) {
+    let at = image::math::Rect::from_xy_ranges(256..1280, 256..1280);
+    let mut c = c.benchmark_group("target: ViewMut");
+
+    let mut target = ImageBuffer::from_pixel(2048, 3072, Rgba([0u8, 0, 0, 255]));
+    // Set up a view that is a little bit strided  (a sub_image)..
+    let mut target = target.as_pixel_view_mut();
+    target.shrink_to(2048, 2048);
+
+    let src = ImageBuffer::from_pixel(2048, 2048, Rgba([255u8, 0, 0, 255]));
+    let part = ImageBuffer::from_pixel(at.width, at.height, Rgba([255u8, 0, 0, 255]));
+
+    let view = image::GenericImageView::view(&src, at);
+
+    const BG: Rgba<u8> = Rgba([0u8, 0, 0, 255]);
+    let samples = image::flat::FlatSamples::with_monocolor(&BG, at.width, at.height);
+    let singular = samples.as_view().unwrap();
+
+    let mut samples = src.as_flat_samples();
+    samples.layout.width = 1024;
+    samples.layout.width_stride *= 2;
+    samples.layout.height = 1024;
+    samples.layout.height_stride *= 2;
+    let skip = samples.as_view().unwrap();
+
+    c.bench_function("copy_from", |b| {
+        b.iter(|| target.copy_from(black_box(&src), 0, 0));
+    });
+
+    c.bench_function("copy_at", |b| {
+        b.iter(|| target.copy_from(black_box(&part), at.x, at.y));
+    });
+
+    c.bench_function("copy_view", |b| {
+        b.iter(|| target.copy_from(black_box(&*view), at.x, at.y));
+    });
+
+    c.bench_function("copy_fill", |b| {
+        b.iter(|| target.copy_from(black_box(&singular), at.x, at.y));
+    });
+
+    c.bench_function("copy_strides", |b| {
+        b.iter(|| target.copy_from(black_box(&skip), at.x, at.y));
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_copy_from,
+    bench_copy_subimage_from,
+    bench_view_copy_from
+);
 criterion_main!(benches);

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -10,7 +10,7 @@ use crate::color::{FromColor, FromPrimitive, Luma, LumaA, Rgb, Rgba};
 use crate::error::{
     ImageResult, ParameterError, ParameterErrorKind, UnsupportedError, UnsupportedErrorKind,
 };
-use crate::flat::{FlatSamples, SampleLayout, ViewOfPixel};
+use crate::flat::{FlatSamples, SampleLayout, ViewMutOfPixel, ViewOfPixel};
 use crate::math::Rect;
 use crate::metadata::cicp::{CicpApplicable, CicpPixelCast, CicpRgb, ColorComponentForCicp};
 use crate::traits::{EncodableLayout, Pixel, PixelWithColorType};
@@ -717,12 +717,39 @@ where
         }
     }
 
+    /// Return an image view on the raw sample buffer.
+    ///
+    /// This is related to [`Self::into_flat_samples`] and [`Self::as_flat_samples`] while
+    /// encapsulating the conversion into an implementation of [`GenericImageView`]. In contrast to
+    /// the generic [`GenericImageView::to_pixel_view`] this is not fallible.
+    ///
+    /// The result is similar to a [`crate::SubImage`] created from [`GenericImageView::try_view`]
+    /// but unlike that generic type it is not strongly tied to the `Self` type and underlying
+    /// buffer used.
+    ///
+    /// # Usage
+    ///
+    /// ```
+    /// use image::{RgbImage, GenericImageView, Rgb};
+    ///
+    /// let mut img = RgbImage::from_pixel(16, 16, Rgb([0xff, 0xab, 0xcd]));
+    /// let strided = img.as_pixel_view();
+    ///
+    /// // This borrows `img` and is still a `GenericImageView`.
+    /// assert_eq!(strided.get_pixel(8, 8), Rgb([0xff, 0xab, 0xcd]));
+    /// ```
+    pub fn as_pixel_view(&self) -> ViewOfPixel<'_, P> {
+        self.as_flat_samples()
+            .into_view()
+            .expect("buffer always uses a non-overlapping strided layout")
+    }
+
     /// Return a mutable view on the raw sample buffer.
     ///
     /// See [`into_flat_samples`](#method.into_flat_samples) for more details.
     pub fn as_flat_samples_mut(&mut self) -> FlatSamples<&mut [P::Subpixel]>
     where
-        Container: AsMut<[P::Subpixel]>,
+        Container: DerefMut<Target = [P::Subpixel]>,
     {
         let layout = self.sample_layout();
         FlatSamples {
@@ -730,6 +757,36 @@ where
             layout,
             color_hint: None, // TODO: the pixel type might contain P::COLOR_TYPE if it satisfies PixelWithColorType
         }
+    }
+
+    /// Return a mutable image view on the raw sample buffer.
+    ///
+    /// This is related to [`Self::into_flat_samples`] and [`Self::as_flat_samples_mut`] while still
+    /// encapsulating the conversion into an implementation of [`GenericImage`]. In contrast to the
+    /// generic [`GenericImage::to_pixel_view_mut`] this is not fallible.
+    ///
+    /// The result is similar to a [`crate::SubImage`] created from [`GenericImage::sub_image`] but
+    /// unlike that generic type it is not strongly tied to the `Self` type and underlying buffer
+    /// used.
+    ///
+    /// # Usage
+    ///
+    /// ```
+    /// use image::{RgbImage, GenericImage, Rgb};
+    ///
+    /// let mut img = RgbImage::from_pixel(16, 16, Rgb([0xff, 0xab, 0xcd]));
+    /// let mut strided = img.as_pixel_view_mut();
+    ///
+    /// // This borrows `img` and is still a `GenericImage` (and a view).
+    /// strided.put_pixel(8, 8, Rgb([0x00, 0x00, 0x00]));
+    /// ```
+    pub fn as_pixel_view_mut(&mut self) -> ViewMutOfPixel<'_, P>
+    where
+        Container: DerefMut<Target = [P::Subpixel]>,
+    {
+        self.as_flat_samples_mut()
+            .into_view_mut()
+            .expect("buffer always uses a non-overlapping strided layout")
     }
 }
 
@@ -1140,7 +1197,7 @@ where
     }
 
     fn to_pixel_view(&self) -> Option<ViewOfPixel<'_, Self::Pixel>> {
-        self.as_flat_samples().into_view().ok()
+        Some(self.as_pixel_view())
     }
 
     /// Returns the pixel located at (x, y), ignoring bounds checking.
@@ -1264,6 +1321,10 @@ where
             }
         }
         true
+    }
+
+    fn to_pixel_view_mut(&mut self) -> Option<ViewMutOfPixel<'_, Self::Pixel>> {
+        Some(self.as_pixel_view_mut())
     }
 }
 

--- a/src/images/flat.rs
+++ b/src/images/flat.rs
@@ -1410,12 +1410,7 @@ where
     }
 
     /// Copy from, assuming that the source is not a simple view layout.
-    pub(crate) fn inherent_copy_from<O>(
-        &mut self,
-        other: &O,
-        x: u32,
-        y: u32,
-    ) -> crate::ImageResult<()>
+    pub(crate) fn inner_copy_from<O>(&mut self, other: &O, x: u32, y: u32) -> crate::ImageResult<()>
     where
         O: GenericImageView<Pixel = P>,
         // Note: not necessary for the implementation per-se but this allows the use of
@@ -1488,6 +1483,38 @@ where
                 let idx = layout.in_bounds_index(0, i + x, k + y);
                 let channels = &mut samples[idx..][..usize::from(P::CHANNEL_COUNT)];
                 *P::from_slice_mut(channels) = p;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn inner_copy_from_samples(
+        &mut self,
+        other: ViewOfPixel<'_, P>,
+        x: u32,
+        y: u32,
+    ) -> crate::ImageResult<()>
+    where
+        // Note: not necessary for the implementation per-se but this allows the use of
+        // `GenericImage`/`GenericImageView` methods and so `test_in_bounds_of`.
+        Buffer: AsRef<[P::Subpixel]>,
+    {
+        let target = Rect::from_image_at(&other, x, y);
+        target.test_in_bounds_of(self)?;
+
+        let in_layout = other.inner.layout;
+        let in_samples = other.image_slice();
+
+        let out_layout = self.inner.layout;
+        let out_samples = self.image_mut_slice();
+
+        for k in 0..target.height {
+            for i in 0..target.width {
+                let iidx = in_layout.in_bounds_index(0, i, k);
+                let oidx = out_layout.in_bounds_index(0, i + x, k + y);
+                out_samples[oidx..][..usize::from(P::CHANNEL_COUNT)]
+                    .copy_from_slice(&in_samples[iidx..][..usize::from(P::CHANNEL_COUNT)]);
             }
         }
 
@@ -1666,10 +1693,10 @@ where
         O: GenericImageView<Pixel = Self::Pixel>,
     {
         if let Some(flat) = other.to_pixel_view() {
-            return self.copy_from_samples(flat, x, y);
+            return self.inner_copy_from_samples(flat, x, y);
         }
 
-        self.inherent_copy_from(other, x, y)
+        self.inner_copy_from(other, x, y)
     }
 }
 

--- a/src/images/flat.rs
+++ b/src/images/flat.rs
@@ -52,6 +52,7 @@ use crate::error::{
     DecodingError, ImageError, ImageFormatHint, ParameterError, ParameterErrorKind,
     UnsupportedError, UnsupportedErrorKind,
 };
+use crate::math::Rect;
 use crate::traits::Pixel;
 use crate::{GenericImage, GenericImageView, ImageBuffer};
 
@@ -295,7 +296,7 @@ impl SampleLayout {
 
         grouped.sort();
 
-        let (min_dim, mid_dim, max_dim) = (grouped[0], grouped[1], grouped[2]);
+        let [min_dim, mid_dim, max_dim] = grouped;
         assert!(min_dim.stride() <= mid_dim.stride() && mid_dim.stride() <= max_dim.stride());
 
         grouped
@@ -308,8 +309,7 @@ impl SampleLayout {
     /// dimension overflows `usize` with its stride we also consider this aliasing.
     #[must_use]
     pub fn has_aliased_samples(&self) -> bool {
-        let grouped = self.increasing_stride_dims();
-        let (min_dim, mid_dim, max_dim) = (grouped[0], grouped[1], grouped[2]);
+        let [min_dim, mid_dim, max_dim] = self.increasing_stride_dims();
 
         let min_size = match min_dim.checked_len() {
             None => return true,
@@ -1408,6 +1408,91 @@ where
         let channels = self.inner.layout.channels;
         self.inner.shrink_to(channels, width, height);
     }
+
+    /// Copy from, assuming that the source is not a simple view layout.
+    pub(crate) fn inherent_copy_from<O>(
+        &mut self,
+        other: &O,
+        x: u32,
+        y: u32,
+    ) -> crate::ImageResult<()>
+    where
+        O: GenericImageView<Pixel = P>,
+        // Note: not necessary for the implementation per-se but this allows the use of
+        // `GenericImage`/`GenericImageView` methods and so `test_in_bounds_of`.
+        Buffer: AsRef<[P::Subpixel]>,
+    {
+        // Do bounds checking here so we can use the non-bounds-checking
+        // functions to copy pixels.
+        let target = Rect::from_image_at(other, x, y);
+        target.test_in_bounds_of(self)?;
+
+        if self.image_mut_slice().is_empty() {
+            // Apparently this is an empty image but the other is inbounds so it is *also* an empty
+            // image. Well, without anything to do let's signal success.
+            return Ok(());
+        }
+
+        let (c, w, h) = self.inner.layout.strides_cwh();
+        // This will be assumed to hold in the following.
+        debug_assert_eq!(
+            c, 1,
+            "Precondition for a `ViewMut`, each Pixel is a slice of channels"
+        );
+
+        if w == usize::from(P::CHANNEL_COUNT) {
+            let layout = self.inner.layout;
+            let buffer = self.image_mut_slice();
+
+            // Edge case: if we have a height of `1` then its height stride may be zero without
+            // violating the aliasing requirements. We will instead always use the whole slice in
+            // that case. Avoids the potential panic.
+            let row_len = if layout.height <= 1 { buffer.len() } else { h };
+            let rows = buffer.chunks_exact_mut(row_len);
+
+            // `ViewMut` has an actual invariant on its buffer size (even though it is generic) that
+            // is enforced by construction.
+            assert!(
+                // Since we verified `test_in_bounds_of´ and the target rectangle is a trustworthy
+                // value, not a generic interface, the addition on the right hand does not overflow
+                // `u32` as it still fits into our own height.
+                rows.len() >= (target.y + target.height) as usize,
+                "ViewMut buffer inconsistent with its layout"
+            );
+
+            for (k, row) in rows
+                .skip(target.y as usize)
+                .take(target.height as usize)
+                .enumerate()
+            {
+                // Adjust the row according to the target region.
+                let row = &mut row[target.x as usize * usize::from(P::CHANNEL_COUNT)..];
+                let row = &mut row[..target.width as usize * usize::from(P::CHANNEL_COUNT)];
+                let chunks = row.chunks_exact_mut(usize::from(P::CHANNEL_COUNT));
+
+                for (i, out_pix) in (0..target.width).zip(chunks) {
+                    let p = other.get_pixel(i, k as u32);
+                    *P::from_slice_mut(out_pix) = p;
+                }
+            }
+
+            return Ok(());
+        }
+
+        let layout = self.inner.layout;
+        let samples = self.image_mut_slice();
+
+        for k in 0..target.height {
+            for i in 0..target.width {
+                let p = other.get_pixel(i, k);
+                let idx = layout.in_bounds_index(0, i + x, k + y);
+                let channels = &mut samples[idx..][..usize::from(P::CHANNEL_COUNT)];
+                *P::from_slice_mut(channels) = p;
+            }
+        }
+
+        Ok(())
+    }
 }
 
 // The out-of-bounds panic for single sample access similar to `slice::index`.
@@ -1574,6 +1659,17 @@ where
         let channel_count = <P as Pixel>::CHANNEL_COUNT as usize;
         let pixel_range = base_index..base_index + channel_count;
         *P::from_slice_mut(&mut self.inner.samples.as_mut()[pixel_range]) = pixel;
+    }
+
+    fn copy_from<O>(&mut self, other: &O, x: u32, y: u32) -> crate::ImageResult<()>
+    where
+        O: GenericImageView<Pixel = Self::Pixel>,
+    {
+        if let Some(flat) = other.to_pixel_view() {
+            return self.copy_from_samples(flat, x, y);
+        }
+
+        self.inherent_copy_from(other, x, y)
     }
 }
 

--- a/src/images/flat.rs
+++ b/src/images/flat.rs
@@ -620,6 +620,12 @@ impl<Buffer> FlatSamples<Buffer> {
     /// Convert this descriptor into a readable image.
     ///
     /// An owned version of [`Self::as_view`] that uses the original buffer type.
+    ///
+    /// FIXME: before exposing this, consider if we want to have strong invariants related to
+    /// `AsRef` of `Buffer` or not. If we provide a generic one then we can not rely on the trait to
+    /// give us a stable address or anything but its pure interface. It may make it difficult to
+    /// introduce efficient code for the relevant case of `Buffer = &[T]`. We could introduce it
+    /// specifically for that buffer type.
     pub(crate) fn into_view<P>(self) -> Result<View<Buffer, P>, Error>
     where
         P: Pixel,
@@ -719,6 +725,43 @@ impl<Buffer> FlatSamples<Buffer> {
         Ok(ViewMut {
             inner: FlatSamples {
                 samples: as_mut,
+                layout: self.layout,
+                color_hint: self.color_hint,
+            },
+            phantom: PhantomData,
+        })
+    }
+
+    /// Turn this buffer into a mutable image.
+    ///
+    /// FIXME: before exposing this, consider if we want to have strong invariants related to
+    /// `AsMut` of `Buffer` or not. If we provide a generic one then we can not rely on the trait to
+    /// give us a stable address or anything but its pure interface. It may make it difficult to
+    /// introduce efficient code for the relevant case of `Buffer = &mut [T]`. We could introduce it
+    /// specifically for that buffer type.
+    pub(crate) fn into_view_mut<P>(mut self) -> Result<ViewMut<Buffer, P>, Error>
+    where
+        P: Pixel,
+        Buffer: AsMut<[P::Subpixel]>,
+    {
+        if !self.layout.is_normal(NormalForm::PixelPacked) {
+            return Err(Error::NormalFormRequired(NormalForm::PixelPacked));
+        }
+
+        if self.layout.channels != P::CHANNEL_COUNT {
+            return Err(Error::ChannelCountMismatch(
+                self.layout.channels,
+                P::CHANNEL_COUNT,
+            ));
+        }
+
+        if !self.layout.fits(self.samples.as_mut().len()) {
+            return Err(Error::TooLarge);
+        }
+
+        Ok(ViewMut {
+            inner: FlatSamples {
+                samples: self.samples,
                 layout: self.layout,
                 color_hint: self.color_hint,
             },

--- a/src/images/flat.rs
+++ b/src/images/flat.rs
@@ -1509,6 +1509,34 @@ where
         let out_layout = self.inner.layout;
         let out_samples = self.image_mut_slice();
 
+        // Check if we can make use of batch copies, row-by-row.
+        if in_layout.width_stride == P::CHANNEL_COUNT.into()
+            && out_layout.width_stride == P::CHANNEL_COUNT.into()
+        {
+            // See `inner_copy_from` where we have the same trick (chunks_exact_mut with 0 stride is
+            // not allowed).
+            let rows = out_samples.chunks_exact_mut({
+                if out_layout.height <= 1 {
+                    out_samples.len()
+                } else {
+                    out_layout.height_stride
+                }
+            });
+
+            let row_samples = target.width as usize * usize::from(P::CHANNEL_COUNT);
+            for (k, orow) in rows
+                .skip(target.y as usize)
+                .take(target.height as usize)
+                .enumerate()
+            {
+                let orow = &mut orow[target.x as usize * usize::from(P::CHANNEL_COUNT)..];
+                let irow = &in_samples[k * in_layout.height_stride..];
+                orow[..row_samples].copy_from_slice(&irow[..row_samples]);
+            }
+
+            return Ok(());
+        }
+
         for k in 0..target.height {
             for i in 0..target.width {
                 let iidx = in_layout.in_bounds_index(0, i, k);

--- a/src/images/flat.rs
+++ b/src/images/flat.rs
@@ -988,21 +988,7 @@ impl<'buf, Subpixel> FlatSamples<&'buf [Subpixel]> {
     /// This can be used as a very cheap source of a `GenericImageView` with an arbitrary number of
     /// pixels of a single color, without any dynamic allocation.
     ///
-    /// ## Examples
-    ///
-    /// ```
-    /// # fn paint_something<T>(_: T) {}
-    /// use image::{flat::FlatSamples, GenericImage, RgbImage, Rgb};
-    ///
-    /// let background = Rgb([20, 20, 20]);
-    /// let bg = FlatSamples::with_monocolor(&background, 200, 200);
-    ///
-    /// let mut image = RgbImage::new(200, 200);
-    /// paint_something(&mut image);
-    ///
-    /// // Reset the canvas
-    /// image.copy_from(&bg.as_view().unwrap(), 0, 0);
-    /// ```
+    /// See also [`View::with_monocolor`].
     pub fn with_monocolor<P>(pixel: &'buf P, width: u32, height: u32) -> Self
     where
         P: Pixel<Subpixel = Subpixel>,
@@ -1314,6 +1300,40 @@ where
     }
 }
 
+impl<'buf, P: Pixel> View<&'buf [P::Subpixel], P> {
+    /// Create a monocolor image from a single pixel.
+    ///
+    /// This can be used as a very cheap source of a `GenericImageView` with an arbitrary number of
+    /// pixels of a single color, without any dynamic allocation.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// # fn paint_something<T>(_: T) {}
+    /// use image::{flat::View, GenericImage, RgbImage, Rgb};
+    ///
+    /// let gray = Rgb([20, 20, 20]);
+    /// let background = View::with_monocolor(&gray, 200, 200);
+    ///
+    /// let mut image = RgbImage::from_pixel(200, 200, gray);
+    /// paint_something(&mut image);
+    ///
+    /// // Reset the canvas
+    /// image.copy_from(&background, 0, 0);
+    /// ```
+    pub fn with_monocolor(pixel: &'buf P, width: u32, height: u32) -> Self
+    where
+        P::Subpixel: crate::Primitive,
+    {
+        // Reuse the validation, in case of `P::channels()` funny business. (View internally prefers
+        // using the constant ``CHANNEL_COUNT` where appropriate afterwards to avoid re-executing a
+        // potential adversarial trait impl).
+        FlatSamples::with_monocolor(pixel, width, height)
+            .into_view()
+            .unwrap()
+    }
+}
+
 impl<Buffer, P: Pixel> ViewMut<Buffer, P>
 where
     Buffer: AsMut<[P::Subpixel]>,
@@ -1510,8 +1530,8 @@ where
         let out_samples = self.image_mut_slice();
 
         // Check if we can make use of batch copies, row-by-row.
-        if in_layout.width_stride == P::CHANNEL_COUNT.into()
-            && out_layout.width_stride == P::CHANNEL_COUNT.into()
+        if in_layout.width_stride == usize::from(P::CHANNEL_COUNT)
+            && out_layout.width_stride == usize::from(P::CHANNEL_COUNT)
         {
             // See `inner_copy_from` where we have the same trick (chunks_exact_mut with 0 stride is
             // not allowed).
@@ -1965,5 +1985,137 @@ mod tests {
         let _: GrayAlphaImage = buffer
             .try_into_buffer()
             .unwrap_or_else(|(error, _)| panic!("Expected buffer to be convertible but {error:?}"));
+    }
+
+    #[test]
+    fn copy_buffer_like_view() {
+        let src = View::with_monocolor(&LumaA([0xffu8, 0xfe]), 2, 3);
+
+        let mut buffer = FlatSamples {
+            samples: [0; 12],
+            layout: SampleLayout {
+                channels: 2,
+                channel_stride: 1,
+                width: 2,
+                width_stride: 2,
+                height: 3,
+                height_stride: 4,
+            },
+            color_hint: None,
+        };
+
+        let mut view = buffer
+            .as_view_mut::<LumaA<u8>>()
+            .expect("This should be a valid mutable buffer");
+
+        view.copy_from(&src, 0, 0)
+            .expect("image fits into the target");
+
+        assert_eq!(buffer.samples.as_chunks::<2>().0, [[0xff, 0xfe]; 6],);
+    }
+
+    #[test]
+    fn copy_heightstride_view() {
+        let src = View::with_monocolor(&LumaA([0xffu8, 0xfe]), 2, 3);
+
+        // Each row has capacity for 5 channels, of which 4 are used.
+        let mut buffer = FlatSamples {
+            samples: [0; 15],
+            layout: SampleLayout {
+                channels: 2,
+                channel_stride: 1,
+                width: 2,
+                width_stride: 2,
+                height: 3,
+                height_stride: 5,
+            },
+            color_hint: None,
+        };
+
+        let mut view = buffer
+            .as_view_mut::<LumaA<u8>>()
+            .expect("This should be a valid mutable buffer");
+
+        view.copy_from(&src, 0, 0)
+            .expect("image fits into the target");
+
+        assert_eq!(
+            buffer.samples.as_chunks::<5>().0,
+            [[0xff, 0xfe, 0xff, 0xfe, 0]; 3],
+        );
+    }
+
+    #[test]
+    fn copy_widthstride_view() {
+        let src = View::with_monocolor(&LumaA([0xffu8, 0xfe]), 2, 3);
+
+        // Each row has capacity for 5 channels, of which 4 are used.
+        let mut buffer = FlatSamples {
+            samples: [0; 18],
+            layout: SampleLayout {
+                channels: 2,
+                channel_stride: 1,
+                width: 2,
+                width_stride: 3,
+                height: 3,
+                height_stride: 6,
+            },
+            color_hint: None,
+        };
+
+        let mut view = buffer
+            .as_view_mut::<LumaA<u8>>()
+            .expect("This should be a valid mutable buffer");
+
+        view.copy_from(&src, 0, 0)
+            .expect("image fits into the target");
+
+        assert_eq!(
+            buffer.samples.as_chunks::<6>().0,
+            [[0xff, 0xfe, 0, 0xff, 0xfe, 0]; 3],
+        );
+    }
+
+    #[test]
+    fn copy_column_major_view() {
+        let src = View::with_monocolor(&LumaA([0xffu8, 0xfe]), 1, 3);
+
+        // Each row has capacity for 5 channels, of which 4 are used.
+        let mut buffer = FlatSamples {
+            samples: [0; 14],
+            layout: SampleLayout {
+                channels: 2,
+                channel_stride: 1,
+                width: 2,
+                width_stride: 8,
+                height: 3,
+                height_stride: 2,
+            },
+            color_hint: None,
+        };
+
+        let mut view = buffer
+            .as_view_mut::<LumaA<u8>>()
+            .expect("This should be a valid mutable buffer");
+
+        view.copy_from(&src, 0, 0)
+            .expect("image fits into the target");
+
+        // First column, i.e. first 3 pixels, affected.
+        assert_eq!(
+            view.image_slice()[0..6].as_chunks::<2>().0,
+            [[0xff, 0xfe]; 3],
+        );
+        // Everything else unchanged.
+        assert_eq!(view.image_slice()[6..], [0; 8]);
+
+        view.copy_from(&src, 1, 0)
+            .expect("image fits into the target");
+
+        assert_eq!(view.image_slice()[6..8], [0, 0]);
+        assert_eq!(
+            view.image_slice()[8..].as_chunks::<2>().0,
+            [[0xff, 0xfe]; 3],
+        );
     }
 }

--- a/src/images/generic_image.rs
+++ b/src/images/generic_image.rs
@@ -221,8 +221,24 @@ pub trait GenericImage: GenericImageView {
     where
         O: GenericImageView<Pixel = Self::Pixel>,
     {
+        // This makes it easy to keep the default implementation without sacrificing performance.
+        // It suffices for impls to override `copy_from_samples` for most of the gains.
         if let Some(flat) = other.to_pixel_view() {
             return self.copy_from_samples(flat, x, y);
+        }
+
+        // Note the order: for types that implement an efficient assignment *from* a basic view we
+        // also expect that they know how to iterate themselves efficiently, they can do their own
+        // View-To-View performance or may do eve better than that if their view is more complex for
+        // some reason. Their choice. On the other hand if the source is _not_ a simple view then it
+        // will likely need to go through individual `GenericImageView::get_pixel` calls. And in
+        // this case we can still save on iterator calls for the target. The customization point
+        // however does not exist; any trait impl that intends to make this fast would need to
+        // provide a full `copy_from` impl. We only need to avoid the recursion here: `ViewMut` will
+        // override its `copy_from` with the intended effect by providing a non-trait inherent
+        // method instead.
+        if let Some(mut view) = self.to_pixel_view_mut() {
+            return view.inherent_copy_from(other, x, y);
         }
 
         // Do bounds checking here so we can use the non-bounds-checking

--- a/src/images/generic_image.rs
+++ b/src/images/generic_image.rs
@@ -1,5 +1,5 @@
 use crate::error::{ImageError, ImageResult};
-use crate::flat::ViewOfPixel;
+use crate::flat::{ViewMutOfPixel, ViewOfPixel};
 use crate::math::Rect;
 use crate::traits::Pixel;
 use crate::{ImageBuffer, SubImage};
@@ -134,6 +134,8 @@ pub trait GenericImageView {
     /// [`GenericImageView`] trait itself does not demand from all its implementations.
     ///
     /// Implementation of this method should be cheap to call.
+    ///
+    /// See [`GenericImage::to_pixel_view_mut`] for images that allow mutating pixels.
     ///
     /// If implemented, a [`SubImage`] proxy of this image will provide a sample view as well.
     fn to_pixel_view(&self) -> Option<ViewOfPixel<'_, Self::Pixel>> {
@@ -314,6 +316,22 @@ pub trait GenericImage: GenericImageView {
     {
         rect.assert_in_bounds_of(self);
         SubImage::new(self, rect)
+    }
+
+    /// If the buffer has a fitting layout, return a canonical mutable view of the samples.
+    ///
+    /// This is the basis of optimization and by default return `None`. It lets consumers of generic
+    /// images access the sample data through a canonical descriptor of its layout directly instead
+    /// of pixel-by-pixel. This provides more efficient, batched, forms of access that the
+    /// [`GenericImage`] trait itself does not demand from all its implementations.
+    ///
+    /// Implementation of this method should be cheap to call.
+    ///
+    /// See [`GenericImageView::to_pixel_view`].
+    ///
+    /// If implemented, a [`SubImage`] proxy of this image will provide a sample view as well.
+    fn to_pixel_view_mut(&mut self) -> Option<ViewMutOfPixel<'_, Self::Pixel>> {
+        None
     }
 }
 

--- a/src/images/generic_image.rs
+++ b/src/images/generic_image.rs
@@ -238,7 +238,7 @@ pub trait GenericImage: GenericImageView {
         // override its `copy_from` with the intended effect by providing a non-trait inherent
         // method instead.
         if let Some(mut view) = self.to_pixel_view_mut() {
-            return view.inherent_copy_from(other, x, y);
+            return view.inner_copy_from(other, x, y);
         }
 
         // Do bounds checking here so we can use the non-bounds-checking

--- a/src/images/sub_image.rs
+++ b/src/images/sub_image.rs
@@ -1,4 +1,9 @@
-use crate::{flat::ViewOfPixel, math::Rect, GenericImage, GenericImageView, ImageBuffer, Pixel};
+use crate::{
+    flat::{ViewMutOfPixel, ViewOfPixel},
+    math::Rect,
+    GenericImage, GenericImageView, ImageBuffer, Pixel,
+};
+
 use std::ops::{Deref, DerefMut};
 
 /// A View into another image
@@ -247,6 +252,20 @@ where
         // potentially optimized implementation gets used.
         self.image
             .copy_from(other, x + self.xoffset, y + self.yoffset)
+    }
+
+    fn to_pixel_view_mut(&mut self) -> Option<ViewMutOfPixel<'_, Self::Pixel>> {
+        let inner = self.image.to_pixel_view_mut()?;
+
+        // Now pivot the inner descriptor.
+        let mut descriptor = inner.into_inner();
+
+        let offset = descriptor.index(0, self.xoffset, self.yoffset)?;
+        descriptor.samples = descriptor.samples.get_mut(offset..)?;
+        descriptor.layout.width = self.xstride;
+        descriptor.layout.height = self.ystride;
+
+        descriptor.into_view_mut().ok()
     }
 }
 


### PR DESCRIPTION
The basis to specialize a lot of the performance improvements possible as identified in https://github.com/image-rs/image/issues/2954#issuecomment-4491084025. This is a direct port of the concept of #2766 that was added for views.

There is a difference in restrictions between `View` and `ViewMut` which is not fully exploited but comes in handy for the common case anyways: the latter does not permit aliasing between any of its channels while the former does not care (a single pixel can be broadcast to represent any size with zero strides). We must however be careful that this does not constrain the stride to be non-zero—for dimensions `<= 1` there is no aliasing regardless of stride.. The stride does not make an argument to `chunks_exact_mut` without further qualification.

Besides that detail the code should be straightforward. We optimize the row-by-row case for the largest performance gains (>800% throughput) and remove redundant bounds checks in the view-to-view-mut copies where the index calculation need no use `checked_*` arithmetic after validating bounds (+40% throughput)