### PR TITLE
Make avif decoder use allocation limits for intermediate buffers

### DIFF
--- a/src/codecs/avif/decoder.rs
+++ b/src/codecs/avif/decoder.rs
@@ -5,7 +5,7 @@ use crate::error::{
 };
 use crate::io::{DecodedImageAttributes, DecoderPreparedImage};
 use crate::metadata::Orientation;
-use crate::{ColorType, ImageDecoder, ImageError, ImageFormat, ImageResult};
+use crate::{ColorType, ImageDecoder, ImageError, ImageFormat, ImageResult, Limits};
 ///
 /// The [AVIF] specification defines an image derivative of the AV1 bitstream, an open video codec.
 ///
@@ -37,6 +37,7 @@ pub struct AvifDecoder<R> {
     alpha_picture: Option<dav1d::Picture>,
     icc_profile: Option<Vec<u8>>,
     orientation: Orientation,
+    limits: Limits,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -44,6 +45,7 @@ enum AvifDecoderError {
     AlphaPlaneFormat(PixelLayout),
     YuvLayoutOnIdentityMatrix(PixelLayout),
     UnsupportedLayoutAndMatrix(PixelLayout, YuvMatrixStrategy),
+    InvalidStride(u32),
 }
 
 impl Display for AvifDecoderError {
@@ -68,8 +70,11 @@ impl Display for AvifDecoderError {
                 PixelLayout::I444 => unreachable!("This option must be handled correctly"),
             },
             AvifDecoderError::UnsupportedLayoutAndMatrix(layout, matrix) => f.write_fmt(
-                format_args!("YUV layout {layout:?} on matrix {matrix:?} is not supported",),
+                format_args!("YUV layout {layout:?} on matrix {matrix:?} is not supported"),
             ),
+            AvifDecoderError::InvalidStride(stride) => f.write_fmt(format_args!(
+                "Avif decoder determined stride {stride} is not valid",
+            )),
         }
     }
 }
@@ -134,6 +139,7 @@ impl<R: Read> AvifDecoder<R> {
             alpha_picture,
             icc_profile,
             orientation,
+            limits: Limits::default(),
         })
     }
 }
@@ -165,17 +171,40 @@ fn convert_orientation(rotation: ImageRotation, mirror: Option<ImageMirror>) -> 
 }
 
 /// Reshaping incorrectly aligned or sized FFI data into Rust constraints
-fn reshape_plane(source: &[u8], stride: usize, width: usize, height: usize) -> Vec<u16> {
-    let mut target_plane = vec![0u16; width * height];
+fn reshape_plane(
+    source: &[u8],
+    stride: u32,
+    width: u32,
+    height: u32,
+    limits: &mut Limits,
+) -> Result<Vec<u16>, ImageError> {
+    if width == 0 || height == 0 {
+        return Ok(vec![]);
+    }
+
+    // Except for an empty image a true stride is required..
+    if stride == 0 {
+        return Err(error_map(AvifDecoderError::InvalidStride(stride)));
+    }
+
+    // Since the original buffer is already allocated, and has the indicated size, we do trust the
+    // width and height buffer to fit into memory by themselves. Just not that this is within our
+    // allocation budget.
+    let count = (width as usize) * (height as usize);
+    limits.reserve_usize(2 * count)?;
+
+    // Since the buffer is not empty, all strides are realized in memory, i.e. fit into usize.
+    let mut target_plane = vec![0u16; count];
     for (shaped_row, src_row) in target_plane
-        .chunks_exact_mut(width)
-        .zip(source.chunks_exact(stride))
+        .chunks_exact_mut(width as usize)
+        .zip(source.chunks_exact(stride as usize))
     {
         for (dst, src) in shaped_row.iter_mut().zip(src_row.as_chunks::<2>().0) {
             *dst = u16::from_ne_bytes(*src);
         }
     }
-    target_plane
+
+    Ok(target_plane)
 }
 
 struct Plane16View<'a> {
@@ -193,12 +222,13 @@ impl Default for Plane16View<'_> {
 }
 
 /// This is correct to transmute FFI data for Y plane and Alpha plane
-fn transmute_y_plane16(
-    plane: &dav1d::Plane,
-    stride: usize,
-    width: usize,
-    height: usize,
-) -> Plane16View<'_> {
+fn transmute_y_plane16<'data>(
+    plane: &'data dav1d::Plane,
+    stride: u32,
+    width: u32,
+    height: u32,
+    limits: &mut Limits,
+) -> Result<Plane16View<'data>, ImageError> {
     let mut y_plane_stride = stride >> 1;
 
     let mut bind_y = vec![];
@@ -206,40 +236,42 @@ fn transmute_y_plane16(
 
     let mut shape_y_plane = || {
         y_plane_stride = width;
-        bind_y = reshape_plane(plane_ref, stride, width, height);
+        bind_y = reshape_plane(plane_ref, stride, width, height, limits)?;
+        Ok::<_, ImageError>(())
     };
 
-    if stride & 1 == 0 {
+    if stride.is_multiple_of(2) {
         match bytemuck::try_cast_slice(plane_ref) {
-            Ok(slice) => Plane16View {
+            Ok(slice) => Ok(Plane16View {
                 data: std::borrow::Cow::Borrowed(slice),
-                stride: y_plane_stride,
-            },
+                stride: y_plane_stride as usize,
+            }),
             Err(_) => {
-                shape_y_plane();
-                Plane16View {
+                shape_y_plane()?;
+                Ok(Plane16View {
                     data: std::borrow::Cow::Owned(bind_y),
-                    stride: y_plane_stride,
-                }
+                    stride: y_plane_stride as usize,
+                })
             }
         }
     } else {
-        shape_y_plane();
-        Plane16View {
+        shape_y_plane()?;
+        Ok(Plane16View {
             data: std::borrow::Cow::Owned(bind_y),
-            stride: y_plane_stride,
-        }
+            stride: y_plane_stride as usize,
+        })
     }
 }
 
 /// This is correct to transmute FFI data for Y plane and Alpha plane
-fn transmute_chroma_plane16(
-    plane: &dav1d::Plane,
+fn transmute_chroma_plane16<'data>(
+    plane: &'data dav1d::Plane,
     pixel_layout: PixelLayout,
-    stride: usize,
-    width: usize,
-    height: usize,
-) -> Plane16View<'_> {
+    stride: u32,
+    width: u32,
+    height: u32,
+    limits: &mut Limits,
+) -> Result<Plane16View<'data>, ImageError> {
     let plane_ref = plane.as_ref();
     let mut chroma_plane_stride = stride >> 1;
     let mut bind_chroma = vec![];
@@ -255,29 +287,38 @@ fn transmute_chroma_plane16(
             PixelLayout::I420 => height.div_ceil(2),
             PixelLayout::I422 | PixelLayout::I444 => height,
         };
-        bind_chroma = reshape_plane(plane_ref, stride, chroma_plane_stride, u_plane_height);
+
+        bind_chroma = reshape_plane(
+            plane_ref,
+            stride,
+            chroma_plane_stride,
+            u_plane_height,
+            limits,
+        )?;
+
+        Ok::<_, ImageError>(())
     };
 
     if stride & 1 == 0 {
         match bytemuck::try_cast_slice(plane_ref) {
-            Ok(slice) => Plane16View {
+            Ok(slice) => Ok(Plane16View {
                 data: std::borrow::Cow::Borrowed(slice),
-                stride: chroma_plane_stride,
-            },
+                stride: chroma_plane_stride as usize,
+            }),
             Err(_) => {
-                shape_chroma_plane();
-                Plane16View {
+                shape_chroma_plane()?;
+                Ok(Plane16View {
                     data: std::borrow::Cow::Owned(bind_chroma),
-                    stride: chroma_plane_stride,
-                }
+                    stride: chroma_plane_stride as usize,
+                })
             }
         }
     } else {
-        shape_chroma_plane();
-        Plane16View {
+        shape_chroma_plane()?;
+        Ok(Plane16View {
             data: std::borrow::Cow::Owned(bind_chroma),
-            stride: chroma_plane_stride,
-        }
+            stride: chroma_plane_stride as usize,
+        })
     }
 }
 
@@ -370,6 +411,11 @@ fn get_matrix(
 }
 
 impl<R: Read> ImageDecoder for AvifDecoder<R> {
+    fn set_limits(&mut self, limits: Limits) -> ImageResult<()> {
+        self.limits = limits;
+        Ok(())
+    }
+
     fn prepare_image(&mut self) -> ImageResult<DecoderPreparedImage> {
         let color = if self.picture.bit_depth() == 8 {
             ColorType::Rgba8
@@ -530,7 +576,7 @@ impl<R: Read> ImageDecoder for AvifDecoder<R> {
 
 impl<R: Read> AvifDecoder<R> {
     fn process_16bit_picture(
-        &self,
+        &mut self,
         target: &mut [u16],
         yuv_range: YuvIntensityRange,
         matrix_strategy: YuvMatrixStrategy,
@@ -547,10 +593,11 @@ impl<R: Read> AvifDecoder<R> {
 
         let y_plane_view = transmute_y_plane16(
             &y_dav1d_plane,
-            self.picture.stride(PlanarImageComponent::Y) as usize,
-            width as usize,
-            height as usize,
-        );
+            self.picture.stride(PlanarImageComponent::Y),
+            width,
+            height,
+            &mut self.limits,
+        )?;
 
         let u_dav1d_plane = self.picture.plane(PlanarImageComponent::U);
         let v_dav1d_plane = self.picture.plane(PlanarImageComponent::V);
@@ -561,17 +608,19 @@ impl<R: Read> AvifDecoder<R> {
             u_plane_view = transmute_chroma_plane16(
                 &u_dav1d_plane,
                 self.picture.pixel_layout(),
-                self.picture.stride(PlanarImageComponent::U) as usize,
-                width as usize,
-                height as usize,
-            );
+                self.picture.stride(PlanarImageComponent::U),
+                width,
+                height,
+                &mut self.limits,
+            )?;
             v_plane_view = transmute_chroma_plane16(
                 &v_dav1d_plane,
                 self.picture.pixel_layout(),
-                self.picture.stride(PlanarImageComponent::V) as usize,
-                width as usize,
-                height as usize,
-            );
+                self.picture.stride(PlanarImageComponent::V),
+                width,
+                height,
+                &mut self.limits,
+            )?;
         }
 
         let image = YuvPlanarImage {
@@ -675,10 +724,11 @@ impl<R: Read> AvifDecoder<R> {
             let a_dav1d_plane = picture.plane(PlanarImageComponent::Y);
             let a_plane_view = transmute_y_plane16(
                 &a_dav1d_plane,
-                picture.stride(PlanarImageComponent::Y) as usize,
-                width as usize,
-                height as usize,
-            );
+                picture.stride(PlanarImageComponent::Y),
+                width,
+                height,
+                &mut self.limits,
+            )?;
 
             for (buf, slice) in Iterator::zip(
                 target.chunks_exact_mut(width as usize * 4),

--- a/src/codecs/avif/yuv.rs
+++ b/src/codecs/avif/yuv.rs
@@ -89,7 +89,7 @@ pub(crate) fn check_yuv_plane_preconditions<V>(
     stride: usize,
     height: usize,
 ) -> Result<(), ImageError> {
-    if plane.len() != stride * height {
+    if Some(plane.len()) != stride.checked_mul(height) {
         return Err(ImageError::Decoding(DecodingError::new(
             ImageFormat::Avif.into(),
             YuvConversionError::YuvPlaneSizeMismatch(
@@ -110,7 +110,7 @@ pub(crate) fn check_rgb_preconditions<V>(
     stride: usize,
     height: usize,
 ) -> Result<(), ImageError> {
-    if rgb_data.len() != stride * height {
+    if Some(rgb_data.len()) != stride.checked_mul(height) {
         return Err(ImageError::Decoding(DecodingError::new(
             ImageFormat::Avif.into(),
             YuvConversionError::RgbDestinationSizeMismatch(ErrorSize {


### PR DESCRIPTION
The decoder will attempt to reinterpret the data slice as a slice of the underlying sample type. For this, both data allocation and the strides need to have the right alignment to ensure the slice reference can be created soundly. In other cases the decoder will reallocate the buffer. This was previously not checked against decoder limits. We still do not configure the `dav1d` object itself but one step at a time.

Fixes: M1 of #2954 

I rewrote the arguments width, height, stride to take `u32`. That is the native type used for all of them. This way there are no questionable `as` casts until they really _need_ to be used for memory operations and there we can locally check that they describe an existing buffer at least their mathematical magnitude.