### PR TITLE
fix(avif): check alpha and primary picture dimensions match

### DIFF
--- a/src/codecs/avif/decoder.rs
+++ b/src/codecs/avif/decoder.rs
@@ -43,6 +43,10 @@ pub struct AvifDecoder<R> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum AvifDecoderError {
     AlphaPlaneFormat(PixelLayout),
+    AlphaPlaneSize {
+        alpha: (u32, u32),
+        primary: (u32, u32),
+    },
     YuvLayoutOnIdentityMatrix(PixelLayout),
     UnsupportedLayoutAndMatrix(PixelLayout, YuvMatrixStrategy),
     InvalidStride(u32),
@@ -57,6 +61,10 @@ impl Display for AvifDecoderError {
                 PixelLayout::I422 => f.write_str("Alpha layout must be 4:0:0, but it was 4:2:2"),
                 PixelLayout::I444 => f.write_str("Alpha layout must be 4:0:0, but it was 4:4:4"),
             },
+            AvifDecoderError::AlphaPlaneSize { alpha, primary } => f.write_fmt(format_args!(
+                "Alpha plane size {}x{} does not match primary picture size {}x{}",
+                alpha.0, alpha.1, primary.0, primary.1,
+            )),
             AvifDecoderError::YuvLayoutOnIdentityMatrix(pixel_layout) => match pixel_layout {
                 PixelLayout::I400 => {
                     f.write_str("YUV layout on 'Identity' matrix must be 4:4:4, but it was 4:0:0")
@@ -539,6 +547,20 @@ impl<R: Read> ImageDecoder for AvifDecoder<R> {
                     )));
                 }
 
+                // The primary and alpha pictures are decoded by separate dav1d
+                // instances; nothing otherwise guarantees they agree on size.
+                // A mismatch would silently truncate the shorter one via the
+                // zip below instead of erroring on the malformed input.
+                if picture.width() != width || picture.height() != height {
+                    return Err(ImageError::Decoding(DecodingError::new(
+                        ImageFormat::Avif.into(),
+                        AvifDecoderError::AlphaPlaneSize {
+                            alpha: (picture.width(), picture.height()),
+                            primary: (width, height),
+                        },
+                    )));
+                }
+
                 let stride = picture.stride(PlanarImageComponent::Y) as usize;
                 let plane = picture.plane(PlanarImageComponent::Y);
 
@@ -718,6 +740,19 @@ impl<R: Read> AvifDecoder<R> {
                 return Err(ImageError::Decoding(DecodingError::new(
                     ImageFormat::Avif.into(),
                     AvifDecoderError::AlphaPlaneFormat(picture.pixel_layout()),
+                )));
+            }
+
+            // See the matching check in read_image's 8-bit path: the primary
+            // and alpha pictures are decoded by separate dav1d instances, so
+            // nothing otherwise guarantees they agree on size.
+            if picture.width() != width || picture.height() != height {
+                return Err(ImageError::Decoding(DecodingError::new(
+                    ImageFormat::Avif.into(),
+                    AvifDecoderError::AlphaPlaneSize {
+                        alpha: (picture.width(), picture.height()),
+                        primary: (width, height),
+                    },
                 )));
             }
 


### PR DESCRIPTION
## Summary

Fixes #3084. The primary and alpha pictures in an AVIF file are decoded by separate `dav1d` instances, so nothing guarantees they agree on size. `read_image` zipped the primary buffer against the alpha plane without checking this — a malformed file with mismatched primary/alpha dimensions would silently truncate compositing to the shorter of the two, instead of erroring on the malformed input.

The 16-bit path (`process_16bit_picture`) had the same underlying gap in a different shape: it reshapes the alpha plane via `transmute_y_plane16` using the *primary* picture's `width`/`height`, without ever confirming the alpha picture's actual dimensions match those.

## Fix

Added a dimension check alongside the existing `pixel_layout` check, in both the 8-bit and 16-bit alpha-compositing paths, returning a new `AvifDecoderError::AlphaPlaneSize { alpha, primary }` variant on mismatch instead of silently truncating.

## Test plan

- `cargo build --features avif -p image` and `cargo test --features avif -p image` — clean, existing `truncate_avif` test still passes, no regression
- `cargo fmt -p image -- --check` and `cargo clippy --features avif -p image -- -D warnings` — both clean

I was not able to add a dedicated regression test for the mismatch case itself: reproducing it requires a malformed AVIF container with two AV1 sub-images (primary + alpha) at different resolutions, and I didn't have a reliable way to construct or find such a fixture. Rather than fabricate something that doesn't actually exercise the mismatch path, I'm disclosing that gap here — happy to add one if pointed at an existing fixture-generation pattern for this codec, or if a maintainer can supply/generate a suitable malformed sample.

## Disclosure

Per this org's CONTRIBUTING.md LLM policy: this PR was substantially developed with AI assistance (Claude), under my direction and review — I investigated the reported root cause myself, wrote/reviewed the fix, and ran the verification above locally before opening this.