### PR TITLE
Add method to expose CICP in image decoder

### DIFF
--- a/examples/decode.rs
+++ b/examples/decode.rs
@@ -6,12 +6,19 @@ fn main() {
     let from = if env::args_os().count() == 2 {
         env::args_os().nth(1).unwrap()
     } else {
-        println!("Please enter a from and into path.");
+        println!("Please enter the path to an image file.");
         std::process::exit(1);
     };
 
     // Use the open function to load an image from a Path.
     // ```open``` returns a dynamic image.
     let im = image::open(Path::new(&from)).unwrap();
-    println!("{}", im.as_bytes().len());
+    println!(
+        "size: {} x {} ({} bytes), type {:?}",
+        im.width(),
+        im.height(),
+        im.as_bytes().len(),
+        im.color(),
+    );
+    println!("color space: {:?}", im.color_space());
 }

--- a/src/codecs/avif/decoder.rs
+++ b/src/codecs/avif/decoder.rs
@@ -3,7 +3,10 @@ use crate::error::{
     DecodingError, ImageFormatHint, LimitError, LimitErrorKind, UnsupportedError,
     UnsupportedErrorKind,
 };
-use crate::io::{DecodedImageAttributes, DecoderPreparedImage};
+use crate::io::{
+    DecodedColorProfile, DecodedImageAttributes, DecodedMetadataHint, DecoderPreparedImage,
+    FormatAttributes,
+};
 use crate::metadata::Orientation;
 use crate::{ColorType, ImageDecoder, ImageError, ImageFormat, ImageResult, Limits};
 ///
@@ -411,6 +414,14 @@ fn get_matrix(
 }
 
 impl<R: Read> ImageDecoder for AvifDecoder<R> {
+    fn format_attributes(&self) -> FormatAttributes {
+        FormatAttributes {
+            icc: DecodedMetadataHint::InHeader,
+            color_profile: DecodedMetadataHint::InHeader,
+            ..FormatAttributes::default()
+        }
+    }
+
     fn set_limits(&mut self, limits: Limits) -> ImageResult<()> {
         self.limits = limits;
         Ok(())
@@ -432,6 +443,11 @@ impl<R: Read> ImageDecoder for AvifDecoder<R> {
 
     fn icc_profile(&mut self) -> ImageResult<Option<Vec<u8>>> {
         Ok(self.icc_profile.clone())
+    }
+
+    fn color_profile(&mut self) -> ImageResult<Option<DecodedColorProfile>> {
+        // TODO: read NCLX once the next mp4parse version exposes it
+        Ok(self.icc_profile()?.map(DecodedColorProfile::from_icc))
     }
 
     fn read_image(&mut self, buf: &mut [u8]) -> ImageResult<DecodedImageAttributes> {

--- a/src/codecs/bmp/decoder.rs
+++ b/src/codecs/bmp/decoder.rs
@@ -1,4 +1,5 @@
-use crate::io::DecoderPreparedImage;
+use crate::io::{DecodedColorProfile, DecodedMetadataHint, DecoderPreparedImage, FormatAttributes};
+use crate::metadata::Cicp;
 use crate::utils::vec_try_with_capacity;
 use std::cmp::{self, Ordering};
 use std::io::{self, BufRead, Seek, SeekFrom};
@@ -2448,6 +2449,14 @@ impl<R: BufRead + Seek> BmpDecoder<R> {
 }
 
 impl<R: BufRead + Seek> ImageDecoder for BmpDecoder<R> {
+    fn format_attributes(&self) -> FormatAttributes {
+        FormatAttributes {
+            icc: DecodedMetadataHint::InHeader,
+            color_profile: DecodedMetadataHint::InHeader,
+            ..FormatAttributes::default()
+        }
+    }
+
     fn prepare_image(&mut self) -> ImageResult<DecoderPreparedImage> {
         let color = if self.indexed_color {
             ColorType::L8
@@ -2465,23 +2474,28 @@ impl<R: BufRead + Seek> ImageDecoder for BmpDecoder<R> {
     }
 
     fn icc_profile(&mut self) -> ImageResult<Option<Vec<u8>>> {
+        Ok(self.icc_profile.clone())
+    }
+
+    fn color_profile(&mut self) -> ImageResult<Option<DecodedColorProfile>> {
         match self.color_space_info {
             Some(ColorSpaceInfo::CalibratedRgb(params)) => {
                 // Synthesize an ICC profile from the calibrated RGB parameters
                 // and store it directly — no file read needed.
-                Ok(Some(
+                Ok(Some(DecodedColorProfile::from_icc(
                     params
                         .to_color_profile()
                         .encode()
                         .expect("synthetic profile should always succeed"),
-                ))
+                )))
             }
-            Some(ColorSpaceInfo::EmbeddedIcc(_)) => {
-                Ok(Some(self.icc_profile.clone().expect("icc was loaded")))
+            Some(ColorSpaceInfo::EmbeddedIcc(_)) => Ok(Some(DecodedColorProfile::from_icc(
+                self.icc_profile.clone().expect("icc was loaded"),
+            ))),
+            Some(ColorSpaceInfo::Srgb) => {
+                Ok(Some(DecodedColorProfile::from_plain_cicp(Cicp::SRGB)))
             }
-            // LCS_sRGB / LCS_WINDOWS_COLOR_SPACE: the caller treats
-            // "no ICC profile" as sRGB, so nothing to store.
-            Some(ColorSpaceInfo::Srgb) | None => Ok(None),
+            None => Ok(None),
         }
     }
 
@@ -2608,6 +2622,7 @@ mod test {
         let mut decoder = BmpDecoder::new(f).unwrap();
         let profile = decoder.icc_profile().unwrap();
         assert!(profile.is_some());
+        assert!(profile == decoder.color_profile().unwrap().unwrap().to_icc().unwrap());
         let profile_data = profile.unwrap();
         assert_eq!(profile_data.len(), 3048);
         validate_icc_profile(
@@ -2622,6 +2637,7 @@ mod test {
         let mut decoder = BmpDecoder::new(f).unwrap();
         let profile = decoder.icc_profile().unwrap();
         assert!(profile.is_some());
+        assert!(profile == decoder.color_profile().unwrap().unwrap().to_icc().unwrap());
         let profile_data = profile.unwrap();
         assert_eq!(profile_data.len(), 540);
         validate_icc_profile(
@@ -2637,7 +2653,7 @@ mod test {
         // pal8v4.bmp has a V4 header with LCS_CALIBRATED_RGB — should synthesize an ICC profile.
         let data = std::fs::read("tests/images/bmp/images/pal8v4.bmp").unwrap();
         let mut decoder = BmpDecoder::new(Cursor::new(&data)).unwrap();
-        let profile = decoder.icc_profile().unwrap();
+        let profile = decoder.color_profile().unwrap().unwrap().to_icc().unwrap();
         assert!(
             profile.is_some(),
             "pal8v4: should have a synthesized ICC profile from calibrated RGB parameters"

--- a/src/codecs/bmp/decoder.rs
+++ b/src/codecs/bmp/decoder.rs
@@ -284,7 +284,7 @@ impl ParsedIccProfile {
 }
 
 /// Color space data parsed from V4/V5 BMP headers.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ColorSpaceInfo {
     /// LCS_CALIBRATED_RGB: endpoint and gamma values specified in the header.
     CalibratedRgb(CalibratedRgb),
@@ -313,31 +313,26 @@ impl ColorSpaceInfo {
                     i32::from_le_bytes(buffer[offset..offset + 4].try_into().unwrap())
                 };
 
-                // FXPT2DOT30 (2.30 fixed-point) → f32.
-                let fxpt2dot30 = |val: i32| -> f32 { val as f32 * (1.0 / (1u64 << 30) as f32) };
-                // FXPT16DOT16 (unsigned 16.16 fixed-point) → f32.
-                let fxpt16dot16 = |val: u32| -> f32 { val as f32 / 65536.0 };
-
                 // CIEXYZTRIPLE: 9 FXPT2DOT30 values at offsets 60-95 from header
                 // start (56-91 from after size field). Layout:
                 //   RedX, RedY, RedZ, GreenX, GreenY, GreenZ, BlueX, BlueY, BlueZ
                 // We read only X and Y per primary (Z is implicit: Z = 1 - X - Y
                 // for chromaticity, but BMP stores raw CIE XYZ values).
-                let rx = fxpt2dot30(read_i32(56));
-                let ry = fxpt2dot30(read_i32(60));
-                let gx = fxpt2dot30(read_i32(68));
-                let gy = fxpt2dot30(read_i32(72));
-                let bx = fxpt2dot30(read_i32(80));
-                let by = fxpt2dot30(read_i32(84));
+                let rx = Fxpt2Dot30(read_i32(56));
+                let ry = Fxpt2Dot30(read_i32(60));
+                let gx = Fxpt2Dot30(read_i32(68));
+                let gy = Fxpt2Dot30(read_i32(72));
+                let bx = Fxpt2Dot30(read_i32(80));
+                let by = Fxpt2Dot30(read_i32(84));
 
                 // Gamma values at offsets 96-107 from header start (92-103 from after size).
-                let gamma_r = fxpt16dot16(read_u32(92));
-                let gamma_g = fxpt16dot16(read_u32(96));
-                let gamma_b = fxpt16dot16(read_u32(100));
+                let gamma_r = Fxpt16Dot16(read_u32(92));
+                let gamma_g = Fxpt16Dot16(read_u32(96));
+                let gamma_b = Fxpt16Dot16(read_u32(100));
 
                 // Validate: Y values must be non-zero (used as denominators in
                 // XYZ→chromaticity conversion by color management libraries).
-                if ry == 0.0 || gy == 0.0 || by == 0.0 {
+                if ry == Fxpt2Dot30(0) || gy == Fxpt2Dot30(0) || by == Fxpt2Dot30(0) {
                     return None;
                 }
 
@@ -362,41 +357,61 @@ impl ColorSpaceInfo {
     }
 }
 
+/// FXPT2DOT30, 2.30 fixed-point
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Fxpt2Dot30(i32);
+
+impl Fxpt2Dot30 {
+    fn to_float(self) -> f32 {
+        self.0 as f32 * (1.0 / (1u64 << 30) as f32)
+    }
+}
+
+/// FXPT16DOT16, unsigned 16.16 fixed-point
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Fxpt16Dot16(u32);
+
+impl Fxpt16Dot16 {
+    fn to_float(self) -> f32 {
+        self.0 as f32 / 65536.0
+    }
+}
+
 /// Calibrated RGB color space parameters from a BMP V4/V5 header.
 ///
 /// When the header's `bV4CSType` is `LCS_CALIBRATED_RGB`, these fields
 /// carry the CIE XYZ endpoint coordinates for the RGB primaries and
-/// per-channel gamma values, parsed from the FXPT2DOT30 / FXPT16DOT16
+/// per-channel gamma values, stored as the raw FXPT2DOT30 / FXPT16DOT16
 /// fixed-point fields in the header.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct CalibratedRgb {
     /// Red primary CIE X coordinate (FXPT2DOT30).
-    rx: f32,
+    rx: Fxpt2Dot30,
     /// Red primary CIE Y coordinate (FXPT2DOT30).
-    ry: f32,
+    ry: Fxpt2Dot30,
     /// Green primary CIE X coordinate (FXPT2DOT30).
-    gx: f32,
+    gx: Fxpt2Dot30,
     /// Green primary CIE Y coordinate (FXPT2DOT30).
-    gy: f32,
+    gy: Fxpt2Dot30,
     /// Blue primary CIE X coordinate (FXPT2DOT30).
-    bx: f32,
+    bx: Fxpt2Dot30,
     /// Blue primary CIE Y coordinate (FXPT2DOT30).
-    by: f32,
+    by: Fxpt2Dot30,
     /// Red channel gamma (unsigned FXPT16DOT16).
-    gamma_r: f32,
+    gamma_r: Fxpt16Dot16,
     /// Green channel gamma (unsigned FXPT16DOT16).
-    gamma_g: f32,
+    gamma_g: Fxpt16Dot16,
     /// Blue channel gamma (unsigned FXPT16DOT16).
-    gamma_b: f32,
+    gamma_b: Fxpt16Dot16,
 }
 
 impl CalibratedRgb {
     /// Build a moxcms `ColorProfile` from the calibrated RGB primaries and gamma.
     fn to_color_profile(self) -> moxcms::ColorProfile {
         let primaries = moxcms::ColorPrimaries {
-            red: moxcms::Chromaticity::new(self.rx, self.ry),
-            green: moxcms::Chromaticity::new(self.gx, self.gy),
-            blue: moxcms::Chromaticity::new(self.bx, self.by),
+            red: moxcms::Chromaticity::new(self.rx.to_float(), self.ry.to_float()),
+            green: moxcms::Chromaticity::new(self.gx.to_float(), self.gy.to_float()),
+            blue: moxcms::Chromaticity::new(self.bx.to_float(), self.by.to_float()),
         };
 
         let mut profile = moxcms::ColorProfile::new_srgb();
@@ -410,9 +425,9 @@ impl CalibratedRgb {
         // when serialised to ICC bytes.
         let safe_gamma = |g: f32| if g > 0.0 { g } else { 1.0 };
         let parametric_trc = |g: f32| moxcms::ToneReprCurve::Parametric(vec![safe_gamma(g)]);
-        profile.red_trc = Some(parametric_trc(self.gamma_r));
-        profile.green_trc = Some(parametric_trc(self.gamma_g));
-        profile.blue_trc = Some(parametric_trc(self.gamma_b));
+        profile.red_trc = Some(parametric_trc(self.gamma_r.to_float()));
+        profile.green_trc = Some(parametric_trc(self.gamma_g.to_float()));
+        profile.blue_trc = Some(parametric_trc(self.gamma_b.to_float()));
         profile
     }
 }
@@ -451,7 +466,7 @@ enum MetadataProgress {
     ReadingPalette { offsets: HeaderOffsets },
     /// Headers and palette (if any) have been read; now reading ICC profile.
     /// Stores header offsets for the ICC profile read.
-    ReadingIccProfile { offsets: HeaderOffsets },
+    ReadingIccProfile,
     /// All metadata has been read successfully.
     Complete,
 }
@@ -465,8 +480,6 @@ struct HeaderOffsets {
     bmp_header_end: u64,
     /// Offset where palette data starts (after headers).
     palette_offset: u64,
-    /// ICC profile metadata if present.
-    icc_profile: Option<ParsedIccProfile>,
 }
 
 /// Progress within the RLE decoding phase.
@@ -1106,6 +1119,7 @@ pub struct BmpDecoder<R> {
     palette: Option<Vec<[u8; 3]>>,
     bitfields: Option<Bitfields>,
     icc_profile: Option<Vec<u8>>,
+    color_space_info: Option<ColorSpaceInfo>,
     spec_strictness: SpecCompliance,
 
     /// Current decoder state for resumable decoding.
@@ -1132,6 +1146,7 @@ impl<R: BufRead + Seek> BmpDecoder<R> {
             colors_used: 0,
             palette: None,
             bitfields: None,
+            color_space_info: None,
             icc_profile: None,
             spec_strictness: SpecCompliance::default(),
             state: DecoderState::default(),
@@ -1460,7 +1475,7 @@ impl<R: BufRead + Seek> BmpDecoder<R> {
     }
 
     /// Read ICC profile data from the file.
-    fn read_icc_profile(&mut self, icc: &ParsedIccProfile) -> ImageResult<()> {
+    fn read_icc_profile(&mut self, icc: ParsedIccProfile) -> ImageResult<()> {
         let profile_end = icc
             .profile_offset
             .checked_add(u64::from(icc.profile_size))
@@ -1574,13 +1589,13 @@ impl<R: BufRead + Seek> BmpDecoder<R> {
                 }
 
                 // Always progress to ReadingIccProfile next
-                let next = MetadataProgress::ReadingIccProfile { offsets };
+                let next = MetadataProgress::ReadingIccProfile;
                 self.state = DecoderState::ReadingMetadata { progress: next };
                 self.read_metadata_impl(next)
             }
-            MetadataProgress::ReadingIccProfile { offsets } => {
+            MetadataProgress::ReadingIccProfile => {
                 // Read ICC profile if present
-                if let Some(ref icc) = offsets.icc_profile {
+                if let Some(ColorSpaceInfo::EmbeddedIcc(icc)) = self.color_space_info {
                     self.read_icc_profile(icc)?;
                 }
 
@@ -1699,7 +1714,6 @@ impl<R: BufRead + Seek> BmpDecoder<R> {
         };
 
         // Parse color space fields from V4/V5 header
-        let mut icc_profile = None;
         if bmp_header_size >= BITMAPV4HEADER_SIZE {
             // Read the header into a buffer for color space parsing.
             // Buffer starts after the 4-byte size field.
@@ -1709,21 +1723,8 @@ impl<R: BufRead + Seek> BmpDecoder<R> {
             self.reader.read_exact(&mut header_buffer)?;
 
             // Extract color space info and handle non-Copy variants immediately
-            match ColorSpaceInfo::parse(&header_buffer, bmp_header_size, bmp_header_offset) {
-                Some(ColorSpaceInfo::CalibratedRgb(params)) => {
-                    // Synthesize an ICC profile from the calibrated RGB parameters
-                    // and store it directly — no file read needed.
-                    if let Ok(encoded) = params.to_color_profile().encode() {
-                        self.icc_profile = Some(encoded);
-                    }
-                }
-                Some(ColorSpaceInfo::EmbeddedIcc(icc)) => {
-                    icc_profile = Some(icc);
-                }
-                // LCS_sRGB / LCS_WINDOWS_COLOR_SPACE: the caller treats
-                // "no ICC profile" as sRGB, so nothing to store.
-                Some(ColorSpaceInfo::Srgb) | None => {}
-            }
+            self.color_space_info =
+                ColorSpaceInfo::parse(&header_buffer, bmp_header_size, bmp_header_offset);
 
             // Seek back to where we were
             self.reader.seek(SeekFrom::Start(current_pos))?;
@@ -1735,7 +1736,6 @@ impl<R: BufRead + Seek> BmpDecoder<R> {
         Ok(HeaderOffsets {
             bmp_header_end,
             palette_offset,
-            icc_profile,
         })
     }
 
@@ -2465,7 +2465,24 @@ impl<R: BufRead + Seek> ImageDecoder for BmpDecoder<R> {
     }
 
     fn icc_profile(&mut self) -> ImageResult<Option<Vec<u8>>> {
-        Ok(self.icc_profile.clone())
+        match self.color_space_info {
+            Some(ColorSpaceInfo::CalibratedRgb(params)) => {
+                // Synthesize an ICC profile from the calibrated RGB parameters
+                // and store it directly — no file read needed.
+                Ok(Some(
+                    params
+                        .to_color_profile()
+                        .encode()
+                        .expect("synthetic profile should always succeed"),
+                ))
+            }
+            Some(ColorSpaceInfo::EmbeddedIcc(_)) => {
+                Ok(Some(self.icc_profile.clone().expect("icc was loaded")))
+            }
+            // LCS_sRGB / LCS_WINDOWS_COLOR_SPACE: the caller treats
+            // "no ICC profile" as sRGB, so nothing to store.
+            Some(ColorSpaceInfo::Srgb) | None => Ok(None),
+        }
     }
 
     fn read_image(&mut self, buf: &mut [u8]) -> ImageResult<DecodedImageAttributes> {
@@ -2846,9 +2863,7 @@ mod test {
                                 MetadataProgress::ReadingPalette { .. } => {
                                     saw_reading_palette = true
                                 }
-                                MetadataProgress::ReadingIccProfile { .. } => {
-                                    saw_reading_icc = true
-                                }
+                                MetadataProgress::ReadingIccProfile => saw_reading_icc = true,
                                 _ => {}
                             }
                         }

--- a/src/codecs/bmp/decoder.rs
+++ b/src/codecs/bmp/decoder.rs
@@ -309,10 +309,13 @@ impl ColorSpaceInfo {
                 let read_u32 = |offset: usize| -> u32 {
                     u32::from_le_bytes(buffer[offset..offset + 4].try_into().unwrap())
                 };
+                let read_i32 = |offset: usize| -> i32 {
+                    i32::from_le_bytes(buffer[offset..offset + 4].try_into().unwrap())
+                };
 
                 // FXPT2DOT30 (2.30 fixed-point) → f32.
-                let fxpt2dot30 = |val: u32| -> f32 { val as f32 * (1.0 / (1u64 << 30) as f32) };
-                // FXPT16DOT16 (16.16 fixed-point) → f32.
+                let fxpt2dot30 = |val: i32| -> f32 { val as f32 * (1.0 / (1u64 << 30) as f32) };
+                // FXPT16DOT16 (unsigned 16.16 fixed-point) → f32.
                 let fxpt16dot16 = |val: u32| -> f32 { val as f32 / 65536.0 };
 
                 // CIEXYZTRIPLE: 9 FXPT2DOT30 values at offsets 60-95 from header
@@ -320,12 +323,12 @@ impl ColorSpaceInfo {
                 //   RedX, RedY, RedZ, GreenX, GreenY, GreenZ, BlueX, BlueY, BlueZ
                 // We read only X and Y per primary (Z is implicit: Z = 1 - X - Y
                 // for chromaticity, but BMP stores raw CIE XYZ values).
-                let rx = fxpt2dot30(read_u32(56));
-                let ry = fxpt2dot30(read_u32(60));
-                let gx = fxpt2dot30(read_u32(68));
-                let gy = fxpt2dot30(read_u32(72));
-                let bx = fxpt2dot30(read_u32(80));
-                let by = fxpt2dot30(read_u32(84));
+                let rx = fxpt2dot30(read_i32(56));
+                let ry = fxpt2dot30(read_i32(60));
+                let gx = fxpt2dot30(read_i32(68));
+                let gy = fxpt2dot30(read_i32(72));
+                let bx = fxpt2dot30(read_i32(80));
+                let by = fxpt2dot30(read_i32(84));
 
                 // Gamma values at offsets 96-107 from header start (92-103 from after size).
                 let gamma_r = fxpt16dot16(read_u32(92));
@@ -379,11 +382,11 @@ struct CalibratedRgb {
     bx: f32,
     /// Blue primary CIE Y coordinate (FXPT2DOT30).
     by: f32,
-    /// Red channel gamma (FXPT16DOT16).
+    /// Red channel gamma (unsigned FXPT16DOT16).
     gamma_r: f32,
-    /// Green channel gamma (FXPT16DOT16).
+    /// Green channel gamma (unsigned FXPT16DOT16).
     gamma_g: f32,
-    /// Blue channel gamma (FXPT16DOT16).
+    /// Blue channel gamma (unsigned FXPT16DOT16).
     gamma_b: f32,
 }
 

--- a/src/codecs/gif.rs
+++ b/src/codecs/gif.rs
@@ -42,8 +42,8 @@ use crate::error::{
     ParameterError, ParameterErrorKind, UnsupportedError, UnsupportedErrorKind,
 };
 use crate::io::{
-    DecodedAnimationAttributes, DecodedImageAttributes, DecodedMetadataHint, DecoderPreparedImage,
-    FormatAttributes,
+    DecodedAnimationAttributes, DecodedColorProfile, DecodedImageAttributes, DecodedMetadataHint,
+    DecoderPreparedImage, FormatAttributes,
 };
 use crate::metadata::LoopCount;
 use crate::traits::Pixel;
@@ -117,6 +117,7 @@ impl<R: BufRead + Seek> ImageDecoder for GifDecoder<R> {
             // FIXME: may appear anywhere.
             xmp: DecodedMetadataHint::InHeader,
             icc: DecodedMetadataHint::InHeader,
+            color_profile: DecodedMetadataHint::InHeader,
             iptc: DecodedMetadataHint::None,
             // FIXME: there is some in a Photoshop 8BIM extension which we do not collect.
             exif: DecodedMetadataHint::Unsupported,
@@ -357,6 +358,10 @@ impl<R: BufRead + Seek> ImageDecoder for GifDecoder<R> {
         let decoder = self.ensure_decoder()?;
         // Similar to XMP metadata
         Ok(decoder.icc_profile().map(Vec::from))
+    }
+
+    fn color_profile(&mut self) -> ImageResult<Option<DecodedColorProfile>> {
+        Ok(self.icc_profile()?.map(DecodedColorProfile::from_icc))
     }
 
     fn xmp_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {

--- a/src/codecs/hdr/decoder.rs
+++ b/src/codecs/hdr/decoder.rs
@@ -6,8 +6,12 @@ use std::{error, fmt};
 use crate::error::{
     DecodingError, ImageError, ImageFormatHint, ImageResult, UnsupportedError, UnsupportedErrorKind,
 };
-use crate::io::DecoderPreparedImage;
 use crate::io::{image_reader_type::SpecCompliance, DecodedImageAttributes};
+use crate::io::{DecodedColorProfile, DecodedMetadataHint, DecoderPreparedImage, FormatAttributes};
+use crate::metadata::{
+    Cicp, CicpColorPrimaries, CicpMatrixCoefficients, CicpTransferCharacteristics,
+    CicpVideoFullRangeFlag,
+};
 use crate::{ColorType, ImageDecoder, ImageFormat, Limits, Rgb};
 
 /// Errors that can occur during decoding and parsing of a HDR image
@@ -304,6 +308,18 @@ impl<R: Read> HdrDecoder<R> {
 }
 
 impl<R: Read> ImageDecoder for HdrDecoder<R> {
+    fn format_attributes(&self) -> FormatAttributes {
+        FormatAttributes {
+            supports_animation: false,
+            supports_sequence: false,
+            icc: DecodedMetadataHint::Unsupported,
+            color_profile: DecodedMetadataHint::InHeader,
+            exif: DecodedMetadataHint::None,
+            xmp: DecodedMetadataHint::None,
+            iptc: DecodedMetadataHint::None,
+        }
+    }
+
     fn prepare_image(&mut self) -> ImageResult<DecoderPreparedImage> {
         let HdrMetadata { width, height, .. } = self.meta;
         Ok(DecoderPreparedImage::new(width, height, ColorType::Rgb32F))
@@ -344,6 +360,36 @@ impl<R: Read> ImageDecoder for HdrDecoder<R> {
         }
 
         Ok(DecodedImageAttributes::default())
+    }
+
+    fn color_profile(&mut self) -> ImageResult<Option<DecodedColorProfile>> {
+        // Radiance HDR images by convention are mostly used with linear light;
+        // however, the color primaries are rarely specified, and the original
+        // Radiance renderer and spec defaulted to BT470 system B primaries
+        // except with 1/3-1/3-1/3 white point. Modern HDR files most likely
+        // use different primaries.
+        if self
+            .metadata()
+            .custom_attributes
+            .iter()
+            .any(|(k, _v)| k == "PRIMARIES")
+        {
+            // TODO: map custom primaries to CICP primaries when possible.
+            return Err(ImageError::Unsupported(
+                UnsupportedError::from_format_and_kind(
+                    ImageFormat::Hdr.into(),
+                    UnsupportedErrorKind::ColorProfileUnconvertible(
+                        "custom primaries not yet supported".into(),
+                    ),
+                ),
+            ));
+        }
+        Ok(Some(DecodedColorProfile::from_plain_cicp(Cicp {
+            primaries: CicpColorPrimaries::Unspecified,
+            transfer: CicpTransferCharacteristics::Linear,
+            matrix: CicpMatrixCoefficients::Identity,
+            full_range: CicpVideoFullRangeFlag::FullRange,
+        })))
     }
 }
 

--- a/src/codecs/ico/decoder.rs
+++ b/src/codecs/ico/decoder.rs
@@ -8,7 +8,8 @@ use crate::error::{
 };
 use crate::io::image_reader_type::SpecCompliance;
 use crate::io::{
-    DecodedAnimationAttributes, DecodedImageAttributes, DecoderPreparedImage, FormatAttributes,
+    DecodedAnimationAttributes, DecodedColorProfile, DecodedImageAttributes, DecoderPreparedImage,
+    FormatAttributes,
 };
 use crate::utils::seek_start_with_offset;
 use crate::{ImageDecoder, ImageFormat};
@@ -460,6 +461,13 @@ impl<R: BufRead + Seek> ImageDecoder for IcoDecoder<R> {
         match &mut self.inner_decoder {
             Bmp(decoder) => decoder.icc_profile(),
             Png(decoder) => decoder.icc_profile(),
+        }
+    }
+
+    fn color_profile(&mut self) -> ImageResult<Option<DecodedColorProfile>> {
+        match &mut self.inner_decoder {
+            Bmp(decoder) => decoder.color_profile(),
+            Png(decoder) => decoder.color_profile(),
         }
     }
 

--- a/src/codecs/ico/decoder.rs
+++ b/src/codecs/ico/decoder.rs
@@ -118,7 +118,7 @@ pub struct IcoDecoder<R: BufRead + Seek> {
 }
 
 enum InnerDecoder<R: BufRead + Seek> {
-    Bmp(BmpDecoder<R>),
+    Bmp(Box<BmpDecoder<R>>),
     Png(Box<PngDecoder<R>>),
 }
 
@@ -286,7 +286,7 @@ impl DirEntry {
         if is_png {
             Ok(Png(Box::new(PngDecoder::new(r))))
         } else {
-            Ok(Bmp(BmpDecoder::new_with_ico_format(r)?))
+            Ok(Bmp(Box::new(BmpDecoder::new_with_ico_format(r)?)))
         }
     }
 }

--- a/src/codecs/jpeg/decoder.rs
+++ b/src/codecs/jpeg/decoder.rs
@@ -6,7 +6,9 @@ use crate::error::{
 };
 use crate::io::decoder::DecodedMetadataHint;
 use crate::io::image_reader_type::SpecCompliance;
-use crate::io::{DecodedImageAttributes, DecoderPreparedImage, FormatAttributes};
+use crate::io::{
+    DecodedColorProfile, DecodedImageAttributes, DecoderPreparedImage, FormatAttributes,
+};
 use crate::{ImageDecoder, ImageFormat, Limits};
 
 type ZuneColorSpace = zune_core::colorspace::ColorSpace;
@@ -107,6 +109,7 @@ impl<R: BufRead + Seek> ImageDecoder for JpegDecoder<R> {
             // our methods currently seek of their own accord anyways, it's just important to
             // uphold this if we do not buffer the whole file.
             icc: DecodedMetadataHint::InHeader,
+            color_profile: DecodedMetadataHint::InHeader,
             exif: DecodedMetadataHint::InHeader,
             xmp: DecodedMetadataHint::InHeader,
             iptc: DecodedMetadataHint::InHeader,
@@ -126,6 +129,10 @@ impl<R: BufRead + Seek> ImageDecoder for JpegDecoder<R> {
     fn icc_profile(&mut self) -> ImageResult<Option<Vec<u8>>> {
         let (decoder, _) = self.ensure_headers()?;
         Ok(decoder.icc_profile())
+    }
+
+    fn color_profile(&mut self) -> ImageResult<Option<DecodedColorProfile>> {
+        Ok(self.icc_profile()?.map(DecodedColorProfile::from_icc))
     }
 
     fn exif_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {

--- a/src/codecs/png.rs
+++ b/src/codecs/png.rs
@@ -8,7 +8,7 @@ use core::num::NonZeroU32;
 use std::borrow::Cow;
 use std::io::{BufRead, Seek, Write};
 
-use png::{BlendOp, DeflateCompression, DisposeOp};
+use png::{BlendOp, DeflateCompression, DisposeOp, ScaledFloat, SrgbRenderingIntent};
 
 use crate::animation::Delay;
 use crate::color::{ColorType, ExtendedColorType};
@@ -18,11 +18,14 @@ use crate::error::{
 };
 use crate::io::decoder::DecodedMetadataHint;
 use crate::io::{
-    DecodedAnimationAttributes, DecodedImageAttributes, DecoderPreparedImage, FormatAttributes,
-    SequenceControl,
+    DecodedAnimationAttributes, DecodedColorProfile, DecodedImageAttributes, DecoderPreparedImage,
+    FormatAttributes, SequenceControl,
 };
 use crate::math::Rect;
-use crate::metadata::LoopCount;
+use crate::metadata::{
+    Cicp, CicpColorPrimaries, CicpMatrixCoefficients, CicpTransferCharacteristics,
+    CicpVideoFullRangeFlag, LoopCount,
+};
 use crate::utils::vec_try_with_capacity;
 use crate::{
     DynamicImage, GenericImage, GenericImageView, ImageDecoder, ImageEncoder, ImageFormat,
@@ -293,6 +296,8 @@ impl<R: BufRead + Seek> ImageDecoder for PngDecoder<R> {
             iptc: DecodedMetadataHint::InHeader,
             // see iCCP chunk order.
             icc: DecodedMetadataHint::InHeader,
+            // see chunk order of all color chunks.
+            color_profile: DecodedMetadataHint::InHeader,
             // see eXIf chunk order.
             exif: DecodedMetadataHint::InHeader,
             ..FormatAttributes::default()
@@ -307,6 +312,166 @@ impl<R: BufRead + Seek> ImageDecoder for PngDecoder<R> {
     fn icc_profile(&mut self) -> ImageResult<Option<Vec<u8>>> {
         let reader = self.ensure_reader_and_header()?;
         Ok(reader.info().icc_profile.as_ref().map(|x| x.to_vec()))
+    }
+
+    fn color_profile(&mut self) -> ImageResult<Option<DecodedColorProfile>> {
+        let reader = self.ensure_reader_and_header()?;
+        let info = reader.info();
+
+        // Per PNG v3 sec. 4.3, cICP is the highest priority color chunk
+        if let Some(cicp) = info.coding_independent_code_points {
+            let Ok(primaries) = CicpColorPrimaries::try_from(cicp.color_primaries) else {
+                return Err(ImageError::Decoding(DecodingError::new(
+                    ImageFormat::Png.into(),
+                    format!(
+                        "Failed to decode CICP color primaries value {}",
+                        cicp.color_primaries
+                    ),
+                )));
+            };
+            let Ok(transfer) = CicpTransferCharacteristics::try_from(cicp.transfer_function) else {
+                return Err(ImageError::Decoding(DecodingError::new(
+                    ImageFormat::Png.into(),
+                    format!(
+                        "Failed to decode CICP transfer function value {}",
+                        cicp.transfer_function
+                    ),
+                )));
+            };
+            // See PNG v3 spec 11.3.2.6 on expected matrix coefficient value
+            if cicp.matrix_coefficients != 0 {
+                return Err(ImageError::Decoding(DecodingError::new(
+                    ImageFormat::Png.into(),
+                    "Invalid nonzero matrix coefficients for PNG CICP".to_string(),
+                )));
+            }
+            let full_range = if cicp.is_video_full_range_image {
+                CicpVideoFullRangeFlag::FullRange
+            } else {
+                CicpVideoFullRangeFlag::NarrowRange
+            };
+
+            Ok(Some(DecodedColorProfile::from_plain_cicp(Cicp {
+                primaries,
+                transfer,
+                matrix: CicpMatrixCoefficients::Identity,
+                full_range,
+            })))
+        } else if let Some(profile) = &info.icc_profile {
+            Ok(Some(DecodedColorProfile::from_icc(profile.to_vec())))
+        } else if let Some(intent) = info.srgb {
+            let mut profile = moxcms::ColorProfile::new_srgb();
+            profile.rendering_intent = match intent {
+                SrgbRenderingIntent::Perceptual => moxcms::RenderingIntent::Perceptual,
+                SrgbRenderingIntent::RelativeColorimetric => {
+                    moxcms::RenderingIntent::RelativeColorimetric
+                }
+                SrgbRenderingIntent::Saturation => moxcms::RenderingIntent::Saturation,
+                SrgbRenderingIntent::AbsoluteColorimetric => {
+                    moxcms::RenderingIntent::AbsoluteColorimetric
+                }
+            };
+            Ok(Some(DecodedColorProfile::from_icc(
+                profile
+                    .encode()
+                    .expect("simple synthetic profile should always succeed"),
+            )))
+        } else if info.gama_chunk.is_some_and(|x| x.into_scaled() != 0) || info.chrm_chunk.is_some()
+        {
+            // NOTE: PNG v3 13.13, Decoder gamma handling, recommends ignoring 0 gAMA as erroneous
+            let Some(gama) = info.gama_chunk.filter(|x| x.into_scaled() != 0) else {
+                return Err(ImageError::Unsupported(
+                    UnsupportedError::from_format_and_kind(
+                        ImageFormat::Png.into(),
+                        UnsupportedErrorKind::ColorProfileUnconvertible(
+                            "conversion of cHRM to color profile without gAMA not implemented"
+                                .to_string(),
+                        ),
+                    ),
+                ));
+            };
+            let Some(chrm) = info.chrm_chunk else {
+                return Err(ImageError::Unsupported(
+                    UnsupportedError::from_format_and_kind(
+                        ImageFormat::Png.into(),
+                        UnsupportedErrorKind::ColorProfileUnconvertible(
+                            "conversion of gAMA to color profile  without cHRM not implemented"
+                                .to_string(),
+                        ),
+                    ),
+                ));
+            };
+
+            // NOTE: PNG v3 13.13, Decoder gamma handling, recommends ignoring 0 gAMA as erroneous
+            let is_gamma22 = gama.into_scaled() == 45455;
+            let is_srgb_primaries = chrm
+                == png::SourceChromaticities {
+                    white: (
+                        ScaledFloat::from_scaled(31270),
+                        ScaledFloat::from_scaled(32900),
+                    ),
+                    red: (
+                        ScaledFloat::from_scaled(64000),
+                        ScaledFloat::from_scaled(33000),
+                    ),
+                    green: (
+                        ScaledFloat::from_scaled(30000),
+                        ScaledFloat::from_scaled(60000),
+                    ),
+                    blue: (
+                        ScaledFloat::from_scaled(15000),
+                        ScaledFloat::from_scaled(6000),
+                    ),
+                };
+
+            // Many images have this combination.
+            // TODO: detect other common primaries and gamma=1.0
+            if is_gamma22 && is_srgb_primaries {
+                Ok(Some(DecodedColorProfile::from_plain_cicp(Cicp {
+                    primaries: CicpColorPrimaries::SRgb,
+                    transfer: CicpTransferCharacteristics::Bt470M,
+                    matrix: CicpMatrixCoefficients::Identity,
+                    full_range: CicpVideoFullRangeFlag::FullRange,
+                })))
+            } else {
+                let mut profile = moxcms::ColorProfile::new_gray_with_gamma(gama.into_value());
+                profile.color_space = moxcms::DataColorSpace::Rgb;
+                let primaries = moxcms::ColorPrimaries {
+                    red: moxcms::Chromaticity::new(
+                        chrm.red.0.into_value(),
+                        chrm.red.1.into_value(),
+                    ),
+                    green: moxcms::Chromaticity::new(
+                        chrm.green.0.into_value(),
+                        chrm.green.1.into_value(),
+                    ),
+                    blue: moxcms::Chromaticity::new(
+                        chrm.blue.0.into_value(),
+                        chrm.blue.1.into_value(),
+                    ),
+                };
+                profile.update_rgb_colorimetry(
+                    moxcms::Chromaticity::new(chrm.white.0.into_value(), chrm.white.1.into_value())
+                        .to_xyyb(),
+                    primaries,
+                );
+
+                let Ok(profile_txt) = profile.encode() else {
+                    return Err(ImageError::Unsupported(
+                        UnsupportedError::from_format_and_kind(
+                            ImageFormat::Png.into(),
+                            UnsupportedErrorKind::ColorProfileUnconvertible(
+                                "failed to convert gAMA and cHRM to ICC".to_string(),
+                            ),
+                        ),
+                    ));
+                };
+
+                Ok(Some(DecodedColorProfile::from_icc(profile_txt)))
+            }
+        } else {
+            Ok(None)
+        }
     }
 
     fn exif_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {

--- a/src/codecs/qoi.rs
+++ b/src/codecs/qoi.rs
@@ -1,7 +1,16 @@
 //! Decoding and encoding of QOI images
 
+use qoi::ColorSpace;
+
 use crate::error::{DecodingError, EncodingError, UnsupportedError, UnsupportedErrorKind};
-use crate::io::{DecodedImageAttributes, DecoderPreparedImage};
+use crate::io::{
+    DecodedColorProfile, DecodedImageAttributes, DecodedMetadataHint, DecoderPreparedImage,
+    FormatAttributes,
+};
+use crate::metadata::{
+    Cicp, CicpColorPrimaries, CicpMatrixCoefficients, CicpTransferCharacteristics,
+    CicpVideoFullRangeFlag,
+};
 use crate::{
     ColorType, ExtendedColorType, ImageDecoder, ImageEncoder, ImageError, ImageFormat, ImageResult,
 };
@@ -24,6 +33,18 @@ where
 }
 
 impl<R: Read> ImageDecoder for QoiDecoder<R> {
+    fn format_attributes(&self) -> FormatAttributes {
+        FormatAttributes {
+            supports_animation: false,
+            supports_sequence: false,
+            icc: DecodedMetadataHint::Unsupported,
+            color_profile: DecodedMetadataHint::InHeader,
+            exif: DecodedMetadataHint::None,
+            xmp: DecodedMetadataHint::None,
+            iptc: DecodedMetadataHint::None,
+        }
+    }
+
     fn prepare_image(&mut self) -> ImageResult<DecoderPreparedImage> {
         let header = self.decoder.header();
         let color = match header.channels {
@@ -41,6 +62,29 @@ impl<R: Read> ImageDecoder for QoiDecoder<R> {
     fn read_image(&mut self, buf: &mut [u8]) -> ImageResult<DecodedImageAttributes> {
         self.decoder.decode_to_buf(buf).map_err(decoding_error)?;
         Ok(DecodedImageAttributes::default())
+    }
+
+    fn color_profile(&mut self) -> ImageResult<Option<DecodedColorProfile>> {
+        // The QOI spec's color space field just distinguishes 'sRGB with linear alpha'
+        // from 'all channels linear'; the issue https://github.com/phoboslab/qoi/issues/25
+        // suggests this was added to help distinguish sRGB color image data from things
+        // like normal maps; the former requires different texture filtering due
+        // to a nonlinear transfer function.
+        Ok(Some(DecodedColorProfile::from_plain_cicp(
+            match self.decoder.header().colorspace {
+                ColorSpace::Srgb => Cicp::SRGB,
+                ColorSpace::Linear => {
+                    // u8+linear is bad for display images, so any QOI file with linear transfer
+                    // function is most likely a normal map or resource lacking color primaries
+                    Cicp {
+                        primaries: CicpColorPrimaries::Unspecified,
+                        transfer: CicpTransferCharacteristics::Linear,
+                        matrix: CicpMatrixCoefficients::Identity,
+                        full_range: CicpVideoFullRangeFlag::FullRange,
+                    }
+                }
+            },
+        )))
     }
 }
 

--- a/src/codecs/tiff.rs
+++ b/src/codecs/tiff.rs
@@ -17,7 +17,9 @@ use crate::error::{
     ParameterError, ParameterErrorKind, UnsupportedError, UnsupportedErrorKind,
 };
 use crate::io::decoder::DecodedMetadataHint;
-use crate::io::{DecodedImageAttributes, DecoderPreparedImage, FormatAttributes};
+use crate::io::{
+    DecodedColorProfile, DecodedImageAttributes, DecoderPreparedImage, FormatAttributes,
+};
 use crate::metadata::Orientation;
 use crate::{utils, ImageDecoder, ImageEncoder, ImageFormat};
 
@@ -386,6 +388,7 @@ impl<R: BufRead + Seek> ImageDecoder for TiffDecoder<R> {
             // is any sort of iTXT chunk.
             xmp: DecodedMetadataHint::PerImage,
             icc: DecodedMetadataHint::PerImage,
+            color_profile: DecodedMetadataHint::PerImage,
             exif: DecodedMetadataHint::PerImage,
             // not provided above.
             iptc: DecodedMetadataHint::Unsupported,
@@ -407,6 +410,10 @@ impl<R: BufRead + Seek> ImageDecoder for TiffDecoder<R> {
         } else {
             Ok(None)
         }
+    }
+
+    fn color_profile(&mut self) -> ImageResult<Option<DecodedColorProfile>> {
+        Ok(self.icc_profile()?.map(DecodedColorProfile::from_icc))
     }
 
     fn xmp_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {

--- a/src/codecs/webp/decoder.rs
+++ b/src/codecs/webp/decoder.rs
@@ -4,8 +4,8 @@ use image_webp::LoopCount;
 
 use crate::error::{DecodingError, ImageError, ImageResult, ParameterError, ParameterErrorKind};
 use crate::io::{
-    DecodedAnimationAttributes, DecodedImageAttributes, DecodedMetadataHint, DecoderPreparedImage,
-    FormatAttributes, SequenceControl,
+    DecodedAnimationAttributes, DecodedColorProfile, DecodedImageAttributes, DecodedMetadataHint,
+    DecoderPreparedImage, FormatAttributes, SequenceControl,
 };
 use crate::{ColorType, Delay, ImageDecoder, ImageFormat, Rgba};
 
@@ -45,6 +45,7 @@ impl<R: BufRead + Seek> ImageDecoder for WebPDecoder<R> {
             // As per extended file format description:
             // <https://developers.google.com/speed/webp/docs/riff_container#extended_file_format>
             icc: DecodedMetadataHint::InHeader,
+            color_profile: DecodedMetadataHint::InHeader,
             exif: DecodedMetadataHint::InHeader,
             xmp: DecodedMetadataHint::InHeader,
             ..FormatAttributes::default()
@@ -109,6 +110,10 @@ impl<R: BufRead + Seek> ImageDecoder for WebPDecoder<R> {
         self.inner
             .icc_profile()
             .map_err(ImageError::from_webp_decode)
+    }
+
+    fn color_profile(&mut self) -> ImageResult<Option<DecodedColorProfile>> {
+        Ok(self.icc_profile()?.map(DecodedColorProfile::from_icc))
     }
 
     fn exif_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -81,6 +81,8 @@ pub enum UnsupportedErrorKind {
     Color(ExtendedColorType),
     /// Dealing with an intricate layout is not implemented for an algorithm.
     ColorLayout(ExtendedColorType),
+    /// The color profile of the image could not be interpreted as the required type
+    ColorProfileUnconvertible(String),
     /// The colors or transfer function of the CICP are not supported.
     ColorspaceCicp(Cicp),
     /// An image format is not supported.
@@ -398,6 +400,11 @@ impl fmt::Display for UnsupportedError {
             UnsupportedErrorKind::ColorLayout(layout) => write!(
                 fmt,
                 "Converting with the texel memory layout {layout:?} is not supported",
+            ),
+            UnsupportedErrorKind::ColorProfileUnconvertible(msg) => write!(
+                fmt,
+                "The encoder or decoder for {} could not translate the color profile into the expected system: {}",
+                self.format, msg,
             ),
             UnsupportedErrorKind::ColorspaceCicp(color) => write!(
                 fmt,

--- a/src/io.rs
+++ b/src/io.rs
@@ -14,8 +14,8 @@ pub(crate) mod image_reader_type;
 pub(crate) mod limits;
 
 pub use decoder::{
-    DecodedAnimationAttributes, DecodedImageAttributes, DecodedMetadataHint, FormatAttributes,
-    SequenceControl,
+    DecodedAnimationAttributes, DecodedColorProfile, DecodedImageAttributes, DecodedMetadataHint,
+    FormatAttributes, SequenceControl,
 };
 
 pub use image_reader_type::DecodedImageMetadata;

--- a/src/io/decoder.rs
+++ b/src/io/decoder.rs
@@ -1,7 +1,7 @@
-use crate::error::ImageResult;
+use crate::error::{ImageFormatHint, ImageResult, UnsupportedError, UnsupportedErrorKind};
 use crate::io::DecoderPreparedImage;
-use crate::metadata::{LoopCount, Orientation};
-use crate::Delay;
+use crate::metadata::{Cicp, LoopCount, Orientation};
+use crate::{Delay, ImageError};
 
 /// The interface for `image` to utilize in reading image files.
 ///
@@ -17,7 +17,7 @@ use crate::Delay;
 ///
 /// configure = "set_limits"
 ///
-/// metadata = "xmp_metadata" | "icc_profile" | "exif_metadata" | "iptc_metadata"
+/// metadata = "xmp_metadata" | "icc_profile" | "exif_metadata" | "iptc_metadata" | "color_profile"
 /// ```
 ///
 /// Deviation from this order can be treated as an error. Future changes to the protocol may
@@ -115,14 +115,29 @@ pub trait ImageDecoder {
 
     /// Returns the ICC color profile embedded in the image, or `Ok(None)` if the image does not have one.
     ///
-    /// For formats that don't support embedded profiles this function should always return
-    /// `Ok(None)`. Decoders for formats with non-standard color profiles may create a synthetic
-    /// profile, see our [`bmp`](`crate::codecs::bmp`) module for an example.
+    /// Note that this function returning a profile does not imply the image actually
+    /// uses the profile. Some formats allow embedding but not using ICC profiles.
     ///
-    /// A decoder that encounters tags which contain a color profile whose encoding it does not
-    /// support should return [`UnsupportedError`](`crate::error::UnsupportedError`). This allows a
-    /// reader to continue while differentiating from missing metadata.
+    /// Use [`ImageDecoder::color_profile`] to determine whether the color profile
+    /// that applies to the image contents can be expressed in ICC format.
     fn icc_profile(&mut self) -> ImageResult<Option<Vec<u8>>> {
+        Ok(None)
+    }
+
+    /// Returns the color profile information of the image. If the image is missing
+    /// any color metadata this will return Ok(None).
+    ///
+    /// If the color profile information of the image cannot accurately be expressed
+    /// using the current implementation of [`DecodedColorProfile`] (as may occur for images
+    /// using new HDR standards), or simply because the decoder has not implemented
+    /// the required conversion logic, this returns
+    /// [`UnsupportedError`](`crate::error::UnsupportedError`). This allows a
+    /// reader to continue while differentiating from images which are missing color
+    /// metadata.
+    ///
+    /// Decoders for formats with non-standard color profiles may create a synthetic
+    /// profile, see our [`bmp`](`crate::codecs::bmp`) module for an example.
+    fn color_profile(&mut self) -> ImageResult<Option<DecodedColorProfile>> {
         Ok(None)
     }
 
@@ -186,6 +201,8 @@ pub struct FormatAttributes {
     pub supports_sequence: bool,
     /// When should ICC profiles be retrieved.
     pub icc: DecodedMetadataHint,
+    /// When should the color profile information be retrieved.
+    pub color_profile: DecodedMetadataHint,
     /// A hint for polling EXIF metadata.
     pub exif: DecodedMetadataHint,
     /// A hint for polling XMP metadata.
@@ -234,6 +251,106 @@ pub struct DecodedImageAttributes {
     /// [`color`][`crate::ImageLayout::color`] field, you do not need to time travel this
     /// information.
     pub original_color_type: Option<crate::ExtendedColorType>,
+}
+
+/// Internal color profile type.
+#[derive(Clone)]
+enum ColorProfileType {
+    Cicp {
+        cicp: Cicp,
+        // TODO: add the optional auxiliary properties needed to tone-map the input
+        // like maxCLL, maxFALL, mastering display color primaries, etc. Which
+        // actually is needed may depend on the transfer function and context.
+    },
+    Icc {
+        data: Vec<u8>,
+    },
+}
+
+/// Color profile information for a decoded image.
+///
+/// This type is opaque to make future extensions to the range of supported image
+/// color profiles easier.
+#[derive(Clone)]
+pub struct DecodedColorProfile {
+    inner: ColorProfileType,
+}
+
+// TODO: add 'from_gamma_and_primaries()', because a few formats
+// use such a color space description, and the logic to map it to ICC
+// or CICP may be worth sharing.
+impl DecodedColorProfile {
+    /// Create a [`DecodedColorProfile`] for an image whose color profile
+    /// can be accurately described by the provided CICP values
+    /// and no other information.
+    ///
+    /// (Some transfer functions may have optional associated parameters;
+    /// if those are present this function is not appropriate.)
+    pub fn from_plain_cicp(cicp: Cicp) -> Self {
+        DecodedColorProfile {
+            inner: ColorProfileType::Cicp { cicp },
+        }
+    }
+
+    /// Create a [`DecodedColorProfile`] for an image whose color profile
+    /// can be accurately described by the provided ICC profile
+    pub fn from_icc(data: Vec<u8>) -> Self {
+        DecodedColorProfile {
+            inner: ColorProfileType::Icc { data },
+        }
+    }
+
+    /// Converts the color profile to an ICC profile if this can be done
+    /// faithfully and returns Ok(None) if the color profile is not representable
+    /// as ICC.
+    ///
+    /// This returns an error when it is unclear if a conversion is possible,
+    /// if the required logic has not been implemented, or the conversion
+    /// fails.
+    ///
+    pub fn to_icc(&self) -> ImageResult<Option<Vec<u8>>> {
+        if let ColorProfileType::Icc { data } = &self.inner {
+            Ok(Some(data.clone()))
+        } else {
+            // TODO: attempt this conversion
+            Err(ImageError::Unsupported(
+                UnsupportedError::from_format_and_kind(
+                    ImageFormatHint::Unknown,
+                    UnsupportedErrorKind::ColorProfileUnconvertible(
+                        "Could not convert CICP to ICC".to_string(),
+                    ),
+                ),
+            ))
+        }
+    }
+
+    /// Converts the color profile to plain CICP values, or returns Ok(None)
+    /// if the color profile is not representable as plain CICP.
+    ///
+    /// This returns an error when it is unclear if a conversion is possible,
+    /// if the required logic has not been implemented, or the conversion
+    /// fails.
+    pub fn to_plain_cicp(&self) -> ImageResult<Option<Cicp>> {
+        match &self.inner {
+            ColorProfileType::Cicp { cicp } => Ok(Some(*cicp)),
+            ColorProfileType::Icc { data } => {
+                // TODO: distinguish ICC profiles which clearly are not convertible
+                // to ICC (for example, CMYK) from ones where it is hard to determine
+                Ok(Some(
+                    crate::metadata::cms_provider()
+                        .parse_icc(data)
+                        .ok_or_else(|| {
+                            ImageError::Unsupported(UnsupportedError::from_format_and_kind(
+                                ImageFormatHint::Unknown,
+                                UnsupportedErrorKind::ColorProfileUnconvertible(
+                                    "Could not convert ICC to CICP".to_string(),
+                                ),
+                            ))
+                        })?,
+                ))
+            }
+        }
+    }
 }
 
 /// A hint when metadata corresponding to the image is decoded.
@@ -302,6 +419,9 @@ impl<T: ?Sized + ImageDecoder> ImageDecoder for Box<T> {
     }
     fn icc_profile(&mut self) -> ImageResult<Option<Vec<u8>>> {
         (**self).icc_profile()
+    }
+    fn color_profile(&mut self) -> ImageResult<Option<DecodedColorProfile>> {
+        (**self).color_profile()
     }
     fn exif_metadata(&mut self) -> ImageResult<Option<Vec<u8>>> {
         (**self).exif_metadata()

--- a/src/io/image_reader_type.rs
+++ b/src/io/image_reader_type.rs
@@ -9,7 +9,7 @@ use crate::error::{
 };
 use crate::io::limits::Limits;
 use crate::io::{DecodedAnimationAttributes, DecodedImageAttributes, DecoderPreparedImage};
-use crate::io::{DecodedMetadataHint, SequenceControl};
+use crate::io::{DecodedColorProfile, DecodedMetadataHint, SequenceControl};
 use crate::metadata::Orientation;
 use crate::{hooks, Delay, Frame, Frames};
 use crate::{DynamicImage, ImageDecoder, ImageError, ImageFormat};
@@ -406,20 +406,21 @@ pub struct ImageReader<'lt> {
 
 #[derive(Default)]
 struct MetadataBuffers {
-    exif: MetadataBlock,
-    icc: MetadataBlock,
-    xmp: MetadataBlock,
-    iptc: MetadataBlock,
+    exif: MetadataBlock<Vec<u8>>,
+    icc: MetadataBlock<Vec<u8>>,
+    color_profile: MetadataBlock<DecodedColorProfile>,
+    xmp: MetadataBlock<Vec<u8>>,
+    iptc: MetadataBlock<Vec<u8>>,
     first_meta_retrieved: bool,
 }
 
 /// Buffer state for one item of metadata, to surface the error at the right time.
-#[derive(Default)]
-enum MetadataBlock {
+#[derive(Default, Debug)]
+enum MetadataBlock<T> {
     /// No buffered metadata.
     #[default]
     None,
-    Ok(Vec<u8>),
+    Ok(T),
     /// There was an error acquiring the metadata, this is the original error.
     Err(ImageError),
     /// The error was already polled. We continue to error but now with a replacement.
@@ -429,12 +430,17 @@ enum MetadataBlock {
     Unsupported(ImageFormatHint),
 }
 
-impl MetadataBlock {
+impl<T> MetadataBlock<T> {
     fn is_not_none(&self) -> bool {
         !matches!(self, MetadataBlock::None)
     }
+}
 
-    fn get(&mut self) -> ImageResult<Option<Vec<u8>>> {
+impl<T> MetadataBlock<T>
+where
+    T: Clone,
+{
+    fn get(&mut self) -> ImageResult<Option<T>> {
         match self {
             MetadataBlock::None => Ok(None),
             MetadataBlock::Ok(data) => Ok(Some(data.clone())),
@@ -656,37 +662,11 @@ impl<'stream> ImageReader<'stream> {
     /// Polls the underlying decoder for any `InHeader` metadata that is constant across a file,
     /// applicable to all images, and appears early.
     fn fill_header_metadata_if_any(&mut self) {
-        type MetadataFn<'a> =
-            fn(&mut (dyn ImageDecoder + 'a)) -> Result<Option<Vec<u8>>, ImageError>;
-
-        // We retrieve `InHeader` metadata only once, before reading any our images.
-        let first_meta_retrieved = self.metadata_buffers.first_meta_retrieved;
-        let format_attrs = self.inner.format_attributes();
-
-        let attributes = [
-            (
-                format_attrs.exif,
-                &mut self.metadata_buffers.exif,
-                <dyn ImageDecoder + '_>::exif_metadata as MetadataFn,
-            ),
-            (
-                format_attrs.icc,
-                &mut self.metadata_buffers.icc,
-                <dyn ImageDecoder + '_>::icc_profile as MetadataFn,
-            ),
-            (
-                format_attrs.xmp,
-                &mut self.metadata_buffers.xmp,
-                <dyn ImageDecoder + '_>::xmp_metadata as MetadataFn,
-            ),
-            (
-                format_attrs.iptc,
-                &mut self.metadata_buffers.iptc,
-                <dyn ImageDecoder + '_>::iptc_metadata as MetadataFn,
-            ),
-        ];
-
-        for (hint, buffer, getter) in attributes {
+        fn is_needed<T>(
+            hint: &DecodedMetadataHint,
+            buffer: &mut MetadataBlock<T>,
+            first_meta_retrieved: bool,
+        ) -> bool {
             let should_buffer_now = match hint {
                 DecodedMetadataHint::InHeader => !first_meta_retrieved,
                 DecodedMetadataHint::PerImage => true,
@@ -694,17 +674,32 @@ impl<'stream> ImageReader<'stream> {
             };
 
             if !should_buffer_now {
-                continue;
+                return false;
             }
-
             // We might have already tried this and succeeded. Expect the same result as last time
             // but avoids the allocation associated with that. A repeated `None` should be cheap,
             // most probably. This holds for variants that retrieve it once.
             if matches!(hint, DecodedMetadataHint::InHeader) && buffer.is_not_none() {
-                continue;
+                return false;
             }
 
-            match getter(self.inner.as_mut()) {
+            true
+        }
+
+        fn get_if_needed<'a, 's, T>(
+            reader: &mut Box<dyn ImageDecoder + 's>,
+            hint: &DecodedMetadataHint,
+            getter: fn(&mut (dyn ImageDecoder + 'a)) -> Result<Option<T>, ImageError>,
+            buffer: &mut MetadataBlock<T>,
+            first_meta_retrieved: bool,
+        ) where
+            's: 'a,
+        {
+            if !is_needed(hint, buffer, first_meta_retrieved) {
+                return;
+            }
+
+            match getter(reader.as_mut()) {
                 Ok(None) => *buffer = MetadataBlock::None,
                 Ok(Some(metadata)) => *buffer = MetadataBlock::Ok(metadata),
                 Err(err) => {
@@ -712,6 +707,50 @@ impl<'stream> ImageReader<'stream> {
                 }
             }
         }
+
+        // We retrieve `InHeader` metadata only once, before reading any our images.
+        let first_meta_retrieved = self.metadata_buffers.first_meta_retrieved;
+        let format_attrs = self.inner.format_attributes();
+
+        get_if_needed(
+            &mut self.inner,
+            &format_attrs.exif,
+            <dyn ImageDecoder + '_>::exif_metadata,
+            &mut self.metadata_buffers.exif,
+            first_meta_retrieved,
+        );
+
+        get_if_needed(
+            &mut self.inner,
+            &format_attrs.color_profile,
+            <dyn ImageDecoder + '_>::color_profile,
+            &mut self.metadata_buffers.color_profile,
+            first_meta_retrieved,
+        );
+
+        get_if_needed(
+            &mut self.inner,
+            &format_attrs.icc,
+            <dyn ImageDecoder + '_>::icc_profile,
+            &mut self.metadata_buffers.icc,
+            first_meta_retrieved,
+        );
+
+        get_if_needed(
+            &mut self.inner,
+            &format_attrs.xmp,
+            <dyn ImageDecoder + '_>::xmp_metadata,
+            &mut self.metadata_buffers.xmp,
+            first_meta_retrieved,
+        );
+
+        get_if_needed(
+            &mut self.inner,
+            &format_attrs.iptc,
+            <dyn ImageDecoder + '_>::iptc_metadata,
+            &mut self.metadata_buffers.iptc,
+            first_meta_retrieved,
+        );
 
         // Note: on error we do not set this flag. You can try again.
         self.metadata_buffers.first_meta_retrieved = true;
@@ -871,6 +910,16 @@ impl<'lt> DecodedImageMetadata<'lt> {
         )
     }
 
+    /// Get the color profile of the previous image if possible
+    pub fn color_profile(&mut self) -> ImageResult<Option<DecodedColorProfile>> {
+        Self::access_block_with(
+            &mut self.metadata_buffers.color_profile,
+            self.inner.format_attributes().color_profile,
+            self.inner,
+            <dyn ImageDecoder + '_>::color_profile,
+        )
+    }
+
     /// Get the ICC profile of the previous image if any.
     pub fn icc_profile(&mut self) -> ImageResult<Option<Vec<u8>>> {
         Self::access_block_with(
@@ -907,15 +956,21 @@ impl<'lt> DecodedImageMetadata<'lt> {
         image: &mut DynamicImage,
     ) -> Result<(), ImageError> {
         // Run all the metadata extraction which we may need.
-        let icc = self.icc_profile()?;
+        let color_profile = match self.color_profile() {
+            Ok(x) => x,
+            Err(ImageError::Unsupported(_)) => None,
+            Err(e) => {
+                return Err(e);
+            }
+        };
         let exif = self.exif_metadata()?;
 
         // Apply the profile. If the profile itself is not valid or not present you get the default
         // presumption: `sRGB`. Otherwise we will try to make sense of the profile and if it is not
-        // RGB we'll treat it as unspecified so that downstream will know that our handling of this
-        // _existing_ profile was not / could not be done with full fidelity.
-        if let Some(icc) = icc {
-            if let Some(cicp) = crate::metadata::cms_provider().parse_icc(&icc) {
+        // a known CICP RGB we'll treat it as unspecified so that downstream will know that our
+        // handling of this _existing_ profile was not / could not be done with full fidelity.
+        if let Some(color_profile) = color_profile {
+            if let Some(cicp) = color_profile.to_plain_cicp().ok().flatten() {
                 // We largely ignore the error itself here, you just get the image with no color
                 // space attached to it.
                 if let Ok(rgb) = cicp.try_into_rgb() {
@@ -948,12 +1003,15 @@ impl<'lt> DecodedImageMetadata<'lt> {
         Ok(())
     }
 
-    fn access_block_with<'l>(
-        block: &mut MetadataBlock,
+    fn access_block_with<'l, T>(
+        block: &mut MetadataBlock<T>,
         meta: DecodedMetadataHint,
         decoder: &mut (dyn ImageDecoder + 'l),
-        access: fn(&'_ mut (dyn ImageDecoder + 'l)) -> ImageResult<Option<Vec<u8>>>,
-    ) -> ImageResult<Option<Vec<u8>>> {
+        access: fn(&'_ mut (dyn ImageDecoder + 'l)) -> ImageResult<Option<T>>,
+    ) -> ImageResult<Option<T>>
+    where
+        T: Clone,
+    {
         match meta {
             DecodedMetadataHint::InHeader => {
                 if matches!(block, MetadataBlock::ErrorTaken) {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -11,7 +11,9 @@ use byteorder_lite::{BigEndian, LittleEndian, ReadBytesExt, WriteBytesExt};
 
 pub use self::cicp::{
     Cicp, CicpColorPrimaries, CicpMatrixCoefficients, CicpTransferCharacteristics, CicpTransform,
-    CicpVideoFullRangeFlag,
+    CicpVideoFullRangeFlag, UnsupportedCicpColorPrimariesError,
+    UnsupportedCicpMatrixCoefficientsError, UnsupportedCicpTransferCharacteristicsError,
+    UnsupportedCicpVideoFullRangeFlagError,
 };
 
 pub(crate) trait CmsProvider {

--- a/src/metadata/cicp.rs
+++ b/src/metadata/cicp.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
 
 /// CICP (coding independent code points) defines the colorimetric interpretation of rgb-ish color
 /// components.
@@ -111,6 +111,41 @@ impl CicpColorPrimaries {
     }
 }
 
+/// Converting [`u8`] to [`CicpColorPrimaries`] failed.
+#[derive(Debug, Clone, Copy)]
+pub struct UnsupportedCicpColorPrimariesError(pub u8);
+
+impl fmt::Display for UnsupportedCicpColorPrimariesError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} is not a known CICP color primaries value", self.0)
+    }
+}
+
+impl TryFrom<u8> for CicpColorPrimaries {
+    type Error = UnsupportedCicpColorPrimariesError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        use CicpColorPrimaries::*;
+        Ok(match value {
+            1 => SRgb,
+            2 => Unspecified,
+            4 => RgbM,
+            5 => RgbB,
+            6 => Bt601,
+            7 => Rgb240m,
+            8 => GenericFilm,
+            9 => Rgb2020,
+            10 => Xyz,
+            11 => SmpteRp431,
+            12 => SmpteRp432,
+            22 => Industry22,
+            _ => {
+                return Err(UnsupportedCicpColorPrimariesError(value));
+            }
+        })
+    }
+}
+
 /// The transfer characteristics, expressing relation between encoded values and linear color
 /// values.
 ///
@@ -201,6 +236,50 @@ impl CicpTransferCharacteristics {
     }
 }
 
+/// Converting [`u8`] to [`CicpTransferCharacteristics`] failed.
+#[derive(Debug, Clone, Copy)]
+pub struct UnsupportedCicpTransferCharacteristicsError(pub u8);
+
+impl fmt::Display for UnsupportedCicpTransferCharacteristicsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} is not a known CICP transfer characteristics value",
+            self.0
+        )
+    }
+}
+
+impl TryFrom<u8> for CicpTransferCharacteristics {
+    type Error = UnsupportedCicpTransferCharacteristicsError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        use CicpTransferCharacteristics::*;
+        Ok(match value {
+            1 => Bt709,
+            2 => Unspecified,
+            4 => Bt470M,
+            5 => Bt470BG,
+            6 => Bt601,
+            7 => Smpte240m,
+            8 => Linear,
+            9 => Log100,
+            10 => LogSqrt,
+            11 => Iec61966_2_4,
+            12 => Bt1361,
+            13 => SRgb,
+            14 => Bt2020_10bit,
+            15 => Bt2020_12bit,
+            16 => Smpte2084,
+            17 => Smpte428,
+            18 => Bt2100Hlg,
+            _ => {
+                return Err(UnsupportedCicpTransferCharacteristicsError(value));
+            }
+        })
+    }
+}
+
 ///
 /// Refer to Rec H.273 Table 4.
 #[repr(u8)]
@@ -256,6 +335,50 @@ pub enum CicpMatrixCoefficients {
     YCgCoRo = 17,
 }
 
+/// Converting [`u8`] to [`CicpMatrixCoefficients`] failed.
+#[derive(Clone, Copy, Debug)]
+pub struct UnsupportedCicpMatrixCoefficientsError(pub u8);
+
+impl fmt::Display for UnsupportedCicpMatrixCoefficientsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} is not a known CICP matrix coefficients value",
+            self.0
+        )
+    }
+}
+
+impl TryFrom<u8> for CicpMatrixCoefficients {
+    type Error = UnsupportedCicpMatrixCoefficientsError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        use CicpMatrixCoefficients::*;
+        Ok(match value {
+            0 => Identity,
+            1 => Bt709,
+            2 => Unspecified,
+            4 => UsFCC,
+            5 => Bt470BG,
+            6 => Smpte170m,
+            7 => Smpte240m,
+            8 => YCgCo,
+            9 => Bt2020NonConstant,
+            10 => Bt2020Constant,
+            11 => Smpte2085,
+            12 => ChromaticityDerivedNonConstant,
+            13 => ChromaticityDerivedConstant,
+            14 => Bt2100,
+            15 => IptPqC2,
+            16 => YCgCoRe,
+            17 => YCgCoRo,
+            _ => {
+                return Err(UnsupportedCicpMatrixCoefficientsError(value));
+            }
+        })
+    }
+}
+
 /// The used encoded value range.
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
@@ -267,6 +390,35 @@ pub enum CicpVideoFullRangeFlag {
     NarrowRange = 0,
     /// The color components are encoded in the full range, e.g., 0-255 for 8-bit.
     FullRange = 1,
+}
+
+/// Converting [`u8`] to [`CicpVideoFullRangeFlag`] failed.
+#[derive(Clone, Copy, Debug)]
+pub struct UnsupportedCicpVideoFullRangeFlagError(pub u8);
+
+impl fmt::Display for UnsupportedCicpVideoFullRangeFlagError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} is not a known CICP video full range flag value",
+            self.0
+        )
+    }
+}
+
+impl TryFrom<u8> for CicpVideoFullRangeFlag {
+    type Error = UnsupportedCicpVideoFullRangeFlagError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        use CicpVideoFullRangeFlag::*;
+        Ok(match value {
+            0 => NarrowRange,
+            1 => FullRange,
+            _ => {
+                return Err(UnsupportedCicpVideoFullRangeFlagError(value));
+            }
+        })
+    }
 }
 
 #[repr(u8)]

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -181,10 +181,11 @@ fn bad_gif_oom() {
 #[cfg(feature = "png")]
 fn resizing_with_alpha() {
     use image::imageops::FilterType;
+    use image::metadata::Cicp;
     use image::GenericImageView as _;
 
     let base: PathBuf = BASE_PATH.iter().collect();
-    let image = image::ImageReaderOptions::open(
+    let mut image = image::ImageReaderOptions::open(
         base.join("regression/image/resize-with-alpha-original.png"),
     )
     .unwrap()
@@ -195,6 +196,9 @@ fn resizing_with_alpha() {
     let mut resizable = image.clone();
     resizable.resize_exact(2 * w, 2 * h, FilterType::Nearest);
     resizable.resize_exact(w, h, FilterType::Nearest);
+
+    image.set_color_space(Cicp::SRGB).unwrap();
+    resizable.set_color_space(Cicp::SRGB).unwrap();
 
     assert_eq!(image, resizable);
 }


### PR DESCRIPTION
This adds a method which exposes the image color space information as CICP values _when possible_.  This is immediately useful for decoders for formats like PNG, which directly supports CICP; but also for specialized formats like HDR (uses linear transfer function, although the official default color primaries are weird) and QOI (has a linear colorspace option that I expect is used for non-color data, assuming it gets used at all).

Edit: the current revision also updates the way ICC color profiles are communicated.

This PR is somewhat minimal; I've not added support for CICP in AVIF as that requires dependency upgrades; or tried to map the full set of PNG color chunks (gAMA, cHRM, sRGB) to CICP when possible; or looked at to what extent various other formats (BMP, JPEG, WEBP, Farbfeld, OpenEXR, TIFF) could have color space information implementable as CICP.  But this (along with synthesizing ICC profiles as needed, similar to the way the BMP decoder does it) is something I'd rather defer if there is no reason to expect it to break the core design.

This would close https://github.com/image-rs/image/issues/2985.