### PR TITLE
Fix `clippy::chunks_exact_to_as_chunks` warnings

### DIFF
--- a/src/codecs/avif/ycgco.rs
+++ b/src/codecs/avif/ycgco.rs
@@ -120,6 +120,8 @@ fn process_halved_chroma_row_cgco<
     let bias_y = range.bias_y as i32;
     let bias_uv = range.bias_uv as i32;
     let (y_iter, y_left) = y_plane.as_chunks::<2>();
+    // TODO: remove this once the false positive is fixed: https://github.com/rust-lang/rust-clippy/issues/17314
+    #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
     let mut rgb_chunks = rgba.chunks_exact_mut(CHANNELS * 2);
 
     let scale_coef = ((max_value as f32 / range.range_y as f32) * (1 << PRECISION) as f32) as i32;

--- a/src/codecs/avif/yuv.rs
+++ b/src/codecs/avif/yuv.rs
@@ -568,6 +568,8 @@ fn process_halved_chroma_row_cbcr<
     let bias_y = range.bias_y as i32;
     let bias_uv = range.bias_uv as i32;
     let (y_iter, y_left) = y_plane.as_chunks::<2>();
+    // TODO: remove this once the false positive is fixed: https://github.com/rust-lang/rust-clippy/issues/17314
+    #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
     let mut rgb_chunks = rgba.chunks_exact_mut(CHANNELS * 2);
     for (((y_src, &u_src), &v_src), rgb_dst) in
         y_iter.iter().zip(u_plane).zip(v_plane).zip(&mut rgb_chunks)

--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -373,14 +373,12 @@ fn blend_and_dispose_region(
     non_disposed_data: &mut [u8],
     frame_data: &mut [u8],
 ) {
-    for (disposed, pixel) in non_disposed_data
-        .chunks_exact_mut(4)
-        .zip(frame_data.chunks_exact_mut(4))
-    {
+    let non_disposed_data = Rgba::<u8>::pixels_from_channels_mut(non_disposed_data);
+    let frame_data = Rgba::<u8>::pixels_from_channels_mut(frame_data);
+
+    for (disposed, pixel) in non_disposed_data.iter_mut().zip(frame_data.iter_mut()) {
         // FIXME: internal dispatch on disposal method may be slow, investigate if this is
         // properly and reliably vectorized.
-        let disposed = Rgba::<u8>::from_slice_mut(disposed);
-        let pixel = Rgba::<u8>::from_slice_mut(pixel);
         blend_and_dispose_pixel(dispose, disposed, pixel);
     }
 }

--- a/src/codecs/ico/decoder.rs
+++ b/src/codecs/ico/decoder.rs
@@ -632,7 +632,7 @@ mod test {
 
         // Every pixel should have alpha=128 (the native alpha from the BMP data).
         // If the AND mask were incorrectly applied, alpha would be 0.
-        for (i, pixel) in buf.chunks_exact(4).enumerate() {
+        for (i, pixel) in buf.as_chunks::<4>().0.iter().enumerate() {
             assert_eq!(
                 pixel[3], 128,
                 "pixel {i}: expected alpha=128, got {}",

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -36,16 +36,8 @@ impl<'a, P: Pixel + 'a> Rows<'a, P> {
             (width as usize).checked_mul(height as usize)
         );
 
-        if width == 0 {
-            #[allow(unknown_lints)] // TODO: remove this once clippy on stable rust has this lint
-            #[allow(clippy::chunks_exact_to_as_chunks)]
-            Rows {
-                pixels: [].chunks_exact(1),
-            }
-        } else {
-            Rows {
-                pixels: pixels.chunks_exact(width as usize),
-            }
+        Rows {
+            pixels: pixels.chunks_exact(width.max(1) as usize),
         }
     }
 }
@@ -122,16 +114,8 @@ impl<'a, P: Pixel + 'a> RowsMut<'a, P> {
             (width as usize).checked_mul(height as usize)
         );
 
-        if width == 0 {
-            #[allow(unknown_lints)] // TODO: remove this once clippy on stable rust has this lint
-            #[allow(clippy::chunks_exact_to_as_chunks)]
-            RowsMut {
-                pixels: [].chunks_exact_mut(1),
-            }
-        } else {
-            RowsMut {
-                pixels: pixels.chunks_exact_mut(width as usize),
-            }
+        RowsMut {
+            pixels: pixels.chunks_exact_mut(width.max(1) as usize),
         }
     }
 }

--- a/src/images/buffer.rs
+++ b/src/images/buffer.rs
@@ -37,6 +37,8 @@ impl<'a, P: Pixel + 'a> Rows<'a, P> {
         );
 
         if width == 0 {
+            #[allow(unknown_lints)] // TODO: remove this once clippy on stable rust has this lint
+            #[allow(clippy::chunks_exact_to_as_chunks)]
             Rows {
                 pixels: [].chunks_exact(1),
             }
@@ -121,6 +123,8 @@ impl<'a, P: Pixel + 'a> RowsMut<'a, P> {
         );
 
         if width == 0 {
+            #[allow(unknown_lints)] // TODO: remove this once clippy on stable rust has this lint
+            #[allow(clippy::chunks_exact_to_as_chunks)]
             RowsMut {
                 pixels: [].chunks_exact_mut(1),
             }
@@ -2433,8 +2437,8 @@ mod test {
 
         assert!(target.copy_from(&source, 0, 4).is_ok());
 
-        let lhs = source.chunks_exact(48);
-        let rhs = target.chunks_exact(48).skip(4).take(8);
+        let lhs = source.as_chunks::<48>().0;
+        let rhs = &target.as_chunks::<48>().0[4..12];
 
         assert!(lhs.eq(rhs));
     }


### PR DESCRIPTION
This PR fixes the new warnings in nightly.

In `buffer.rs`, ~~I had to allow two instances, because the `pixels` field needs a `ChunksExact` iterator, so `as_exact` simply isn't possible.~~ I solved it differently. I unified the two branches to make `[].chunks_exact(1)` unnecessary.

The instances in AVIF are ignored because they are false positives. I reported this as a bug to clippy (https://github.com/rust-lang/rust-clippy/issues/17314).