### PR TITLE
Remove unnecessary clones

### DIFF
--- a/src/metadata/moxcms.rs
+++ b/src/metadata/moxcms.rs
@@ -75,7 +75,7 @@ impl super::CmsProvider for Moxcms {
             )?,
             f32: Self::build_transforms(
                 f32_fallback.clone().map(Some),
-                f32_fallback.clone(),
+                f32_fallback,
                 output_coefs,
             )?,
             output_coefs,
@@ -164,7 +164,7 @@ impl Moxcms {
         let trs = trs.map(Option::unwrap);
 
         // rgb-rgb transforms are done directly via moxcms.
-        let slices = trs.clone().map(|tr| {
+        let slices = trs.map(|tr| {
             Arc::new(move |input: &[P], output: &mut [P]| {
                 tr.transform(input, output).expect("transform failed")
             }) as Arc<dyn Fn(&[P], &mut [P]) + Send + Sync>
@@ -302,7 +302,7 @@ impl Moxcms {
 
         // luma-luma both expand and contract
         let luma_luma = {
-            let [tr33, tr34, tr43, tr44] = f32.clone();
+            let [tr33, tr34, tr43, tr44] = f32;
 
             [
                 Arc::new(move |input: &[P], output: &mut [P]| {

--- a/tests/truncate_images.rs
+++ b/tests/truncate_images.rs
@@ -16,8 +16,7 @@ fn process_images<F>(dir: &str, input_format: ImageFormat, func: F)
 where
     F: Fn(PathBuf),
 {
-    let base: PathBuf = BASE_PATH.iter().collect();
-    let mut path = base.clone();
+    let mut path: PathBuf = BASE_PATH.iter().collect();
     path.push(dir);
     path.push("**");
     path.push("*");


### PR DESCRIPTION
If I am not overlooking anything, I believe these clones are redundant and can thus be safely removed.

For reference, these changes were found by an optimizer developed as a research project.

CC @nunoplopes