### PR TITLE
Fix filter3x3 panic on zero-dimension images

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,9 @@ Features:
 Structural changes:
   - Increased MSRV to 1.88.0 (from 1.85.0)
 
+Bug fixes:
+  - Fixed `imageops::filter3x3` panicking with a subtract overflow on images with a zero dimension (#3026)
+
 ### Version 0.25.9
 
 Features:

--- a/src/imageops/sample.rs
+++ b/src/imageops/sample.rs
@@ -924,8 +924,8 @@ where
         sum => 1.0 / sum,
     };
 
-    for y in 1..height - 1 {
-        for x in 1..width - 1 {
+    for y in 1..height.saturating_sub(1) {
+        for x in 1..width.saturating_sub(1) {
             let mut t = [0.0; MAX_CHANNEL];
 
             // TODO: There is no need to recalculate the kernel for each pixel.
@@ -1655,10 +1655,23 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{resize, sample_bilinear, sample_nearest, FilterType};
+    use super::{filter3x3, resize, sample_bilinear, sample_nearest, FilterType};
     use crate::{GenericImageView, ImageBuffer, RgbImage};
     #[cfg(feature = "benchmarks")]
     use test;
+
+    #[test]
+    fn filter3x3_zero_dimension_no_panic() {
+        // Images with a zero or one dimension have no interior pixels, so
+        // `filter3x3` must produce an equally-sized image without panicking
+        // (the loop bounds previously underflowed `width - 1` / `height - 1`).
+        let kernel = [0.0, -1.0, 0.0, -1.0, 5.0, -1.0, 0.0, -1.0, 0.0];
+        for &(w, h) in &[(0, 0), (0, 5), (5, 0), (1, 1), (1, 5), (5, 1)] {
+            let img = crate::GrayImage::new(w, h);
+            let out = filter3x3(&img, &kernel);
+            assert_eq!(out.dimensions(), (w, h));
+        }
+    }
 
     #[bench]
     #[cfg(all(feature = "benchmarks", feature = "png"))]


### PR DESCRIPTION
Closes #3026.

`imageops::filter3x3` loops over `1..width - 1` / `1..height - 1`. When an image has a zero width or height, these subtractions underflow, panicking with "attempt to subtract with overflow" (debug) or wrapping to a near-`u32::MAX` range (release).

Switched both bounds to `saturating_sub(1)` so a zero dimension yields an empty range, matching the existing behavior for a dimension of 1 (no interior pixels, output left as-is). Added a regression test covering the 0 and 1 dimension cases.

Note: #3028 (the `unsharpen`/gaussian-blur path) is handled separately by #3007; this only touches the independent `filter3x3` code path.