### PR TITLE
PNG: Stricter XMP detection

### DIFF
--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -310,7 +310,7 @@ impl<R: BufRead + Seek> ImageDecoder for PngDecoder<R> {
             .info()
             .utf8_text
             .iter()
-            .find(|chunk| chunk.keyword.contains(XMP_KEY))
+            .find(|chunk| chunk.keyword == XMP_KEY)
             .cloned()
         {
             itx_chunk.decompress_text().map_err(ImageError::from_png)?;


### PR DESCRIPTION
Addresses L43 from #2954.

I think literal equality should be correct here, because the PNG spec says that keyword should be [comparably by equality](https://www.libpng.org/pub/png/spec/1.2/PNG-Chunks.html#:~:text=Keywords%20must%20be%20spelled%20exactly%20as%20registered%2C%20so%20that%20decoders%20can%20use%20simple%20literal%20comparisons%20when%20looking%20for%20particular%20keywords.) and [because of Wikipedia](https://en.wikipedia.org/wiki/PNG#:~:text=The%20Extensible%20Metadata%20Platform%20(XMP)%20uses%20this%20chunk%20with%20a%20keyword%20%27XML%3Acom.adobe.xmp%27).