### PR TITLE
Fix expanding bit depth in AVIF

### DIFF
--- a/src/codecs/avif/decoder.rs
+++ b/src/codecs/avif/decoder.rs
@@ -691,9 +691,10 @@ impl<R: Read> AvifDecoder<R> {
         }
 
         // Expand current bit depth to target 16
-        let target_expand_bits = 16u32 - self.picture.bit_depth() as u32;
-        for item in target.iter_mut() {
-            *item = (*item).rotate_left(target_expand_bits);
+        let shl = 16 - bit_depth;
+        let shr = bit_depth - shl;
+        for px in target.iter_mut() {
+            *px = (*px << shl) | (*px >> shr);
         }
 
         Ok(())


### PR DESCRIPTION
Rotate left replicates bits, with assumption that our data is 16 bit, by amount shifted left, so for 10 bit it shift left by 6 and it replicates 0 bits to the lower half, but we need 6.
Hence rotate left is `(value << n) | (value >> (16 - n))` but we need `(value << n) | (value >> (bit_depth - n))`.