### PR TITLE
Add `f16` color formats to `ExtendedColorType`

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -153,7 +153,6 @@ pub enum ExtendedColorType {
     /// Pixel is 8-bit BGR with an alpha channel
     Bgra8,
 
-    // TODO f16 types?
     /// Pixel is 32-bit float luminance
     L32F,
     /// Pixel is 32-bit float luminance with an alpha channel
@@ -170,6 +169,15 @@ pub enum ExtendedColorType {
 
     /// Pixel is 8-bit YCbCr
     YCbCr8,
+
+    /// Pixel is 16-bit float luminance
+    L16F,
+    /// Pixel is 16-bit float luminance with an alpha channel
+    La16F,
+    /// Pixel is 16-bit float RGB
+    Rgb16F,
+    /// Pixel is 16-bit float RGBA
+    Rgba16F,
 
     /// Pixel is of unknown color type with the specified bits per pixel. This can apply to pixels
     /// which are associated with an external palette. In that case, the pixel value is an index
@@ -191,6 +199,7 @@ impl ExtendedColorType {
             | ExtendedColorType::L4
             | ExtendedColorType::L8
             | ExtendedColorType::L16
+            | ExtendedColorType::L16F
             | ExtendedColorType::L32F
             | ExtendedColorType::Unknown(_) => 1,
             ExtendedColorType::La1
@@ -198,6 +207,7 @@ impl ExtendedColorType {
             | ExtendedColorType::La4
             | ExtendedColorType::La8
             | ExtendedColorType::La16
+            | ExtendedColorType::La16F
             | ExtendedColorType::La32F => 2,
             ExtendedColorType::Rgb1
             | ExtendedColorType::Rgb2
@@ -205,6 +215,7 @@ impl ExtendedColorType {
             | ExtendedColorType::Rgb5x1
             | ExtendedColorType::Rgb8
             | ExtendedColorType::Rgb16
+            | ExtendedColorType::Rgb16F
             | ExtendedColorType::Rgb32F
             | ExtendedColorType::YCbCr8
             | ExtendedColorType::Bgr8 => 3,
@@ -213,6 +224,7 @@ impl ExtendedColorType {
             | ExtendedColorType::Rgba4
             | ExtendedColorType::Rgba8
             | ExtendedColorType::Rgba16
+            | ExtendedColorType::Rgba16F
             | ExtendedColorType::Rgba32F
             | ExtendedColorType::Bgra8
             | ExtendedColorType::Cmyk8
@@ -246,6 +258,10 @@ impl ExtendedColorType {
             ExtendedColorType::La16 => 32,
             ExtendedColorType::Rgb16 => 48,
             ExtendedColorType::Rgba16 => 64,
+            ExtendedColorType::L16F => 16,
+            ExtendedColorType::La16F => 32,
+            ExtendedColorType::Rgb16F => 48,
+            ExtendedColorType::Rgba16F => 64,
             ExtendedColorType::L32F => 32,
             ExtendedColorType::La32F => 64,
             ExtendedColorType::Rgb32F => 96,


### PR DESCRIPTION
I split off `f16` colors from #3015, because that PR might take a little.

## Motivation

fp16 is already a common and widespread format for representing colors. It can losslessly represent 11-bit UNORM and has the ability to represent number outside the range 0-1. This makes it a great format for HDR content. Image formats that natively support fp16 are TIFF and DDS.

While Rust itself has yet to stabilize `f16`, there is value in adding these to `ExtendedColorType` even if we don't support de/encoding images with it *right now*. The main pro is that decoders can use these variants to accurately report the original color type. For example, DDS has the `R16G16B16A16_FLOAT` color type.

### Description

I added `L16F`, `La16F`, `Rgb16F`, and `Rgba16F` to `ExtendedColorType`. They are placed last (but before `Unknown(u8)`) to not mess with serde.
