### PR TITLE
docs(encoder): correct write_image panic condition for ExtendedColorType

### DIFF
--- a/src/codecs/bmp/encoder.rs
+++ b/src/codecs/bmp/encoder.rs
@@ -26,7 +26,9 @@ impl<W: Write> BmpEncoder<W> {
     ///
     /// # Panics
     ///
-    /// Panics if `width * height * c.bytes_per_pixel() != image.len()`.
+    /// Panics if the buffer does not hold exactly the number of bytes required for the given
+    /// `width`, `height`, and color type, accounting for rows padded to whole bytes for
+    /// sub-byte color types: `height * ((width * color_type.bits_per_pixel() as u32 + 7) / 8)`.
     #[track_caller]
     pub fn encode(
         &mut self,
@@ -43,7 +45,9 @@ impl<W: Write> BmpEncoder<W> {
     ///
     /// # Panics
     ///
-    /// Panics if `width * height * c.bytes_per_pixel() != image.len()`.
+    /// Panics if the buffer does not hold exactly the number of bytes required for the given
+    /// `width`, `height`, and color type, accounting for rows padded to whole bytes for
+    /// sub-byte color types: `height * ((width * color_type.bits_per_pixel() as u32 + 7) / 8)`.
     #[track_caller]
     pub fn encode_with_palette(
         &mut self,

--- a/src/codecs/jpeg/encoder.rs
+++ b/src/codecs/jpeg/encoder.rs
@@ -192,7 +192,9 @@ impl<W: Write> JpegEncoder<W> {
     ///
     /// # Panics
     ///
-    /// Panics if `width * height * color_type.bytes_per_pixel() != image.len()`.
+    /// Panics if the buffer does not hold exactly the number of bytes required for the given
+    /// `width`, `height`, and `color_type`, accounting for rows padded to whole bytes for
+    /// sub-byte color types: `height * ((width * color_type.bits_per_pixel() as u32 + 7) / 8)`.
     #[track_caller]
     fn encode(
         self,

--- a/src/codecs/tga/encoder.rs
+++ b/src/codecs/tga/encoder.rs
@@ -159,7 +159,9 @@ impl<W: Write> TgaEncoder<W> {
     ///
     /// # Panics
     ///
-    /// Panics if `width * height * color_type.bytes_per_pixel() != data.len()`.
+    /// Panics if the buffer does not hold exactly the number of bytes required for the given
+    /// `width`, `height`, and `color_type`, accounting for rows padded to whole bytes for
+    /// sub-byte color types: `height * ((width * color_type.bits_per_pixel() as u32 + 7) / 8)`.
     #[track_caller]
     pub fn encode(
         mut self,

--- a/src/codecs/tiff.rs
+++ b/src/codecs/tiff.rs
@@ -785,7 +785,9 @@ impl<W: Write + Seek> ImageEncoder for TiffEncoder<W> {
     ///
     /// # Panics
     ///
-    /// Panics if `width * height * color_type.bytes_per_pixel() != data.len()`.
+    /// Panics if the buffer does not hold exactly the number of bytes required for the given
+    /// `width`, `height`, and `color_type`, accounting for rows padded to whole bytes for
+    /// sub-byte color types: `height * ((width * color_type.bits_per_pixel() as u32 + 7) / 8)`.
     #[track_caller]
     fn write_image(
         self,

--- a/src/codecs/webp/encoder.rs
+++ b/src/codecs/webp/encoder.rs
@@ -43,7 +43,9 @@ impl<W: Write> WebPEncoder<W> {
     ///
     /// # Panics
     ///
-    /// Panics if `width * height * color.bytes_per_pixel() != data.len()`.
+    /// Panics if the buffer does not hold exactly the number of bytes required for the given
+    /// `width`, `height`, and color type, accounting for rows padded to whole bytes for
+    /// sub-byte color types: `height * ((width * color_type.bits_per_pixel() as u32 + 7) / 8)`.
     #[track_caller]
     pub fn encode(
         self,

--- a/src/color.rs
+++ b/src/color.rs
@@ -294,8 +294,12 @@ impl ExtendedColorType {
         }
     }
 
-    /// Returns the number of bytes required to hold a width x height image of this color type.
-    pub(crate) fn buffer_size(self, width: u32, height: u32) -> u64 {
+    /// Returns the number of bytes required to hold a `width x height` image of this color type.
+    ///
+    /// Each pixel row occupies exactly `width * bits_per_pixel()` bits, rounded **up to the
+    /// nearest byte** (no additional row padding is added). The total is `row_bytes * height`,
+    /// saturating at [`u64::MAX`] for astronomically large inputs.
+    pub fn buffer_size(self, width: u32, height: u32) -> u64 {
         let bpp = self.bits_per_pixel() as u64;
         let row_pitch = (width as u64 * bpp).div_ceil(8);
         row_pitch.saturating_mul(height as u64)

--- a/src/io/encoder.rs
+++ b/src/io/encoder.rs
@@ -32,7 +32,11 @@ pub trait ImageEncoder {
     ///
     /// # Panics
     ///
-    /// Panics if `width * height * color_type.bytes_per_pixel() != buf.len()`.
+    /// Panics if `buf` does not hold exactly the number of bytes required for the given `width`,
+    /// `height`, and `color_type`. Pixel rows are laid out in row-major order. For color types
+    /// whose `bits_per_pixel()` is not a multiple of 8 (such as `L1`), each row is padded to a
+    /// whole number of bytes, so the expected length is
+    /// `height * ((width * color_type.bits_per_pixel() as u32 + 7) / 8)`.
     fn write_image(
         self,
         buf: &[u8],

--- a/src/io/encoder.rs
+++ b/src/io/encoder.rs
@@ -32,11 +32,7 @@ pub trait ImageEncoder {
     ///
     /// # Panics
     ///
-    /// Panics if `buf` does not hold exactly the number of bytes required for the given `width`,
-    /// `height`, and `color_type`. Pixel rows are laid out in row-major order. For color types
-    /// whose `bits_per_pixel()` is not a multiple of 8 (such as `L1`), each row is padded to a
-    /// whole number of bytes, so the expected length is
-    /// `height * ((width * color_type.bits_per_pixel() as u32 + 7) / 8)`.
+    /// Panics if `buf.len() as u64 != color_type.buffer_size(width, height)`.
     fn write_image(
         self,
         buf: &[u8],


### PR DESCRIPTION
Fixes #2425.

The `# Panics` doc on `ImageEncoder::write_image` and the per-codec `encode` methods stated `Panics if width * height * color_type.bytes_per_pixel() != buf.len()`. These functions take an `ExtendedColorType`, which has no `bytes_per_pixel()` method (only `bits_per_pixel()`), and the formula is wrong for sub-byte color types like `L1`.

This corrects the documented condition to match the actual requirement: the buffer must hold exactly the bytes for the given dimensions and color type, with each row padded to a whole number of bytes (`height * ((width * bits_per_pixel + 7) / 8)`), which is what `ExtendedColorType::buffer_size` already computes.

As noted in the issue, the same stale text was copied across several files; updated all six occurrences in `io/encoder.rs`, `codecs/tiff.rs`, `codecs/jpeg/encoder.rs`, `codecs/tga/encoder.rs`, `codecs/webp/encoder.rs`, and `codecs/bmp/encoder.rs`.

`cargo doc --no-deps --lib` builds with no new warnings.
