### PR TITLE
Generic API for encoder options

### DIFF
--- a/src/codecs/avif/encoder.rs
+++ b/src/codecs/avif/encoder.rs
@@ -91,9 +91,7 @@ impl Default for AvifOptions {
     }
 }
 impl EncoderOptions for AvifOptions {
-    type Encoder<W: Write + Seek> = AvifEncoder<W>;
-
-    fn build<W: Write + Seek>(self, w: W) -> ImageResult<Self::Encoder<W>> {
+    fn build<W: Write + Seek>(self, w: W) -> ImageResult<impl ImageEncoder> {
         let encoder = AvifEncoder::new_with_speed_quality(w, self.speed, self.quality)
             .with_colorspace(self.color_space)
             .with_num_threads(self.num_threads);

--- a/src/codecs/avif/encoder.rs
+++ b/src/codecs/avif/encoder.rs
@@ -12,7 +12,7 @@ use crate::color::{FromColor, Luma, LumaA, Rgb, Rgba};
 use crate::error::{
     EncodingError, ParameterError, ParameterErrorKind, UnsupportedError, UnsupportedErrorKind,
 };
-use crate::{ExtendedColorType, ImageBuffer, ImageEncoder, ImageFormat, Pixel};
+use crate::{EncoderOptions, ExtendedColorType, ImageBuffer, ImageEncoder, ImageFormat, Pixel};
 use crate::{ImageError, ImageResult};
 
 use bytemuck::{try_cast_slice, try_cast_slice_mut, Pod, PodCastError};
@@ -50,6 +50,50 @@ impl ColorSpace {
 enum RgbColor<'buf> {
     Rgb8(Img<&'buf [RGB8]>),
     Rgba8(Img<&'buf [RGBA8]>),
+}
+
+/// Encoding options for the AVIF format.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct AvifOptions {
+    /// The quality of the AVIF encoding, from 1 to 100. Higher is better quality and larger file size.
+    ///
+    /// Defaults to **80**.
+    pub quality: u8,
+    /// The speed of the AVIF encoding, from 1 to 10. Higher is faster but lower quality.
+    ///
+    /// Defaults to **4**.
+    pub speed: u8,
+    /// The color space to encode with.
+    ///
+    /// If `None`, the color space will be chosen dynamically for each image. No particular choice
+    /// is guaranteed and the chosen color space may change without warning between versions of the
+    /// library.
+    ///
+    /// Defaults to [`ColorSpace::Bt709`].
+    pub color_space: ColorSpace,
+    /// The number of threads to use for encoding.
+    ///
+    /// If `None`, the encoder will use all available threads.
+    ///
+    /// Defaults to `None`.
+    // TODO: Using `usize` is weird. Also None == all seems weird too. Why not usize::MAX == all?
+    pub num_threads: Option<usize>,
+}
+impl Default for AvifOptions {
+    fn default() -> Self {
+        Self {
+            quality: 80,
+            speed: 4,
+            color_space: ColorSpace::Bt709,
+            num_threads: None,
+        }
+    }
+}
+impl EncoderOptions for AvifOptions {
+    fn format(&self) -> ImageFormat {
+        ImageFormat::Avif
+    }
 }
 
 impl<W: Write> AvifEncoder<W> {
@@ -93,6 +137,21 @@ impl<W: Write> AvifEncoder<W> {
 }
 
 impl<W: Write> ImageEncoder for AvifEncoder<W> {
+    fn set_encoder_options(&mut self, options: &dyn EncoderOptions) -> ImageResult<()> {
+        let avif_options = AvifOptions::try_from_ref(options)?;
+
+        let mut temp = Encoder::new();
+        std::mem::swap(&mut temp, &mut self.encoder);
+        self.encoder = temp
+            .with_quality(f32::from(avif_options.quality.clamp(1, 100)))
+            .with_alpha_quality(f32::from(avif_options.quality.clamp(1, 100)))
+            .with_speed(avif_options.speed.clamp(1, 10))
+            .with_internal_color_model(avif_options.color_space.to_ravif())
+            .with_num_threads(avif_options.num_threads);
+
+        Ok(())
+    }
+
     /// Encode image data with the indicated color type.
     ///
     /// The encoder currently requires all data to be RGBA8, it will be converted internally if

--- a/src/codecs/avif/encoder.rs
+++ b/src/codecs/avif/encoder.rs
@@ -92,9 +92,7 @@ impl Default for AvifOptions {
 }
 impl EncoderOptions for AvifOptions {
     type Encoder<W: Write + Seek> = AvifEncoder<W>;
-    fn format(&self) -> ImageFormat {
-        ImageFormat::Avif
-    }
+
     fn build<W: Write + Seek>(self, w: W) -> ImageResult<Self::Encoder<W>> {
         let encoder = AvifEncoder::new_with_speed_quality(w, self.speed, self.quality)
             .with_colorspace(self.color_space)

--- a/src/codecs/avif/encoder.rs
+++ b/src/codecs/avif/encoder.rs
@@ -5,7 +5,7 @@
 /// [AVIF]: https://aomediacodec.github.io/av1-avif/
 use std::borrow::Cow;
 use std::cmp::min;
-use std::io::Write;
+use std::io::{Seek, Write};
 use std::mem::size_of;
 
 use crate::color::{FromColor, Luma, LumaA, Rgb, Rgba};
@@ -91,8 +91,15 @@ impl Default for AvifOptions {
     }
 }
 impl EncoderOptions for AvifOptions {
+    type Encoder<W: Write + Seek> = AvifEncoder<W>;
     fn format(&self) -> ImageFormat {
         ImageFormat::Avif
+    }
+    fn build<W: Write + Seek>(self, w: W) -> ImageResult<Self::Encoder<W>> {
+        let encoder = AvifEncoder::new_with_speed_quality(w, self.speed, self.quality)
+            .with_colorspace(self.color_space)
+            .with_num_threads(self.num_threads);
+        Ok(encoder)
     }
 }
 
@@ -137,21 +144,6 @@ impl<W: Write> AvifEncoder<W> {
 }
 
 impl<W: Write> ImageEncoder for AvifEncoder<W> {
-    fn set_encoder_options(&mut self, options: &dyn EncoderOptions) -> ImageResult<()> {
-        let avif_options = AvifOptions::try_from_ref(options)?;
-
-        let mut temp = Encoder::new();
-        std::mem::swap(&mut temp, &mut self.encoder);
-        self.encoder = temp
-            .with_quality(f32::from(avif_options.quality.clamp(1, 100)))
-            .with_alpha_quality(f32::from(avif_options.quality.clamp(1, 100)))
-            .with_speed(avif_options.speed.clamp(1, 10))
-            .with_internal_color_model(avif_options.color_space.to_ravif())
-            .with_num_threads(avif_options.num_threads);
-
-        Ok(())
-    }
-
     /// Encode image data with the indicated color type.
     ///
     /// The encoder currently requires all data to be RGBA8, it will be converted internally if

--- a/src/codecs/avif/mod.rs
+++ b/src/codecs/avif/mod.rs
@@ -6,7 +6,7 @@
 #[cfg(feature = "avif-native")]
 pub use self::decoder::AvifDecoder;
 #[cfg(feature = "avif")]
-pub use self::encoder::{AvifEncoder, ColorSpace};
+pub use self::encoder::{AvifEncoder, AvifOptions, ColorSpace};
 
 #[cfg(feature = "avif-native")]
 mod decoder;

--- a/src/codecs/jpeg/encoder.rs
+++ b/src/codecs/jpeg/encoder.rs
@@ -172,9 +172,7 @@ impl Default for JpegOptions {
     }
 }
 impl EncoderOptions for JpegOptions {
-    type Encoder<W: Write + Seek> = JpegEncoder<W>;
-
-    fn build<W: Write + Seek>(self, w: W) -> ImageResult<Self::Encoder<W>> {
+    fn build<W: Write + Seek>(self, w: W) -> ImageResult<impl ImageEncoder> {
         let mut encoder = JpegEncoder::new_with_quality(w, self.quality);
         encoder.set_chroma_subsampling(self.chroma_subsampling);
         encoder.set_optimize_huffman_tables(self.optimize_huffman_tables);

--- a/src/codecs/jpeg/encoder.rs
+++ b/src/codecs/jpeg/encoder.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::too_many_arguments)]
-use std::io::Write;
+use std::io::{Seek, Write};
 use std::{error, fmt};
 
 use crate::error::{
@@ -140,10 +140,10 @@ impl error::Error for EncoderError {}
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct JpegOptions {
-    // /// The quality of the JPEG encoding, from 1 to 100. Higher is better quality and larger file size.
-    // ///
-    // /// Defaults to **75**.
-    // pub quality: u8,
+    /// The quality of the JPEG encoding, from 1 to 100. Higher is better quality and larger file size.
+    ///
+    /// Defaults to **75**.
+    pub quality: u8,
     /// The chroma subsampling mode. See [ChromaSubsampling] for details.
     pub chroma_subsampling: ChromaSubsampling,
     /// Spend extra time optimizing Huffman tables. Slightly reduces file size at the cost of encoding speed.
@@ -163,7 +163,7 @@ pub struct JpegOptions {
 impl Default for JpegOptions {
     fn default() -> Self {
         JpegOptions {
-            // quality: 75,
+            quality: 75,
             chroma_subsampling: ChromaSubsampling::S420,
             optimize_huffman_tables: false,
             progress: false,
@@ -172,8 +172,19 @@ impl Default for JpegOptions {
     }
 }
 impl EncoderOptions for JpegOptions {
+    type Encoder<W: Write + Seek> = JpegEncoder<W>;
     fn format(&self) -> ImageFormat {
         ImageFormat::Jpeg
+    }
+    fn build<W: Write + Seek>(self, w: W) -> ImageResult<Self::Encoder<W>> {
+        let mut encoder = JpegEncoder::new_with_quality(w, self.quality);
+        encoder.set_chroma_subsampling(self.chroma_subsampling);
+        encoder.set_optimize_huffman_tables(self.optimize_huffman_tables);
+        encoder.set_progressive(self.progress);
+        if let Some(pixel_density) = self.pixel_density {
+            encoder.set_pixel_density(pixel_density);
+        }
+        Ok(encoder)
     }
 }
 
@@ -290,20 +301,6 @@ impl<W: Write> JpegEncoder<W> {
 }
 
 impl<W: Write> ImageEncoder for JpegEncoder<W> {
-    fn set_encoder_options(&mut self, options: &dyn EncoderOptions) -> ImageResult<()> {
-        let options = JpegOptions::try_from_ref(options)?;
-
-        // TODO: quality
-        self.set_chroma_subsampling(options.chroma_subsampling);
-        self.set_optimize_huffman_tables(options.optimize_huffman_tables);
-        self.set_progressive(options.progress);
-        if let Some(pixel_density) = options.pixel_density {
-            self.set_pixel_density(pixel_density);
-        }
-
-        Ok(())
-    }
-
     #[track_caller]
     fn write_image(
         self,

--- a/src/codecs/jpeg/encoder.rs
+++ b/src/codecs/jpeg/encoder.rs
@@ -173,9 +173,7 @@ impl Default for JpegOptions {
 }
 impl EncoderOptions for JpegOptions {
     type Encoder<W: Write + Seek> = JpegEncoder<W>;
-    fn format(&self) -> ImageFormat {
-        ImageFormat::Jpeg
-    }
+
     fn build<W: Write + Seek>(self, w: W) -> ImageResult<Self::Encoder<W>> {
         let mut encoder = JpegEncoder::new_with_quality(w, self.quality);
         encoder.set_chroma_subsampling(self.chroma_subsampling);

--- a/src/codecs/jpeg/encoder.rs
+++ b/src/codecs/jpeg/encoder.rs
@@ -5,7 +5,9 @@ use std::{error, fmt};
 use crate::error::{
     EncodingError, ImageError, ImageFormatHint, ImageResult, UnsupportedError, UnsupportedErrorKind,
 };
-use crate::{ColorType, DynamicImage, ExtendedColorType, ImageEncoder, ImageFormat};
+use crate::{
+    ColorType, DynamicImage, EncoderOptions, ExtendedColorType, ImageEncoder, ImageFormat,
+};
 
 use jpeg_encoder::Encoder;
 
@@ -41,7 +43,7 @@ pub enum ChromaSubsampling {
     S422,
     /// **4:2:0** The resolution of color information is reduced by a factor of 2 both horizontally and vertically.
     ///
-    /// Results in a smaller file size. Well suited for photographs where it incurs no visial quality loss.
+    /// Results in a smaller file size. Well suited for photographs where it incurs no visual quality loss.
     S420,
 }
 
@@ -133,6 +135,47 @@ impl From<EncoderError> for ImageError {
 }
 
 impl error::Error for EncoderError {}
+
+/// Encoding options for the JPEG format.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct JpegOptions {
+    // /// The quality of the JPEG encoding, from 1 to 100. Higher is better quality and larger file size.
+    // ///
+    // /// Defaults to **75**.
+    // pub quality: u8,
+    /// The chroma subsampling mode. See [ChromaSubsampling] for details.
+    pub chroma_subsampling: ChromaSubsampling,
+    /// Spend extra time optimizing Huffman tables. Slightly reduces file size at the cost of encoding speed.
+    ///
+    /// Defaults to **false**.
+    pub optimize_huffman_tables: bool,
+    /// Progressive files allow showing a low-resolution view of the entire image before it's fully downloaded.
+    /// Useful for large images that will be displayed on the web.
+    ///
+    /// Defaults to **false**.
+    pub progress: bool,
+    /// The pixel density of the images the encoder will encode.
+    /// If this method is not called, then a default pixel aspect ratio of 1x1 will be applied,
+    /// and no DPI information will be stored in the image.
+    pub pixel_density: Option<PixelDensity>,
+}
+impl Default for JpegOptions {
+    fn default() -> Self {
+        JpegOptions {
+            // quality: 75,
+            chroma_subsampling: ChromaSubsampling::S420,
+            optimize_huffman_tables: false,
+            progress: false,
+            pixel_density: None,
+        }
+    }
+}
+impl EncoderOptions for JpegOptions {
+    fn format(&self) -> ImageFormat {
+        ImageFormat::Jpeg
+    }
+}
 
 /// The representation of a JPEG encoder
 pub struct JpegEncoder<W: Write> {
@@ -247,6 +290,20 @@ impl<W: Write> JpegEncoder<W> {
 }
 
 impl<W: Write> ImageEncoder for JpegEncoder<W> {
+    fn set_encoder_options(&mut self, options: &dyn EncoderOptions) -> ImageResult<()> {
+        let options = JpegOptions::try_from_ref(options)?;
+
+        // TODO: quality
+        self.set_chroma_subsampling(options.chroma_subsampling);
+        self.set_optimize_huffman_tables(options.optimize_huffman_tables);
+        self.set_progressive(options.progress);
+        if let Some(pixel_density) = options.pixel_density {
+            self.set_pixel_density(pixel_density);
+        }
+
+        Ok(())
+    }
+
     #[track_caller]
     fn write_image(
         self,

--- a/src/codecs/jpeg/mod.rs
+++ b/src/codecs/jpeg/mod.rs
@@ -7,7 +7,9 @@
 //! * <http://www.w3.org/Graphics/JPEG/itu-t81.pdf> - The JPEG specification
 
 pub use self::decoder::JpegDecoder;
-pub use self::encoder::{ChromaSubsampling, JpegEncoder, PixelDensity, PixelDensityUnit};
+pub use self::encoder::{
+    ChromaSubsampling, JpegEncoder, JpegOptions, PixelDensity, PixelDensityUnit,
+};
 
 mod decoder;
 mod encoder;

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -25,8 +25,8 @@ use crate::math::Rect;
 use crate::metadata::LoopCount;
 use crate::utils::vec_try_with_capacity;
 use crate::{
-    DynamicImage, GenericImage, GenericImageView, ImageDecoder, ImageEncoder, ImageFormat,
-    ImageLayout, Limits, Luma, LumaA, Rgb, Rgba,
+    DynamicImage, EncoderOptions, GenericImage, GenericImageView, ImageDecoder, ImageEncoder,
+    ImageFormat, ImageLayout, Limits, Luma, LumaA, Rgb, Rgba,
 };
 
 // http://www.w3.org/TR/PNG-Structure.html
@@ -691,9 +691,8 @@ pub struct PngEncoder<W: Write> {
 }
 
 /// DEFLATE compression level of a PNG encoder. The default setting is `Fast`.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Default)]
 #[non_exhaustive]
-#[derive(Default)]
 pub enum CompressionType {
     /// No compression whatsoever
     Uncompressed,
@@ -711,9 +710,8 @@ pub enum CompressionType {
 /// Filter algorithms used to process image data to improve compression.
 ///
 /// The default filter is `Adaptive`.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Default)]
 #[non_exhaustive]
-#[derive(Default)]
 pub enum FilterType {
     /// No processing done, best used for low bit depth grayscale or data with a
     /// low color count
@@ -730,6 +728,35 @@ pub enum FilterType {
     /// scanline rather than one filter for the entire image
     #[default]
     Adaptive,
+}
+
+/// Encoding options for the PNG format.
+///
+/// It is best to view the options as a _hint_ to the implementation on the smallest or fastest
+/// option for encoding a particular image. That is, using options that map directly to a PNG
+/// image parameter will use this parameter where possible. But variants that have no direct
+/// mapping may be interpreted differently in minor versions. The exact output is expressly
+/// __not__ part of the SemVer stability guarantee.
+#[derive(Default, Debug, Clone)]
+#[non_exhaustive]
+pub struct PngOptions {
+    /// DEFLATE compression level of a PNG encoder.
+    ///
+    /// Defaults to [`CompressionType::Fast`].
+    pub compression: CompressionType,
+    /// Filter algorithms used to process image data.
+    ///
+    /// Note that it is not optimal to use a single filter type, so an adaptive
+    /// filter type is selected as the default. The filter which best minimizes
+    /// file size may change with the type of compression used.
+    ///
+    /// Defaults to [`FilterType::Adaptive`].
+    pub filter: FilterType,
+}
+impl EncoderOptions for PngOptions {
+    fn format(&self) -> ImageFormat {
+        ImageFormat::Png
+    }
 }
 
 impl<W: Write> PngEncoder<W> {
@@ -857,6 +884,12 @@ impl<W: Write> PngEncoder<W> {
 }
 
 impl<W: Write> ImageEncoder for PngEncoder<W> {
+    fn set_encoder_options(&mut self, options: &dyn EncoderOptions) -> ImageResult<()> {
+        let options = PngOptions::try_from_ref(options)?;
+        self.compression = options.compression;
+        self.filter = options.filter;
+        Ok(())
+    }
     /// Write a PNG image with the specified width, height, and color type.
     ///
     /// For color types with 16-bit per channel or larger, the contents of `buf` should be in

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -755,9 +755,7 @@ pub struct PngOptions {
 }
 impl EncoderOptions for PngOptions {
     type Encoder<W: Write + Seek> = PngEncoder<W>;
-    fn format(&self) -> ImageFormat {
-        ImageFormat::Png
-    }
+
     fn build<W: Write + Seek>(self, w: W) -> ImageResult<Self::Encoder<W>> {
         Ok(PngEncoder::new_with_quality(
             w,

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -754,8 +754,16 @@ pub struct PngOptions {
     pub filter: FilterType,
 }
 impl EncoderOptions for PngOptions {
+    type Encoder<W: Write + Seek> = PngEncoder<W>;
     fn format(&self) -> ImageFormat {
         ImageFormat::Png
+    }
+    fn build<W: Write + Seek>(self, w: W) -> ImageResult<Self::Encoder<W>> {
+        Ok(PngEncoder::new_with_quality(
+            w,
+            self.compression,
+            self.filter,
+        ))
     }
 }
 
@@ -884,12 +892,6 @@ impl<W: Write> PngEncoder<W> {
 }
 
 impl<W: Write> ImageEncoder for PngEncoder<W> {
-    fn set_encoder_options(&mut self, options: &dyn EncoderOptions) -> ImageResult<()> {
-        let options = PngOptions::try_from_ref(options)?;
-        self.compression = options.compression;
-        self.filter = options.filter;
-        Ok(())
-    }
     /// Write a PNG image with the specified width, height, and color type.
     ///
     /// For color types with 16-bit per channel or larger, the contents of `buf` should be in

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -754,9 +754,7 @@ pub struct PngOptions {
     pub filter: FilterType,
 }
 impl EncoderOptions for PngOptions {
-    type Encoder<W: Write + Seek> = PngEncoder<W>;
-
-    fn build<W: Write + Seek>(self, w: W) -> ImageResult<Self::Encoder<W>> {
+    fn build<W: Write + Seek>(self, w: W) -> ImageResult<impl ImageEncoder> {
         Ok(PngEncoder::new_with_quality(
             w,
             self.compression,

--- a/src/codecs/pnm/encoder.rs
+++ b/src/codecs/pnm/encoder.rs
@@ -46,9 +46,7 @@ pub struct PnmOptions {
 }
 impl EncoderOptions for PnmOptions {
     type Encoder<W: Write + Seek> = PnmEncoder<W>;
-    fn format(&self) -> ImageFormat {
-        ImageFormat::Pnm
-    }
+
     fn build<W: Write + Seek>(self, w: W) -> ImageResult<Self::Encoder<W>> {
         let mut encoder = PnmEncoder::new(w);
         if let Some(subtype) = self.subtype {

--- a/src/codecs/pnm/encoder.rs
+++ b/src/codecs/pnm/encoder.rs
@@ -1,5 +1,6 @@
 //! Encoding of PNM Images
 use crate::utils::vec_try_with_capacity;
+use crate::EncoderOptions;
 use std::fmt;
 use std::io;
 use std::io::Write;
@@ -27,6 +28,25 @@ enum HeaderStrategy {
 pub enum FlatSamples<'a> {
     U8(&'a [u8]),
     U16(&'a [u16]),
+}
+
+/// Encoding options for the PNM format.
+#[derive(Debug, Default, Clone)]
+#[non_exhaustive]
+pub struct PnmOptions {
+    /// The specific PNM subtype to encode to.
+    ///
+    /// If `None`, the subtype will be chosen dynamically for each image. No
+    /// particular choice is guaranteed and the chosen subtype may change
+    /// without warning between versions of the library.
+    ///
+    /// Defaults to `None`.
+    pub subtype: Option<PnmSubtype>,
+}
+impl EncoderOptions for PnmOptions {
+    fn format(&self) -> ImageFormat {
+        ImageFormat::Pnm
+    }
 }
 
 /// Encodes images to any of the `pnm` image formats.
@@ -335,6 +355,17 @@ impl<W: Write> PnmEncoder<W> {
 }
 
 impl<W: Write> ImageEncoder for PnmEncoder<W> {
+    fn set_encoder_options(&mut self, options: &dyn EncoderOptions) -> ImageResult<()> {
+        let options = PnmOptions::try_from_ref(options)?;
+
+        self.header = options
+            .subtype
+            .map(HeaderStrategy::Subtype)
+            .unwrap_or(HeaderStrategy::Dynamic);
+
+        Ok(())
+    }
+
     #[track_caller]
     fn write_image(
         mut self,

--- a/src/codecs/pnm/encoder.rs
+++ b/src/codecs/pnm/encoder.rs
@@ -45,9 +45,7 @@ pub struct PnmOptions {
     pub subtype: Option<PnmSubtype>,
 }
 impl EncoderOptions for PnmOptions {
-    type Encoder<W: Write + Seek> = PnmEncoder<W>;
-
-    fn build<W: Write + Seek>(self, w: W) -> ImageResult<Self::Encoder<W>> {
+    fn build<W: Write + Seek>(self, w: W) -> ImageResult<impl ImageEncoder> {
         let mut encoder = PnmEncoder::new(w);
         if let Some(subtype) = self.subtype {
             encoder = encoder.with_subtype(subtype);

--- a/src/codecs/pnm/encoder.rs
+++ b/src/codecs/pnm/encoder.rs
@@ -3,6 +3,7 @@ use crate::utils::vec_try_with_capacity;
 use crate::EncoderOptions;
 use std::fmt;
 use std::io;
+use std::io::Seek;
 use std::io::Write;
 
 use super::AutoBreak;
@@ -44,8 +45,16 @@ pub struct PnmOptions {
     pub subtype: Option<PnmSubtype>,
 }
 impl EncoderOptions for PnmOptions {
+    type Encoder<W: Write + Seek> = PnmEncoder<W>;
     fn format(&self) -> ImageFormat {
         ImageFormat::Pnm
+    }
+    fn build<W: Write + Seek>(self, w: W) -> ImageResult<Self::Encoder<W>> {
+        let mut encoder = PnmEncoder::new(w);
+        if let Some(subtype) = self.subtype {
+            encoder = encoder.with_subtype(subtype);
+        }
+        Ok(encoder)
     }
 }
 
@@ -355,17 +364,6 @@ impl<W: Write> PnmEncoder<W> {
 }
 
 impl<W: Write> ImageEncoder for PnmEncoder<W> {
-    fn set_encoder_options(&mut self, options: &dyn EncoderOptions) -> ImageResult<()> {
-        let options = PnmOptions::try_from_ref(options)?;
-
-        self.header = options
-            .subtype
-            .map(HeaderStrategy::Subtype)
-            .unwrap_or(HeaderStrategy::Dynamic);
-
-        Ok(())
-    }
-
     #[track_caller]
     fn write_image(
         mut self,

--- a/src/codecs/pnm/mod.rs
+++ b/src/codecs/pnm/mod.rs
@@ -6,7 +6,7 @@
 //! interpretation as an image and will be rejected.
 use self::autobreak::AutoBreak;
 pub use self::decoder::PnmDecoder;
-pub use self::encoder::PnmEncoder;
+pub use self::encoder::{PnmEncoder, PnmOptions};
 use self::header::HeaderRecord;
 pub use self::header::{
     ArbitraryHeader, ArbitraryTuplType, BitmapHeader, GraymapHeader, PixmapHeader,

--- a/src/codecs/tga/encoder.rs
+++ b/src/codecs/tga/encoder.rs
@@ -53,9 +53,7 @@ impl Default for TgaOptions {
     }
 }
 impl EncoderOptions for TgaOptions {
-    type Encoder<W: Write + Seek> = TgaEncoder<W>;
-
-    fn build<W: Write + Seek>(self, w: W) -> ImageResult<Self::Encoder<W>> {
+    fn build<W: Write + Seek>(self, w: W) -> ImageResult<impl ImageEncoder> {
         let mut encoder = TgaEncoder::new(w);
         if !self.use_rle {
             encoder = encoder.disable_rle();

--- a/src/codecs/tga/encoder.rs
+++ b/src/codecs/tga/encoder.rs
@@ -1,6 +1,9 @@
 use super::header::Header;
 use crate::{codecs::tga::header::ImageType, error::EncodingError, utils::vec_try_with_capacity};
-use crate::{DynamicImage, ExtendedColorType, ImageEncoder, ImageError, ImageFormat, ImageResult};
+use crate::{
+    DynamicImage, EncoderOptions, ExtendedColorType, ImageEncoder, ImageError, ImageFormat,
+    ImageResult,
+};
 use std::{error, fmt, io::Write};
 
 /// Errors that can occur during encoding and saving of a TGA image.
@@ -33,6 +36,26 @@ impl From<EncoderError> for ImageError {
 }
 
 impl error::Error for EncoderError {}
+
+/// Encoding options for the TGA format.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct TgaOptions {
+    /// Whether to use run-length encoding (RLE) for the image data.
+    ///
+    /// Defaults to `true`.
+    pub use_rle: bool,
+}
+impl Default for TgaOptions {
+    fn default() -> Self {
+        Self { use_rle: true }
+    }
+}
+impl EncoderOptions for TgaOptions {
+    fn format(&self) -> ImageFormat {
+        ImageFormat::Tga
+    }
+}
 
 /// TGA encoder.
 pub struct TgaEncoder<W: Write> {
@@ -242,6 +265,12 @@ impl<W: Write> TgaEncoder<W> {
 }
 
 impl<W: Write> ImageEncoder for TgaEncoder<W> {
+    fn set_encoder_options(&mut self, options: &dyn EncoderOptions) -> ImageResult<()> {
+        let options = TgaOptions::try_from_ref(options)?;
+        self.use_rle = options.use_rle;
+        Ok(())
+    }
+
     #[track_caller]
     fn write_image(
         self,

--- a/src/codecs/tga/encoder.rs
+++ b/src/codecs/tga/encoder.rs
@@ -54,9 +54,7 @@ impl Default for TgaOptions {
 }
 impl EncoderOptions for TgaOptions {
     type Encoder<W: Write + Seek> = TgaEncoder<W>;
-    fn format(&self) -> ImageFormat {
-        ImageFormat::Tga
-    }
+
     fn build<W: Write + Seek>(self, w: W) -> ImageResult<Self::Encoder<W>> {
         let mut encoder = TgaEncoder::new(w);
         if !self.use_rle {

--- a/src/codecs/tga/encoder.rs
+++ b/src/codecs/tga/encoder.rs
@@ -4,6 +4,7 @@ use crate::{
     DynamicImage, EncoderOptions, ExtendedColorType, ImageEncoder, ImageError, ImageFormat,
     ImageResult,
 };
+use std::io::Seek;
 use std::{error, fmt, io::Write};
 
 /// Errors that can occur during encoding and saving of a TGA image.
@@ -52,8 +53,16 @@ impl Default for TgaOptions {
     }
 }
 impl EncoderOptions for TgaOptions {
+    type Encoder<W: Write + Seek> = TgaEncoder<W>;
     fn format(&self) -> ImageFormat {
         ImageFormat::Tga
+    }
+    fn build<W: Write + Seek>(self, w: W) -> ImageResult<Self::Encoder<W>> {
+        let mut encoder = TgaEncoder::new(w);
+        if !self.use_rle {
+            encoder = encoder.disable_rle();
+        }
+        Ok(encoder)
     }
 }
 
@@ -265,12 +274,6 @@ impl<W: Write> TgaEncoder<W> {
 }
 
 impl<W: Write> ImageEncoder for TgaEncoder<W> {
-    fn set_encoder_options(&mut self, options: &dyn EncoderOptions) -> ImageResult<()> {
-        let options = TgaOptions::try_from_ref(options)?;
-        self.use_rle = options.use_rle;
-        Ok(())
-    }
-
     #[track_caller]
     fn write_image(
         self,

--- a/src/codecs/tga/mod.rs
+++ b/src/codecs/tga/mod.rs
@@ -5,7 +5,7 @@
 
 pub use self::decoder::TgaDecoder;
 
-pub use self::encoder::TgaEncoder;
+pub use self::encoder::{TgaEncoder, TgaOptions};
 
 mod decoder;
 mod encoder;

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -1168,7 +1168,7 @@ where
     ///
     /// See [`save_buffer_with_options`](crate::save_buffer_with_options) for
     /// supported types.
-    pub fn save_with_options<Q>(&self, path: Q, options: &dyn EncoderOptions) -> ImageResult<()>
+    pub fn save_with_options<Q>(&self, path: Q, options: impl EncoderOptions) -> ImageResult<()>
     where
         Q: AsRef<Path>,
     {

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -18,7 +18,10 @@ use crate::{
     metadata::{Cicp, CicpColorPrimaries, CicpTransferCharacteristics, CicpTransform},
     save_buffer, save_buffer_with_format, write_buffer_with_format, ImageError,
 };
-use crate::{DynamicImage, GenericImage, GenericImageView, ImageEncoder, ImageFormat, Primitive};
+use crate::{
+    save_buffer_with_options, DynamicImage, EncoderOptions, GenericImage, GenericImageView,
+    ImageEncoder, ImageFormat, Primitive,
+};
 
 /// Iterate over rows of an image
 ///
@@ -1158,6 +1161,24 @@ where
             self.height(),
             P::COLOR_TYPE,
             format,
+        )
+    }
+
+    /// Saves the buffer to a file at the specified path with the given options.
+    ///
+    /// See [`save_buffer_with_options`](crate::save_buffer_with_options) for
+    /// supported types.
+    pub fn save_with_options<Q>(&self, path: Q, options: &dyn EncoderOptions) -> ImageResult<()>
+    where
+        Q: AsRef<Path>,
+    {
+        save_buffer_with_options(
+            path,
+            self.subpixels().as_bytes(),
+            self.width(),
+            self.height(),
+            P::COLOR_TYPE,
+            options,
         )
     }
 

--- a/src/images/dynimage.rs
+++ b/src/images/dynimage.rs
@@ -1681,6 +1681,8 @@ impl DynamicImage {
     /// ## Example
     ///
     /// ```no_run
+    /// # #[cfg(feature = "png")]
+    /// # fn main() -> image::ImageResult<()> {
     /// # use image::{DynamicImage, ColorType};
     /// use image::codecs::png;
     /// let image = DynamicImage::new(32, 32, ColorType::Rgba8);
@@ -1688,7 +1690,7 @@ impl DynamicImage {
     /// let mut options = png::PngOptions::default();
     /// options.compression = png::CompressionType::Best;
     /// image.save_with_options("file.png", &options).unwrap();
-    /// # image::ImageResult::Ok(())
+    /// # Ok(()) }
     /// ```
     pub fn save_with_options<Q>(&self, path: Q, options: &dyn EncoderOptions) -> ImageResult<()>
     where

--- a/src/images/dynimage.rs
+++ b/src/images/dynimage.rs
@@ -1681,16 +1681,16 @@ impl DynamicImage {
     /// ## Example
     ///
     /// ```no_run
-    /// # #[cfg(feature = "png")]
-    /// # fn main() -> image::ImageResult<()> {
+    /// # #[cfg(feature = "png")] {
     /// # use image::{DynamicImage, ColorType};
     /// use image::codecs::png;
     /// let image = DynamicImage::new(32, 32, ColorType::Rgba8);
     ///
     /// let mut options = png::PngOptions::default();
     /// options.compression = png::CompressionType::Best;
-    /// image.save_with_options("file.png", &options).unwrap();
-    /// # Ok(()) }
+    /// image.save_with_options("file.png", &options)?;
+    /// # }
+    /// # image::ImageResult::Ok(())
     /// ```
     pub fn save_with_options<Q>(&self, path: Q, options: &dyn EncoderOptions) -> ImageResult<()>
     where

--- a/src/images/dynimage.rs
+++ b/src/images/dynimage.rs
@@ -1688,18 +1688,17 @@ impl DynamicImage {
     ///
     /// let mut options = png::PngOptions::default();
     /// options.compression = png::CompressionType::Best;
-    /// image.save_with_options("file.png", &options)?;
+    /// image.save_with_options("file.png", options)?;
     /// # }
     /// # image::ImageResult::Ok(())
     /// ```
-    pub fn save_with_options<Q>(&self, path: Q, options: &dyn EncoderOptions) -> ImageResult<()>
+    pub fn save_with_options<Q>(&self, path: Q, options: impl EncoderOptions) -> ImageResult<()>
     where
         Q: AsRef<Path>,
     {
-        let file = &mut BufWriter::new(File::create(path)?);
-        let mut encoder = encoder_for_format(options.format(), file)?;
-        encoder.set_encoder_options(options)?;
-        self.write_with_encoder_impl(encoder)
+        let file = BufWriter::new(File::create(path)?);
+        let encoder = options.build(file)?;
+        self.write_with_encoder_impl(Box::new(encoder))
     }
 }
 

--- a/src/images/dynimage.rs
+++ b/src/images/dynimage.rs
@@ -17,6 +17,7 @@ use crate::io::{DecodedImageAttributes, DecoderPreparedImage};
 use crate::math::{resize_dimensions, Rect};
 use crate::metadata::Orientation;
 use crate::traits::Pixel;
+use crate::EncoderOptions;
 use crate::{
     imageops,
     metadata::{Cicp, CicpColorPrimaries, CicpTransferCharacteristics},
@@ -1664,6 +1665,38 @@ impl DynamicImage {
     {
         let file = &mut BufWriter::new(File::create(path)?);
         let encoder = encoder_for_format(format, file)?;
+        self.write_with_encoder_impl(encoder)
+    }
+
+    /// Saves the buffer to a file with the specified options.
+    ///
+    /// The format is derived from the options.
+    ///
+    /// ## Color Conversion
+    ///
+    /// Unlike other encoding methods in this crate, methods on `DynamicImage` try to automatically
+    /// convert the image to some color type supported by the encoder. This may result in a loss of
+    /// precision or the removal of the alpha channel.
+    ///
+    /// ## Example
+    ///
+    /// ```no_run
+    /// # use image::{DynamicImage, ColorType};
+    /// use image::codecs::png;
+    /// let image = DynamicImage::new(32, 32, ColorType::Rgba8);
+    ///
+    /// let mut options = png::PngOptions::default();
+    /// options.compression = png::CompressionType::Best;
+    /// image.save_with_options("file.png", &options).unwrap();
+    /// # image::ImageResult::Ok(())
+    /// ```
+    pub fn save_with_options<Q>(&self, path: Q, options: &dyn EncoderOptions) -> ImageResult<()>
+    where
+        Q: AsRef<Path>,
+    {
+        let file = &mut BufWriter::new(File::create(path)?);
+        let mut encoder = encoder_for_format(options.format(), file)?;
+        encoder.set_encoder_options(options)?;
         self.write_with_encoder_impl(encoder)
     }
 }

--- a/src/io/encoder.rs
+++ b/src/io/encoder.rs
@@ -119,16 +119,7 @@ pub trait ImageEncoder {
 
 /// Encoding options for a specific format.
 pub trait EncoderOptions {
-    /// Downcase a generic reference to specific encoding options.
-    ///
-    /// If the given reference is not of the expected type, returns an [`ImageError::Parameter`] error.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// let options: &dyn EncoderOptions = todo!();
-    /// let jpeg_options: &PngOptions = PngOptions::try_from_ref(options)?;
-    /// ```
+    /// Creates the encoder for the options.
     fn build<W: Write + Seek>(self, w: W) -> ImageResult<impl ImageEncoder>;
 }
 

--- a/src/io/encoder.rs
+++ b/src/io/encoder.rs
@@ -1,10 +1,7 @@
-use std::any::Any;
+use std::io::{Seek, Write};
 
-use crate::error::{
-    ImageFormatHint, ImageResult, ParameterError, ParameterErrorKind, UnsupportedError,
-    UnsupportedErrorKind,
-};
-use crate::{ColorType, DynamicImage, ExtendedColorType, ImageError, ImageFormat};
+use crate::error::{ImageFormatHint, ImageResult, UnsupportedError, UnsupportedErrorKind};
+use crate::{ColorType, DynamicImage, ExtendedColorType, ImageFormat};
 
 /// Nominally public but DO NOT expose this type.
 ///
@@ -105,23 +102,6 @@ pub trait ImageEncoder {
         ))
     }
 
-    /// Set encoder options for the image.
-    ///
-    /// Returns [`ImageError::Unsupported`] if the encoder does not support any options.
-    /// If the the given options are not supported by the encoder, returns an [`ImageError::Parameter`] error.
-    fn set_encoder_options(&mut self, options: &dyn EncoderOptions) -> ImageResult<()> {
-        Err(ImageError::Unsupported(
-            UnsupportedError::from_format_and_kind(
-                // TODO: Better error message. Say which format doesn't support options.
-                ImageFormatHint::Unknown,
-                UnsupportedErrorKind::GenericFeature(format!(
-                    "Encoder options are not supported for this format. Cannot use given {:?} options.",
-                    options.format()
-                )),
-            ),
-        ))
-    }
-
     /// Convert the image to a compatible format for the encoder. This is used by the encoding
     /// methods on `DynamicImage`.
     ///
@@ -138,7 +118,10 @@ pub trait ImageEncoder {
 }
 
 /// Encoding options for a specific format.
-pub trait EncoderOptions: Any {
+pub trait EncoderOptions {
+    /// The encoder these options are for.
+    type Encoder<W: Write + Seek>: ImageEncoder;
+
     /// The image format these options are for.
     fn format(&self) -> ImageFormat;
 
@@ -152,21 +135,7 @@ pub trait EncoderOptions: Any {
     /// let options: &dyn EncoderOptions = todo!();
     /// let jpeg_options: &PngOptions = PngOptions::try_from_ref(options)?;
     /// ```
-    fn try_from_ref(r: &dyn EncoderOptions) -> ImageResult<&Self>
-    where
-        Self: Sized,
-    {
-        let any = r as &dyn Any;
-        any.downcast_ref::<Self>().ok_or_else(|| {
-            ImageError::Parameter(ParameterError::from_kind(ParameterErrorKind::Generic(
-                format!(
-                    "Invalid encoder options type: expected {}, got options for {:?}",
-                    std::any::type_name::<Self>(),
-                    r.format()
-                ),
-            )))
-        })
-    }
+    fn build<W: Write + Seek>(self, w: W) -> ImageResult<Self::Encoder<W>>;
 }
 
 pub(crate) trait ImageEncoderBoxed: ImageEncoder {

--- a/src/io/encoder.rs
+++ b/src/io/encoder.rs
@@ -1,7 +1,7 @@
 use std::io::{Seek, Write};
 
 use crate::error::{ImageFormatHint, ImageResult, UnsupportedError, UnsupportedErrorKind};
-use crate::{ColorType, DynamicImage, ExtendedColorType, ImageFormat};
+use crate::{ColorType, DynamicImage, ExtendedColorType};
 
 /// Nominally public but DO NOT expose this type.
 ///
@@ -121,9 +121,6 @@ pub trait ImageEncoder {
 pub trait EncoderOptions {
     /// The encoder these options are for.
     type Encoder<W: Write + Seek>: ImageEncoder;
-
-    /// The image format these options are for.
-    fn format(&self) -> ImageFormat;
 
     /// Downcase a generic reference to specific encoding options.
     ///

--- a/src/io/encoder.rs
+++ b/src/io/encoder.rs
@@ -119,9 +119,6 @@ pub trait ImageEncoder {
 
 /// Encoding options for a specific format.
 pub trait EncoderOptions {
-    /// The encoder these options are for.
-    type Encoder<W: Write + Seek>: ImageEncoder;
-
     /// Downcase a generic reference to specific encoding options.
     ///
     /// If the given reference is not of the expected type, returns an [`ImageError::Parameter`] error.
@@ -132,7 +129,7 @@ pub trait EncoderOptions {
     /// let options: &dyn EncoderOptions = todo!();
     /// let jpeg_options: &PngOptions = PngOptions::try_from_ref(options)?;
     /// ```
-    fn build<W: Write + Seek>(self, w: W) -> ImageResult<Self::Encoder<W>>;
+    fn build<W: Write + Seek>(self, w: W) -> ImageResult<impl ImageEncoder>;
 }
 
 pub(crate) trait ImageEncoderBoxed: ImageEncoder {

--- a/src/io/encoder.rs
+++ b/src/io/encoder.rs
@@ -1,5 +1,10 @@
-use crate::error::{ImageFormatHint, ImageResult, UnsupportedError, UnsupportedErrorKind};
-use crate::{ColorType, DynamicImage, ExtendedColorType};
+use std::any::Any;
+
+use crate::error::{
+    ImageFormatHint, ImageResult, ParameterError, ParameterErrorKind, UnsupportedError,
+    UnsupportedErrorKind,
+};
+use crate::{ColorType, DynamicImage, ExtendedColorType, ImageError, ImageFormat};
 
 /// Nominally public but DO NOT expose this type.
 ///
@@ -100,6 +105,23 @@ pub trait ImageEncoder {
         ))
     }
 
+    /// Set encoder options for the image.
+    ///
+    /// Returns [`ImageError::Unsupported`] if the encoder does not support any options.
+    /// If the the given options are not supported by the encoder, returns an [`ImageError::Parameter`] error.
+    fn set_encoder_options(&mut self, options: &dyn EncoderOptions) -> ImageResult<()> {
+        Err(ImageError::Unsupported(
+            UnsupportedError::from_format_and_kind(
+                // TODO: Better error message. Say which format doesn't support options.
+                ImageFormatHint::Unknown,
+                UnsupportedErrorKind::GenericFeature(format!(
+                    "Encoder options are not supported for this format. Cannot use given {:?} options.",
+                    options.format()
+                )),
+            ),
+        ))
+    }
+
     /// Convert the image to a compatible format for the encoder. This is used by the encoding
     /// methods on `DynamicImage`.
     ///
@@ -112,6 +134,38 @@ pub trait ImageEncoder {
         _input: &DynamicImage,
     ) -> Option<DynamicImage> {
         None
+    }
+}
+
+/// Encoding options for a specific format.
+pub trait EncoderOptions: Any {
+    /// The image format these options are for.
+    fn format(&self) -> ImageFormat;
+
+    /// Downcase a generic reference to specific encoding options.
+    ///
+    /// If the given reference is not of the expected type, returns an [`ImageError::Parameter`] error.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let options: &dyn EncoderOptions = todo!();
+    /// let jpeg_options: &PngOptions = PngOptions::try_from_ref(options)?;
+    /// ```
+    fn try_from_ref(r: &dyn EncoderOptions) -> ImageResult<&Self>
+    where
+        Self: Sized,
+    {
+        let any = r as &dyn Any;
+        any.downcast_ref::<Self>().ok_or_else(|| {
+            ImageError::Parameter(ParameterError::from_kind(ParameterErrorKind::Generic(
+                format!(
+                    "Invalid encoder options type: expected {}, got options for {:?}",
+                    std::any::type_name::<Self>(),
+                    r.format()
+                ),
+            )))
+        })
     }
 }
 

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -5,7 +5,7 @@ use std::{iter, mem::size_of};
 
 use crate::io::encoder::ImageEncoderBoxed;
 use crate::io::DecodedImageAttributes;
-use crate::{codecs::*, EncoderOptions, ExtendedColorType, ImageReaderOptions};
+use crate::{EncoderOptions, ExtendedColorType, ImageEncoder, ImageReaderOptions, codecs::*};
 
 use crate::error::{
     ImageError, ImageFormatHint, ImageResult, LimitError, LimitErrorKind, UnsupportedError,
@@ -68,11 +68,10 @@ pub fn save_buffer_with_options(
     width: u32,
     height: u32,
     color: impl Into<ExtendedColorType>,
-    options: &dyn EncoderOptions,
+    options: impl EncoderOptions,
 ) -> ImageResult<()> {
-    let buffered_file_write = &mut BufWriter::new(File::create(path)?); // always seekable
-    let mut encoder = encoder_for_format(options.format(), buffered_file_write)?;
-    encoder.set_encoder_options(options)?;
+    let buffered_file_write =   BufWriter::new(File::create(path)?); // always seekable
+    let encoder = options.build(buffered_file_write)?;
     encoder.write_image(buf, width, height, color.into())
 }
 

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -5,7 +5,7 @@ use std::{iter, mem::size_of};
 
 use crate::io::encoder::ImageEncoderBoxed;
 use crate::io::DecodedImageAttributes;
-use crate::{codecs::*, ExtendedColorType, ImageReaderOptions};
+use crate::{codecs::*, EncoderOptions, ExtendedColorType, ImageReaderOptions};
 
 use crate::error::{
     ImageError, ImageFormatHint, ImageResult, LimitError, LimitErrorKind, UnsupportedError,
@@ -55,6 +55,24 @@ pub fn save_buffer_with_format(
 ) -> ImageResult<()> {
     let buffered_file_write = &mut BufWriter::new(File::create(path)?); // always seekable
     let encoder = encoder_for_format(format, buffered_file_write)?;
+    encoder.write_image(buf, width, height, color.into())
+}
+
+/// Saves the supplied buffer to a file given the path. The format is derived from the given options.
+///
+/// The buffer is assumed to have the correct format according to the specified color type. This
+/// will lead to corrupted files if the buffer contains malformed data.
+pub fn save_buffer_with_options(
+    path: impl AsRef<Path>,
+    buf: &[u8],
+    width: u32,
+    height: u32,
+    color: impl Into<ExtendedColorType>,
+    options: &dyn EncoderOptions,
+) -> ImageResult<()> {
+    let buffered_file_write = &mut BufWriter::new(File::create(path)?); // always seekable
+    let mut encoder = encoder_for_format(options.format(), buffered_file_write)?;
+    encoder.set_encoder_options(options)?;
     encoder.write_image(buf, width, height, color.into())
 }
 

--- a/src/io/free_functions.rs
+++ b/src/io/free_functions.rs
@@ -5,7 +5,7 @@ use std::{iter, mem::size_of};
 
 use crate::io::encoder::ImageEncoderBoxed;
 use crate::io::DecodedImageAttributes;
-use crate::{EncoderOptions, ExtendedColorType, ImageEncoder, ImageReaderOptions, codecs::*};
+use crate::{codecs::*, EncoderOptions, ExtendedColorType, ImageEncoder, ImageReaderOptions};
 
 use crate::error::{
     ImageError, ImageFormatHint, ImageResult, LimitError, LimitErrorKind, UnsupportedError,
@@ -70,7 +70,7 @@ pub fn save_buffer_with_options(
     color: impl Into<ExtendedColorType>,
     options: impl EncoderOptions,
 ) -> ImageResult<()> {
-    let buffered_file_write =   BufWriter::new(File::create(path)?); // always seekable
+    let buffered_file_write = BufWriter::new(File::create(path)?); // always seekable
     let encoder = options.build(buffered_file_write)?;
     encoder.write_image(buf, width, height, color.into())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,11 +150,13 @@ pub use crate::images::dynimage::{
     write_buffer_with_format,
 };
 
-pub use crate::io::free_functions::{guess_format, load, save_buffer, save_buffer_with_format};
+pub use crate::io::free_functions::{
+    guess_format, load, save_buffer, save_buffer_with_format, save_buffer_with_options,
+};
 
 pub use crate::io::{
     decoder::ImageDecoder,
-    encoder::ImageEncoder,
+    encoder::{EncoderOptions, ImageEncoder},
     format::ImageFormat,
     image_reader_type::{ImageReader, ImageReaderOptions, SpecCompliance},
     limits::{LimitSupport, Limits},


### PR DESCRIPTION
The story for saving images with custom encoding options isn't great. Encoders are a patchwork of different API styles and capabilities, and the trait governing them has fundamental limitations too (#2556).

In this PR, I hope to improve the situation a little by adding an API for universal encoding options. Example usage:

```rs
let image = DynamicImage::new(32, 32, ColorType::Rgba8);

let mut options = image::codecs::png::PngOptions:.default();
options.compression = image::codecs::png::CompressionType::Best;
image.save_with_options("image.png", &options)?;
```

Instead of having to use encoders and their (arguably) low-level APIs directly, users can now provide a struct of encoding options instead. This makes it easy to configure encoders in a generic way.

Formats that currently support encoding options are PNG, JPEG, AVIF, PNM, and TGA.

Changes:
- Add `EncodingOptions` trait.
- Add `{DynamicImage,ImageBuffer}::save_with_options` and `save_buffer_with_options`.
- Add options structs for formats.

TODO:
- [x] JPEG quality. The encoder doesn't have an option to change it. Can be resolved by either changing `jpeg-encoder` (https://github.com/vstroebel/jpeg-encoder/pull/36) or changing our encoder. For now, I just excluded quality form the options that can be set.

---

Should help with #2810