### PR TITLE
Remove `Frame` x/y offset

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -39,10 +39,6 @@ impl Iterator for Frames<'_> {
 pub struct Frame {
     /// Delay between the frames in milliseconds
     delay: Delay,
-    /// x offset
-    left: u32,
-    /// y offset
-    top: u32,
     buffer: RgbaImage,
 }
 
@@ -71,21 +67,14 @@ impl Frame {
     pub fn new(buffer: RgbaImage) -> Frame {
         Frame {
             delay: Delay::from_ratio(Ratio { numer: 0, denom: 1 }),
-            left: 0,
-            top: 0,
             buffer,
         }
     }
 
     /// Constructs a new frame
     #[must_use]
-    pub fn from_parts(buffer: RgbaImage, left: u32, top: u32, delay: Delay) -> Frame {
-        Frame {
-            delay,
-            left,
-            top,
-            buffer,
-        }
+    pub fn from_parts(buffer: RgbaImage, delay: Delay) -> Frame {
+        Frame { delay, buffer }
     }
 
     /// Delay of this frame
@@ -109,18 +98,6 @@ impl Frame {
     #[must_use]
     pub fn into_buffer(self) -> RgbaImage {
         self.buffer
-    }
-
-    /// Returns the x offset
-    #[must_use]
-    pub fn left(&self) -> u32 {
-        self.left
-    }
-
-    /// Returns the y offset
-    #[must_use]
-    pub fn top(&self) -> u32 {
-        self.top
     }
 }
 

--- a/src/io/decoder.rs
+++ b/src/io/decoder.rs
@@ -212,17 +212,11 @@ impl Default for DecodedAnimationAttributes {
 
 /// Additional attributes of an image available after decoding.
 ///
-/// The [`Default`] is implemented and returns a value suitable for very basic images from formats
+/// [`Default`] is implemented and returns a value suitable for very basic images from formats
 /// that contain only one raster graphic.
 #[derive(Clone, Debug, Default)]
 #[non_exhaustive]
 pub struct DecodedImageAttributes {
-    /// The x-coordinate of the top-left rectangle of the image relative to canvas indicated by the
-    /// sequence of frames.
-    pub x: u32,
-    /// The y-coordinate of the top-left rectangle of the image relative to canvas indicated by the
-    /// sequence of frames.
-    pub y: u32,
     /// A suggested presentation offset relative to the previous image.
     pub delay: Option<Delay>,
     /// Orientation of the image, not relayed through EXIF metadata.

--- a/src/io/image_reader_type.rs
+++ b/src/io/image_reader_type.rs
@@ -842,12 +842,10 @@ impl<'stream> ImageReader<'stream> {
                 Err(err) => return Some(Err(err)),
             };
 
-            let x = frame_decoded.attributes().x;
-            let y = frame_decoded.attributes().y;
             let delay = frame_decoded.attributes().delay.unwrap_or(no_delay);
             let frame = frame.into_rgba8();
 
-            let frame = Frame::from_parts(frame, x, y, delay);
+            let frame = Frame::from_parts(frame, delay);
             Some(Ok(frame))
         });
 


### PR DESCRIPTION
The x/y (or top/left) offsets in `Frame` weren't used anywhere. All decoders returned an offset of (0,0), and the GIF encoder (which takes frames) ignored frame offsets.

In this PR, I removed offsets from `Frame` and `DecodedImageAttributes`.

Aside: We may want to rename `from_parts` to `with_delay`.