### PR TITLE
Change `Frame` from `RgbaImage` to `DynamicImage`

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 use std::time::Duration;
 
 use crate::error::ImageResult;
-use crate::RgbaImage;
+use crate::DynamicImage;
 
 /// An implementation dependent iterator, reading the frames as requested
 pub struct Frames<'a> {
@@ -43,7 +43,7 @@ pub struct Frame {
     left: u32,
     /// y offset
     top: u32,
-    buffer: RgbaImage,
+    buffer: DynamicImage,
 }
 
 /// The delay of a frame relative to the previous one.
@@ -68,7 +68,7 @@ pub struct Delay {
 impl Frame {
     /// Constructs a new frame without any delay.
     #[must_use]
-    pub fn new(buffer: RgbaImage) -> Frame {
+    pub fn new(buffer: DynamicImage) -> Frame {
         Frame {
             delay: Delay::from_ratio(Ratio { numer: 0, denom: 1 }),
             left: 0,
@@ -79,7 +79,7 @@ impl Frame {
 
     /// Constructs a new frame
     #[must_use]
-    pub fn from_parts(buffer: RgbaImage, left: u32, top: u32, delay: Delay) -> Frame {
+    pub fn from_parts(buffer: DynamicImage, left: u32, top: u32, delay: Delay) -> Frame {
         Frame {
             delay,
             left,
@@ -96,18 +96,18 @@ impl Frame {
 
     /// Returns the image buffer
     #[must_use]
-    pub fn buffer(&self) -> &RgbaImage {
+    pub fn buffer(&self) -> &DynamicImage {
         &self.buffer
     }
 
     /// Returns a mutable image buffer
-    pub fn buffer_mut(&mut self) -> &mut RgbaImage {
+    pub fn buffer_mut(&mut self) -> &mut DynamicImage {
         &mut self.buffer
     }
 
     /// Returns the image buffer
     #[must_use]
-    pub fn into_buffer(self) -> RgbaImage {
+    pub fn into_buffer(self) -> DynamicImage {
         self.buffer
     }
 

--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -579,7 +579,7 @@ impl<W: Write> GifEncoder<W> {
         // get the delay before converting img_frame
         let frame_delay = img_frame.delay().into_ratio().to_integer();
         // convert img_frame into RgbaImage
-        let mut rbga_frame = img_frame.into_buffer();
+        let mut rbga_frame = img_frame.into_buffer().to_rgba8();
         let (width, height) = self.gif_dimensions(rbga_frame.width(), rbga_frame.height())?;
 
         // Create the gif::Frame from the animation::Frame

--- a/src/io/image_reader_type.rs
+++ b/src/io/image_reader_type.rs
@@ -845,7 +845,6 @@ impl<'stream> ImageReader<'stream> {
             let x = frame_decoded.attributes().x;
             let y = frame_decoded.attributes().y;
             let delay = frame_decoded.attributes().delay.unwrap_or(no_delay);
-            let frame = frame.into_rgba8();
 
             let frame = Frame::from_parts(frame, x, y, delay);
             Some(Ok(frame))

--- a/tests/reference_images.rs
+++ b/tests/reference_images.rs
@@ -106,8 +106,7 @@ fn main() -> std::process::ExitCode {
                             // Select a single frame
                             let frame = frames.drain(frame_num..).next().unwrap();
 
-                            // Convert the frame to a`RgbaImage`
-                            DynamicImage::from(frame.into_buffer())
+                            frame.into_buffer()
                         }
 
                         #[cfg(feature = "png")]
@@ -121,8 +120,7 @@ fn main() -> std::process::ExitCode {
                             // Select a single frame
                             let frame = frames.drain(frame_num..).next().unwrap();
 
-                            // Convert the frame to a`RgbaImage`
-                            DynamicImage::from(frame.into_buffer())
+                            frame.into_buffer()
                         }
                         _ => unreachable!(
                             "Format is unspported or disabled. Should have been detected earlier"


### PR DESCRIPTION
Fixes #2996.
Might also fix (idk) #2398.

This PR changes `Frame` to use an `DynamicImage` internally. This allows `Frames` and co. to represent animations that aren't RGBA8. As a side effect, this removes a forced DynImg -> Rgba8 conversion in `ImageReader::into_frames`, but also adds one in `GifEncoder`.

Not sure if we super duper want/need this.

Also, we may want to rename `Frame::buffer` to `Frame::image` (same for related methods), but I'm not sure if it's worth it.
