### PR TITLE
Use the same panic docs for all encoders

### DIFF
--- a/src/codecs/avif/encoder.rs
+++ b/src/codecs/avif/encoder.rs
@@ -98,10 +98,15 @@ impl<W: Write> ImageEncoder for AvifEncoder<W> {
     /// The encoder currently requires all data to be RGBA8, it will be converted internally if
     /// necessary. When data is suitably aligned, i.e. u16 channels to two bytes, then the
     /// conversion may be more efficient.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `buf.len() != color_type.buffer_size(width, height)`.
+    /// See [`ExtendedColorType::buffer_size`] for more information.
     #[track_caller]
     fn write_image(
         mut self,
-        data: &[u8],
+        buf: &[u8],
         width: u32,
         height: u32,
         color: ExtendedColorType,
@@ -109,9 +114,9 @@ impl<W: Write> ImageEncoder for AvifEncoder<W> {
         let expected_buffer_len = color.buffer_size(width, height);
         assert_eq!(
             expected_buffer_len,
-            data.len() as u64,
+            buf.len() as u64,
             "Invalid buffer length: expected {expected_buffer_len} got {} for {width}x{height} image",
-            data.len(),
+            buf.len(),
         );
 
         self.set_color(color);
@@ -119,7 +124,7 @@ impl<W: Write> ImageEncoder for AvifEncoder<W> {
         // owned version in our own buffer or zero-copy if possible by using the input buffer.
         // This requires going through `rgb`.
         let mut fallback = vec![]; // This vector is used if we need to do a color conversion.
-        let result = match Self::encode_as_img(&mut fallback, data, width, height, color)? {
+        let result = match Self::encode_as_img(&mut fallback, buf, width, height, color)? {
             RgbColor::Rgb8(buffer) => self.encoder.encode_rgb(buffer),
             RgbColor::Rgba8(buffer) => self.encoder.encode_rgba(buffer),
         };

--- a/src/codecs/bmp/encoder.rs
+++ b/src/codecs/bmp/encoder.rs
@@ -26,9 +26,8 @@ impl<W: Write> BmpEncoder<W> {
     ///
     /// # Panics
     ///
-    /// Panics if the buffer does not hold exactly the number of bytes required for the given
-    /// `width`, `height`, and color type, accounting for rows padded to whole bytes for
-    /// sub-byte color types: `height * ((width * color_type.bits_per_pixel() as u32 + 7) / 8)`.
+    /// Panics if `image.len() != color_type.buffer_size(width, height)`.
+    /// See [`ExtendedColorType::buffer_size`] for more information.
     #[track_caller]
     pub fn encode(
         &mut self,
@@ -45,9 +44,8 @@ impl<W: Write> BmpEncoder<W> {
     ///
     /// # Panics
     ///
-    /// Panics if the buffer does not hold exactly the number of bytes required for the given
-    /// `width`, `height`, and color type, accounting for rows padded to whole bytes for
-    /// sub-byte color types: `height * ((width * color_type.bits_per_pixel() as u32 + 7) / 8)`.
+    /// Panics if `image.len() != color_type.buffer_size(width, height)`.
+    /// See [`ExtendedColorType::buffer_size`] for more information.
     #[track_caller]
     pub fn encode_with_palette(
         &mut self,

--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -504,6 +504,11 @@ impl<W: Write> GifEncoder<W> {
     }
 
     /// Encode a single image.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `data.len() != color_type.buffer_size(width, height)`.
+    /// See [`ExtendedColorType::buffer_size`] for more information.
     pub fn encode(
         &mut self,
         data: &[u8],

--- a/src/codecs/ico/encoder.rs
+++ b/src/codecs/ico/encoder.rs
@@ -68,6 +68,11 @@ impl<'a> IcoFrame<'a> {
     /// Construct a new `IcoFrame` by encoding `buf` as a PNG
     ///
     /// The `width` and `height` must be between 1 and 256 (inclusive)
+    ///
+    /// # Panics
+    ///
+    /// Panics if `buf.len() != color_type.buffer_size(width, height)`.
+    /// See [`ExtendedColorType::buffer_size`] for more information.
     pub fn as_png(
         buf: &[u8],
         width: u32,
@@ -125,12 +130,6 @@ impl<W: Write> IcoEncoder<W> {
 }
 
 impl<W: Write> ImageEncoder for IcoEncoder<W> {
-    /// Write an ICO image with the specified width, height, and color type.
-    ///
-    /// For color types with 16-bit per channel or larger, the contents of `buf` should be in
-    /// native endian.
-    ///
-    /// WARNING: In image 0.23.14 and earlier this method erroneously expected buf to be in big endian.
     #[track_caller]
     fn write_image(
         self,

--- a/src/codecs/jpeg/encoder.rs
+++ b/src/codecs/jpeg/encoder.rs
@@ -192,9 +192,8 @@ impl<W: Write> JpegEncoder<W> {
     ///
     /// # Panics
     ///
-    /// Panics if the buffer does not hold exactly the number of bytes required for the given
-    /// `width`, `height`, and `color_type`, accounting for rows padded to whole bytes for
-    /// sub-byte color types: `height * ((width * color_type.bits_per_pixel() as u32 + 7) / 8)`.
+    /// Panics if `image.len() != color_type.buffer_size(width, height)`.
+    /// See [`ExtendedColorType::buffer_size`] for more information.
     #[track_caller]
     fn encode(
         self,

--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -317,10 +317,6 @@ impl<W> ImageEncoder for OpenExrEncoder<W>
 where
     W: Write + Seek,
 {
-    /// Writes the complete image.
-    ///
-    /// Assumes the writer is buffered. In most cases, you should wrap your writer in a `BufWriter`
-    /// for best performance.
     #[track_caller]
     fn write_image(
         self,

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -857,11 +857,6 @@ impl<W: Write> PngEncoder<W> {
 }
 
 impl<W: Write> ImageEncoder for PngEncoder<W> {
-    /// Write a PNG image with the specified width, height, and color type.
-    ///
-    /// For color types with 16-bit per channel or larger, the contents of `buf` should be in
-    /// native endian. `PngEncoder` will automatically convert to big endian as required by the
-    /// underlying PNG format.
     #[track_caller]
     fn write_image(
         self,

--- a/src/codecs/tga/encoder.rs
+++ b/src/codecs/tga/encoder.rs
@@ -159,9 +159,8 @@ impl<W: Write> TgaEncoder<W> {
     ///
     /// # Panics
     ///
-    /// Panics if the buffer does not hold exactly the number of bytes required for the given
-    /// `width`, `height`, and `color_type`, accounting for rows padded to whole bytes for
-    /// sub-byte color types: `height * ((width * color_type.bits_per_pixel() as u32 + 7) / 8)`.
+    /// Panics if `buf.len() != color_type.buffer_size(width, height)`.
+    /// See [`ExtendedColorType::buffer_size`] for more information.
     #[track_caller]
     pub fn encode(
         mut self,

--- a/src/codecs/tiff.rs
+++ b/src/codecs/tiff.rs
@@ -779,15 +779,6 @@ impl<W: Write + Seek> TiffEncoder<W> {
 }
 
 impl<W: Write + Seek> ImageEncoder for TiffEncoder<W> {
-    /// Encodes the image `image` that has dimensions `width` and `height` and `ColorType` `c`.
-    ///
-    /// 16-bit types assume the buffer is native endian.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the buffer does not hold exactly the number of bytes required for the given
-    /// `width`, `height`, and `color_type`, accounting for rows padded to whole bytes for
-    /// sub-byte color types: `height * ((width * color_type.bits_per_pixel() as u32 + 7) / 8)`.
     #[track_caller]
     fn write_image(
         self,

--- a/src/codecs/webp/encoder.rs
+++ b/src/codecs/webp/encoder.rs
@@ -43,9 +43,8 @@ impl<W: Write> WebPEncoder<W> {
     ///
     /// # Panics
     ///
-    /// Panics if the buffer does not hold exactly the number of bytes required for the given
-    /// `width`, `height`, and color type, accounting for rows padded to whole bytes for
-    /// sub-byte color types: `height * ((width * color_type.bits_per_pixel() as u32 + 7) / 8)`.
+    /// Panics if `buf.len() != color_type.buffer_size(width, height)`.
+    /// See [`ExtendedColorType::buffer_size`] for more information.
     #[track_caller]
     pub fn encode(
         self,

--- a/src/io/encoder.rs
+++ b/src/io/encoder.rs
@@ -32,7 +32,8 @@ pub trait ImageEncoder {
     ///
     /// # Panics
     ///
-    /// Panics if `buf.len() as u64 != color_type.buffer_size(width, height)`.
+    /// Panics if `buf.len() != color_type.buffer_size(width, height)`.
+    /// See [`ExtendedColorType::buffer_size`] for more information.
     fn write_image(
         self,
         buf: &[u8],


### PR DESCRIPTION
Follow-up to #2982.

I looked through all encoders and found that some were missing panic docs. So I:

1. added missing panic docs,
2. updated existing panic docs to all use the same wording, and
3. removed docs on impls of `ImageEncoder::write_image` if those docs contain no information on top of the one inherited from the trait docs.