### PR TITLE
Inline Limits::free

### DIFF
--- a/src/io/limits.rs
+++ b/src/io/limits.rs
@@ -155,6 +155,7 @@ impl Limits {
     /// together with [`reserve`].
     ///
     /// [`reserve`]: Self::reserve
+    #[inline]
     pub fn free(&mut self, amount: u64) {
         if let Some(max_alloc) = self.max_alloc.as_mut() {
             *max_alloc = max_alloc.saturating_add(amount);


### PR DESCRIPTION
## Summary

This adds `#[inline]` to `Limits::free`.

## Why this can improve performance

`Limits::free` is a tiny helper that forwards released allocation budget back into `max_alloc`. Inlining lets callers avoid a function call around the small `Option` check and saturating add.

## Validation

- `git diff --check`
- `cargo check --manifest-path Cargo.toml --lib`

## Benchmark

Draft note: I do not have a fresh public API benchmark that isolates this internal decoder limit helper. The change is intentionally small and submitted as a draft for maintainer feedback.
