### PR TITLE
fix(bmp): reject zero height for ICO-embedded BMP (panic on crafted input)

### DIFF
--- a/src/codecs/bmp/decoder.rs
+++ b/src/codecs/bmp/decoder.rs
@@ -1729,6 +1729,15 @@ impl<R: BufRead + Seek> BmpDecoder<R> {
         // The height field in an ICO file is doubled to account for the AND mask
         // (whether or not an AND mask is actually present).
         self.height /= 2;
+
+        // The halving above happens after `read_metadata`'s overflow/zero checks,
+        // so a malformed entry with an odd doubled-height (e.g. 1) leaves height at
+        // 0 here. A zero height would later panic in the pixel readers, which do
+        // `(self.height - 1).try_into::<u32>().unwrap()`. Reject it as invalid.
+        if self.height == 0 {
+            return Err(DecoderError::InvalidHeight.into());
+        }
+
         Ok(())
     }
 

--- a/src/codecs/ico/decoder.rs
+++ b/src/codecs/ico/decoder.rs
@@ -644,4 +644,46 @@ mod test {
             IcoDecoder::with_spec_compliance(std::io::Cursor::new(&data), SpecCompliance::Strict);
         assert!(decoder_strict.is_err());
     }
+
+    // A BMP-backed ICO entry whose embedded BITMAPINFOHEADER height is odd (here 1)
+    // is halved to 0 by the ICO double-height convention. Decoding must return an
+    // error, not panic in the BMP pixel reader. Regression test for the
+    // `(self.height - 1).try_into().unwrap()` panic.
+    #[test]
+    fn ico_bmp_odd_embedded_height_does_not_panic() {
+        let mut v: Vec<u8> = Vec::new();
+        // ICONDIR: reserved=0, type=1 (icon), count=1
+        v.extend_from_slice(&[0, 0, 1, 0, 1, 0]);
+        // ICONDIRENTRY (16 bytes)
+        v.extend_from_slice(&[1, 1, 0, 0]); // width, height, color_count, reserved
+        v.extend_from_slice(&1u16.to_le_bytes()); // color planes
+        v.extend_from_slice(&32u16.to_le_bytes()); // bpp
+        let len_pos = v.len();
+        v.extend_from_slice(&0u32.to_le_bytes()); // image_length (patched below)
+        v.extend_from_slice(&22u32.to_le_bytes()); // image_offset = 6 + 16
+        let img_start = v.len();
+        // BITMAPINFOHEADER (40 bytes), no BITMAPFILEHEADER (ICO convention)
+        v.extend_from_slice(&40u32.to_le_bytes()); // header size
+        v.extend_from_slice(&1i32.to_le_bytes()); // width = 1
+        v.extend_from_slice(&1i32.to_le_bytes()); // height = 1 (odd -> halves to 0)
+        v.extend_from_slice(&1u16.to_le_bytes()); // planes
+        v.extend_from_slice(&32u16.to_le_bytes()); // bit_count = 32 (full-byte path)
+        v.extend_from_slice(&0u32.to_le_bytes()); // compression = BI_RGB
+        v.extend_from_slice(&[0u8; 20]); // size_image, ppm x/y, colors_used, important
+        v.extend_from_slice(&[0u8; 64]); // pixel/mask bytes
+        let img_len = (v.len() - img_start) as u32;
+        v[len_pos..len_pos + 4].copy_from_slice(&img_len.to_le_bytes());
+
+        // Default (lenient) mode — the path used by `image::load_from_memory`.
+        // The decode must fail with an error rather than panic; the error may
+        // surface at any stage (construction is fail-fast here).
+        let decode = |bytes: &[u8]| -> ImageResult<()> {
+            let mut decoder = IcoDecoder::new(std::io::Cursor::new(bytes))?;
+            let total = decoder.prepare_image()?.total_bytes();
+            let mut buf = vec![0u8; usize::try_from(total).unwrap()];
+            decoder.read_image(&mut buf)?;
+            Ok(())
+        };
+        assert!(decode(&v).is_err());
+    }
 }


### PR DESCRIPTION

A BMP-backed ICO whose embedded `BITMAPINFOHEADER` height is odd (e.g. `1`) panics
the decoder instead of returning an error. Reachable on the default (lenient)
`image::load_from_memory` path with a ~120-byte input.

### Cause

`read_metadata_in_ico_format` halves the BMP height to undo the ICO double-height
convention (`src/codecs/bmp/decoder.rs:1731`). This halving runs *after*
`read_metadata`'s dimension validation, so an entry with an odd doubled-height
leaves `self.height == 0`. The full-byte (24/32-bit) and 16-bit pixel readers then
evaluate `(self.height - 1).try_into::<u32>().unwrap()`, which panics with
`TryFromIntError` on a zero height.

A standalone BMP with `height == 0` is already rejected by `check_for_overflow`;
only the ICO halving can produce a post-validation zero.

### Fix

Reject a zero height immediately after halving, reusing the existing
`DecoderError::InvalidHeight` and mirroring the `width < 0` / `height == i32::MIN`
checks already in the same parser. No public API change.

A regression test is added first (it panics without the fix); the fix commit makes
it pass. The existing BMP/ICO unit suites and the `tests/bad/` corpus stay green.

### Minimal reproducer

```rust
// default (lenient) decode of a 1x1 32bpp BMP-in-ICO whose embedded
// BITMAPINFOHEADER height is 1 -> halved to 0 -> panic at decoder.rs:2054
let mut v = vec![0,0,1,0,1,0, 1,1,0,0, 1,0, 32,0];      // ICONDIR + entry head
v.extend_from_slice(&104u32.to_le_bytes());              // image_length
v.extend_from_slice(&22u32.to_le_bytes());               // image_offset
v.extend_from_slice(&40u32.to_le_bytes());               // BITMAPINFOHEADER size
v.extend_from_slice(&1i32.to_le_bytes());                // width = 1
v.extend_from_slice(&1i32.to_le_bytes());                // height = 1 (odd)
v.extend_from_slice(&[1,0, 32,0]);                       // planes, bpp=32
v.extend_from_slice(&[0u8; 80]);                         // compression + pixels
let _ = image::load_from_memory_with_format(&v, image::ImageFormat::Ico); // panics on main
```