### PR TITLE
Simplify doc links

### DIFF
--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -478,8 +478,7 @@ impl<W: Write> GifEncoder<W> {
     }
 
     /// Create a new GIF encoder, and has the speed parameter `speed`. See
-    /// [`Frame::from_rgba_speed`](https://docs.rs/gif/latest/gif/struct.Frame.html#method.from_rgba_speed)
-    /// for more information.
+    /// [`Frame::from_rgba_speed`] for more information.
     pub fn new_with_speed(w: W, speed: i32) -> GifEncoder<W> {
         assert!(
             (1..=30).contains(&speed),

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -401,9 +401,6 @@ impl<R: BufRead + Seek> ImageDecoder for PngDecoder<R> {
 /// An animated adapter of [`PngDecoder`].
 ///
 /// See [`PngDecoder::apng`] for more information.
-///
-/// [`PngDecoder`]: struct.PngDecoder.html
-/// [`PngDecoder::apng`]: struct.PngDecoder.html#method.apng
 pub struct ApngDecoder<R: BufRead + Seek> {
     inner: PngDecoder<R>,
     /// The current output buffer.

--- a/src/codecs/pnm/decoder.rs
+++ b/src/codecs/pnm/decoder.rs
@@ -40,7 +40,7 @@ enum DecoderError {
     HeaderLineUnknown(String),
     /// At least one of the required lines were missing from the header (are `None` here)
     ///
-    /// Same names as [`PnmHeaderLine`](enum.PnmHeaderLine.html)
+    /// Same names as [`PnmHeaderLine`]
     #[allow(missing_docs)]
     HeaderLineMissing {
         height: Option<u32>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,8 +10,6 @@
 //! `image` does not promise to remain on a particular version of its underlying decoders but if
 //! you ensure to use the same version of the dependency (or at least of the error type) through
 //! external means then you could inspect the error type in slightly more detail.
-//!
-//! [`ImageError`]: enum.ImageError.html
 
 use std::collections::TryReserveError;
 use std::error::Error;
@@ -67,9 +65,8 @@ pub enum ImageError {
 
 /// The implementation for an operation was not provided.
 ///
-/// See the variant [`Unsupported`] for more documentation.
-///
-/// [`Unsupported`]: enum.ImageError.html#variant.Unsupported
+/// This is used as an opaque representation for the [`ImageError::Unsupported`] variant. See its
+/// documentation for more information.
 #[derive(Debug)]
 pub struct UnsupportedError {
     format: ImageFormatHint,
@@ -97,8 +94,6 @@ pub enum UnsupportedErrorKind {
 ///
 /// This is used as an opaque representation for the [`ImageError::Encoding`] variant. See its
 /// documentation for more information.
-///
-/// [`ImageError::Encoding`]: enum.ImageError.html#variant.Encoding
 #[derive(Debug)]
 pub struct EncodingError {
     format: ImageFormatHint,
@@ -109,8 +104,6 @@ pub struct EncodingError {
 ///
 /// This is used as an opaque representation for the [`ImageError::Parameter`] variant. See its
 /// documentation for more information.
-///
-/// [`ImageError::Parameter`]: enum.ImageError.html#variant.Parameter
 #[derive(Debug)]
 pub struct ParameterError {
     kind: ParameterErrorKind,
@@ -147,8 +140,6 @@ pub enum ParameterErrorKind {
 ///
 /// This is used as an opaque representation for the [`ImageError::Decoding`] variant. See its
 /// documentation for more information.
-///
-/// [`ImageError::Decoding`]: enum.ImageError.html#variant.Decoding
 #[derive(Debug)]
 pub struct DecodingError {
     format: ImageFormatHint,
@@ -159,8 +150,6 @@ pub struct DecodingError {
 ///
 /// This is used as an opaque representation for the [`ImageError::Limits`] variant. See its
 /// documentation for more information.
-///
-/// [`ImageError::Limits`]: enum.ImageError.html#variant.Limits
 #[derive(Debug)]
 pub struct LimitError {
     kind: LimitErrorKind,

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -23,8 +23,6 @@ use crate::{DynamicImage, GenericImage, GenericImageView, ImageEncoder, ImageFor
 /// Iterate over rows of an image
 ///
 /// This iterator is created with [`ImageBuffer::rows`]. See its document for details.
-///
-/// [`ImageBuffer::rows`]: ../struct.ImageBuffer.html#method.rows
 pub struct Rows<'a, P: Pixel + 'a> {
     pixels: ChunksExact<'a, P>,
 }
@@ -109,8 +107,6 @@ where
 /// Iterate over mutable rows of an image
 ///
 /// This iterator is created with [`ImageBuffer::rows_mut`]. See its document for details.
-///
-/// [`ImageBuffer::rows_mut`]: ../struct.ImageBuffer.html#method.rows_mut
 pub struct RowsMut<'a, P: Pixel + 'a> {
     pixels: ChunksExactMut<'a, P>,
 }
@@ -453,20 +449,14 @@ where
 /// The crate defines a few type aliases with regularly used pixel types for your convenience, such
 /// as [`RgbImage`], [`GrayImage`] etc.
 ///
-/// [`GenericImage`]: trait.GenericImage.html
-/// [`GenericImageView`]: trait.GenericImageView.html
-/// [`RgbImage`]: type.RgbImage.html
-/// [`GrayImage`]: type.GrayImage.html
-///
 /// To convert between images of different Pixel types use [`DynamicImage`].
 ///
 /// You can retrieve a complete description of the buffer's layout and contents through
 /// [`as_flat_samples`] and [`as_flat_samples_mut`]. This can be handy to also use the contents in
 /// a foreign language, map it as a GPU host buffer or other similar tasks.
 ///
-/// [`DynamicImage`]: enum.DynamicImage.html
-/// [`as_flat_samples`]: #method.as_flat_samples
-/// [`as_flat_samples_mut`]: #method.as_flat_samples_mut
+/// [`as_flat_samples`]: Self::as_flat_samples
+/// [`as_flat_samples_mut`]: Self::as_flat_samples_mut
 ///
 /// ## Examples
 ///
@@ -1027,7 +1017,7 @@ where
     /// Saves the buffer to a file at the specified path in
     /// the specified format.
     ///
-    /// See [`save_buffer_with_format`](fn.save_buffer_with_format.html) for
+    /// See [`save_buffer_with_format`](crate::save_buffer_with_format) for
     /// supported types.
     pub fn save_with_format<Q>(&self, path: Q, format: ImageFormat) -> ImageResult<()>
     where

--- a/src/images/buffer_par.rs
+++ b/src/images/buffer_par.rs
@@ -191,7 +191,7 @@ where
     /// Returns a parallel iterator over the pixels of this image and their coordinates, usable with `rayon`.
     /// See [`enumerate_pixels`] for more information.
     ///
-    /// [`enumerate_pixels`]: #method.enumerate_pixels
+    /// [`enumerate_pixels`]: Self::enumerate_pixels
     pub fn par_enumerate_pixels(&self) -> EnumeratePixelsPar<'_, P> {
         EnumeratePixelsPar {
             pixels: self.pixels().par_iter(),
@@ -209,7 +209,7 @@ where
     /// Returns a parallel iterator over the mutable pixels of this image and their coordinates, usable with `rayon`.
     /// See [`enumerate_pixels_mut`] for more information.
     ///
-    /// [`enumerate_pixels_mut`]: #method.enumerate_pixels_mut
+    /// [`enumerate_pixels_mut`]: Self::enumerate_pixels_mut
     pub fn par_enumerate_pixels_mut(&mut self) -> EnumeratePixelsMutPar<'_, P> {
         let width = self.width();
         EnumeratePixelsMutPar {

--- a/src/images/dynimage.rs
+++ b/src/images/dynimage.rs
@@ -1718,11 +1718,11 @@ pub fn load_from_memory(buffer: &[u8]) -> ImageResult<DynamicImage> {
 /// Create a new image from a byte slice
 ///
 /// This is just a simple wrapper that constructs an `std::io::Cursor` around the buffer and then
-/// calls `load` with that reader.
+/// calls [`load`] with that reader.
 ///
 /// Try [`ImageReaderOptions`] for more advanced uses.
 ///
-/// [`load`]: fn.load.html
+/// [`load`]: crate::load
 #[inline(always)]
 pub fn load_from_memory_with_format(buf: &[u8], format: ImageFormat) -> ImageResult<DynamicImage> {
     // Note: this function (and `load_from_memory`) were supposed to be generic over `AsRef<[u8]>`

--- a/src/images/flat.rs
+++ b/src/images/flat.rs
@@ -72,14 +72,11 @@ use crate::{GenericImage, GenericImageView, ImageBuffer};
 /// single pixel as the backing storage for an arbitrarily sized read-only raster by mapping each
 /// pixel to the same samples by setting some strides to `0`.
 ///
-/// [`GenericImage`]: ../trait.GenericImage.html
-/// [`GenericImageView`]: ../trait.GenericImageView.html
-/// [`ImageBuffer::as_flat_samples`]: ../struct.ImageBuffer.html#method.as_flat_samples
-/// [`is_normal`]: #method.is_normal
-/// [`has_aliased_samples`]: #method.has_aliased_samples
-/// [`as_view`]: #method.as_view
-/// [`as_view_mut`]: #method.as_view_mut
-/// [`with_monocolor`]: #method.with_monocolor
+/// [`is_normal`]: Self::is_normal
+/// [`has_aliased_samples`]: Self::has_aliased_samples
+/// [`as_view`]: Self::as_view
+/// [`as_view_mut`]: Self::as_view_mut
+/// [`with_monocolor`]: Self::with_monocolor
 #[derive(Clone, Debug)]
 pub struct FlatSamples<Buffer> {
     /// Underlying linear container holding sample values.

--- a/src/images/generic_image.rs
+++ b/src/images/generic_image.rs
@@ -51,7 +51,7 @@ pub trait GenericImageView {
     ///
     /// The coordinates must be [`in_bounds`] of the image.
     ///
-    /// [`in_bounds`]: #method.in_bounds
+    /// [`in_bounds`]: Self::in_bounds
     unsafe fn unsafe_get_pixel(&self, x: u32, y: u32) -> Self::Pixel {
         self.get_pixel(x, y)
     }
@@ -197,7 +197,7 @@ pub trait GenericImage: GenericImageView {
     ///
     /// The coordinates must be [`in_bounds`] of the image.
     ///
-    /// [`in_bounds`]: traits.GenericImageView.html#method.in_bounds
+    /// [`in_bounds`]: GenericImageView::in_bounds
     unsafe fn unsafe_put_pixel(&mut self, x: u32, y: u32, pixel: Self::Pixel) {
         self.put_pixel(x, y, pixel);
     }
@@ -215,8 +215,7 @@ pub trait GenericImage: GenericImageView {
     /// # Returns
     /// Returns an error if the image is too large to be copied at the given position
     ///
-    /// [`GenericImageView::view`]: trait.GenericImageView.html#method.view
-    /// [`FlatSamples`]: flat/struct.FlatSamples.html
+    /// [`FlatSamples`]: crate::FlatSamples
     fn copy_from<O>(&mut self, other: &O, x: u32, y: u32) -> ImageResult<()>
     where
         O: GenericImageView<Pixel = Self::Pixel>,

--- a/src/io/decoder.rs
+++ b/src/io/decoder.rs
@@ -38,9 +38,9 @@ pub trait ImageDecoder {
     /// **Note**: By default, _no_ limits are defined. This may be changed in future major version
     /// increases.
     ///
-    /// [`Limits`]: ./io/struct.Limits.html
-    /// [`Limits::check_support`]: ./io/struct.Limits.html#method.check_support
-    /// [`Limits::check_dimensions`]: ./io/struct.Limits.html#method.check_dimensions
+    /// [`Limits`]: crate::Limits
+    /// [`Limits::check_support`]: crate::Limits::check_support
+    /// [`Limits::check_dimensions`]: crate::Limits::check_dimensions
     fn set_limits(&mut self, limits: crate::Limits) -> ImageResult<()> {
         limits.check_support(&crate::LimitSupport::default())?;
         let layout = self.prepare_image()?;

--- a/src/io/image_reader_type.rs
+++ b/src/io/image_reader_type.rs
@@ -81,7 +81,7 @@ enum Format {
 /// As a final fallback or if only a specific format must be used, the reader always allows manual
 /// specification of the supposed image format with [`set_format`].
 ///
-/// [`set_format`]: #method.set_format
+/// [`set_format`]: Self::set_format
 pub struct ImageReaderOptions<R: Read + Seek> {
     /// The reader. Should be buffered.
     inner: R,
@@ -102,8 +102,8 @@ impl<'a, R: 'a + BufRead + Seek> ImageReaderOptions<R> {
     /// It is possible to guess the format based on the content of the read object with
     /// [`with_guessed_format`], or to set the format directly with [`set_format`].
     ///
-    /// [`with_guessed_format`]: #method.with_guessed_format
-    /// [`set_format`]: method.set_format
+    /// [`with_guessed_format`]: Self::with_guessed_format
+    /// [`set_format`]:Self::set_format
     pub fn new(buffered_reader: R) -> Self {
         ImageReaderOptions {
             inner: buffered_reader,
@@ -454,7 +454,7 @@ impl ImageReaderOptions<BufReader<File>> {
     /// If you want to inspect the content for a better guess on the format, which does not depend
     /// on file extensions, follow this call with a call to [`with_guessed_format`].
     ///
-    /// [`with_guessed_format`]: #method.with_guessed_format
+    /// [`with_guessed_format`]: Self::with_guessed_format
     pub fn open<P>(path: P) -> io::Result<Self>
     where
         P: AsRef<Path>,

--- a/src/io/limits.rs
+++ b/src/io/limits.rs
@@ -25,8 +25,7 @@ pub struct LimitSupport {}
 /// The limit check should only ever fail if a limit will be exceeded or an unsupported strict
 /// limit is used.
 ///
-/// [`LimitSupport`]: ./struct.LimitSupport.html
-/// [`ImageDecoder::set_limits`]: ../trait.ImageDecoder.html#method.set_limits
+/// [`ImageDecoder::set_limits`]: crate::ImageDecoder::set_limits
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[allow(missing_copy_implementations)]
 #[non_exhaustive]
@@ -119,7 +118,7 @@ impl Limits {
 
     /// This function acts identically to [`reserve`], but takes a `usize` for convenience.
     ///
-    /// [`reserve`]: #method.reserve
+    /// [`reserve`]: Self::reserve
     pub fn reserve_usize(&mut self, amount: usize) -> ImageResult<()> {
         match u64::try_from(amount) {
             Ok(n) => self.reserve(n),
@@ -137,7 +136,7 @@ impl Limits {
     /// used to create an [`ImageBuffer`] and does all the math for you.
     ///
     /// [`ImageBuffer`]: crate::ImageBuffer
-    /// [`reserve`]: #method.reserve
+    /// [`reserve`]: Self::reserve
     pub fn reserve_buffer(
         &mut self,
         width: u32,
@@ -155,7 +154,7 @@ impl Limits {
     /// This function increases the `max_alloc` limit with amount. Should only be used
     /// together with [`reserve`].
     ///
-    /// [`reserve`]: #method.reserve
+    /// [`reserve`]: Self::reserve
     pub fn free(&mut self, amount: u64) {
         if let Some(max_alloc) = self.max_alloc.as_mut() {
             *max_alloc = max_alloc.saturating_add(amount);
@@ -164,7 +163,7 @@ impl Limits {
 
     /// This function acts identically to [`free`], but takes a `usize` for convenience.
     ///
-    /// [`free`]: #method.free
+    /// [`free`]: Self::free
     pub fn free_usize(&mut self, amount: usize) {
         match u64::try_from(amount) {
             Ok(n) => self.free(n),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,8 @@
 //!
 //! With default features, the crate includes support for [many common image formats](codecs/index.html#supported-formats).
 //!
-//! [`save`]: enum.DynamicImage.html#method.save
-//! [`write_to`]: enum.DynamicImage.html#method.write_to
+//! [`save`]: DynamicImage::save
+//! [`write_to`]: DynamicImage::write_to
 //!
 //! # Image buffers
 //!
@@ -63,11 +63,6 @@
 //! * [`flat`] module containing types for interoperability with generic channel
 //!   matrices and foreign interfaces.
 //!
-//! [`GenericImageView`]: trait.GenericImageView.html
-//! [`GenericImage`]: trait.GenericImage.html
-//! [`ImageBuffer`]: struct.ImageBuffer.html
-//! [`DynamicImage`]: enum.DynamicImage.html
-//! [`flat`]: flat/index.html
 //!
 //! # Low level encoding/decoding API
 //!
@@ -107,10 +102,6 @@
 //! # }
 //! # #[cfg(not(feature = "png"))] fn main() {}
 //! ```
-//!
-//! [`DynamicImage::from_decoder`]: enum.DynamicImage.html#method.from_decoder
-//! [`ImageDecoder`]: trait.ImageDecoder.html
-//! [`ImageEncoder`]: trait.ImageEncoder.html
 #![warn(missing_docs)]
 #![warn(unused_qualifications)]
 #![deny(unreachable_pub)]


### PR DESCRIPTION
I didn't like that some doc links relied on HTML ids in and the page layout of rendered docs. These worked for rendered docs, but not in IDEs like VSCode. This was pretty annoying since I couldn't just just click on them.

This PR uses Rust item paths pretty much everywhere. E.g. `Self::reserve` instead of `#method.reserve`. This also has the advantage that dev (like me!) don't have to learn 2 syntaxes for links. It's the normal Rust item paths we write every day and not a rustdoc-specific path syntax

I also removed unnecessary references. E.g. `[`PngDecoder`]: struct.PngDecoder.html` when `PngDecoder` is in scope.