### PR TITLE
Validate ICC configured size does not surpass bmp file size

### DIFF
--- a/src/codecs/bmp/decoder.rs
+++ b/src/codecs/bmp/decoder.rs
@@ -1458,8 +1458,25 @@ impl<R: BufRead + Seek> BmpDecoder<R> {
 
     /// Read ICC profile data from the file.
     fn read_icc_profile(&mut self, icc: &ParsedIccProfile) -> ImageResult<()> {
+        let profile_end = icc
+            .profile_offset
+            .checked_add(u64::from(icc.profile_size))
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "BMP ICC profile range overflow")
+            })?;
+        let stream_len = self.reader.seek(SeekFrom::End(0))?;
+        if profile_end > stream_len {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "BMP ICC profile extends beyond file",
+            )
+            .into());
+        }
+
         self.reader.seek(SeekFrom::Start(icc.profile_offset))?;
-        let mut profile_data = vec![0u8; icc.profile_size as usize];
+        let profile_size = icc.profile_size as usize;
+        let mut profile_data = vec_try_with_capacity(profile_size)?;
+        profile_data.resize(profile_size, 0);
         self.reader.read_exact(&mut profile_data)?;
         self.icc_profile = Some(profile_data);
         Ok(())

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1,5 +1,5 @@
 use std::fs::{self, File};
-use std::io::{BufReader, Cursor};
+use std::io::{BufReader, Cursor, ErrorKind};
 use std::path::PathBuf;
 
 const BASE_PATH: [&str; 2] = [".", "tests"];
@@ -99,6 +99,32 @@ fn ico_bmp_v5_with_icc_profile() {
     // Verify the image has expected dimensions (127x64 from rgb24prof.bmp)
     assert_eq!(img.width(), 127);
     assert_eq!(img.height(), 64);
+}
+
+#[cfg(feature = "bmp")]
+#[test]
+fn bmp_v5_rejects_truncated_icc_profile_before_allocation() {
+    let mut bmp = vec![0; 138];
+    bmp[0..2].copy_from_slice(b"BM");
+    bmp[2..6].copy_from_slice(&138u32.to_le_bytes());
+    bmp[10..14].copy_from_slice(&138u32.to_le_bytes());
+    bmp[14..18].copy_from_slice(&124u32.to_le_bytes());
+    bmp[18..22].copy_from_slice(&1i32.to_le_bytes());
+    bmp[22..26].copy_from_slice(&1i32.to_le_bytes());
+    bmp[26..28].copy_from_slice(&1u16.to_le_bytes());
+    bmp[28..30].copy_from_slice(&32u16.to_le_bytes());
+    bmp[70..74].copy_from_slice(&u32::from_be_bytes(*b"MBED").to_le_bytes());
+    bmp[126..130].copy_from_slice(&0x90u32.to_le_bytes());
+    bmp[130..134].copy_from_slice(&u32::MAX.to_le_bytes());
+
+    let err = match image::codecs::bmp::BmpDecoder::new(Cursor::new(bmp)) {
+        Ok(_) => panic!("truncated ICC profile should fail"),
+        Err(err) => err,
+    };
+
+    assert!(
+        matches!(err, image::ImageError::IoError(err) if err.kind() == ErrorKind::UnexpectedEof)
+    );
 }
 
 // Test that BMP bitmaps with extra `BI_BITFIELD` values are parsed correctly.


### PR DESCRIPTION
This PR hardens BMP V5 embedded ICC profile handling.

The decoder now validates the declared ICC profile byte range before allocating the profile buffer. It computes `profile_offset + profile_size` with overflow checking, compares the result against the seekable input length, and returns an `UnexpectedEof`` error if the profile extends beyond the file. The profile buffer allocation now also uses the crate’s fallible allocation helper instead of direct `vec![...]` allocation.

A regression test was added for the Chromium issue 537617325 crash class. The test builds an in-memory 138-byte BMP V5 file with `bV5CSType == "MBED"`, `bV5ProfileData == 0x90`, and `bV5ProfileSize == u32::MAX`, then verifies that decoder construction fails with `UnexpectedEof` instead of attempting to allocate the declared profile size.

This fixes #3094 