### PR TITLE
Add `with_format_from_path` to `ImageReaderOptions`

### DIFF
--- a/src/io/image_reader_type.rs
+++ b/src/io/image_reader_type.rs
@@ -140,6 +140,30 @@ impl<'a, R: 'a + BufRead + Seek> ImageReaderOptions<R> {
         self.format = Some(Format::BuiltIn(format));
     }
 
+    /// Make a format guess based on the given path, replacing it on success.
+    ///
+    /// If the path has no extension or the extension is empty, nothing changes.
+    /// No IO operation is performed.
+    ///
+    /// ## Example
+    ///
+    /// ```no_run
+    /// # use image::ImageError;
+    /// # use image::ImageReaderOptions;
+    /// # fn main() -> Result<(), ImageError> {
+    /// # let some_data = std::io::Cursor::new(&[]);
+    /// let image = ImageReaderOptions::new(some_data)
+    ///     .with_format_from_path("image.png")
+    ///     .decode()?;
+    /// # Ok(()) }
+    /// ```
+    pub fn with_format_from_path<P: AsRef<Path>>(mut self, path: P) -> Self {
+        if let Some(ext) = path.as_ref().extension().filter(|ext| !ext.is_empty()) {
+            self.format = Some(Format::Extension(ext.to_owned()));
+        }
+        self
+    }
+
     /// Remove the current information on the image format.
     ///
     /// Note that many operations require format information to be present and will return e.g. an
@@ -368,17 +392,8 @@ impl ImageReaderOptions<BufReader<File>> {
     }
 
     fn open_impl(path: &Path) -> io::Result<Self> {
-        let format = path
-            .extension()
-            .filter(|ext| !ext.is_empty())
-            .map(|ext| Format::Extension(ext.to_owned()));
-
-        Ok(ImageReaderOptions {
-            inner: BufReader::new(File::open(path)?),
-            format,
-            limits: Limits::default(),
-            spec_compliance: SpecCompliance::default(),
-        })
+        let reader = BufReader::new(File::open(path)?);
+        Ok(Self::new(reader).with_format_from_path(path))
     }
 }
 


### PR DESCRIPTION
This change makes the logic turning a path to a format in `ImageReaderOptions::open` public using the new `ImageReaderOptions::with_format_from_path` function.

The main use case here is that it's now possible (and easy) to create an `ImageReaderOptions` (and `ImageReader`) with the exact same semantics as `::open` but with a custom reader. This previously wasn't possible, because we had no way to set the format based on a path or file extension.

Note: I view this as orthogonal to changes like #2683 and #2662. My main goal here is that `::open` shouldn't have magic sauce that users can't recreate. I also want a sort of progressive disclosure, where we don't let the user fall directly into the dark pits of complexity but provide a path downward that they can descend at their own pace.

This resolves #1659. The user can now create their own `BufReader` with a given capacity and pass it to `ImageReaderOptions::new` like so:

```rs
// works exactly like `ImageReaderOptions::open(path).into_dimensions()` but with custom capacity
let file = File::open(path)?;
let reader = BufReader::with_capacity(1024, file);
let dimensions = ImageReaderOptions::new(reader)
    .with_format_from_path(path)
    .into_dimensions()?;
```

---

Bikeshedding: I couldn't decide between making the new method builder-like and setter-like. The things on `ImageReaderOptions` are a weird mix of functions that look like they belong to a builder and functions that don't. For example, `::limits` is a setter and `::format` is a getter. I went with `with_format_from_path` to mimic `with_guessed_format`, but I'm not married to the idea.