### PR TITLE
Limits: Check `isize::MAX` for memory allocations

### DIFF
--- a/src/io/limits.rs
+++ b/src/io/limits.rs
@@ -104,6 +104,15 @@ impl Limits {
     /// This function checks that the current limit allows for reserving the set amount
     /// of bytes, it then reduces the limit accordingly.
     pub fn reserve(&mut self, amount: u64) -> ImageResult<()> {
+        if amount > isize::MAX as u64 {
+            // Memory allocations in Rust cannot exceed isize::MAX bytes. So
+            // reserving more memory than that is not allowed, even if it would
+            // fall within the memory budget.
+            return Err(ImageError::Limits(error::LimitError::from_kind(
+                error::LimitErrorKind::InsufficientMemory,
+            )));
+        }
+
         if let Some(max_alloc) = self.max_alloc.as_mut() {
             if *max_alloc < amount {
                 return Err(ImageError::Limits(error::LimitError::from_kind(


### PR DESCRIPTION
Addresses M19 from #2954 

Allocations in Rust cannot be larger than `isize::MAX` bytes. So trying to reserve more memory than that is never valid, as trying to allocate that amount of memory will always result in a panic (assuming it isn't handled another way).

This is relevant to us, because some decoders use saturating arithmetic with the assumption that `Limits` will detect and reject allocations that are too large. However, `Limits::no_limits()` and even a `Limits` with `u64::MAX` memory limit currently bypassed this.

---

Related question: Should `Limits::max_alloc` be a `u64` instead of an `Option<u64>`? I don't see the point in it being an option when `u64::MAX` (or even `isize::MAX as u64`) is a suitable value to mean "no limit". 