### PR TITLE
Remove YCbCr8 mapping from `ExtendedColorType::color_type`

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -296,7 +296,6 @@ impl ExtendedColorType {
             ExtendedColorType::La32F => Some(ColorType::La32F),
             ExtendedColorType::Rgb32F => Some(ColorType::Rgb32F),
             ExtendedColorType::Rgba32F => Some(ColorType::Rgba32F),
-            ExtendedColorType::YCbCr8 => Some(ColorType::Rgb8),
             _ => None,
         }
     }


### PR DESCRIPTION
We messed up when reviewing #2817. Or at least, I didn't catch that.

`YCbCr8` is obviously not equivalent to `Rgb8`, so it should not be in `ExtendedColorType::color_type`.