### PR TITLE
Optimize pixel map operations

### DIFF
--- a/src/imageops/colorops.rs
+++ b/src/imageops/colorops.rs
@@ -31,18 +31,7 @@ pub fn grayscale_with_type<NewPixel, I: GenericImageView>(
 where
     NewPixel: Pixel + FromColor<Luma<Subpixel<I>>>,
 {
-    let (width, height) = image.dimensions();
-    let mut out = ImageBuffer::new(width, height);
-    out.copy_color_space_from(&image.buffer_with_dimensions(0, 0));
-
-    for (x, y, pixel) in image.pixels() {
-        let grayscale = pixel.to_luma();
-        let new_pixel = grayscale.into_color(); // no-op for luma->luma
-
-        out.put_pixel(x, y, new_pixel);
-    }
-
-    out
+    super::map_pixels(image, |pixel| pixel.to_luma().into_color())
 }
 
 /// Convert the supplied image to a grayscale image with the specified pixel type. Alpha channel is preserved.
@@ -52,34 +41,16 @@ pub fn grayscale_with_type_alpha<NewPixel, I: GenericImageView>(
 where
     NewPixel: Pixel + FromColor<LumaA<Subpixel<I>>>,
 {
-    let (width, height) = image.dimensions();
-    let mut out = ImageBuffer::new(width, height);
-    out.copy_color_space_from(&image.buffer_with_dimensions(0, 0));
-
-    for (x, y, pixel) in image.pixels() {
-        let grayscale = pixel.to_luma_alpha();
-        let new_pixel = grayscale.into_color(); // no-op for luma->luma
-
-        out.put_pixel(x, y, new_pixel);
-    }
-
-    out
+    super::map_pixels(image, |pixel| pixel.to_luma_alpha().into_color())
 }
 
 /// Invert each pixel within the supplied image.
 /// This function operates in place.
 pub fn invert<I: GenericImage>(image: &mut I) {
-    // TODO find a way to use pixels?
-    let (width, height) = image.dimensions();
-
-    for y in 0..height {
-        for x in 0..width {
-            let mut p = image.get_pixel(x, y);
-            p.invert();
-
-            image.put_pixel(x, y, p);
-        }
-    }
+    super::map_pixels_in_place(image, |mut p| {
+        p.invert();
+        p
+    });
 }
 
 /// Adjust the contrast of the supplied image.

--- a/src/imageops/mod.rs
+++ b/src/imageops/mod.rs
@@ -1,7 +1,7 @@
 //! Image Processing Functions
 use crate::math::Rect;
 use crate::traits::{Lerp, Pixel, Primitive};
-use crate::{GenericImage, GenericImageView, SubImage};
+use crate::{GenericImage, GenericImageView, ImageBuffer, SubImage};
 
 /// Affine transformations
 pub use self::affine::{
@@ -322,6 +322,75 @@ where
         for x in 0..range_width {
             let p = top.get_pixel(origin_top_x + x, origin_top_y + y);
             bottom.put_pixel(origin_bottom_x + x, origin_bottom_y + y, p);
+        }
+    }
+}
+
+pub(crate) fn map_pixels<From: Pixel, To: Pixel>(
+    image: &impl GenericImageView<Pixel = From>,
+    f: impl Fn(From) -> To,
+) -> ImageBuffer<To, Vec<To::Subpixel>> {
+    let (width, height) = image.dimensions();
+    let mut out = ImageBuffer::new(width, height);
+    out.copy_color_space_from(&image.buffer_with_dimensions(0, 0));
+
+    // some of the below function don't like empty images
+    if width == 0 || height == 0 {
+        return out;
+    }
+
+    // fast path for row-major packed views
+    if let Some(view) = image.to_pixel_view() {
+        if let Some(row_iter) = view.iter_rows() {
+            for (row, out_row) in row_iter.zip(out.rows_mut()) {
+                let row_pixels = From::pixels_from_channels(row);
+                debug_assert_eq!(row_pixels.len(), out_row.len());
+
+                for (p, out_p) in row_pixels.iter().zip(out_row.iter_mut()) {
+                    *out_p = f(*p);
+                }
+            }
+            return out;
+        }
+    }
+
+    // fallback if no favorable view exists
+    for (x, y, pixel) in image.pixels() {
+        out.put_pixel(x, y, f(pixel));
+    }
+    out
+}
+pub(crate) fn map_pixels_in_place<P: Pixel>(
+    image: &mut impl GenericImage<Pixel = P>,
+    f: impl Fn(P) -> P,
+) {
+    let (width, height) = image.dimensions();
+
+    // some of the below function don't like empty images
+    if width == 0 || height == 0 {
+        return;
+    }
+
+    // fast path for row-major packed views
+    if let Some(mut view) = image.to_pixel_view_mut() {
+        if let Some(row_iter) = view.iter_rows_mut() {
+            for row in row_iter {
+                let row_pixels = P::pixels_from_channels_mut(row);
+                debug_assert_eq!(row_pixels.len(), width as usize);
+
+                for p in row_pixels {
+                    *p = f(*p);
+                }
+            }
+            return;
+        }
+    }
+
+    // fallback if no favorable view exists
+    for y in 0..height {
+        for x in 0..width {
+            let p = image.get_pixel(x, y);
+            image.put_pixel(x, y, f(p));
         }
     }
 }

--- a/src/images/flat.rs
+++ b/src/images/flat.rs
@@ -1568,6 +1568,36 @@ where
 
         Ok(())
     }
+
+    /// If the underlying samples are in row-major form and packed pixels, return
+    /// an iterator over the rows of the image.
+    pub(crate) fn iter_rows_mut(
+        &mut self,
+    ) -> Option<impl Iterator<Item = &mut [P::Subpixel]> + '_> {
+        let layout = self.flat().layout;
+        let channels = P::CHANNEL_COUNT;
+        let row_len = layout.width as usize * channels as usize;
+        let row_stride = layout.height_stride;
+
+        if layout.channel_stride != 1
+            || layout.channels != channels
+            || layout.width_stride != channels as usize
+            || row_len > row_stride
+        {
+            return None;
+        }
+
+        let data = self.image_mut_slice();
+
+        // Note: We cannot used chunks_exact_mut. We allow row_stride > row_len,
+        // and `data` will be exactly `row_len + row_stride * (height - 1)` long.
+        // So the last row will be exactly `row_len` long, making `chunks_exact_mut(row_stride)` incorrect.
+
+        Some(
+            data.chunks_mut(row_stride)
+                .map(move |row| &mut row[..row_len]),
+        )
+    }
 }
 
 // The out-of-bounds panic for single sample access similar to `slice::index`.


### PR DESCRIPTION
This adds 2 internal functions, `map_pixels` and `map_pixels_in_place`, that I used to re-implement color operations. These new functions contain fast paths based on `::to_pixel_view` and `::to_pixel_view_mut`.

Interestingly, this did not speed up color operations as much as I expected:

```
grayscale               time:   [2.4140 ms 2.4304 ms 2.4528 ms]
                        change: [-41.028% -40.272% -39.548%] (p = 0.00 < 0.05)
                        Performance has improved.

grayscale_alpha         time:   [2.7753 ms 2.8050 ms 2.8409 ms]
                        change: [-42.708% -41.901% -41.093%] (p = 0.00 < 0.05)
                        Performance has improved.

invert                  time:   [2.9125 ms 2.9882 ms 3.0735 ms]
                        change: [-25.416% -22.636% -19.695%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Note: The benchmark for `invert` makes a full copy of the input image before applying the operation. This probably eats a lot of the improvement.

Still good, but I expected more. I suspect that the branch predictor helped a lot before.

Anyway, I only ported 3 functions for now. I'd like to do `brighten` and co in a separate PR, because I want to take this chance to remove their code duplication.

Open questions:
- [ ] Should the fast path be dyn? All code is currently monomorphized over both the image type and operations type. This is unnecessary since all image types can share one copy without loss in performance.
- [ ] Should the new methods be part of `GenericImage` and `GenericImageView`? They seem useful for users.