### PR TITLE
Match MIME type case-insensitively in ImageFormat::from_mime_type

### DIFF
--- a/src/io/format.rs
+++ b/src/io/format.rs
@@ -130,6 +130,10 @@ impl ImageFormat {
 
     /// Return the image format specified by a MIME type.
     ///
+    /// The type and subtype are matched case-insensitively, as required by the
+    /// MIME specification. MIME type parameters (such as `; charset=utf-8`) are
+    /// not supported and must be stripped by the caller beforehand.
+    ///
     /// # Example
     ///
     /// ```
@@ -142,7 +146,9 @@ impl ImageFormat {
     where
         M: AsRef<str>,
     {
-        match mime_type.as_ref() {
+        // NOTE: MIME type and subtype are case-insensitive, so normalize before matching.
+        let mime_type = mime_type.as_ref().to_ascii_lowercase();
+        match mime_type.as_str() {
             "image/avif" => Some(ImageFormat::Avif),
             "image/jpeg" => Some(ImageFormat::Jpeg),
             "image/png" => Some(ImageFormat::Png),
@@ -364,6 +370,35 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn from_mime_type_is_case_insensitive() {
+        // The type and subtype of a MIME type are case-insensitive per RFC 2045,
+        // so `from_mime_type` must accept any casing (as seen in real HTTP headers).
+        assert_eq!(
+            ImageFormat::from_mime_type("image/png"),
+            Some(ImageFormat::Png)
+        );
+        assert_eq!(
+            ImageFormat::from_mime_type("IMAGE/PNG"),
+            Some(ImageFormat::Png)
+        );
+        assert_eq!(
+            ImageFormat::from_mime_type("Image/Png"),
+            Some(ImageFormat::Png)
+        );
+        assert_eq!(
+            ImageFormat::from_mime_type("IMAGE/X-TARGA"),
+            Some(ImageFormat::Tga)
+        );
+        // Unknown MIME types still return `None`.
+        assert_eq!(ImageFormat::from_mime_type("image/jheic"), None);
+        // Parameters are not supported and must be stripped by the caller.
+        assert_eq!(
+            ImageFormat::from_mime_type("image/png; charset=utf-8"),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #2693

## Problem

`ImageFormat::from_mime_type` compared the input against a fixed set of
lowercase literal MIME types using exact string equality. Per the MIME /
media-type specification (RFC 2045 §5.1), the `type` and `subtype` of a media
type are case-insensitive. As a result, a valid `Content-Type` header value
such as `IMAGE/PNG` or `Image/Png` (both of which occur in real-world HTTP
responses) incorrectly returned `None` instead of `Some(ImageFormat::Png)`.

## Root cause

`src/io/format.rs:145` — `from_mime_type` matched `mime_type.as_ref()` directly
against lowercase literals, so any non-lowercase casing fell through to the
`_ => None` arm.

## Fix

Normalize the input with `to_ascii_lowercase()` before matching, mirroring the
existing approach already used by the sibling method `from_extension` in the
same file (`src/io/format.rs:73`). This makes the type/subtype match
case-insensitive with no change to the recognized set of MIME types.

This is the minimal, bounded fix aligned with the maintainer direction in the
issue thread:
- fintelia: "I'd be fine switching the checks to use case-insensitive
  comparison … anything beyond that I'd rather just document as a limitation."
- RunDevelopment: limit `from_mime_type` to MIME types without parameters and
  document that users have to remove them.

Accordingly, MIME type parameters (e.g. `image/png; charset=utf-8`) are **not**
parsed; the doc comment now states that parameters are unsupported and must be
stripped by the caller. This keeps the change small and avoids pulling in a
full MIME-parsing dependency.

## Tests

Added `from_mime_type_is_case_insensitive` to the existing
`#[cfg(test)] mod tests` block in `src/io/format.rs`. It asserts:
- `image/png`, `IMAGE/PNG`, `Image/Png` all map to `ImageFormat::Png`
- `IMAGE/X-TARGA` maps to `ImageFormat::Tga` (covers a multi-token subtype)
- an unknown type (`image/jheic`) still returns `None`
- a parameterized type (`image/png; charset=utf-8`) returns `None` (documented
  limitation)

## Verification (before / after)

Before the fix (reproduces the issue):

```
test io::format::tests::from_mime_type_is_case_insensitive ... FAILED
assertion `left == right` failed
  left: None
 right: Some(Png)
```

After the fix:

```
$ cargo test --no-default-features --lib io::format
test io::format::tests::from_mime_type_is_case_insensitive ... ok
test result: ok. 6 passed; 0 failed
$ cargo test --doc from_mime_type      # doc example still compiles/passes: ok
$ cargo fmt -- --check                 # clean
$ cargo clippy --all-features --lib -- -D warnings   # clean
```

## Compatibility

Non-breaking. The public signature is unchanged. Every input that previously
returned `Some(_)` still returns the same value; the only behavioral change is
that additional (previously rejected) casings of the same MIME types now
resolve, which is strictly more permissive.
