### PR TITLE
Provide defaults for more `Pixel` methods

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -445,22 +445,10 @@ impl<T: $($bound+)*> Pixel for $ident<T> {
         pix
     }
 
-    fn map<F>(& self, f: F) -> $ident<T> where F: FnMut(T) -> T {
-        let mut this = (*self).clone();
-        this.apply(f);
-        this
-    }
-
     fn apply<F>(&mut self, mut f: F) where F: FnMut(T) -> T {
         for v in &mut self.0 {
             *v = f(*v)
         }
-    }
-
-    fn map_with_alpha<F, G>(&self, f: F, g: G) -> $ident<T> where F: FnMut(T) -> T, G: FnMut(T) -> T {
-        let mut this = (*self).clone();
-        this.apply_with_alpha(f, g);
-        this
     }
 
     fn apply_with_alpha<F, G>(&mut self, mut f: F, mut g: G) where F: FnMut(T) -> T, G: FnMut(T) -> T {
@@ -473,12 +461,6 @@ impl<T: $($bound+)*> Pixel for $ident<T> {
         if let Some(v) = self.0.get_mut(ALPHA) {
             *v = g(*v)
         }
-    }
-
-    fn map2<F>(&self, other: &Self, f: F) -> $ident<T> where F: FnMut(T, T) -> T {
-        let mut this = (*self).clone();
-        this.apply2(other, f);
-        this
     }
 
     fn apply2<F>(&mut self, other: &$ident<T>, mut f: F) where F: FnMut(T, T) -> T {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -508,7 +508,12 @@ pub trait Pixel: Copy + Clone {
     /// Apply the function ```f``` to each channel of this pixel.
     fn map<F>(&self, f: F) -> Self
     where
-        F: FnMut(Self::Subpixel) -> Self::Subpixel;
+        F: FnMut(Self::Subpixel) -> Self::Subpixel,
+    {
+        let mut this = *self;
+        this.apply(f);
+        this
+    }
 
     /// Apply the function ```f``` to each channel of this pixel.
     fn apply<F>(&mut self, f: F)
@@ -520,7 +525,12 @@ pub trait Pixel: Copy + Clone {
     fn map_with_alpha<F, G>(&self, f: F, g: G) -> Self
     where
         F: FnMut(Self::Subpixel) -> Self::Subpixel,
-        G: FnMut(Self::Subpixel) -> Self::Subpixel;
+        G: FnMut(Self::Subpixel) -> Self::Subpixel,
+    {
+        let mut this = *self;
+        this.apply_with_alpha(f, g);
+        this
+    }
 
     /// Apply the function ```f``` to each channel except the alpha channel.
     /// Apply the function ```g``` to the alpha channel. Works in-place.
@@ -534,9 +544,7 @@ pub trait Pixel: Copy + Clone {
     where
         F: FnMut(Self::Subpixel) -> Self::Subpixel,
     {
-        let mut this = *self;
-        this.apply_with_alpha(f, |x| x);
-        this
+        self.map_with_alpha(f, |x| x)
     }
 
     /// Apply the function ```f``` to each channel except the alpha channel.
@@ -552,7 +560,12 @@ pub trait Pixel: Copy + Clone {
     /// ```other``` pairwise.
     fn map2<F>(&self, other: &Self, f: F) -> Self
     where
-        F: FnMut(Self::Subpixel, Self::Subpixel) -> Self::Subpixel;
+        F: FnMut(Self::Subpixel, Self::Subpixel) -> Self::Subpixel,
+    {
+        let mut this = *self;
+        this.apply2(other, f);
+        this
+    }
 
     /// Apply the function ```f``` to each channel of this pixel and
     /// ```other``` pairwise. Works in-place.


### PR DESCRIPTION
I thought it would be good idea to provide defaults for `Pixel` methods that can be implemented in terms of other methods.

This makes it easier to implement `Pixel` and reduces the complexity of the `define_colors` macro.