### PR TITLE
Improve `Debug` formatting for `Delay`

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -60,7 +60,7 @@ pub struct Frame {
 ///
 /// assert_eq!(delay_10ms, delay_10000us);
 /// ```
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd)]
 pub struct Delay {
     ratio: Ratio,
 }
@@ -300,6 +300,17 @@ impl From<Delay> for Duration {
     }
 }
 
+impl std::fmt::Debug for Delay {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (numer, denom) = self.numer_denom_ms();
+        if denom == 1 {
+            write!(f, "Delay({numer} ms)")
+        } else {
+            write!(f, "Delay({numer}/{denom} ms)")
+        }
+    }
+}
+
 #[inline]
 const fn gcd(mut a: u32, mut b: u32) -> u32 {
     while b != 0 {
@@ -427,5 +438,21 @@ mod tests {
         // Not precisely the original but should be smaller than 0.
         let delay = Delay::from_saturating_duration(duration);
         assert_eq!(delay.into_ratio().to_integer(), 0);
+    }
+
+    #[test]
+    fn delay_debug_formatting() {
+        assert_eq!(
+            format!("{:?}", Delay::from_numer_denom_ms(10, 1)),
+            "Delay(10 ms)"
+        );
+        assert_eq!(
+            format!("{:?}", Delay::from_numer_denom_ms(100_000, 100)),
+            "Delay(1000 ms)"
+        );
+        assert_eq!(
+            format!("{:?}", Delay::from_numer_denom_ms(1000, 30)), // 30 fps
+            "Delay(100/3 ms)"
+        );
     }
 }


### PR DESCRIPTION
I'm working on something `Delay`'s horrible `Debug` formatting got in the way. I.e. here's what 10ms looked like before this PR:

```
Delay { ratio: Ratio { numer: 10, denom: 1 } }
```

Here's what it is now:

```
Delay(10 ms)
```

In general, delays that are whole milliseconds are formatted as just that. Delays that have fractional part are formatted as fractions. E.g. `Delay(100/3 ms)` for 33.333... ms.