### PR TITLE
Update cargo deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -43,9 +43,4 @@ wildcards = "allow" # at least until https://github.com/EmbarkStudios/cargo-deny
 deny = []
 skip = [
     { name = "syn" },        # Some deps depend on 2 while others use 3 (e.g. newer serde-derive versions)
-    { name = "bitflags" },   # Some deps depend on 1.3.2 while others on 2.6.0
-    { name = "hashbrown" },  # Some deps depend on 0.13.2 while others on 0.14.5
-    { name = "zune-core" },  # Some deps depend on 0.4.12 while others on 0.5.0
-    { name = "zune-jpeg" },  # Some deps depend on 0.4.21 while others on 0.5.1
-    { name = "winnow" },     # Some deps depend on 0.7.15 while others on 1.0.0
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -42,6 +42,7 @@ multiple-versions = "deny"
 wildcards = "allow" # at least until https://github.com/EmbarkStudios/cargo-deny/issues/241 is fixed
 deny = []
 skip = [
+    { name = "syn" },        # Some deps depend on 2 while others use 3 (e.g. newer serde-derive versions)
     { name = "bitflags" },   # Some deps depend on 1.3.2 while others on 2.6.0
     { name = "hashbrown" },  # Some deps depend on 0.13.2 while others on 0.14.5
     { name = "zune-core" },  # Some deps depend on 0.4.12 while others on 0.5.0


### PR DESCRIPTION
Since `syn=3` was published we have an outdated deny list, not every proc macro has updated yet but `serde-derive` is leading the charge.