### PR TITLE
ICO: Change select best entry logic

### DIFF
--- a/src/codecs/ico/decoder.rs
+++ b/src/codecs/ico/decoder.rs
@@ -192,7 +192,19 @@ fn read_entry<R: Read>(r: &mut R, spec: SpecCompliance) -> ImageResult<DirEntry>
     }
 
     // buf[6..8]: may be bit depth (0 = unspecified) or vertical hotspot for CUR files
-    let bits_per_pixel = u16::from_le_bytes(buf[6..8].try_into().unwrap());
+    let mut bits_per_pixel = u16::from_le_bytes(buf[6..8].try_into().unwrap());
+    let color_count = buf[2];
+
+    // Some icons don't have a bit depth, only a color count. Convert the color count
+    // to the minimum necessary bit depth.
+    if bits_per_pixel == 0 {
+        let count = match color_count {
+            0 => 256,
+            c => u16::from(c),
+        };
+        bits_per_pixel = count.next_power_of_two().trailing_zeros() as u16;
+    }
+
     if spec == SpecCompliance::Strict && bits_per_pixel > 256 {
         return Err(DecoderError::IcoEntryTooManyBitsPerPixelOrHotspot.into());
     }
@@ -200,7 +212,7 @@ fn read_entry<R: Read>(r: &mut R, spec: SpecCompliance) -> ImageResult<DirEntry>
     Ok(DirEntry {
         width: buf[0],
         height: buf[1],
-        color_count: buf[2],
+        color_count,
         reserved: buf[3],
         num_color_planes,
         bits_per_pixel,
@@ -209,9 +221,9 @@ fn read_entry<R: Read>(r: &mut R, spec: SpecCompliance) -> ImageResult<DirEntry>
     })
 }
 
-/// Find the entry with the highest (color depth, size).
+/// Find the entry with the highest (size, color depth).
 ///
-/// If two entries have the same color depth and size, pick the first one.
+/// If two entries have the same size and color depth, pick the first one.
 /// While ICO files with multiple identical size and bpp entries are rare, they
 /// do exist. Since we can't make an educated guess which one is best, picking
 /// the first one is a reasonable default.
@@ -221,8 +233,8 @@ fn best_entry(entries: Vec<DirEntry>) -> ImageResult<DirEntry> {
         .rev() // ties should pick the first entry, not the last
         .max_by_key(|entry| {
             (
-                entry.bits_per_pixel,
                 u32::from(entry.real_width()) * u32::from(entry.real_height()),
+                entry.bits_per_pixel,
             )
         })
         .ok_or(DecoderError::NoEntries.into())
@@ -643,5 +655,29 @@ mod test {
         let decoder_strict =
             IcoDecoder::with_spec_compliance(std::io::Cursor::new(&data), SpecCompliance::Strict);
         assert!(decoder_strict.is_err());
+    }
+
+    #[test]
+    fn best_entry_selection() {
+        let data = vec![
+            0x00, 0x00, 0x01, 0x00, 0x02, 0x00,
+            // Entry 1: 16x16, 32 bpp
+            16, 16, 0, 0, 1, 0, 32, 0, 8, 0, 0, 0, 38, 0, 0, 0, 
+            // Entry 2: 32x32, 0 bpp, 0 color_count
+            32, 32, 0, 0, 1, 0, 0, 0, 8, 0, 0, 0, 46, 0, 0, 0,
+        ];
+
+        let mut r = std::io::Cursor::new(&data);
+        let entries = read_entries(&mut r, SpecCompliance::Lenient).unwrap();
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].width, 16);
+        assert_eq!(entries[0].bits_per_pixel, 32);
+
+        assert_eq!(entries[1].width, 32);
+        assert_eq!(entries[1].bits_per_pixel, 8);
+
+        let best = best_entry(entries).unwrap();
+        assert_eq!(best.width, 32);
     }
 }

--- a/src/codecs/ico/decoder.rs
+++ b/src/codecs/ico/decoder.rs
@@ -193,6 +193,10 @@ fn read_entry<R: Read>(r: &mut R, spec: SpecCompliance) -> ImageResult<DirEntry>
 
     // buf[6..8]: may be bit depth (0 = unspecified) or vertical hotspot for CUR files
     let mut bits_per_pixel = u16::from_le_bytes(buf[6..8].try_into().unwrap());
+    if spec == SpecCompliance::Strict && bits_per_pixel > 256 {
+        return Err(DecoderError::IcoEntryTooManyBitsPerPixelOrHotspot.into());
+    }
+
     let color_count = buf[2];
 
     // Some icons don't have a bit depth, only a color count. Convert the color count
@@ -203,10 +207,6 @@ fn read_entry<R: Read>(r: &mut R, spec: SpecCompliance) -> ImageResult<DirEntry>
             c => u16::from(c),
         };
         bits_per_pixel = count.next_power_of_two().trailing_zeros() as u16;
-    }
-
-    if spec == SpecCompliance::Strict && bits_per_pixel > 256 {
-        return Err(DecoderError::IcoEntryTooManyBitsPerPixelOrHotspot.into());
     }
 
     Ok(DirEntry {
@@ -660,9 +660,8 @@ mod test {
     #[test]
     fn best_entry_selection() {
         let data = vec![
-            0x00, 0x00, 0x01, 0x00, 0x02, 0x00,
-            // Entry 1: 16x16, 32 bpp
-            16, 16, 0, 0, 1, 0, 32, 0, 8, 0, 0, 0, 38, 0, 0, 0, 
+            0x00, 0x00, 0x01, 0x00, 0x02, 0x00, // Entry 1: 16x16, 32 bpp
+            16, 16, 0, 0, 1, 0, 32, 0, 8, 0, 0, 0, 38, 0, 0, 0,
             // Entry 2: 32x32, 0 bpp, 0 color_count
             32, 32, 0, 0, 1, 0, 0, 0, 8, 0, 0, 0, 46, 0, 0, 0,
         ];


### PR DESCRIPTION
As discussed in https://github.com/image-rs/image/pull/3032, this PR updates the best entry selection logic to match the one from Chrome: first, compare the area, and then bpp.  This PR also adds logic to fill in missing bpp values (use `color_count` to set `bits_per_pixel  = ceil(log2(color_count))`).