### PR TITLE
Improve RGB to luma conversion logic

### DIFF
--- a/benches/convert.rs
+++ b/benches/convert.rs
@@ -103,19 +103,46 @@ pub fn bench_cast_intra_colorspace(c: &mut Criterion) {
 }
 
 pub fn bench_cast_with_coefficient(c: &mut Criterion) {
-    let source =
-        DynamicImage::ImageRgba8(ImageBuffer::from_pixel(256, 256, Rgba([0u8, 0, 0, 255])));
+    let rgba8 = DynamicImage::new(256, 256, image::ColorType::Rgb8);
 
     c.bench_function("cast_dynamic_rgba8_l8", |b| {
-        b.iter(|| black_box(&source).to_luma8());
+        b.iter(|| black_box(&rgba8).to_luma8());
     });
 
     c.bench_function("cast_dynamic_rgba8_l16", |b| {
-        b.iter(|| black_box(&source).to_luma16());
+        b.iter(|| black_box(&rgba8).to_luma16());
     });
 
     c.bench_function("cast_dynamic_rgba8_la16", |b| {
-        b.iter(|| black_box(&source).to_luma_alpha16());
+        b.iter(|| black_box(&rgba8).to_luma_alpha16());
+    });
+
+    let rgba16 = DynamicImage::new(256, 256, image::ColorType::Rgb16);
+
+    c.bench_function("cast_dynamic_rgba16_l8", |b| {
+        b.iter(|| black_box(&rgba16).to_luma8());
+    });
+
+    c.bench_function("cast_dynamic_rgba16_l16", |b| {
+        b.iter(|| black_box(&rgba16).to_luma16());
+    });
+
+    c.bench_function("cast_dynamic_rgba16_la16", |b| {
+        b.iter(|| black_box(&rgba16).to_luma_alpha16());
+    });
+
+    let rgba32f = DynamicImage::new(256, 256, image::ColorType::Rgba32F);
+
+    c.bench_function("cast_dynamic_rgba32f_l8", |b| {
+        b.iter(|| black_box(&rgba32f).to_luma8());
+    });
+
+    c.bench_function("cast_dynamic_rgba32f_l16", |b| {
+        b.iter(|| black_box(&rgba32f).to_luma16());
+    });
+
+    c.bench_function("cast_dynamic_rgba32f_la16", |b| {
+        b.iter(|| black_box(&rgba32f).to_luma_alpha16());
     });
 }
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,10 +1,11 @@
 use std::ops::{Index, IndexMut};
 
-use num_traits::{NumCast, Zero};
+use num_traits::Zero;
 
 use crate::{
     error::TryFromExtendedColorError,
-    traits::{Enlargeable, Pixel, Primitive},
+    primitive_sealed::RgbToLuma,
+    traits::{Pixel, Primitive},
 };
 
 /// An enumeration over supported color types and bit depths
@@ -515,11 +516,11 @@ define_colors! {
     ///
     /// For the purpose of color conversion, as well as blending, the implementation of `Pixel`
     /// assumes an `sRGB` color space of its data.
-    pub struct Rgb<T: Primitive Enlargeable>([T; 3, 0]) = "RGB";
+    pub struct Rgb<T: Primitive>([T; 3, 0]) = "RGB";
     /// Grayscale colors.
     pub struct Luma<T: Primitive>([T; 1, 0]) = "Y";
     /// RGB colors + alpha channel
-    pub struct Rgba<T: Primitive Enlargeable>([T; 4, 1]) = "RGBA";
+    pub struct Rgba<T: Primitive>([T; 4, 1]) = "RGBA";
     /// Grayscale colors + alpha channel
     pub struct LumaA<T: Primitive>([T; 2, 1]) = "YA";
 }
@@ -637,18 +638,6 @@ where
     }
 }
 
-/// Coefficients to transform from sRGB to a CIE Y (luminance) value.
-const SRGB_LUMA: [u32; 3] = [2126, 7152, 722];
-const SRGB_LUMA_DIV: u32 = 10000;
-
-#[inline]
-fn rgb_to_luma<T: Primitive + Enlargeable>(rgb: &[T]) -> T {
-    let l = <T::Larger as NumCast>::from(SRGB_LUMA[0]).unwrap() * rgb[0].to_larger()
-        + <T::Larger as NumCast>::from(SRGB_LUMA[1]).unwrap() * rgb[1].to_larger()
-        + <T::Larger as NumCast>::from(SRGB_LUMA[2]).unwrap() * rgb[2].to_larger();
-    T::clamp_from(l / <T::Larger as NumCast>::from(SRGB_LUMA_DIV).unwrap())
-}
-
 // `FromColor` for Luma
 impl<S: Primitive, T: Primitive> FromColor<Luma<S>> for Luma<T>
 where
@@ -670,26 +659,23 @@ where
     }
 }
 
-impl<S: Primitive + Enlargeable, T: Primitive> FromColor<Rgb<S>> for Luma<T>
+impl<S: Primitive, T: Primitive> FromColor<Rgb<S>> for Luma<T>
 where
     T: FromPrimitive<S>,
 {
     fn from_color(&mut self, other: &Rgb<S>) {
-        let gray = self.channels_mut();
-        let rgb = other.channels();
-        gray[0] = T::from_primitive(rgb_to_luma(rgb));
+        let [r, g, b] = other.0;
+        self.0[0] = T::from_primitive(RgbToLuma::rgb_to_luma(r, g, b));
     }
 }
 
-impl<S: Primitive + Enlargeable, T: Primitive> FromColor<Rgba<S>> for Luma<T>
+impl<S: Primitive, T: Primitive> FromColor<Rgba<S>> for Luma<T>
 where
     T: FromPrimitive<S>,
 {
     fn from_color(&mut self, other: &Rgba<S>) {
-        let gray = self.channels_mut();
-        let rgb = other.channels();
-        let l = rgb_to_luma(rgb);
-        gray[0] = T::from_primitive(l);
+        let [r, g, b, _a] = other.0;
+        self.0[0] = T::from_primitive(RgbToLuma::rgb_to_luma(r, g, b));
     }
 }
 
@@ -707,27 +693,25 @@ where
     }
 }
 
-impl<S: Primitive + Enlargeable, T: Primitive> FromColor<Rgb<S>> for LumaA<T>
+impl<S: Primitive, T: Primitive> FromColor<Rgb<S>> for LumaA<T>
 where
     T: FromPrimitive<S>,
 {
     fn from_color(&mut self, other: &Rgb<S>) {
-        let gray_a = self.channels_mut();
-        let rgb = other.channels();
-        gray_a[0] = T::from_primitive(rgb_to_luma(rgb));
-        gray_a[1] = T::DEFAULT_MAX_VALUE;
+        let [r, g, b] = other.0;
+        self.0[0] = T::from_primitive(RgbToLuma::rgb_to_luma(r, g, b));
+        self.0[1] = T::DEFAULT_MAX_VALUE;
     }
 }
 
-impl<S: Primitive + Enlargeable, T: Primitive> FromColor<Rgba<S>> for LumaA<T>
+impl<S: Primitive, T: Primitive> FromColor<Rgba<S>> for LumaA<T>
 where
     T: FromPrimitive<S>,
 {
     fn from_color(&mut self, other: &Rgba<S>) {
-        let gray_a = self.channels_mut();
-        let rgba = other.channels();
-        gray_a[0] = T::from_primitive(rgb_to_luma(rgba));
-        gray_a[1] = T::from_primitive(rgba[3]);
+        let [r, g, b, a] = other.0;
+        self.0[0] = T::from_primitive(RgbToLuma::rgb_to_luma(r, g, b));
+        self.0[1] = T::from_primitive(a);
     }
 }
 

--- a/src/primitive_sealed.rs
+++ b/src/primitive_sealed.rs
@@ -183,15 +183,15 @@ macro_rules! impl_with_blur_acc_f32 {
 
 impl_with_blur_acc_f32!(u16, u32, u64, usize, i8, i16, i32, i64, isize, f32, f64);
 
-/// Coefficients to transform from sRGB to a CIE Y (luminance) value.
-///
-/// The coefficients are 2126/10000, 7152/10000, and 722/10000 for R, G, and B respectively.
-const SRGB_LUMA: [u32; 3] = [2126, 7152, 722];
-const SRGB_LUMA_DIV: u32 = 10000;
+/// Converts sRGB to luma using standard coefficients for all primitives.
 pub(crate) trait RgbToLuma: Copy + Sized + crate::traits::Enlargeable {
     #[inline]
     fn rgb_to_luma(r: Self, g: Self, b: Self) -> Self {
         use num_traits::NumCast;
+
+        /// Coefficients to transform from sRGB to a CIE Y (luminance) value.
+        const SRGB_LUMA: [u32; 3] = [2126, 7152, 722];
+        const SRGB_LUMA_DIV: u32 = 10000;
 
         let l = <Self::Larger as NumCast>::from(SRGB_LUMA[0]).unwrap() * r.to_larger()
             + <Self::Larger as NumCast>::from(SRGB_LUMA[1]).unwrap() * g.to_larger()
@@ -222,18 +222,10 @@ impl RgbToLuma for i64 {}
 impl RgbToLuma for f32 {
     #[inline]
     fn rgb_to_luma(r: f32, g: f32, b: f32) -> f32 {
-        const SCALE_R: f32 = SRGB_LUMA[0] as f32 / SRGB_LUMA_DIV as f32;
-        const SCALE_G: f32 = SRGB_LUMA[1] as f32 / SRGB_LUMA_DIV as f32;
-        const SCALE_B: f32 = SRGB_LUMA[2] as f32 / SRGB_LUMA_DIV as f32;
+        const SCALE_R: f32 = 2126. / 10000.;
+        const SCALE_G: f32 = 7152. / 10000.;
+        const SCALE_B: f32 = 722. / 10000.;
         SCALE_R * r + SCALE_G * g + SCALE_B * b
     }
 }
-impl RgbToLuma for f64 {
-    #[inline]
-    fn rgb_to_luma(r: f64, g: f64, b: f64) -> f64 {
-        const SCALE_R: f64 = SRGB_LUMA[0] as f64 / SRGB_LUMA_DIV as f64;
-        const SCALE_G: f64 = SRGB_LUMA[1] as f64 / SRGB_LUMA_DIV as f64;
-        const SCALE_B: f64 = SRGB_LUMA[2] as f64 / SRGB_LUMA_DIV as f64;
-        SCALE_R * r + SCALE_G * g + SCALE_B * b
-    }
-}
+impl RgbToLuma for f64 {}

--- a/src/primitive_sealed.rs
+++ b/src/primitive_sealed.rs
@@ -7,7 +7,10 @@ use crate::imageops::fast_blur::BlurAccumulator;
 /// This trait is `pub` but not exported, so it cannot be implemented outside
 /// this crate.
 #[allow(private_bounds)]
-pub trait PrimitiveSealed: Sized + NearestFrom<f32> + WithBlurAcc + BgraSwizzle {}
+pub trait PrimitiveSealed:
+    Sized + NearestFrom<f32> + WithBlurAcc + BgraSwizzle + RgbToLuma
+{
+}
 
 impl PrimitiveSealed for usize {}
 impl PrimitiveSealed for u8 {}
@@ -179,3 +182,58 @@ macro_rules! impl_with_blur_acc_f32 {
 }
 
 impl_with_blur_acc_f32!(u16, u32, u64, usize, i8, i16, i32, i64, isize, f32, f64);
+
+/// Coefficients to transform from sRGB to a CIE Y (luminance) value.
+///
+/// The coefficients are 2126/10000, 7152/10000, and 722/10000 for R, G, and B respectively.
+const SRGB_LUMA: [u32; 3] = [2126, 7152, 722];
+const SRGB_LUMA_DIV: u32 = 10000;
+pub(crate) trait RgbToLuma: Copy + Sized + crate::traits::Enlargeable {
+    #[inline]
+    fn rgb_to_luma(r: Self, g: Self, b: Self) -> Self {
+        use num_traits::NumCast;
+
+        let l = <Self::Larger as NumCast>::from(SRGB_LUMA[0]).unwrap() * r.to_larger()
+            + <Self::Larger as NumCast>::from(SRGB_LUMA[1]).unwrap() * g.to_larger()
+            + <Self::Larger as NumCast>::from(SRGB_LUMA[2]).unwrap() * b.to_larger();
+        Self::clamp_from(l / <Self::Larger as NumCast>::from(SRGB_LUMA_DIV).unwrap())
+    }
+}
+impl RgbToLuma for usize {}
+impl RgbToLuma for u8 {
+    fn rgb_to_luma(r: u8, g: u8, b: u8) -> u8 {
+        // The following constants give the same results as:
+        //   ((r as u32 * 2126 + g as u32 * 7152 + b as u32 * 722 + 5000) / 10000) as u8
+        // Note that results are correctly rounded to the nearest integer.
+        const W_R: u32 = ((1_u64 << 24) * 2126).div_ceil(10000) as u32;
+        const W_G: u32 = ((1_u64 << 24) * 7152).div_ceil(10000) as u32;
+        const W_B: u32 = ((1_u64 << 24) * 722).div_ceil(10000) as u32;
+        ((r as u32 * W_R + g as u32 * W_G + b as u32 * W_B + 0x800000) >> 24) as u8
+    }
+}
+impl RgbToLuma for u16 {}
+impl RgbToLuma for u32 {}
+impl RgbToLuma for u64 {}
+impl RgbToLuma for isize {}
+impl RgbToLuma for i8 {}
+impl RgbToLuma for i16 {}
+impl RgbToLuma for i32 {}
+impl RgbToLuma for i64 {}
+impl RgbToLuma for f32 {
+    #[inline]
+    fn rgb_to_luma(r: f32, g: f32, b: f32) -> f32 {
+        const SCALE_R: f32 = SRGB_LUMA[0] as f32 / SRGB_LUMA_DIV as f32;
+        const SCALE_G: f32 = SRGB_LUMA[1] as f32 / SRGB_LUMA_DIV as f32;
+        const SCALE_B: f32 = SRGB_LUMA[2] as f32 / SRGB_LUMA_DIV as f32;
+        SCALE_R * r + SCALE_G * g + SCALE_B * b
+    }
+}
+impl RgbToLuma for f64 {
+    #[inline]
+    fn rgb_to_luma(r: f64, g: f64, b: f64) -> f64 {
+        const SCALE_R: f64 = SRGB_LUMA[0] as f64 / SRGB_LUMA_DIV as f64;
+        const SCALE_G: f64 = SRGB_LUMA[1] as f64 / SRGB_LUMA_DIV as f64;
+        const SCALE_B: f64 = SRGB_LUMA[2] as f64 / SRGB_LUMA_DIV as f64;
+        SCALE_R * r + SCALE_G * g + SCALE_B * b
+    }
+}


### PR DESCRIPTION
Closes: #3013 

Changes:
- Move RGB -> Luma conversion into sealed trait.
- Change u8 behavior. Luma is now correctly rounded.
- Remove trait bound `Rgb<T>: Enlargeable` and `Rgba<T>: Enlargeable`.
- Expand convert benchmark

My main goal was to make the RGB to luma conversion faster. To that end, I added optimized implementations for u8 and f32. However, this didn't work out. The benchmarks show **no change** at all. Frankly, I don't understand why. The new implementations are doing purely less work and should be close to optimal.

- [`u8` CE](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DEArgoKkl9ZATwDKjdAGFUtEywZ7HAGTwNMAHLuAEaYxCAAbABMpAAOqAqEdgwubh568Ym2Ar7%2BQSyh4dGWmNbZDEIETMQEqe6eXCVlyZXVBLmBIWGRMeZtdemNfTUd%2BYU9AJSWqCbEyOwcAKRRAMyLAKwAQgyoAPoshsD0GwAiixoAgrEmwQDUVAy3wIxheMi7JgAcEMTAwUwgW7LCIbTZfU6kW5pAFAqIRFgmAhArbg9YnCZAgDsm3OF1u%2BPuj1%2BwV2RF20J%2BgK%2BkNAt2pt2CVM%2BGIAtIsVtg6Z8sTjLgT%2BbcAPTC24uTBUGjIPCMAgKW5EeXEQwKfjEFj3YiodUKABKAHFNvLULcmKKAJKcgCatwgaT8hnmGIAbmITJgAHS4gUEtAMcy3IT6za7bxyACyF0BoJMKyi7MNazRQJWJ2RmyiXDhkMxXHWMVumKicbR8a93tuvv9gYNIfDF12JzNADUqbHk6muBouxpS5cy976EjaO2A0HaxHQT2kwAqW7EE1ymNRWGG6vB0MTrZcU63WfABd0tvLVdjjcXUHF1Ozu5MRex3t48u2oWjmtnhvNjG3rn9rFnPt8gSqo2sSTCQtCGJ%2BHOfxMO6t67MgCAmAwADWCggCA7JOJI7LYBAEzuho7qEGE%2BHugAXngsS2u4sEkcQ%2ByIvhGKLNiv78tO0IjsSpJ7BSoGThC0H/KC25opCAlbJeEwPvyrH/uemIKbiyyJtsewHEYxwlpc1x3A8tyoLEtgsHg5GYOgHzfKBUZwtGnxCdCtnwoiaaouiPK/gZPFkvxTI0v5DJMqyuFcp5gHeiKAAqCCYPcri0KgADufj7pWVSCHKwB4E6cUELFtwKKwcXEJgCgmLQsoLphEUCiK%2BJQPO35LrutwZnCK5PAeLWzjmeadTed7Lr1Rades3YYoKtydhN3UObV/IigEqAEHlCBMEipXlZVcrVHFaDEKVNi0AAnnOMwMFg6BGvKBX%2BHt/p%2BKtzzEJ6C0%2BgI/oAOq7DqrbLuyqZQFwHwRJIyZOFhbWSBis7tREBH4E6CGYHQEAzV2X5DbJ5bpbcP16v9I7A6D4NYVDUQw61fVRIjOUo2jGMaFjh5xisvKPt6eM/ZsROAza6OkxDFNUyNtPukjDO0Oj3bM9197s%2BxBKNfLw3479nX7s1bazgTA2q61POdRoqifLLcu4aFlMs%2BCtXySptXAT8MHgbRkFEjBcEKAhSGoehmErNhuFkUR9FkZR1HQsRq0MQiBDMeFnMCpxtHcX8vHkrRzsiVsU4nBJMGiUJknpqcMmK3bSkqVXAHnqsoI7PshzaQpemEoZxl4KZ5mWV8uySKo2cwsC9mObRzlx25DloixbGOx7JK%2BVn4RcgFq9BVyIUcmFrEc%2BWQpTTFcX8LQiUpUYFafRlVXZblt1xUVbBzmVFVVbeNVJ4tU0NT8Btw5mERNZ/wLLmAGURDSDVZtTUax5bjjUxi%2BJmNt5qfwJEtFaa0NrP22m/Uql9DqYGOmdTUyEro3XynFe6W0kRPUwC9N6qD8Tc1%2BnzFMAsQYmDBsLQO0NYZtQAXTZG8xGayxtgrPeuMr7q0JlA/mJNOFk0DiLPhNNBFSxlrNbWbMJFcykTzVhQNBYKO4U4Xh0DxaS2EdLJBqscbehVlow2GtYFayGk4vU%2BtHG612IaWBJszaiKFCbJmCDmooLkjXc8tVBzCSYIo1MoEvY%2B2QmhDCWEuAgg5CHOxUJMBDlovEqEtEkmIRSd7OOaTA44SyQRHsFck5O1AtIIpBwqZQSadHUiBEI40VaZ02OTEJizx0QKGJwRErIBQiOEwmZPgYSoJqFg5JMC7GCCdVaCgIDTiaeXEZ/IYnIA0NM2MGFfIrLWRsiA4zUCTNVrspW%2BIDlcGOVEU5fFznrLKlAa5tzLbb1jGI2mOT9l5IrADNhS43nLNWZ8zZVyJlTL%2BZyMGgL7nvUeaC5AKwXlQvoDCy58KbmIo5KFAAnAjO5wKCQp1aSOUEDyBQ%2BT4lnQ5glxIVinJsMS%2BcOUXjLqQBl/ImWZwOBAZAYlNh50hOKou7KZVSX5YKgkwqKTIGLJKoSarZU8q1QqmeAr0WMvTkvUVWK2U6rUty6ValpIGsYciM49SInKUibiAyBw/D4UTl/W4sRiBPVoAwMAkBlhxjYlXIskITDrAzn3ZgOVMAQBWFwIZD57aXA4FMWgnB1i8E8BwLQpBUCcB1GYJECgZhzDiqpHgpACCaEzVMFCIBxrulJSsclhZoikvWJmRo2aOCSDzQ2otnBeDoQ0HWhtUw4CwCQGgFgsQ6BhHIJQBdS76DhGIFwHtk6aCVTCOhK5I7gj2mICdTgtbT3MHPQAeWCNoQh9buC8AXWwQQt6GCnUvbwLAwQTDACcGIWg6EX2kCwJpI4CxC34COrYXKoHC2YFUIQxECxa20IHYW2geBghKnPS4LAI6CD%2BpYD%2B0guViDBASJgE4mBIM4aMNOvgBhgAKCbNKJKt7YiMHI/wQQIgxDsCkDIQQigVDqALToPQBgmOmHMPoXD6FIBTCMuUUDLJTFqZZPQXKtBAYrF4KgSj/qsDKagMwNgIALJJAEBR10CwogaAzI2poT7kgOEugMBopAfB%2BE6AUbojRMi2ZSK4eoGQEihdGF0cIQxSjuYEK0Go3m9BWESxUKoIx/NjCC5YLLtRwuDHy20GLgW4tTArbMeYEgs05uHVJ0dHA5xluQNNNt6xCI2lwIQEgsJk0TF4M%2BrQM6kAzAINcCwFAxVag3WEAIxVODyYIG1rg7pMQREIrwGzRBTN6H48IUQ4gRMHfE2oEduhGhJSVLEH9dWOC5tIPmwtxaOC3sRJNwyVAWvmFWx1rrEAXCLuXfOGtg2p1SaGaQZtkhSWEQiBoWMmIViYg0JIT4mJSX6E4EO0gZGZpPZHa98dIBJ3DdcwOqIDWXtjohyNqYlHEj2EkEAA%3D%3D%3D): Both the old generic and optimized implementations do not vectorize at all. The compiler also loads each byte individually. The only difference is that the optimized version does everything in 32-bit registers, while the generic version uses 64-bit registers to perform the division with a multiply shift (which in turn leads to the compiler unrolling the optimized version once).
- [`f32` CE](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:14,fontUsePx:'0',j:1,lang:rust,selection:(endColumn:12,endLineNumber:33,positionColumn:12,positionLineNumber:33,selectionStartColumn:12,selectionStartLineNumber:33,startColumn:12,startLineNumber:33),source:'%23%5Bno_mangle%5D%0Apub+fn+generic_f32(rgba:+%26%5Bf32%5D,+luma:+%26mut+%5Bf32%5D)+%7B%0A++++fn+rgb_to_luma(r:+f32,+g:+f32,+b:+f32)+-%3E+f32+%7B%0A++++++++///+Coefficients+to+transform+from+sRGB+to+a+CIE+Y+(luminance)+value.%0A++++++++const+SRGB_LUMA:+%5Bu32%3B+3%5D+%3D+%5B2126,+7152,+722%5D%3B%0A++++++++const+SRGB_LUMA_DIV:+u32+%3D+10000%3B%0A%0A++++++++let+l+%3D+SRGB_LUMA%5B0%5D+as+f64+*+r+as+f64%0A++++++++++++%2B+SRGB_LUMA%5B1%5D+as+f64+*+g+as+f64%0A++++++++++++%2B+SRGB_LUMA%5B2%5D+as+f64+*+b+as+f64%3B%0A++++++++(l+/+SRGB_LUMA_DIV+as+f64)+as+f32%0A++++%7D%0A%0A++++for+(rgba,+luma)+in+rgba.as_chunks::%3C4%3E().0.iter().zip(luma.iter_mut())+%7B%0A++++++++*luma+%3D+rgb_to_luma(rgba%5B0%5D,+rgba%5B1%5D,+rgba%5B2%5D)%3B%0A++++%7D%0A%7D%0A%0A%23%5Bno_mangle%5D%0Apub+fn+optimized_f32(rgba:+%26%5Bf32%5D,+luma:+%26mut+%5Bf32%5D)+%7B%0A++++fn+rgb_to_luma(r:+f32,+g:+f32,+b:+f32)+-%3E+f32+%7B%0A++++++++const+SCALE_R:+f32+%3D+2126.+/+10000.%3B%0A++++++++const+SCALE_G:+f32+%3D+7152.+/+10000.%3B%0A++++++++const+SCALE_B:+f32+%3D+722.+/+10000.%3B%0A++++++++SCALE_R+*+r+%2B+SCALE_G+*+g+%2B+SCALE_B+*+b%0A++++%7D%0A%0A++++for+(rgba,+luma)+in+rgba.as_chunks::%3C4%3E().0.iter().zip(luma.iter_mut())+%7B%0A++++++++*luma+%3D+rgb_to_luma(rgba%5B0%5D,+rgba%5B1%5D,+rgba%5B2%5D)%3B%0A++++%7D%0A%7D%0A%0Afn+main()+%7B%7D%0A'),l:'5',n:'0',o:'Rust+source+%231',t:'0')),k:50.9396726295121,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:r1950,filters:(b:'0',binary:'1',binaryObject:'1',commentOnly:'1',debugCalls:'1',demangle:'0',directives:'0',execute:'1',intel:'0',libraryCode:'0',trim:'1',verboseDemangling:'0'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:1,lang:rust,libs:!(),options:'-C+opt-level%3D3',overrides:!((name:edition,value:'2021')),selection:(endColumn:1,endLineNumber:1,positionColumn:1,positionLineNumber:1,selectionStartColumn:1,selectionStartLineNumber:1,startColumn:1,startLineNumber:1),source:1),l:'5',n:'0',o:'+rustc+1.95.0+(Editor+%231)',t:'0'),(h:output,i:(compilerName:'rustc+1.76.0',editorid:1,fontScale:14,fontUsePx:'0',j:1,wrap:'1'),l:'5',n:'0',o:'Output+of+rustc+1.95.0+(Compiler+%231)',t:'0')),k:49.0603273704879,l:'4',m:100,n:'0',o:'',s:0,t:'0')),l:'2',n:'0',o:'',t:'0')),version:4): The generic version uses *`f64`* to do all calculations while the optimized uses `f32`. The SIMD for both is bad. The f32 version is actually super easy to vectorize well (just do rgba * [W_R, W_G, W_B, 0] and then sum), but the compiler doesn't do this.

In any case, even without a perf win, removing the `Enlargeable` bound and correct rounding for `u8` should still be a win.