### PR TITLE
Fix overflow in `thumbnail`

### DIFF
--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -682,15 +682,49 @@ where
     S: Primitive + Enlargeable,
 {
     let mut sum = ThumbnailSum::zeroed();
+    let pixel_count: u64 = (right - left) as u64 * (top - bottom) as u64;
 
-    for y in bottom..top {
-        for x in left..right {
-            let k = image.get_pixel(x, y);
-            sum.add_pixel(k);
+    // Crushing down huge images to very small thumbnails can result in overflow of `sum`.
+    // This is especially a problem for u8 and u16. Their ::Larger is u32 for both.
+    // This gives u8 a head room of 24 bits (which is enough to handle blocks with 2^24 pixels),
+    // but u16 only has 16 bits (which is only enough for 2^16 pixels).
+    // To prevent overflow and guarantee correctness even in edge cases, huge blocks need to be
+    // detected and split into smaller blocks.
+    let sample_count = if pixel_count > 256 * 256 {
+        // edge case where huge blocks need to be split into smaller blocks
+        // Blocks are currently split into 256x256 sub-blocks (or smaller).
+        // Note that this does not make overflow impossible. It simply adds 16 bits of headroom.
+        // So u8 now supports blocks with up to 2^40 pixels and u16 supports blocks with up to 2^32 pixels.
+        // This should be enough to prevent overflow in practice.
+        const STEP_SIZE: u32 = 256;
+
+        for y in (bottom..top).step_by(STEP_SIZE as usize) {
+            for x in (left..right).step_by(STEP_SIZE as usize) {
+                let k = thumbnail_sample_block(
+                    image,
+                    x,
+                    x.saturating_add(STEP_SIZE).min(right),
+                    y,
+                    y.saturating_add(STEP_SIZE).min(top),
+                );
+                sum.add_pixel(k);
+            }
         }
-    }
 
-    let n = <S::Larger as NumCast>::from((right - left) * (top - bottom)).unwrap();
+        ((right - left) as u64 / STEP_SIZE as u64) * ((top - bottom) as u64 / STEP_SIZE as u64)
+    } else {
+        // standard case where all pixels are summed directly
+        for y in bottom..top {
+            for x in left..right {
+                let k = image.get_pixel(x, y);
+                sum.add_pixel(k);
+            }
+        }
+
+        pixel_count
+    };
+
+    let n = <S::Larger as NumCast>::from(sample_count).unwrap();
 
     // For integer types division truncates, so we need to add n/2 to round to
     // the nearest integer. Floating point types do not need this.
@@ -735,10 +769,7 @@ where
     let fact_left = (1. - fract) / ((top - bottom) as f32);
 
     let mix_left_and_right = |leftv: S::Larger, rightv: S::Larger| {
-        <S as NumCast>::from(
-            fact_left * leftv.to_f32().unwrap() + fact_right * rightv.to_f32().unwrap(),
-        )
-        .expect("Average sample value should fit into sample type")
+        S::nearest_from(fact_left * leftv.to_f32().unwrap() + fact_right * rightv.to_f32().unwrap())
     };
 
     let left = sum_left.0;
@@ -785,8 +816,7 @@ where
     let fact_bot = (1. - fract) / ((right - left) as f32);
 
     let mix_bot_and_top = |botv: S::Larger, topv: S::Larger| {
-        <S as NumCast>::from(fact_bot * botv.to_f32().unwrap() + fact_top * topv.to_f32().unwrap())
-            .expect("Average sample value should fit into sample type")
+        S::nearest_from(fact_bot * botv.to_f32().unwrap() + fact_top * topv.to_f32().unwrap())
     };
 
     let bot = sum_bot.0;
@@ -830,13 +860,12 @@ where
     let fact_bl = (1. - frac_v) * (1. - frac_h);
 
     let mix = |br: S, tr: S, bl: S, tl: S| {
-        <S as NumCast>::from(
+        S::nearest_from(
             fact_br * br.to_f32().unwrap()
                 + fact_tr * tr.to_f32().unwrap()
                 + fact_bl * bl.to_f32().unwrap()
                 + fact_tl * tl.to_f32().unwrap(),
         )
-        .expect("Average sample value should fit into sample type")
     };
 
     // Make a copy of any pixel, we'll fully overwrite it.
@@ -1857,5 +1886,38 @@ mod tests {
         assert!(result.into_raw().into_iter().all(|c| c == 0));
         let result = resize(&empty, 256, 256, FilterType::Lanczos3);
         assert!(result.into_raw().into_iter().all(|c| c == 0));
+    }
+
+    #[test]
+    fn thumbnail_huge_block() {
+        struct SingleColor<P> {
+            color: P,
+            width: u32,
+            height: u32,
+        }
+        impl<P: crate::Pixel> GenericImageView for SingleColor<P> {
+            type Pixel = P;
+            fn dimensions(&self) -> (u32, u32) {
+                (self.width, self.height)
+            }
+            #[inline(always)]
+            fn get_pixel(&self, _x: u32, _y: u32) -> Self::Pixel {
+                self.color
+            }
+        }
+
+        let huge_u8: SingleColor<crate::Luma<u8>> = SingleColor {
+            color: crate::Luma([255]),
+            width: 4096,
+            height: 4113,
+        }; // 4096 * 4113 * 255 barely overflows 2^32, so it would trigger a bug if large blocks were not handled
+        super::thumbnail(&huge_u8, 1, 1);
+
+        let huge_u16: SingleColor<crate::Luma<u16>> = SingleColor {
+            color: crate::Luma([65535]),
+            width: 1024,
+            height: 1024,
+        }; // 1024^2 * 65535 obviously overflows 2^32
+        super::thumbnail(&huge_u16, 1, 1);
     }
 }

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -1890,34 +1890,12 @@ mod tests {
 
     #[test]
     fn thumbnail_huge_block() {
-        struct SingleColor<P> {
-            color: P,
-            width: u32,
-            height: u32,
-        }
-        impl<P: crate::Pixel> GenericImageView for SingleColor<P> {
-            type Pixel = P;
-            fn dimensions(&self) -> (u32, u32) {
-                (self.width, self.height)
-            }
-            #[inline(always)]
-            fn get_pixel(&self, _x: u32, _y: u32) -> Self::Pixel {
-                self.color
-            }
-        }
-
-        let huge_u8: SingleColor<crate::Luma<u8>> = SingleColor {
-            color: crate::Luma([255]),
-            width: 4096,
-            height: 4113,
-        }; // 4096 * 4113 * 255 barely overflows 2^32, so it would trigger a bug if large blocks were not handled
+        // 4096 * 4113 * 255 barely overflows 2^32, so it would trigger a bug if large blocks were not handled
+        let huge_u8 = ImageBuffer::from_pixel(4096, 4113, crate::Luma([255_u8]));
         super::thumbnail(&huge_u8, 1, 1);
 
-        let huge_u16: SingleColor<crate::Luma<u16>> = SingleColor {
-            color: crate::Luma([65535]),
-            width: 1024,
-            height: 1024,
-        }; // 1024^2 * 65535 obviously overflows 2^32
+        // 1024^2 * 65535 obviously overflows 2^32
+        let huge_u16 = ImageBuffer::from_pixel(1024, 1024, crate::Luma([65535_u16]));
         super::thumbnail(&huge_u16, 1, 1);
     }
 }


### PR DESCRIPTION
Addresses L20 from #2954.

While Claude correctly reported that `(right - left) * (top - bottom)` can overflow, it missed the much larger issues that `sum` can overflow easily.

This PR fixes both issues by splitting large blocks into smaller ones. This doesn't make overflow impossible, but much harder to hit. In particular, all subpixel types now support at least 2^32 pixels per block.

**Fly-by improvements:** I noticed that some f32 -> subpixel casts weren't rounded correctly, so I replaced them with `NearestFrom`.

---

The test I added is somewhat slow. It takes 1.7 sec to run on my machine because the u8 case needs to sum ~2^24 bytes. Unfortunately, tests run without optimizations... I tried implementing a single-color `GenericImageView` (which returns a constant for `get_pixel`), but that only got me down to 1.3 sec.