### PR TITLE
ICO encoder: Write 1 color plane

### DIFF
--- a/src/codecs/ico/encoder.rs
+++ b/src/codecs/ico/encoder.rs
@@ -197,8 +197,8 @@ fn write_direntry<W: Write>(
     w.write_u8(0)?;
     // Reserved field (must be zero):
     w.write_u8(0)?;
-    // Color planes:
-    w.write_u16::<LittleEndian>(0)?;
+    // Color planes: 1 is correct, 0 is merely accepted in most circumstances.
+    w.write_u16::<LittleEndian>(1)?;
     // Bits per pixel:
     w.write_u16::<LittleEndian>(color.bits_per_pixel())?;
     // Image data size, in bytes:


### PR DESCRIPTION
[According to Wikipedia](https://en.wikipedia.org/wiki/ICO_(file_format)#cite_note-iconPlanes-17), "Setting the color planes to 0 or 1 is treated equivalently by the operating system". However, I found that there are edge cases where 0 and 1 are not treated equally and only 1 is accepted (the size fallback from #3042 only seems to trigger if `wPlanes` is 1). The corresponding `biPlanes` in `BITMAPINFOHEADER` is also required to 1.

For those reasons, I think our encoder should emit 1 for color planes for best compatibility. This PR implements that.
