### PR TITLE
Unify panic handling for all encoders

### DIFF
--- a/src/codecs/avif/encoder.rs
+++ b/src/codecs/avif/encoder.rs
@@ -106,13 +106,7 @@ impl<W: Write> ImageEncoder for AvifEncoder<W> {
         height: u32,
         color: ExtendedColorType,
     ) -> ImageResult<()> {
-        let expected_buffer_len = color.buffer_size(width, height);
-        assert_eq!(
-            expected_buffer_len,
-            data.len() as u64,
-            "Invalid buffer length: expected {expected_buffer_len} got {} for {width}x{height} image",
-            data.len(),
-        );
+        color.assert_buf_len(width, height, data);
 
         self.set_color(color);
         // `ravif` needs strongly typed data so let's convert. We can either use a temporarily

--- a/src/codecs/bmp/encoder.rs
+++ b/src/codecs/bmp/encoder.rs
@@ -57,6 +57,8 @@ impl<W: Write> BmpEncoder<W> {
         color_type: ExtendedColorType,
         palette: Option<&[[u8; 3]]>,
     ) -> ImageResult<()> {
+        color_type.assert_buf_len(width, height, image);
+
         if palette.is_some()
             && color_type != ExtendedColorType::L1
             && color_type != ExtendedColorType::L8
@@ -76,14 +78,6 @@ impl<W: Write> BmpEncoder<W> {
                 crate::error::LimitErrorKind::DimensionError,
             )));
         }
-
-        let expected_buffer_len = color_type.buffer_size(width, height);
-        assert_eq!(
-            expected_buffer_len,
-            image.len() as u64,
-            "Invalid buffer length: expected {expected_buffer_len} got {} for {width}x{height} image",
-            image.len(),
-        );
 
         let bmp_header_size = BITMAPFILEHEADER_SIZE;
 

--- a/src/codecs/farbfeld.rs
+++ b/src/codecs/farbfeld.rs
@@ -159,6 +159,8 @@ impl<W: Write> ImageEncoder for FarbfeldEncoder<W> {
         height: u32,
         color_type: ExtendedColorType,
     ) -> ImageResult<()> {
+        color_type.assert_buf_len(width, height, buf);
+
         if color_type != ExtendedColorType::Rgba16 {
             return Err(ImageError::Unsupported(
                 UnsupportedError::from_format_and_kind(

--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -504,6 +504,7 @@ impl<W: Write> GifEncoder<W> {
     }
 
     /// Encode a single image.
+    #[track_caller]
     pub fn encode(
         &mut self,
         data: &[u8],
@@ -511,6 +512,8 @@ impl<W: Write> GifEncoder<W> {
         height: u32,
         color: ExtendedColorType,
     ) -> ImageResult<()> {
+        color.assert_buf_len(width, height, data);
+
         let (width, height) = self.gif_dimensions(width, height)?;
         match color {
             ExtendedColorType::Rgb8 => {
@@ -633,6 +636,7 @@ impl<W: Write> GifEncoder<W> {
     }
 }
 impl<W: Write> ImageEncoder for GifEncoder<W> {
+    #[track_caller]
     fn write_image(
         mut self,
         buf: &[u8],

--- a/src/codecs/hdr/encoder.rs
+++ b/src/codecs/hdr/encoder.rs
@@ -12,6 +12,7 @@ pub struct HdrEncoder<W: Write> {
 }
 
 impl<W: Write> ImageEncoder for HdrEncoder<W> {
+    #[track_caller]
     fn write_image(
         self,
         unaligned_bytes: &[u8],
@@ -19,9 +20,12 @@ impl<W: Write> ImageEncoder for HdrEncoder<W> {
         height: u32,
         color_type: ExtendedColorType,
     ) -> ImageResult<()> {
+        color_type.assert_buf_len(width, height, unaligned_bytes);
+
         match color_type {
             ExtendedColorType::Rgb32F => {
                 let bytes_per_pixel = color_type.bits_per_pixel() as usize / 8;
+
                 let rgbe_pixels = unaligned_bytes
                     .chunks_exact(bytes_per_pixel)
                     .map(|bytes| to_rgbe8(Rgb::<f32>(bytemuck::pod_read_unaligned(bytes))));

--- a/src/codecs/ico/encoder.rs
+++ b/src/codecs/ico/encoder.rs
@@ -139,13 +139,7 @@ impl<W: Write> ImageEncoder for IcoEncoder<W> {
         height: u32,
         color_type: ExtendedColorType,
     ) -> ImageResult<()> {
-        let expected_buffer_len = color_type.buffer_size(width, height);
-        assert_eq!(
-            expected_buffer_len,
-            buf.len() as u64,
-            "Invalid buffer length: expected {expected_buffer_len} got {} for {width}x{height} image",
-            buf.len(),
-        );
+        color_type.assert_buf_len(width, height, buf);
 
         let image = IcoFrame::as_png(buf, width, height, color_type)?;
         self.encode_images(&[image])

--- a/src/codecs/jpeg/encoder.rs
+++ b/src/codecs/jpeg/encoder.rs
@@ -203,13 +203,7 @@ impl<W: Write> JpegEncoder<W> {
         height: u32,
         color_type: ExtendedColorType,
     ) -> ImageResult<()> {
-        let expected_buffer_len = color_type.buffer_size(width, height);
-        assert_eq!(
-            expected_buffer_len,
-            image.len() as u64,
-            "Invalid buffer length: expected {expected_buffer_len} got {} for {width}x{height} image",
-            image.len(),
-        );
+        color_type.assert_buf_len(width, height, image);
 
         let (width, height) = match (u16::try_from(width), u16::try_from(height)) {
             (Ok(w @ 1..), Ok(h @ 1..)) => (w, h),

--- a/src/codecs/openexr.rs
+++ b/src/codecs/openexr.rs
@@ -329,13 +329,7 @@ where
         height: u32,
         color_type: ExtendedColorType,
     ) -> ImageResult<()> {
-        let expected_buffer_len = color_type.buffer_size(width, height);
-        assert_eq!(
-            expected_buffer_len,
-            buf.len() as u64,
-            "Invalid buffer length: expected {expected_buffer_len} got {} for {width}x{height} image",
-            buf.len(),
-        );
+        color_type.assert_buf_len(width, height, buf);
 
         write_buffer(self.0, buf, width, height, color_type)
     }

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -872,13 +872,7 @@ impl<W: Write> ImageEncoder for PngEncoder<W> {
     ) -> ImageResult<()> {
         use ExtendedColorType::*;
 
-        let expected_buffer_len = color_type.buffer_size(width, height);
-        assert_eq!(
-            expected_buffer_len,
-            buf.len() as u64,
-            "Invalid buffer length: expected {expected_buffer_len} got {} for {width}x{height} image",
-            buf.len(),
-        );
+        color_type.assert_buf_len(width, height, buf);
 
         // PNG images are big endian. For 16 bit per channel and larger types,
         // the buffer may need to be reordered to big endian per the

--- a/src/codecs/pnm/encoder.rs
+++ b/src/codecs/pnm/encoder.rs
@@ -343,13 +343,7 @@ impl<W: Write> ImageEncoder for PnmEncoder<W> {
         height: u32,
         color_type: ExtendedColorType,
     ) -> ImageResult<()> {
-        let expected_buffer_len = color_type.buffer_size(width, height);
-        assert_eq!(
-            expected_buffer_len,
-            buf.len() as u64,
-            "Invalid buffer length: expected {expected_buffer_len} got {} for {width}x{height} image",
-            buf.len(),
-        );
+        color_type.assert_buf_len(width, height, buf);
 
         self.encode(buf, width, height, color_type)
     }

--- a/src/codecs/qoi.rs
+++ b/src/codecs/qoi.rs
@@ -73,6 +73,8 @@ impl<W: Write> ImageEncoder for QoiEncoder<W> {
         height: u32,
         color_type: ExtendedColorType,
     ) -> ImageResult<()> {
+        color_type.assert_buf_len(width, height, buf);
+
         if !matches!(
             color_type,
             ExtendedColorType::Rgba8 | ExtendedColorType::Rgb8
@@ -84,14 +86,6 @@ impl<W: Write> ImageEncoder for QoiEncoder<W> {
                 ),
             ));
         }
-
-        let expected_buffer_len = color_type.buffer_size(width, height);
-        assert_eq!(
-            expected_buffer_len,
-            buf.len() as u64,
-            "Invalid buffer length: expected {expected_buffer_len} got {} for {width}x{height} image",
-            buf.len(),
-        );
 
         // Encode data in QOI
         let data = qoi::encode_to_vec(buf, width, height).map_err(encoding_error)?;

--- a/src/codecs/tga/encoder.rs
+++ b/src/codecs/tga/encoder.rs
@@ -170,13 +170,7 @@ impl<W: Write> TgaEncoder<W> {
         height: u32,
         color_type: ExtendedColorType,
     ) -> ImageResult<()> {
-        let expected_buffer_len = color_type.buffer_size(width, height);
-        assert_eq!(
-            expected_buffer_len,
-            buf.len() as u64,
-            "Invalid buffer length: expected {expected_buffer_len} got {} for {width}x{height} image",
-            buf.len(),
-        );
+        color_type.assert_buf_len(width, height, buf);
 
         // Validate dimensions.
         if width == 0 || height == 0 {

--- a/src/codecs/tiff.rs
+++ b/src/codecs/tiff.rs
@@ -799,13 +799,9 @@ impl<W: Write + Seek> ImageEncoder for TiffEncoder<W> {
         use tiff::encoder::colortype::{
             Gray16, Gray8, RGB32Float, RGBA32Float, RGB16, RGB8, RGBA16, RGBA8,
         };
-        let expected_buffer_len = color_type.buffer_size(width, height);
-        assert_eq!(
-            expected_buffer_len,
-            buf.len() as u64,
-            "Invalid buffer length: expected {expected_buffer_len} got {} for {width}x{height} image",
-            buf.len(),
-        );
+
+        color_type.assert_buf_len(width, height, buf);
+
         match color_type {
             ExtendedColorType::L8 => self.write_tiff::<Gray8>(width, height, buf),
             ExtendedColorType::Rgb8 => self.write_tiff::<RGB8>(width, height, buf),

--- a/src/codecs/webp/encoder.rs
+++ b/src/codecs/webp/encoder.rs
@@ -54,13 +54,7 @@ impl<W: Write> WebPEncoder<W> {
         height: u32,
         color_type: ExtendedColorType,
     ) -> ImageResult<()> {
-        let expected_buffer_len = color_type.buffer_size(width, height);
-        assert_eq!(
-            expected_buffer_len,
-            buf.len() as u64,
-            "Invalid buffer length: expected {expected_buffer_len} got {} for {width}x{height} image",
-            buf.len(),
-        );
+        color_type.assert_buf_len(width, height, buf);
 
         let color_type = match color_type {
             ExtendedColorType::L8 => image_webp::ColorType::L8,

--- a/src/color.rs
+++ b/src/color.rs
@@ -304,6 +304,18 @@ impl ExtendedColorType {
         let row_pitch = (width as u64 * bpp).div_ceil(8);
         row_pitch.saturating_mul(height as u64)
     }
+
+    /// Asserts that the buffer has the correct length for an image of the given dimensions and color.
+    #[track_caller]
+    pub(crate) fn assert_buf_len(self, width: u32, height: u32, buf: &[u8]) {
+        let expected_buffer_len = self.buffer_size(width, height);
+        assert_eq!(
+            expected_buffer_len,
+            buf.len() as u64,
+            "Invalid buffer length: expected {expected_buffer_len} but got {} for {width}x{height} {self:?} image",
+            buf.len(),
+        );
+    }
 }
 
 impl From<ColorType> for ExtendedColorType {


### PR DESCRIPTION
Changes:
- Add `assert_buf_len` util method to `ExtendedColorType` to help with checking.
- Use the same check in all encoders and trace callers consistently.

I noticed that some encoders didn't panic when the trait docs said they should. So I made sure all encoders do a buffer length check.

Maybe the util method should be in `crate::util`? I put it on `ExtendedColorType` purely because it was easy for now.