### PR TITLE
Remove `Format::can_{read,write}`

### DIFF
--- a/src/io/format.rs
+++ b/src/io/format.rs
@@ -210,52 +210,6 @@ impl ImageFormat {
         }
     }
 
-    /// Return if the `ImageFormat` can be decoded by the lib.
-    #[inline]
-    #[must_use]
-    pub fn can_read(&self) -> bool {
-        // Needs to be updated once a new variant's decoder is added to free_functions.rs::load
-        match self {
-            ImageFormat::Png => true,
-            ImageFormat::Gif => true,
-            ImageFormat::Jpeg => true,
-            ImageFormat::WebP => true,
-            ImageFormat::Tiff => true,
-            ImageFormat::Tga => true,
-            ImageFormat::Bmp => true,
-            ImageFormat::Ico => true,
-            ImageFormat::Hdr => true,
-            ImageFormat::OpenExr => true,
-            ImageFormat::Pnm => true,
-            ImageFormat::Farbfeld => true,
-            ImageFormat::Avif => true,
-            ImageFormat::Qoi => true,
-        }
-    }
-
-    /// Return if the `ImageFormat` can be encoded by the lib.
-    #[inline]
-    #[must_use]
-    pub fn can_write(&self) -> bool {
-        // Needs to be updated once a new variant's encoder is added to free_functions.rs::save_buffer_with_format_impl
-        match self {
-            ImageFormat::Gif => true,
-            ImageFormat::Ico => true,
-            ImageFormat::Jpeg => true,
-            ImageFormat::Png => true,
-            ImageFormat::Bmp => true,
-            ImageFormat::Tiff => true,
-            ImageFormat::Tga => true,
-            ImageFormat::Pnm => true,
-            ImageFormat::Farbfeld => true,
-            ImageFormat::Avif => true,
-            ImageFormat::WebP => true,
-            ImageFormat::Hdr => true,
-            ImageFormat::OpenExr => true,
-            ImageFormat::Qoi => true,
-        }
-    }
-
     /// Return a list of applicable extensions for this format.
     ///
     /// All currently recognized image formats specify at least on extension but for future


### PR DESCRIPTION
Since the removal of DDS, all formats implemented by `image` have been able to both encode and decode images. This makes `Format::can_{read,write}` functionally useless since they always return true. Given #2908 and that we now have `image-extras`, I think it is unlikely that partially implemented formats will be added again in the future.