### PR TITLE
Remove unnecessary `#[allow(clippy::chunks_exact_to_as_chunks)]`

### DIFF
--- a/src/codecs/avif/ycgco.rs
+++ b/src/codecs/avif/ycgco.rs
@@ -120,8 +120,6 @@ fn process_halved_chroma_row_cgco<
     let bias_y = range.bias_y as i32;
     let bias_uv = range.bias_uv as i32;
     let (y_iter, y_left) = y_plane.as_chunks::<2>();
-    // TODO: remove this once the false positive is fixed: https://github.com/rust-lang/rust-clippy/issues/17314
-    #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
     let mut rgb_chunks = rgba.chunks_exact_mut(CHANNELS * 2);
 
     let scale_coef = ((max_value as f32 / range.range_y as f32) * (1 << PRECISION) as f32) as i32;

--- a/src/codecs/avif/yuv.rs
+++ b/src/codecs/avif/yuv.rs
@@ -568,8 +568,6 @@ fn process_halved_chroma_row_cbcr<
     let bias_y = range.bias_y as i32;
     let bias_uv = range.bias_uv as i32;
     let (y_iter, y_left) = y_plane.as_chunks::<2>();
-    // TODO: remove this once the false positive is fixed: https://github.com/rust-lang/rust-clippy/issues/17314
-    #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
     let mut rgb_chunks = rgba.chunks_exact_mut(CHANNELS * 2);
     for (((y_src, &u_src), &v_src), rgb_dst) in
         y_iter.iter().zip(u_plane).zip(v_plane).zip(&mut rgb_chunks)


### PR DESCRIPTION
I fixed the bug in clippy two weeks ago, so I *think* our CI should already have the fix since it uses nightly (toolchain).

Follow-up to #3058.