### PR TITLE
Only change image pixels in `{from,into}_raw_{bgr,bgra}`

### DIFF
--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -1434,13 +1434,13 @@ where
     /// Construct an image by swapping `Bgr` channels into an `Rgb` order.
     pub fn from_raw_bgr(width: u32, height: u32, container: Container) -> Option<Self> {
         let mut img = Self::from_raw(width, height, container)?;
-        S::swizzle_rgb_bgr(img.as_mut());
+        S::swizzle_rgb_bgr(img.subpixels_mut());
         Some(img)
     }
 
     /// Return the underlying raw buffer after converting it into `Bgr` channel order.
     pub fn into_raw_bgr(mut self) -> Container {
-        S::swizzle_rgb_bgr(self.as_mut());
+        S::swizzle_rgb_bgr(self.subpixels_mut());
         self.into_raw()
     }
 }
@@ -1454,13 +1454,13 @@ where
     /// Construct an image by swapping `BgrA` channels into an `RgbA` order.
     pub fn from_raw_bgra(width: u32, height: u32, container: Container) -> Option<Self> {
         let mut img = Self::from_raw(width, height, container)?;
-        S::swizzle_rgba_bgra(img.as_mut());
+        S::swizzle_rgba_bgra(img.subpixels_mut());
         Some(img)
     }
 
     /// Return the underlying raw buffer after converting it into `BgrA` channel order.
     pub fn into_raw_bgra(mut self) -> Container {
-        S::swizzle_rgba_bgra(self.as_mut());
+        S::swizzle_rgba_bgra(self.subpixels_mut());
         self.into_raw()
     }
 }


### PR DESCRIPTION
Addresses C4 and L7 from #2954.


This changes `{from,into}_raw_{bgr,bgra}` to only perform the BGR <-> RGB conversion on pixels in the image. This has 2 effects:

1. If the buffer is too large, then data outside the image is no longer modified. We don't guarantee this, but I think users would expect that we don't do unnecessary work.
2. If the buffer is too small (i.e. invalid), then the `into_raw_*` methods will now panic. This can only happen if the user breaks the invariant of the type. I think panicking is preferable to returning data that does not comply with the invariant of the `ImageBuffer`.