### PR TITLE
TIFF: Add support for f32 grayscale images

### DIFF
--- a/src/codecs/tiff.rs
+++ b/src/codecs/tiff.rs
@@ -118,6 +118,7 @@ where
             tiff::ColorType::Gray(1) => ColorType::L8,
             tiff::ColorType::Gray(8) => ColorType::L8,
             tiff::ColorType::Gray(16) => ColorType::L16,
+            tiff::ColorType::Gray(32) => ColorType::Rgb32F, // TODO: Change to L32f when supported
             tiff::ColorType::GrayA(8) => ColorType::La8,
             tiff::ColorType::GrayA(16) => ColorType::La16,
             tiff::ColorType::RGB(8) => ColorType::Rgb8,
@@ -152,6 +153,7 @@ where
 
         let original_color_type = match tiff_color_type {
             tiff::ColorType::Gray(1) => ExtendedColorType::L1,
+            tiff::ColorType::Gray(32) => ExtendedColorType::L32F,
             tiff::ColorType::CMYK(8) => ExtendedColorType::Cmyk8,
             tiff::ColorType::CMYK(16) => ExtendedColorType::Cmyk16,
             tiff::ColorType::YCbCr(8) => ExtendedColorType::YCbCr8,
@@ -575,6 +577,17 @@ impl<R: BufRead + Seek> ImageDecoder for TiffDecoder<R> {
                     out_row.copy_from_slice(&utils::expand_bits(1, width, in_row));
                 }
             }
+            DecodingResult::F32(v) if info.original_color_type == ExtendedColorType::L32F => {
+                // convert L32F to RGB32F
+                // TODO: remove when ColorType::L32F is supported
+                let buf_f32 = buf.as_chunks_mut::<4>().0;
+                let buf_f32_rgb = buf_f32.as_chunks_mut::<3>().0;
+
+                for (l, rgb) in v.iter().zip(buf_f32_rgb.iter_mut()) {
+                    let l_bytes = l.to_ne_bytes();
+                    *rgb = [l_bytes; 3];
+                }
+            }
             DecodingResult::U8(v) if info.original_color_type == ExtendedColorType::YCbCr8 => {
                 let [lr, lg, lb] = info.ycbcr_coefficients;
                 let ycbcr = v.as_chunks::<3>().0;
@@ -797,7 +810,7 @@ impl<W: Write + Seek> ImageEncoder for TiffEncoder<W> {
         color_type: ExtendedColorType,
     ) -> ImageResult<()> {
         use tiff::encoder::colortype::{
-            Gray16, Gray8, RGB32Float, RGBA32Float, RGB16, RGB8, RGBA16, RGBA8,
+            Gray16, Gray32Float, Gray8, RGB32Float, RGBA32Float, RGB16, RGB8, RGBA16, RGBA8,
         };
         let expected_buffer_len = color_type.buffer_size(width, height);
         assert_eq!(
@@ -813,6 +826,7 @@ impl<W: Write + Seek> ImageEncoder for TiffEncoder<W> {
             ExtendedColorType::L16 => self.write_tiff::<Gray16>(width, height, buf),
             ExtendedColorType::Rgb16 => self.write_tiff::<RGB16>(width, height, buf),
             ExtendedColorType::Rgba16 => self.write_tiff::<RGBA16>(width, height, buf),
+            ExtendedColorType::L32F => self.write_tiff::<Gray32Float>(width, height, buf),
             ExtendedColorType::Rgb32F => self.write_tiff::<RGB32Float>(width, height, buf),
             ExtendedColorType::Rgba32F => self.write_tiff::<RGBA32Float>(width, height, buf),
             _ => Err(ImageError::Unsupported(
@@ -839,7 +853,10 @@ impl<W: Write + Seek> ImageEncoder for TiffEncoder<W> {
 mod tests {
     use std::io::Cursor;
 
-    use crate::{ExtendedColorType, ImageDecoder as _, ImageEncoder};
+    use crate::{
+        EncodableLayout, ExtendedColorType, GenericImageView, ImageBuffer, ImageDecoder as _,
+        ImageEncoder, ImageReader, Luma, Pixel, PixelWithColorType, Rgb, Rgba,
+    };
 
     use super::{TiffDecoder, TiffEncoder};
 
@@ -863,5 +880,47 @@ mod tests {
             .expect("Error decoding XMP")
             .expect("XMP is empty");
         assert_eq!(xmp, decoded_xmp);
+    }
+
+    #[test]
+    fn roundtrip_color_types() {
+        let img_l8 = ImageBuffer::from_fn(32, 32, |x, y| Luma([(x + y) as u8]));
+        let img_rgb8 = ImageBuffer::from_fn(32, 32, |x, y| Rgb([x as u8, y as u8, (x + y) as u8]));
+        let img_rgba8 = ImageBuffer::from_fn(32, 32, |x, y| {
+            Rgba([x as u8, y as u8, (x + y) as u8, (x * y) as u8])
+        });
+
+        assert_roundtrip::<Luma<u8>>(&img_l8);
+        assert_roundtrip::<Rgb<u8>>(&img_rgb8);
+        assert_roundtrip::<Rgba<u8>>(&img_rgba8);
+
+        assert_roundtrip::<Luma<u16>>(&img_l8.convert());
+        assert_roundtrip::<Rgb<u16>>(&img_rgb8.convert());
+        assert_roundtrip::<Rgba<u16>>(&img_rgba8.convert());
+
+        assert_roundtrip::<Luma<f32>>(&img_l8.convert());
+        assert_roundtrip::<Rgb<f32>>(&img_rgb8.convert());
+        assert_roundtrip::<Rgba<f32>>(&img_rgba8.convert());
+
+        fn assert_roundtrip<P: Pixel + PixelWithColorType>(img: &ImageBuffer<P, Vec<P::Subpixel>>)
+        where
+            [P::Subpixel]: EncodableLayout,
+            Rgba<u8>: crate::color::FromColor<P>,
+        {
+            let mut encoded = Vec::new();
+            let encoder = TiffEncoder::new(Cursor::new(&mut encoded));
+            ImageBuffer::write_with_encoder(img, encoder).expect("Could not encoder image");
+
+            let mut reader = ImageReader::new(Cursor::new(encoded)).unwrap();
+            let (decoded, meta) = reader.decode().expect("Could not decode image");
+
+            assert_eq!(img.dimensions(), decoded.dimensions());
+            assert_eq!(Some(P::COLOR_TYPE), meta.attributes().original_color_type);
+
+            let img_rgba8 = img.convert::<Rgba<u8>>();
+            let decoded_rgba8 = decoded.to_rgba8();
+
+            assert_eq!(img_rgba8, decoded_rgba8);
+        }
     }
 }

--- a/src/codecs/tiff.rs
+++ b/src/codecs/tiff.rs
@@ -118,7 +118,7 @@ where
             tiff::ColorType::Gray(1) => ColorType::L8,
             tiff::ColorType::Gray(8) => ColorType::L8,
             tiff::ColorType::Gray(16) => ColorType::L16,
-            tiff::ColorType::Gray(32) => ColorType::Rgb32F, // TODO: Change to L32f when supported
+            tiff::ColorType::Gray(32) => ColorType::L32F,
             tiff::ColorType::GrayA(8) => ColorType::La8,
             tiff::ColorType::GrayA(16) => ColorType::La16,
             tiff::ColorType::RGB(8) => ColorType::Rgb8,
@@ -153,7 +153,6 @@ where
 
         let original_color_type = match tiff_color_type {
             tiff::ColorType::Gray(1) => ExtendedColorType::L1,
-            tiff::ColorType::Gray(32) => ExtendedColorType::L32F,
             tiff::ColorType::CMYK(8) => ExtendedColorType::Cmyk8,
             tiff::ColorType::CMYK(16) => ExtendedColorType::Cmyk16,
             tiff::ColorType::YCbCr(8) => ExtendedColorType::YCbCr8,
@@ -575,17 +574,6 @@ impl<R: BufRead + Seek> ImageDecoder for TiffDecoder<R> {
                     .zip(buf.chunks_exact_mut(width as usize))
                 {
                     out_row.copy_from_slice(&utils::expand_bits(1, width, in_row));
-                }
-            }
-            DecodingResult::F32(v) if info.original_color_type == ExtendedColorType::L32F => {
-                // convert L32F to RGB32F
-                // TODO: remove when ColorType::L32F is supported
-                let buf_f32 = buf.as_chunks_mut::<4>().0;
-                let buf_f32_rgb = buf_f32.as_chunks_mut::<3>().0;
-
-                for (l, rgb) in v.iter().zip(buf_f32_rgb.iter_mut()) {
-                    let l_bytes = l.to_ne_bytes();
-                    *rgb = [l_bytes; 3];
                 }
             }
             DecodingResult::U8(v) if info.original_color_type == ExtendedColorType::YCbCr8 => {


### PR DESCRIPTION
I added support for encoding and decoding f32 grayscale TIFF images. Encoding is supported directly (thanks to #2793), but decoding is awkward. Since `ColorType` doesn't support L32F, I convert the grayscale data to RGB. This works but is a rather ugly workaround (#2934 would be nice). 

I also added a test for roundtrip encoding decoding for important color types.